### PR TITLE
Make test join_with_hash_collision deterministic

### DIFF
--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -1381,7 +1381,7 @@ mod tests {
             ("y", &vec![200, 300]),
         );
 
-        let random_state = RandomState::new();
+        let random_state = RandomState::with_seeds(0, 0, 0, 0);
         let hashes_buff = &mut vec![0; left.num_rows()];
         let hashes =
             create_hashes(&[left.columns()[0].clone()], &random_state, hashes_buff)?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #227

 # Rationale for this change
Fix non-deterministic test

# What changes are included in this PR?

Initialize the random state with a constant seed, so no hashes will end up with the same entry by chance.

# Are there any user-facing changes?

No

FYI
@jorgecarleitao 