### PR TITLE
[ARROW-12441] [DataFusion] Cross join implementation

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -940,6 +940,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
             }
             LogicalPlan::Extension { .. } => unimplemented!(),
             LogicalPlan::Union { .. } => unimplemented!(),
+            LogicalPlan::CrossJoin { .. } => unimplemented!(),
         }
     }
 }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1375,6 +1375,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_q9() -> Result<()> {
+        run_query(9).await
+    }
+
+    #[tokio::test]
     async fn run_q10() -> Result<()> {
         run_query(10).await
     }

--- a/datafusion/README.md
+++ b/datafusion/README.md
@@ -213,7 +213,9 @@ DataFusion also includes a simple command-line interactive SQL utility. See the 
   - [ ] MINUS
 - [x] Joins
   - [x] INNER JOIN
-  - [ ] CROSS JOIN
+  - [x] LEFT JOIN
+  - [x] RIGHT JOIN
+  - [x] CROSS JOIN
   - [ ] OUTER JOIN
 - [ ] Window
 

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -270,6 +270,20 @@ impl LogicalPlanBuilder {
             }))
         }
     }
+    /// Apply a cross join
+    pub fn cross_join(&self, right: &LogicalPlan) -> Result<Self> {
+        let left_fields = self.plan.schema().fields().iter();
+        let right_fields = right.schema().fields();
+        let fields = left_fields.chain(right_fields).cloned().collect();
+
+        let schema = DFSchema::new(fields)?;
+
+        Ok(Self::from(&LogicalPlan::CrossJoin {
+            left: Arc::new(self.plan.clone()),
+            right: Arc::new(right.clone()),
+            schema: DFSchemaRef::new(schema),
+        }))
+    }
 
     /// Repartition
     pub fn repartition(&self, partitioning_scheme: Partitioning) -> Result<Self> {

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -272,11 +272,7 @@ impl LogicalPlanBuilder {
     }
     /// Apply a cross join
     pub fn cross_join(&self, right: &LogicalPlan) -> Result<Self> {
-        let left_fields = self.plan.schema().fields().iter();
-        let right_fields = right.schema().fields();
-        let fields = left_fields.chain(right_fields).cloned().collect();
-
-        let schema = DFSchema::new(fields)?;
+        let schema = self.plan.schema().join(right.schema())?;
 
         Ok(Self::from(&LogicalPlan::CrossJoin {
             left: Arc::new(self.plan.clone()),

--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -113,6 +113,15 @@ pub enum LogicalPlan {
         /// The output schema, containing fields from the left and right inputs
         schema: DFSchemaRef,
     },
+    /// Apply Cross Join to two logical plans
+    CrossJoin {
+        /// Left input
+        left: Arc<LogicalPlan>,
+        /// Right input
+        right: Arc<LogicalPlan>,
+        /// The output schema, containing fields from the left and right inputs
+        schema: DFSchemaRef,
+    },
     /// Repartition the plan based on a partitioning scheme.
     Repartition {
         /// The incoming logical plan
@@ -203,6 +212,7 @@ impl LogicalPlan {
             LogicalPlan::Aggregate { schema, .. } => &schema,
             LogicalPlan::Sort { input, .. } => input.schema(),
             LogicalPlan::Join { schema, .. } => &schema,
+            LogicalPlan::CrossJoin { schema, .. } => &schema,
             LogicalPlan::Repartition { input, .. } => input.schema(),
             LogicalPlan::Limit { input, .. } => input.schema(),
             LogicalPlan::CreateExternalTable { schema, .. } => &schema,
@@ -229,6 +239,11 @@ impl LogicalPlan {
                 right,
                 schema,
                 ..
+            }
+            | LogicalPlan::CrossJoin {
+                left,
+                right,
+                schema,
             } => {
                 let mut schemas = left.all_schemas();
                 schemas.extend(right.all_schemas());
@@ -290,8 +305,9 @@ impl LogicalPlan {
             | LogicalPlan::EmptyRelation { .. }
             | LogicalPlan::Limit { .. }
             | LogicalPlan::CreateExternalTable { .. }
-            | LogicalPlan::Explain { .. } => vec![],
-            LogicalPlan::Union { .. } => {
+            | LogicalPlan::CrossJoin { .. }
+            | LogicalPlan::Explain { .. }
+            | LogicalPlan::Union { .. } => {
                 vec![]
             }
         }
@@ -307,6 +323,7 @@ impl LogicalPlan {
             LogicalPlan::Aggregate { input, .. } => vec![input],
             LogicalPlan::Sort { input, .. } => vec![input],
             LogicalPlan::Join { left, right, .. } => vec![left, right],
+            LogicalPlan::CrossJoin { left, right, .. } => vec![left, right],
             LogicalPlan::Limit { input, .. } => vec![input],
             LogicalPlan::Extension { node } => node.inputs(),
             LogicalPlan::Union { inputs, .. } => inputs.iter().collect(),
@@ -396,7 +413,8 @@ impl LogicalPlan {
             LogicalPlan::Repartition { input, .. } => input.accept(visitor)?,
             LogicalPlan::Aggregate { input, .. } => input.accept(visitor)?,
             LogicalPlan::Sort { input, .. } => input.accept(visitor)?,
-            LogicalPlan::Join { left, right, .. } => {
+            LogicalPlan::Join { left, right, .. }
+            | LogicalPlan::CrossJoin { left, right, .. } => {
                 left.accept(visitor)? && right.accept(visitor)?
             }
             LogicalPlan::Union { inputs, .. } => {
@@ -668,6 +686,9 @@ impl LogicalPlan {
                         let join_expr: Vec<String> =
                             keys.iter().map(|(l, r)| format!("{} = {}", l, r)).collect();
                         write!(f, "Join: {}", join_expr.join(", "))
+                    }
+                    LogicalPlan::CrossJoin { .. } => {
+                        write!(f, "CrossJoin:")
                     }
                     LogicalPlan::Repartition {
                         partitioning_scheme,

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -72,7 +72,8 @@ impl OptimizerRule for ConstantFolding {
             | LogicalPlan::Explain { .. }
             | LogicalPlan::Limit { .. }
             | LogicalPlan::Union { .. }
-            | LogicalPlan::Join { .. } => {
+            | LogicalPlan::Join { .. }
+            | LogicalPlan::CrossJoin { .. } => {
                 // apply the optimization to all inputs of the plan
                 let inputs = plan.inputs();
                 let new_inputs = inputs

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -314,7 +314,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                 .collect::<HashSet<_>>();
             issue_filters(state, used_columns, plan)
         }
-        LogicalPlan::Join { left, right, .. } => {
+        LogicalPlan::Join { left, right, .. } | LogicalPlan::CrossJoin {left, right, ..} => {
             let (pushable_to_left, pushable_to_right, keep) =
                 get_join_predicates(&state, &left.schema(), &right.schema());
 

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -314,7 +314,8 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                 .collect::<HashSet<_>>();
             issue_filters(state, used_columns, plan)
         }
-        LogicalPlan::Join { left, right, .. } | LogicalPlan::CrossJoin {left, right, ..} => {
+        LogicalPlan::Join { left, right, .. }
+        | LogicalPlan::CrossJoin { left, right, .. } => {
             let (pushable_to_left, pushable_to_right, keep) =
                 get_join_predicates(&state, &left.schema(), &right.schema());
 

--- a/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -67,6 +67,10 @@ fn get_num_rows(logical_plan: &LogicalPlan) -> Option<usize> {
             // we cannot predict the cardinality of the join output
             None
         }
+        LogicalPlan::CrossJoin { left, right, .. } => {
+            // number of rows is equal to num_left * num_right
+            get_num_rows(left).and_then(|x| get_num_rows(right).map(|y| x * y))
+        }
         LogicalPlan::Repartition { .. } => {
             // we cannot predict how rows will be repartitioned
             None
@@ -134,6 +138,29 @@ impl OptimizerRule for HashBuildProbeOrder {
                         right: Arc::new(right),
                         on: on.clone(),
                         join_type: *join_type,
+                        schema: schema.clone(),
+                    })
+                }
+            }
+            LogicalPlan::CrossJoin {
+                left,
+                right,
+                schema,
+            } => {
+                let left = self.optimize(left)?;
+                let right = self.optimize(right)?;
+                if should_swap_join_order(&left, &right) {
+                    // Swap left and right
+                    Ok(LogicalPlan::CrossJoin {
+                        left: Arc::new(right),
+                        right: Arc::new(left),
+                        schema: schema.clone(),
+                    })
+                } else {
+                    // Keep join as is
+                    Ok(LogicalPlan::CrossJoin {
+                        left: Arc::new(left),
+                        right: Arc::new(right),
                         schema: schema.clone(),
                     })
                 }

--- a/datafusion/src/optimizer/projection_push_down.rs
+++ b/datafusion/src/optimizer/projection_push_down.rs
@@ -270,6 +270,7 @@ fn optimize_plan(
         | LogicalPlan::Sort { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Union { .. }
+        | LogicalPlan::CrossJoin { .. }
         | LogicalPlan::Extension { .. } => {
             let expr = plan.expressions();
             // collect all required columns by this plan

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -208,6 +208,11 @@ pub fn from_plan(
             on: on.clone(),
             schema: schema.clone(),
         }),
+        LogicalPlan::CrossJoin { schema, .. } => Ok(LogicalPlan::CrossJoin {
+            left: Arc::new(inputs[0].clone()),
+            right: Arc::new(inputs[1].clone()),
+            schema: schema.clone(),
+        }),
         LogicalPlan::Limit { n, .. } => Ok(LogicalPlan::Limit {
             n: *n,
             input: Arc::new(inputs[0].clone()),

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -260,7 +260,10 @@ impl Stream for CrossJoinStream {
     ) -> std::task::Poll<Option<Self::Item>> {
         if self.left_index > 0 && self.left_index < self.left_data.num_rows() {
             let start = Instant::now();
-            let right_batch = self.right_batch.lock().unwrap().clone().unwrap();
+            let right_batch = {
+                let right_batch = self.right_batch.lock();
+                right_batch.clone().unwrap()
+            };
             let result =
                 build_batch(self.left_index, &right_batch, &self.left_data, &self.schema);
             self.num_input_rows += right_batch.num_rows();

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -158,7 +158,7 @@ impl ExecutionPlan for CrossJoinExec {
                     *build_side = Some(batches.clone());
 
                     debug!(
-                        "Built build-side of cartesian join containing {} rows in {} ms",
+                        "Built build-side of cross join containing {} rows in {} ms",
                         num_rows,
                         start.elapsed().as_millis()
                     );

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -294,7 +294,7 @@ impl Stream for CrossJoinStream {
                     self.left_index = 1;
 
                     let mut right_batch = self.right_batch.lock().unwrap();
-                    *right_batch = Some(batch.clone());
+                    *right_batch = Some(batch);
 
                     Some(result)
                 }

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -176,7 +176,7 @@ impl ExecutionPlan for CrossJoinExec {
                 vec![],
                 self.schema.clone(),
                 None,
-            )?))
+            )?));
         }
 
         Ok(Box::pin(CrossJoinStream {

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -1,0 +1,283 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the join plan for executing partitions in parallel and then joining the results
+//! into a set of partitions.
+
+use futures::StreamExt;
+use std::{any::Any, sync::Arc};
+
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::error::Result as ArrowResult;
+use arrow::record_batch::RecordBatch;
+use futures::{Stream, TryStreamExt};
+
+use futures::lock::Mutex;
+
+use super::{hash_utils::check_join_is_valid, merge::MergeExec};
+use crate::{
+    error::{DataFusionError, Result},
+    scalar::ScalarValue,
+};
+use async_trait::async_trait;
+use std::time::Instant;
+
+use super::{ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream};
+use crate::physical_plan::coalesce_batches::concat_batches;
+use log::debug;
+
+/// Data of the left side
+type JoinLeftData = Vec<RecordBatch>;
+
+/// executes partitions in parallel and combines them into a set of
+/// partitions by combining all values from the left with all values on the right
+#[derive(Debug)]
+pub struct CrossJoinExec {
+    /// left (build) side which gets loaded in memory
+    left: Arc<dyn ExecutionPlan>,
+    /// right (probe) side which are combined with left side
+    right: Arc<dyn ExecutionPlan>,
+    /// The schema once the join is applied
+    schema: SchemaRef,
+    /// Build-side data
+    build_side: Arc<Mutex<Option<JoinLeftData>>>,
+}
+
+impl CrossJoinExec {
+    /// Tries to create a new [CrossJoinExec].
+    /// # Error
+    /// This function errors when it is not possible to join the left and right sides on keys `on`.
+    pub fn try_new(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+    ) -> Result<Self> {
+        let left_schema = left.schema();
+        let right_schema = right.schema();
+        check_join_is_valid(&left_schema, &right_schema, &[])?;
+
+        let left_schema = left.schema();
+        let left_fields = left_schema.fields().iter();
+        let right_schema = right.schema();
+
+        let right_fields = right_schema.fields().iter();
+
+        // left then right
+        let all_columns = left_fields.chain(right_fields).cloned().collect();
+
+        let schema = Arc::new(Schema::new(all_columns));
+
+        Ok(CrossJoinExec {
+            left,
+            right,
+            schema,
+            build_side: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    /// left (build) side which gets loaded in memory
+    pub fn left(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.left
+    }
+
+    /// right side which gets combined with left side
+    pub fn right(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.right
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for CrossJoinExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.left.clone(), self.right.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match children.len() {
+            2 => Ok(Arc::new(CrossJoinExec::try_new(
+                children[0].clone(),
+                children[1].clone(),
+            )?)),
+            _ => Err(DataFusionError::Internal(
+                "CrossJoinExec wrong number of children".to_string(),
+            )),
+        }
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.right.output_partitioning()
+    }
+
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        // we only want to compute the build side once
+        let left_data = {
+            let mut build_side = self.build_side.lock().await;
+
+            match build_side.as_ref() {
+                Some(stream) => stream.clone(),
+                None => {
+                    let start = Instant::now();
+
+                    // merge all left parts into a single stream
+                    let merge = MergeExec::new(self.left.clone());
+                    let stream = merge.execute(0).await?;
+
+                    // Load all batches and count the rows
+                    let (batches, num_rows) = stream
+                        .try_fold((Vec::new(), 0usize), |mut acc, batch| async {
+                            acc.1 += batch.num_rows();
+                            acc.0.push(batch);
+                            Ok(acc)
+                        })
+                        .await?;
+
+                    *build_side = Some(batches.clone());
+
+                    debug!(
+                        "Built build-side of cartesian join containing {} rows in {} ms",
+                        num_rows,
+                        start.elapsed().as_millis()
+                    );
+
+                    batches
+                }
+            }
+        };
+
+        let stream = self.right.execute(partition).await?;
+
+        Ok(Box::pin(CrossJoinStream {
+            schema: self.schema.clone(),
+            left_data,
+            right: stream,
+            num_input_batches: 0,
+            num_input_rows: 0,
+            num_output_batches: 0,
+            num_output_rows: 0,
+            join_time: 0,
+        }))
+    }
+}
+
+/// A stream that issues [RecordBatch]es as they arrive from the right  of the join.
+struct CrossJoinStream {
+    /// Input schema
+    schema: Arc<Schema>,
+    /// data from the left side
+    left_data: JoinLeftData,
+    /// right
+    right: SendableRecordBatchStream,
+    /// number of input batches
+    num_input_batches: usize,
+    /// number of input rows
+    num_input_rows: usize,
+    /// number of batches produced
+    num_output_batches: usize,
+    /// number of rows produced
+    num_output_rows: usize,
+    /// total time for joining probe-side batches to the build-side batches
+    join_time: usize,
+}
+
+impl RecordBatchStream for CrossJoinStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+fn build_batch(
+    batch: &RecordBatch,
+    left_data: &[RecordBatch],
+    schema: &Schema,
+) -> ArrowResult<RecordBatch> {
+    let mut batches = Vec::new();
+    let mut num_rows = 0;
+    for left in left_data.iter() {
+        for i in 0..left.num_rows() {
+            // for each value on the left, repeat the value of the right
+            let arrays = left
+                .columns()
+                .iter()
+                .map(|arr| {
+                    let scalar = ScalarValue::try_from_array(arr, i)?;
+                    Ok(scalar.to_array_of_size(batch.num_rows()))
+                })
+                .collect::<Result<Vec<_>>>()
+                .map_err(|x| x.into_arrow_external_error())?;
+
+            let batch = RecordBatch::try_new(
+                Arc::new(schema.clone()),
+                arrays
+                    .iter()
+                    .chain(batch.columns().iter())
+                    .cloned()
+                    .collect(),
+            )?;
+
+            batches.push(batch);
+            num_rows += left.num_rows();
+        }
+    }
+    concat_batches(&Arc::new(schema.clone()), &batches, num_rows)
+}
+
+impl Stream for CrossJoinStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.right
+            .poll_next_unpin(cx)
+            .map(|maybe_batch| match maybe_batch {
+                Some(Ok(batch)) => {
+                    let start = Instant::now();
+                    let result = build_batch(&batch, &self.left_data, &self.schema);
+                    self.num_input_batches += 1;
+                    self.num_input_rows += batch.num_rows();
+                    if let Ok(ref batch) = result {
+                        self.join_time += start.elapsed().as_millis() as usize;
+                        self.num_output_batches += 1;
+                        self.num_output_rows += batch.num_rows();
+                    }
+                    Some(result)
+                }
+                other => {
+                    debug!(
+                        "Processed {} probe-side input batches containing {} rows and \
+                        produced {} output batches containing {} rows in {} ms",
+                        self.num_input_batches,
+                        self.num_input_rows,
+                        self.num_output_batches,
+                        self.num_output_rows,
+                        self.join_time
+                    );
+                    other
+                }
+            })
+    }
+}

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -60,7 +60,7 @@ pub struct CrossJoinExec {
 impl CrossJoinExec {
     /// Tries to create a new [CrossJoinExec].
     /// # Error
-    /// This function errors when it is not possible to join the left and right sides on keys `on`.
+    /// This function errors when left and right schema's can't be combined
     pub fn try_new(
         left: Arc<dyn ExecutionPlan>,
         right: Arc<dyn ExecutionPlan>,

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines the join plan for executing partitions in parallel and then joining the results
-//! into a set of partitions.
+//! Defines the cross join plan for loading the left side of the cross join
+//! and producing batches in parallel for the right partitions
 
 use futures::{lock::Mutex, StreamExt};
 use std::{any::Any, sync::Arc, task::Poll};

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -261,7 +261,7 @@ impl Stream for CrossJoinStream {
         if self.left_index > 0 && self.left_index < self.left_data.num_rows() {
             let start = Instant::now();
             let right_batch = {
-                let right_batch = self.right_batch.lock();
+                let right_batch = self.right_batch.lock().unwrap();
                 right_batch.clone().unwrap()
             };
             let result =

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -52,11 +52,6 @@ fn check_join_set_is_valid(
     right: &HashSet<String>,
     on: &JoinOn,
 ) -> Result<()> {
-    if on.is_empty() {
-        return Err(DataFusionError::Plan(
-            "The 'on' clause of a join cannot be empty".to_string(),
-        ));
-    }
     let on_left = &on.iter().map(|on| on.0.to_string()).collect::<HashSet<_>>();
     let left_missing = on_left.difference(left).collect::<HashSet<_>>();
 

--- a/datafusion/src/physical_plan/memory.rs
+++ b/datafusion/src/physical_plan/memory.rs
@@ -17,6 +17,7 @@
 
 //! Execution plan for reading in-memory batches of data
 
+use core::fmt;
 use std::any::Any;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -31,7 +32,6 @@ use async_trait::async_trait;
 use futures::Stream;
 
 /// Execution plan for reading in-memory batches of data
-#[derive(Debug)]
 pub struct MemoryExec {
     /// The partitions to query
     partitions: Vec<Vec<RecordBatch>>,
@@ -39,6 +39,15 @@ pub struct MemoryExec {
     schema: SchemaRef,
     /// Optional projection
     projection: Option<Vec<usize>>,
+}
+
+impl fmt::Debug for MemoryExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "partitions: [...]")?;
+        write!(f, "schema: {:?}", self.schema)?;
+        write!(f, "projection: {:?}", self.projection)
+
+    }
 }
 
 #[async_trait]

--- a/datafusion/src/physical_plan/memory.rs
+++ b/datafusion/src/physical_plan/memory.rs
@@ -46,7 +46,6 @@ impl fmt::Debug for MemoryExec {
         write!(f, "partitions: [...]")?;
         write!(f, "schema: {:?}", self.schema)?;
         write!(f, "projection: {:?}", self.projection)
-
     }
 }
 

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -333,6 +333,7 @@ pub trait Accumulator: Send + Sync + Debug {
 
 pub mod aggregates;
 pub mod array_expressions;
+pub mod cross_join;
 pub mod coalesce_batches;
 pub mod common;
 #[cfg(feature = "crypto_expressions")]

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -333,9 +333,9 @@ pub trait Accumulator: Send + Sync + Debug {
 
 pub mod aggregates;
 pub mod array_expressions;
-pub mod cross_join;
 pub mod coalesce_batches;
 pub mod common;
+pub mod cross_join;
 #[cfg(feature = "crypto_expressions")]
 pub mod crypto_expressions;
 pub mod csv;

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -20,8 +20,8 @@
 use std::sync::Arc;
 
 use super::{
-    aggregates, empty::EmptyExec, expressions::binary, functions,
-    hash_join::PartitionMode, udaf, union::UnionExec,
+    aggregates, cross_join::CrossJoinExec, empty::EmptyExec, expressions::binary,
+    functions, hash_join::PartitionMode, udaf, union::UnionExec,
 };
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::ExecutionContextState;
@@ -327,6 +327,11 @@ impl DefaultPhysicalPlanner {
                         PartitionMode::CollectLeft,
                     )?))
                 }
+            }
+            LogicalPlan::CrossJoin { left, right, .. } => {
+                let left = self.create_initial_plan(left, ctx_state)?;
+                let right = self.create_initial_plan(right, ctx_state)?;
+                Ok(Arc::new(CrossJoinExec::try_new(left, right)?))
             }
             LogicalPlan::EmptyRelation {
                 produce_one_row,

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -367,9 +367,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         left: &LogicalPlan,
         right: &LogicalPlan,
     ) -> Result<LogicalPlan> {
-        LogicalPlanBuilder::from(&left)
-            .cross_join(&right)?
-            .build()
+        LogicalPlanBuilder::from(&left).cross_join(&right)?.build()
     }
 
     fn parse_join(
@@ -499,9 +497,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         }
                     }
                     if join_keys.is_empty() {
-                        left = LogicalPlanBuilder::from(&left)
-                            .cross_join(right)?
-                            .build()?;
+                        left =
+                            LogicalPlanBuilder::from(&left).cross_join(right)?.build()?;
                     } else {
                         let left_keys: Vec<_> =
                             join_keys.iter().map(|(l, _)| *l).collect();
@@ -529,9 +526,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 } else {
                     let mut left = plans[0].clone();
                     for right in plans.iter().skip(1) {
-                        left = LogicalPlanBuilder::from(&left)
-                            .cross_join(right)?
-                            .build()?;
+                        left =
+                            LogicalPlanBuilder::from(&left).cross_join(right)?.build()?;
                     }
                     Ok(left)
                 }

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -355,11 +355,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             JoinOperator::Inner(constraint) => {
                 self.parse_join(left, &right, constraint, JoinType::Inner)
             }
+            JoinOperator::CrossJoin => self.parse_cross_join(left, &right),
             other => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported JOIN operator {:?}",
                 other
             ))),
         }
+    }
+    fn parse_cross_join(
+        &self,
+        left: &LogicalPlan,
+        right: &LogicalPlan,
+    ) -> Result<LogicalPlan> {
+        LogicalPlanBuilder::from(&left)
+            .cross_join(&right)?
+            .build()
     }
 
     fn parse_join(
@@ -489,9 +499,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         }
                     }
                     if join_keys.is_empty() {
-                        return Err(DataFusionError::NotImplemented(
-                            "Cartesian joins are not supported".to_string(),
-                        ));
+                        left = LogicalPlanBuilder::from(&left)
+                            .cross_join(right)?
+                            .build()?;
                     } else {
                         let left_keys: Vec<_> =
                             join_keys.iter().map(|(l, _)| *l).collect();
@@ -517,9 +527,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 if plans.len() == 1 {
                     Ok(plans[0].clone())
                 } else {
-                    Err(DataFusionError::NotImplemented(
-                        "Cartesian joins are not supported".to_string(),
-                    ))
+                    let mut left = plans[0].clone();
+                    for right in plans.iter().skip(1) {
+                        left = LogicalPlanBuilder::from(&left)
+                            .cross_join(right)?
+                            .build()?;
+                    }
+                    Ok(left)
                 }
             }
         };

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1289,7 +1289,7 @@ async fn equijoin_implicit_syntax_reversed() -> Result<()> {
 }
 
 #[tokio::test]
-async fn cartesian_join() -> Result<()> {
+async fn cross_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
 
     let sql = "SELECT t1_id, t1_name, t2_name FROM t1, t2 ORDER BY t1_id";

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1290,13 +1290,45 @@ async fn equijoin_implicit_syntax_reversed() -> Result<()> {
 
 #[tokio::test]
 async fn cartesian_join() -> Result<()> {
-    let ctx = create_join_context("t1_id", "t2_id")?;
+    let mut ctx = create_join_context("t1_id", "t2_id")?;
+
     let sql = "SELECT t1_id, t1_name, t2_name FROM t1, t2 ORDER BY t1_id";
-    let maybe_plan = ctx.create_logical_plan(&sql);
+    let actual = execute(&mut ctx, sql).await;
+
+    assert_eq!(4 * 4, actual.len());
+
+    let sql = "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE 1=1 ORDER BY t1_id";
+    let actual = execute(&mut ctx, sql).await;
+
+    assert_eq!(4 * 4, actual.len());
+
+    let sql = "SELECT t1_id, t1_name, t2_name FROM t1 CROSS JOIN t2";
+    let actual = execute(&mut ctx, sql).await;
+
+    assert_eq!(4 * 4, actual.len());
+
     assert_eq!(
-        "This feature is not implemented: Cartesian joins are not supported",
-        &format!("{}", maybe_plan.err().unwrap())
+        actual,
+        [
+            ["11", "a", "z"],
+            ["11", "a", "y"],
+            ["11", "a", "x"],
+            ["11", "a", "w"],
+            ["22", "b", "z"],
+            ["22", "b", "y"],
+            ["22", "b", "x"],
+            ["22", "b", "w"],
+            ["33", "c", "z"],
+            ["33", "c", "y"],
+            ["33", "c", "x"],
+            ["33", "c", "w"],
+            ["44", "d", "z"],
+            ["44", "d", "y"],
+            ["44", "d", "x"],
+            ["44", "d", "w"]
+        ]
     );
+
     Ok(())
 }
 


### PR DESCRIPTION
This is a first (naive, but probably not that bad) implementation of the cross join and CROSS JOIN syntax.

https://issues.apache.org/jira/browse/ARROW-12441

The left side gets loaded into memory and the right side is streamed and gets combined with the left side.

To keep memory usage down, we keep a "cursor" of values on the left side and producing the batches one by one instead of concatenating the result of the full cartesian product.

FYI @andygrove @alamb @jorgecarleitao

This also makes query 9 run in DataFusion (though performance is not OK, but I believe that should be not related to the cross join itself, but is caused by another issue).

