### PR TITLE
Add option param for standalone mode

### DIFF
--- a/ballista/rust/executor/executor_config_spec.toml
+++ b/ballista/rust/executor/executor_config_spec.toml
@@ -77,3 +77,8 @@ name = "concurrent_tasks"
 type = "usize"
 default = "4"
 doc = "Max concurrent tasks."
+
+[[param]]
+name = "scheduler_data_path"
+type = "String"
+doc = "Path for standalone data"

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -107,8 +107,14 @@ async fn main() -> Result<()> {
 
     if opt.local {
         info!("Running in local mode. Scheduler will be run in-proc");
-        let client = StandaloneClient::try_new_temporary()
-            .context("Could not create standalone config backend")?;
+
+        let client = match opt.scheduler_data_path {
+            Some(v) => StandaloneClient::try_new(v)
+                .context("Could not create standalone config backend")?,
+            None => StandaloneClient::try_new_temporary()
+                .context("Could not create standalone config backend")?,
+        };
+        
         let server =
             SchedulerGrpcServer::new(SchedulerServer::new(Arc::new(client), namespace));
         let addr = format!("{}:{}", bind_host, scheduler_port);

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
             None => StandaloneClient::try_new_temporary()
                 .context("Could not create standalone config backend")?,
         };
-        
+
         let server =
             SchedulerGrpcServer::new(SchedulerServer::new(Arc::new(client), namespace));
         let addr = format!("{}:{}", bind_host, scheduler_port);


### PR DESCRIPTION
 # Related Issue
https://github.com/apache/arrow-datafusion/issues/43

 # Rationale for this change
Currently `StandaloneClient` instance can be created by saving data to a specific file, or to temporary file. But it executor only runs by generating temporary file, so add parameter to give specific file path.

# What changes are included in this PR?
It creates client with `StandaloneClient::try_new(path)` if path has been defined, or `StandaloneClient::try_new_temporary()` if not defined.


