### PR TITLE
MINOR: Remove empty rust dir

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,5 +1,0 @@
-Cargo.lock
-target
-rusty-tags.vi
-.history
-.flatbuffers/


### PR DESCRIPTION
Remove `rust` directoty that only contained a `.gitignore` file