### PR TITLE
update arrow-rs deps to latest master

### DIFF
--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,5 +31,5 @@ futures = "0.3"
 log = "0.4"
 tokio = "1.0"
 
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
 datafusion = { path = "../../../datafusion" }

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -40,8 +40,8 @@ tokio = "1.0"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
 
 datafusion = { path = "../../../datafusion" }
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -44,8 +44,8 @@ tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
 
 datafusion = { path = "../../../datafusion" }
 

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -52,7 +52,7 @@ tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"
 
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
 datafusion = { path = "../../../datafusion" }
 
 [dev-dependencies]

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -29,7 +29,7 @@ publish = false
 
 
 [dev-dependencies]
-arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014" }
 datafusion = { path = "../datafusion" }
 prost = "0.7"
 tonic = "0.4"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -51,8 +51,8 @@ unicode_expressions = ["unicode-segmentation"]
 [dependencies]
 ahash = "0.7"
 hashbrown = "0.11"
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd", features = ["prettyprint"] }
-parquet = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd", features = ["arrow"] }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014", features = ["prettyprint"] }
+parquet = { git = "https://github.com/apache/arrow-rs", rev = "ed00e4d4a160cd5182bfafb81fee2240ec005014", features = ["arrow"] }
 sqlparser = "0.9.0"
 clap = "2.33"
 rustyline = {version = "7.0", optional = true}

--- a/dev/update_arrow_deps.py
+++ b/dev/update_arrow_deps.py
@@ -1,8 +1,29 @@
-# Script that updates the arrow dependencies in datafusion
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script that updates the arrow dependencies in datafusion and ballista, locall
+#
 # installation:
 # pip install tomlkit requests
 #
 # usage:
+# python update_arrow_deps.py
 
 from pathlib import Path
 

--- a/dev/update_arrow_deps.py
+++ b/dev/update_arrow_deps.py
@@ -31,14 +31,19 @@ from pathlib import Path
 import tomlkit
 import requests
 
+
 # find latest arrow-rs sha
 def get_arrow_sha():
     url = 'https://api.github.com/repos/apache/arrow-rs/branches/master'
     response = requests.get(url)
     return response.json()['commit']['sha']
 
+
 # Update all entries that look like
-# {'git': 'https://github.com/apache/arrow-rs', 'rev': 'c3fe3bab9905739fdda75301dab07a18c91731bd', 'features': ['prettyprint']}
+# {
+#   'git': 'https://github.com/apache/arrow-rs',
+#   'rev': 'c3fe3bab9905739fdda75301dab07a18c91731bd'
+# }
 # to point at a new SHA
 def update_dependencies(dependencies, new_sha):
     if dependencies is None:

--- a/dev/update_arrow_deps.py
+++ b/dev/update_arrow_deps.py
@@ -1,0 +1,57 @@
+# Script that updates the arrow dependencies in datafusion
+# installation:
+# pip install tomlkit requests
+#
+# usage:
+
+from pathlib import Path
+
+# use tomlkit as it preserves comments and other formatting
+import tomlkit
+import requests
+
+# find latest arrow-rs sha
+def get_arrow_sha():
+    url = 'https://api.github.com/repos/apache/arrow-rs/branches/master'
+    response = requests.get(url)
+    return response.json()['commit']['sha']
+
+# Update all entries that look like
+# {'git': 'https://github.com/apache/arrow-rs', 'rev': 'c3fe3bab9905739fdda75301dab07a18c91731bd', 'features': ['prettyprint']}
+# to point at a new SHA
+def update_dependencies(dependencies, new_sha):
+    if dependencies is None:
+        return
+    for dep_name in dependencies:
+        dep = dependencies[dep_name]
+        if hasattr(dep, 'get'):
+            if dep.get('git') == 'https://github.com/apache/arrow-rs':
+                dep['rev'] = new_sha
+
+
+def update_cargo_toml(cargo_toml, new_sha):
+    print('updating {}'.format(cargo_toml.absolute()))
+    with open(cargo_toml) as f:
+        data = f.read()
+
+    doc = tomlkit.parse(data)
+
+    update_dependencies(doc.get('dependencies'), new_sha)
+    update_dependencies(doc.get('dev-dependencies'), new_sha)
+
+    with open(cargo_toml, 'w') as f:
+        f.write(tomlkit.dumps(doc))
+
+
+# Begin main script
+
+repo_root = Path(__file__).parent.parent.absolute()
+
+
+new_sha = get_arrow_sha()
+
+print('Updating files in {} to use sha {}'.format(repo_root, new_sha))
+
+
+for cargo_toml in repo_root.rglob('Cargo.toml'):
+    update_cargo_toml(cargo_toml, new_sha)


### PR DESCRIPTION
Update to the latest arrow-rs master along with a script to automate the process

 # Rationale for this change
Get the latest and greatest Arrow, and add a script to make it easier to do in the future

# What changes are included in this PR?
1. Update to latest arrow + code 
2. Script to automatically update dependencies in the future

# Example

```shell
python update_arrow_deps.py
Updating files in /Users/alamb/Software/arrow-datafusion to use sha ed00e4d4a160cd5182bfafb81fee2240ec005014
updating /Users/alamb/Software/arrow-datafusion/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/ballista/rust/core/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/ballista/rust/scheduler/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/ballista/rust/executor/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/ballista/rust/client/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/datafusion/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/datafusion-examples/Cargo.toml
updating /Users/alamb/Software/arrow-datafusion/benchmarks/Cargo.toml

```
