### PR TITLE
[Ballista] Remove hard coded ballista versions in scripts

### DIFF
--- a/dev/build-rust-base.sh
+++ b/dev/build-rust-base.sh
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-BALLISTA_VERSION=0.5.0-SNAPSHOT
 set -e
+
+. ./dev/build-set-env.sh
 docker build -t ballistacompute/rust-base:$BALLISTA_VERSION -f dev/docker/rust-base.dockerfile .

--- a/dev/build-rust.sh
+++ b/dev/build-rust.sh
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-BALLISTA_VERSION=0.5.0-SNAPSHOT
-
 set -e
 
+. ./dev/build-set-env.sh
 docker build -t ballistacompute/ballista-rust:$BALLISTA_VERSION -f dev/docker/rust.dockerfile .

--- a/dev/build-set-env.sh
+++ b/dev/build-set-env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,17 +17,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#set -e
-
-. ./dev/build-set-env.sh
-docker build -t ballistacompute/ballista-tpchgen:$BALLISTA_VERSION -f tpchgen.dockerfile .
-
-# Generate data into the ./data directory if it does not already exist
-FILE=./data/supplier.tbl
-if test -f "$FILE"; then
-    echo "$FILE exists."
-else
-  mkdir data 2>/dev/null
-  docker run -v `pwd`/data:/data -it --rm ballistacompute/ballista-tpchgen:$BALLISTA_VERSION
-  ls -l data
-fi
+export BALLISTA_VERSION=$(awk -F'[ ="]+' '$1 == "version" { print $2 }' ballista/rust/core/Cargo.toml)

--- a/dev/build-ui.sh
+++ b/dev/build-ui.sh
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-BALLISTA_VERSION=0.4.2-SNAPSHOT
-
 set -e
 
+. ./dev/build-set-env.sh
 docker build -t ballistacompute/ballista-scheduler-ui:$BALLISTA_VERSION -f dev/docker/ui.scheduler.dockerfile ballista/ui/scheduler


### PR DESCRIPTION
# Which issue does this PR close?

Closes #32 .

 # Rationale for this change
Versions are hardcoded in too many places.

# What changes are included in this PR?
Greps version from `ballista/rust/core/Cargo.toml` and exports it, so other scripts can use it.

# Are there any user-facing changes?
N/A
