### PR TITLE
Remove namespace from executors

### DIFF
--- a/ballista/rust/executor/executor_config_spec.toml
+++ b/ballista/rust/executor/executor_config_spec.toml
@@ -25,13 +25,6 @@ name = "version"
 doc = "Print version of this executable"
 
 [[param]]
-abbr = "n"
-name = "namespace"
-type = "String"
-doc = "Namespace for the ballista cluster that this executor will join. yippee"
-default = "std::string::String::from(\"ballista\")"
-
-[[param]]
 name = "scheduler_host"
 type = "String"
 default = "std::string::String::from(\"localhost\")"

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -70,7 +70,6 @@ async fn main() -> Result<()> {
         std::process::exit(0);
     }
 
-    let namespace = opt.namespace;
     let external_host = opt.external_host;
     let bind_host = opt.bind_host;
     let port = opt.port;
@@ -115,8 +114,10 @@ async fn main() -> Result<()> {
                 .context("Could not create standalone config backend")?,
         };
 
-        let server =
-            SchedulerGrpcServer::new(SchedulerServer::new(Arc::new(client), namespace));
+        let server = SchedulerGrpcServer::new(SchedulerServer::new(
+            Arc::new(client),
+            "ballista".to_string(),
+        ));
         let addr = format!("{}:{}", bind_host, scheduler_port);
         let addr = addr
             .parse()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #66.

# Are there any user-facing changes?

Yes. The `namespace` CLI option in the ballista executors disappear. This is actually good, since the description of that param was not in sync with the implementation.