### PR TITLE
Refactor datafusion/src/physical_plan/common.rs build_file_list to take less param and reuse code

### DIFF
--- a/datafusion/src/datasource/csv.rs
+++ b/datafusion/src/datasource/csv.rs
@@ -71,8 +71,7 @@ impl CsvFile {
         let schema = Arc::new(match options.schema {
             Some(s) => s.clone(),
             None => {
-                let mut filenames: Vec<String> = vec![];
-                common::build_file_list(path, &mut filenames, options.file_extension)?;
+                let filenames = common::build_file_list(path, options.file_extension)?;
                 if filenames.is_empty() {
                     return Err(DataFusionError::Plan(format!(
                         "No files found at {path} with file extension {file_extension}",

--- a/datafusion/src/physical_plan/common.rs
+++ b/datafusion/src/physical_plan/common.rs
@@ -78,8 +78,19 @@ pub async fn collect(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatc
         .map_err(DataFusionError::from)
 }
 
-/// Recursively build a list of files in a directory with a given extension
-pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Result<()> {
+/// Recursively builds a list of files in a directory with a given extension
+pub fn build_file_list(dir: &str, ext: &str) -> Result<Vec<String>> {
+    let mut filenames: Vec<String> = Vec::new();
+    build_file_list_recurse(dir, &mut filenames, ext)?;
+    Ok(filenames)
+}
+
+/// Recursively build a list of files in a directory with a given extension with an accumulator list
+fn build_file_list_recurse(
+    dir: &str,
+    filenames: &mut Vec<String>,
+    ext: &str,
+) -> Result<()> {
     let metadata = metadata(dir)?;
     if metadata.is_file() {
         if dir.ends_with(ext) {
@@ -91,7 +102,7 @@ pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Res
             let path = entry.path();
             if let Some(path_name) = path.to_str() {
                 if path.is_dir() {
-                    build_file_list(path_name, filenames, ext)?;
+                    build_file_list_recurse(path_name, filenames, ext)?;
                 } else if path_name.ends_with(ext) {
                     filenames.push(path_name.to_string());
                 }

--- a/datafusion/src/physical_plan/csv.rs
+++ b/datafusion/src/physical_plan/csv.rs
@@ -199,8 +199,7 @@ impl CsvExec {
     ) -> Result<Self> {
         let file_extension = String::from(options.file_extension);
 
-        let mut filenames: Vec<String> = vec![];
-        common::build_file_list(path, &mut filenames, file_extension.as_str())?;
+        let filenames = common::build_file_list(path, file_extension.as_str())?;
         if filenames.is_empty() {
             return Err(DataFusionError::Execution(format!(
                 "No files found at {path} with file extension {file_extension}",

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -389,7 +389,7 @@ impl ExecutionPlan for HashJoinExec {
             num_output_rows: 0,
             join_time: 0,
             random_state: self.random_state.clone(),
-            visited_left_side: visited_left_side,
+            visited_left_side,
             is_exhausted: false,
         }))
     }

--- a/datafusion/src/physical_plan/parquet.rs
+++ b/datafusion/src/physical_plan/parquet.rs
@@ -118,8 +118,7 @@ impl ParquetExec {
     ) -> Result<Self> {
         // build a list of filenames from the specified path, which could be a single file or
         // a directory containing one or more parquet files
-        let mut filenames: Vec<String> = vec![];
-        common::build_file_list(path, &mut filenames, ".parquet")?;
+        let filenames = common::build_file_list(path, ".parquet")?;
         if filenames.is_empty() {
             Err(DataFusionError::Plan(format!(
                 "No Parquet files found at path {}",


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.

Closes #254

 # Rationale for this change
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

# What changes are included in this PR?

There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.

Basically a new fn without the mut ref accumulator list param is added, wrapping the original one. All call sites are updated.

# Are there any user-facing changes?

- No

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `breaking change` label.
