### PR TITLE
Add query 19 to TPC-H regression tests

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -681,6 +681,11 @@ mod tests {
         run_query(14).await
     }
 
+    #[tokio::test]
+    async fn run_q19() -> Result<()> {
+        run_query(19).await
+    }
+
     /// Specialised String representation
     fn col_str(column: &ArrayRef, row_index: usize) -> String {
         if column.is_null(row_index) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #58

 # Rationale for this change
The query failed before because of a missing cross join. The query runs now (but takes an almost infinite time to run because of the cross join, which probably is a bug or missing optimization somewhere in the planner).

# What changes are included in this PR?

Add query 19 to TPC-H regression tests

# Are there any user-facing changes?

No