### PR TITLE
misc(README): Replace Cube.js with Cube Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Here are some of the projects known to use DataFusion:
 
 * [Ballista](https://github.com/ballista-compute/ballista) Distributed Compute Platform
 * [Cloudfuse Buzz](https://github.com/cloudfuse-io/buzz-rust)
-* [Cube.js](https://github.com/cube-js/cube.js)
+* [Cube Store](https://github.com/cube-js/cube.js/tree/master/rust)
 * [datafusion-python](https://pypi.org/project/datafusion)
 * [delta-rs](https://github.com/delta-io/delta-rs)
 * [InfluxDB IOx](https://github.com/influxdata/influxdb_iox) Time Series Database


### PR DESCRIPTION
Hello!

Cube.js is a repository, which contains multiple parts, but DF is used inside Cube Store, which is a pre-aggregation DB.

Thanks