### PR TITLE
Fix Filter / where clause without column names is removed in optimization pass

### DIFF
--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -381,7 +381,6 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                     new_filters.push(filter_expr.clone());
                 }
             }
-            println!("{:?}", &state);
 
             issue_filters(
                 state,

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -237,6 +237,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             let mut predicates = vec![];
             split_members(predicate, &mut predicates);
 
+            // Predicates without referencing columns (WHERE FALSE, WHERE 1=1, etc.)
             let mut no_col_predicates = vec![];
 
             predicates
@@ -252,6 +253,9 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                     }
                     Ok(())
                 })?;
+            // Predicates without columns will not be pushed down.
+            // As those contain only literals, they could be optimized using constant folding
+            // and removal of WHERE TRUE / WHERE FALSE
             if !no_col_predicates.is_empty() {
                 Ok(add_filter(optimize(input, state)?, &no_col_predicates))
             } else {

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -516,6 +516,7 @@ mod tests {
             .project(vec![col("c"), col("b")])?
             .filter(col("a").eq(lit(1i64)))?
             .build()?;
+        // filter is before double projection
         let expected = "\
             Projection: #c, #b\
             \n  Projection: #a, #b, #c\

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -475,6 +475,20 @@ async fn csv_query_group_by_and_having_and_where() -> Result<()> {
 }
 
 #[tokio::test]
+async fn all_where_empty() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT *
+               FROM aggregate_test_100
+               WHERE 1=2";
+    let mut actual = execute(&mut ctx, sql).await;
+    actual.sort();
+    let expected: Vec<Vec<String>> = vec![];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn csv_query_having_without_group_by() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx)?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #220

 # Rationale for this change
DataFusion gives wrong results for filters that don't reference any column 

# What changes are included in this PR?

Workarounds the issue by not pushing down predicates that do not reference any column (1=2, FALSE, TRUE). 
As we should be able to remove these anyway with constant folding and removing/replacing `WHERE FALSE`/ `WHERE TRUE`, I think this is a good option.

# Are there any user-facing changes?

No, results should be correct now.