### PR TITLE
Allow table providers to indicate their type for catalog metadata

### DIFF
--- a/datafusion/src/datasource/datasource.rs
+++ b/datafusion/src/datasource/datasource.rs
@@ -66,6 +66,17 @@ pub enum TableProviderFilterPushDown {
     Exact,
 }
 
+/// Indicates the type of this table for metadata/catalog purposes.
+#[derive(Debug, Clone, Copy)]
+pub enum TableType {
+    /// An ordinary physical table.
+    Base,
+    /// A non-materialised table that itself uses a query internally to provide data.
+    View,
+    /// A transient table.
+    Temporary,
+}
+
 /// Source table
 pub trait TableProvider: Sync + Send {
     /// Returns the table provider as [`Any`](std::any::Any) so that it can be
@@ -74,6 +85,11 @@ pub trait TableProvider: Sync + Send {
 
     /// Get a reference to the schema for this table
     fn schema(&self) -> SchemaRef;
+
+    /// Get the type of this table for metadata/catalog purposes.
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
 
     /// Create an ExecutionPlan that will scan the table.
     fn scan(

--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -24,5 +24,5 @@ pub mod memory;
 pub mod parquet;
 
 pub use self::csv::{CsvFile, CsvReadOptions};
-pub use self::datasource::TableProvider;
+pub use self::datasource::{TableProvider, TableType};
 pub use self::memory::MemTable;


### PR DESCRIPTION
# Which issue does this PR close?
Closes #191.

 # Rationale for this change
This allows registered TableProviders to approximately indicate the mechanism used to retrieve data during query execution, which in turn allows tables to be logged with a `table_type` column in `information_schema.tables`. This was previously partially supported by classifying all registered tables as `BASE TABLE` and all generated system tables as `VIEW`.

This means that DataFusion consumers can now build systems that allow end-users to differentiate between relation types. For example, you could build a TableProvider that stores a query plan, use this as a view in your execution context, and end users would be aware that any queries over it in turn trigger a query internally. This is also often used to split relations into different lists for tables vs views in GUI/IDE setups.

# What changes are included in this PR?
- Added `TableType` enum
- Exposed new trait method, `TableProvider::table_type`
- Updated information_schema builder to use new table types

# Are there any user-facing changes?
`TableProvider::table_type` is introduced as a new trait method, but comes with a default implementation returning `TableType::Base` to preserve back-compat.