### PR TITLE
Fix Left join implementation is incorrect for 0 or multiple batches on the right side

### DIFF
--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -1360,7 +1360,7 @@ mod tests {
         let batch = build_table_i32(a, b, c);
         let schema = batch.schema();
         Arc::new(
-            MemoryExec::try_new(&vec![vec![batch.clone(), batch.clone()]], schema, None)
+            MemoryExec::try_new(&[vec![batch.clone(), batch]], schema, None)
                 .unwrap(),
         )
     }

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -27,7 +27,7 @@ use arrow::{
         TimestampMicrosecondArray, TimestampNanosecondArray, UInt32BufferBuilder,
         UInt32Builder, UInt64BufferBuilder, UInt64Builder,
     },
-    compute::{self, take},
+    compute,
     datatypes::{TimeUnit, UInt32Type, UInt64Type},
 };
 use smallvec::{smallvec, SmallVec};
@@ -1015,7 +1015,7 @@ fn produce_unmatched(
     for (idx, column_index) in column_indices.iter().enumerate() {
         let array = if column_index.is_left {
             let array = left_data.1.column(column_index.index);
-            take(array.as_ref(), &indices, None).unwrap()
+            compute::take(array.as_ref(), &indices, None).unwrap()
         } else {
             let datatype = schema.field(idx).data_type();
             arrow::array::new_null_array(datatype, num_rows)

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -1372,7 +1372,7 @@ mod tests {
     async fn join_left_multi_batch() {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
-            ("b1", &vec![4, 5, 7]),
+            ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
             ("c1", &vec![7, 8, 9]),
         );
         let right = build_table_two_batches(
@@ -1409,7 +1409,7 @@ mod tests {
     async fn join_left_empty_right() {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
-            ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
+            ("b1", &vec![4, 5, 7]),
             ("c1", &vec![7, 8, 9]),
         );
         let right = build_table_i32(("a2", &vec![]), ("b1", &vec![]), ("c2", &vec![]));

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -462,8 +462,7 @@ struct HashJoinStream {
     /// Random state used for hashing initialization
     random_state: RandomState,
     /// Keeps track of the left side rows whether they are visited
-    /// TODO: use a more memory efficient data structure
-    visited_left_side: Vec<bool>,
+    visited_left_side: Vec<bool>, // TODO: use a more memory efficient data structure, https://github.com/apache/arrow-datafusion/issues/240
     /// There is nothing to process anymore and left side is processed in case of left join
     is_exhausted: bool,
 }

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -1372,7 +1372,7 @@ mod tests {
     async fn join_left_multi_batch() {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
-            ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
+            ("b1", &vec![4, 5, 7]),
             ("c1", &vec![7, 8, 9]),
         );
         let right = build_table_two_batches(

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -22,7 +22,7 @@ use arrow::datatypes::{Field, Schema};
 use std::collections::HashSet;
 
 /// All valid types of joins.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum JoinType {
     /// Inner join
     Inner,

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -31,7 +31,7 @@ use arrow::{
     util::display::array_value_to_string,
 };
 
-use datafusion::execution::context::ExecutionContext;
+use datafusion::{execution::context::ExecutionContext, prelude::ExecutionConfig};
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::prelude::create_udf;
 use datafusion::{

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -31,6 +31,7 @@ use arrow::{
     util::display::array_value_to_string,
 };
 
+use datafusion::execution::context::ExecutionContext;
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::prelude::create_udf;
 use datafusion::{
@@ -41,7 +42,6 @@ use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::ColumnarValue,
 };
-use datafusion::{execution::context::ExecutionContext, prelude::ExecutionConfig};
 
 #[tokio::test]
 async fn nyc() -> Result<()> {

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -31,7 +31,6 @@ use arrow::{
     util::display::array_value_to_string,
 };
 
-use datafusion::{execution::context::ExecutionContext, prelude::ExecutionConfig};
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::prelude::create_udf;
 use datafusion::{
@@ -42,6 +41,7 @@ use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::ColumnarValue,
 };
+use datafusion::{execution::context::ExecutionContext, prelude::ExecutionConfig};
 
 #[tokio::test]
 async fn nyc() -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?
Closes #235
Closes #239
Closes #143

 # Rationale for this change
Fixes behavior of left join with regard to multiple batches on the right side and 0 right side batches.

This way it also also likely much faster as it avoids keeping generating / keeping / indexing into a `HashSet` for each right side batch.

# What changes are included in this PR?

* We add a `Vec<bool>` to keep track of left-side rows that didn't match with the right side. (number o left rows bytes extra memory usage for left joins, not that much compared to storing the left side data and hashmap + indices. It could be more memory-efficient by using a bitmap instead.
* Generate rows for any item that is not marked as visited.
* Add some tests for 0 / multiple batches on the right

# Are there any user-facing changes?

Only correctness improvements