### PR TITLE
Make external hostname in executor optional

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -514,6 +514,16 @@ message ExecutorMetadata {
   uint32 port = 3;
 }
 
+message ExecutorRegistration {
+  string id = 1;
+  // "optional" keyword is stable in protoc 3.15 but prost is still on 3.14 (see https://github.com/danburkert/prost/issues/430)
+  // this syntax is ugly but is binary compatible with the "optional" keyword (see https://stackoverflow.com/questions/42622015/how-to-define-an-optional-field-in-protobuf-3)
+  oneof optional_host {
+    string host = 2;
+  }
+  uint32 port = 3;
+}
+
 message GetExecutorMetadataParams {}
 
 message GetExecutorMetadataResult {
@@ -542,7 +552,7 @@ message TaskStatus {
 }
 
 message PollWorkParams {
-  ExecutorMetadata metadata = 1;
+  ExecutorRegistration metadata = 1;
   bool can_accept_task = 2;
   // All tasks must be reported until they reach the failed or completed state
   repeated TaskStatus task_status = 3;

--- a/ballista/rust/core/src/client.rs
+++ b/ballista/rust/core/src/client.rs
@@ -58,7 +58,6 @@ pub struct BallistaClient {
 impl BallistaClient {
     /// Create a new BallistaClient to connect to the executor listening on the specified
     /// host and port
-
     pub async fn try_new(host: &str, port: u16) -> Result<Self> {
         let addr = format!("http://{}:{}", host, port);
         debug!("BallistaClient connecting to {}", addr);

--- a/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 use std::{any::Any, pin::Pin};
 
-use crate::client::BallistaClient;
 use crate::memory_stream::MemoryStream;
 use crate::serde::scheduler::PartitionLocation;
 

--- a/ballista/rust/executor/executor_config_spec.toml
+++ b/ballista/rust/executor/executor_config_spec.toml
@@ -49,8 +49,7 @@ doc = "Local IP address to bind to."
 [[param]]
 name = "external_host"
 type = "String"
-default = "std::string::String::from(\"localhost\")"
-doc = "Host name or IP address to register with scheduler so that other executors can connect to this executor."
+doc = "Host name or IP address to register with scheduler so that other executors can connect to this executor. If none is provided, the scheduler will use the connecting IP address to communicate with the executor."
 
 [[param]]
 abbr = "p"

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -24,7 +24,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use log::{debug, error, info, warn};
 use tonic::transport::Channel;
 
-use ballista_core::serde::scheduler::ExecutorMeta;
+use ballista_core::serde::protobuf::ExecutorRegistration;
 use ballista_core::{
     client::BallistaClient,
     serde::protobuf::{
@@ -37,10 +37,9 @@ use protobuf::CompletedTask;
 pub async fn poll_loop(
     mut scheduler: SchedulerGrpcClient<Channel>,
     executor_client: BallistaClient,
-    executor_meta: ExecutorMeta,
+    executor_meta: ExecutorRegistration,
     concurrent_tasks: usize,
 ) {
-    let executor_meta: protobuf::ExecutorMetadata = executor_meta.into();
     let available_tasks_slots = Arc::new(AtomicUsize::new(concurrent_tasks));
     let (task_status_sender, mut task_status_receiver) =
         std::sync::mpsc::channel::<TaskStatus>();

--- a/ballista/rust/executor/src/lib.rs
+++ b/ballista/rust/executor/src/lib.rs
@@ -19,34 +19,3 @@
 
 pub mod collect;
 pub mod flight_service;
-
-#[derive(Debug, Clone)]
-pub struct ExecutorConfig {
-    pub(crate) host: String,
-    pub(crate) port: u16,
-    /// Directory for temporary files, such as IPC files
-    pub(crate) work_dir: String,
-    pub(crate) concurrent_tasks: usize,
-}
-
-impl ExecutorConfig {
-    pub fn new(host: &str, port: u16, work_dir: &str, concurrent_tasks: usize) -> Self {
-        Self {
-            host: host.to_owned(),
-            port,
-            work_dir: work_dir.to_owned(),
-            concurrent_tasks,
-        }
-    }
-}
-
-#[allow(dead_code)]
-pub struct BallistaExecutor {
-    pub(crate) config: ExecutorConfig,
-}
-
-impl BallistaExecutor {
-    pub fn new(config: ExecutorConfig) -> Self {
-        Self { config }
-    }
-}

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -17,7 +17,10 @@
 
 //! Ballista Rust executor binary.
 
-use std::sync::Arc;
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+};
 
 use anyhow::{Context, Result};
 use arrow_flight::flight_service_server::FlightServiceServer;
@@ -28,15 +31,17 @@ use tonic::transport::Server;
 use uuid::Uuid;
 
 use ballista_core::{
-    client::BallistaClient, serde::protobuf::scheduler_grpc_client::SchedulerGrpcClient,
+    client::BallistaClient,
+    serde::protobuf::{
+        executor_registration, scheduler_grpc_client::SchedulerGrpcClient,
+        ExecutorRegistration,
+    },
 };
 use ballista_core::{
     print_version, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
-    serde::scheduler::ExecutorMeta, BALLISTA_VERSION,
+    BALLISTA_VERSION,
 };
-use ballista_executor::{
-    flight_service::BallistaFlightService, BallistaExecutor, ExecutorConfig,
-};
+use ballista_executor::flight_service::BallistaFlightService;
 use ballista_scheduler::{state::StandaloneClient, SchedulerServer};
 use config::prelude::*;
 
@@ -80,7 +85,7 @@ async fn main() -> Result<()> {
         .with_context(|| format!("Could not parse address: {}", addr))?;
 
     let scheduler_host = if opt.local {
-        external_host.to_owned()
+        "localhost".to_string()
     } else {
         opt.scheduler_host
     };
@@ -94,14 +99,16 @@ async fn main() -> Result<()> {
             .into_string()
             .unwrap(),
     );
-    let config =
-        ExecutorConfig::new(&external_host, port, &work_dir, opt.concurrent_tasks);
-    info!("Running with config: {:?}", config);
+    info!("Running with config:");
+    info!("work_dir: {}", work_dir);
+    info!("concurrent_tasks: {}", opt.concurrent_tasks);
 
-    let executor_meta = ExecutorMeta {
+    let executor_meta = ExecutorRegistration {
         id: Uuid::new_v4().to_string(), // assign this executor a unique ID
-        host: external_host.clone(),
-        port,
+        optional_host: external_host
+            .clone()
+            .map(executor_registration::OptionalHost::Host),
+        port: port as u32,
     };
 
     if opt.local {
@@ -117,8 +124,9 @@ async fn main() -> Result<()> {
         let server = SchedulerGrpcServer::new(SchedulerServer::new(
             Arc::new(client),
             "ballista".to_string(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
         ));
-        let addr = format!("{}:{}", bind_host, scheduler_port);
+        let addr = format!("localhost:{}", scheduler_port);
         let addr = addr
             .parse()
             .with_context(|| format!("Could not parse {}", addr))?;
@@ -158,8 +166,7 @@ async fn main() -> Result<()> {
     let scheduler = SchedulerGrpcClient::connect(scheduler_url)
         .await
         .context("Could not connect to scheduler")?;
-    let executor = Arc::new(BallistaExecutor::new(config));
-    let service = BallistaFlightService::new(executor);
+    let service = BallistaFlightService::new(work_dir);
 
     let server = FlightServiceServer::new(service);
     info!(
@@ -167,7 +174,14 @@ async fn main() -> Result<()> {
         BALLISTA_VERSION, addr
     );
     let server_future = tokio::spawn(Server::builder().add_service(server).serve(addr));
-    let client = BallistaClient::try_new(&external_host, port).await?;
+    let client_host = external_host.as_deref().unwrap_or_else(|| {
+        if bind_host == "0.0.0.0" {
+            "localhost"
+        } else {
+            &bind_host
+        }
+    });
+    let client = BallistaClient::try_new(client_host, port).await?;
     tokio::spawn(execution_loop::poll_loop(
         scheduler,
         client,

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -176,6 +176,8 @@ async fn main() -> Result<()> {
     let server_future = tokio::spawn(Server::builder().add_service(server).serve(addr));
     let client_host = external_host.as_deref().unwrap_or_else(|| {
         if bind_host == "0.0.0.0" {
+            // If the executor is being bound to "0.0.0.0" (which means use all ips in all eth devices)
+            // then use "localhost" to connect to itself through the BallistaClient
             "localhost"
         } else {
             &bind_host

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: '2.0'
+version: '2.2'
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.4.9
@@ -28,18 +28,10 @@ services:
       - ./data:/data
     depends_on:
       - etcd
-  ballista-executor-1:
+  ballista-executor:
     image: ballistacompute/ballista-rust:0.5.0-SNAPSHOT
-    command: "/executor --bind-host 0.0.0.0 --port 50051 --external-host ballista-executor-1 --scheduler-host ballista-scheduler"
-    environment:
-      - RUST_LOG=info
-    volumes:
-      - ./data:/data
-    depends_on:
-      - ballista-scheduler
-  ballista-executor-2:
-    image: ballistacompute/ballista-rust:0.5.0-SNAPSHOT
-    command: "/executor --bind-host 0.0.0.0 --port 50052 --external-host ballista-executor-2 --scheduler-host ballista-scheduler"
+    command: "/executor --bind-host 0.0.0.0 --port 50051 --scheduler-host ballista-scheduler"
+    scale: 2
     environment:
       - RUST_LOG=info
     volumes:
@@ -57,6 +49,5 @@ services:
       - ../..:/ballista
     depends_on:
       - ballista-scheduler
-      - ballista-executor-1
-      - ballista-executor-2
+      - ballista-executor
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #76.

 # Rationale for this change
From the issue:

> Having the ability to set an external/advertised hostname is great since it provides users a lot of flexibility in network deployments. However, having it a required argument is a pain for the most common scenario, where the scheduler, client and executors talk to each other in the same network (e.g. k8s or docker-compose).
>
> We should make the external hostname optional. If the scheduler receives executor metadata without a hostname, it should register the caller's IP address as the hostname.
>
> This will make it easier to deploy the executors as a kubernetes deployment, or to docker-compose scale ballista-executor= in the integration tests.

# What changes are included in this PR?

- Make hostname optional upon executor registration
- Removed a bunch of old code in the planner

# Are there any user-facing changes?

Advertised hostname is now optional when launching the executor.