### PR TITLE
Implement count distinct for dictionary arrays

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1768,10 +1768,12 @@ mod tests {
             assert_batches_sorted_eq!(expected, &results);
 
             // Now, use dict as an aggregate
-            let results =
-                plan_and_collect(&mut ctx, "SELECT val, count(distinct dict) FROM t GROUP BY val")
-                    .await
-                    .expect("ran plan correctly");
+            let results = plan_and_collect(
+                &mut ctx,
+                "SELECT val, count(distinct dict) FROM t GROUP BY val",
+            )
+            .await
+            .expect("ran plan correctly");
 
             let expected = vec![
                 "+-----+----------------------+",
@@ -1783,7 +1785,6 @@ mod tests {
                 "+-----+----------------------+",
             ];
             assert_batches_sorted_eq!(expected, &results);
-
         }
 
         run_test_case::<Int8Type>().await;

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1796,9 +1796,6 @@ mod tests {
         run_test_case::<UInt64Type>().await;
     }
 
-
-
-
     async fn run_count_distinct_integers_aggregated_scenario(
         partitions: Vec<Vec<(&str, u64)>>,
     ) -> Result<Vec<RecordBatch>> {
@@ -1924,8 +1921,6 @@ mod tests {
 
         Ok(())
     }
-
-
 
     #[test]
     fn aggregate_with_alias() -> Result<()> {

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1766,6 +1766,24 @@ mod tests {
                 "+-----+-------------+",
             ];
             assert_batches_sorted_eq!(expected, &results);
+
+            // Now, use dict as an aggregate
+            let results =
+                plan_and_collect(&mut ctx, "SELECT val, count(distinct dict) FROM t GROUP BY val")
+                    .await
+                    .expect("ran plan correctly");
+
+            let expected = vec![
+                "+-----+----------------------+",
+                "| val | COUNT(DISTINCT dict) |",
+                "+-----+----------------------+",
+                "| 1   | 2                    |",
+                "| 2   | 2                    |",
+                "| 4   | 1                    |",
+                "+-----+----------------------+",
+            ];
+            assert_batches_sorted_eq!(expected, &results);
+
         }
 
         run_test_case::<Int8Type>().await;
@@ -1777,6 +1795,9 @@ mod tests {
         run_test_case::<UInt32Type>().await;
         run_test_case::<UInt64Type>().await;
     }
+
+
+
 
     async fn run_count_distinct_integers_aggregated_scenario(
         partitions: Vec<Vec<(&str, u64)>>,
@@ -1903,6 +1924,8 @@ mod tests {
 
         Ok(())
     }
+
+
 
     #[test]
     fn aggregate_with_alias() -> Result<()> {

--- a/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/datafusion/src/physical_plan/distinct_expressions.rs
@@ -47,8 +47,8 @@ pub struct DistinctCount {
     name: String,
     /// The DataType for the final count
     data_type: DataType,
-    /// The DataType for each input argument
-    input_data_types: Vec<DataType>,
+    /// The DataType used to hold the state for each input
+    state_data_types: Vec<DataType>,
     /// The input arguments
     exprs: Vec<Arc<dyn PhysicalExpr>>,
 }
@@ -61,8 +61,10 @@ impl DistinctCount {
         name: String,
         data_type: DataType,
     ) -> Self {
+        let state_data_types = input_data_types.into_iter().map(state_type).collect();
+
         Self {
-            input_data_types,
+            state_data_types,
             exprs,
             name,
             data_type,
@@ -70,15 +72,14 @@ impl DistinctCount {
     }
 }
 
-// return the type to use to accumulate state for the specified input type
+/// return the type to use to accumulate state for the specified input type
 fn state_type(data_type: DataType) -> DataType {
     match data_type {
         // when aggregating dictionary values, use the underlying value type
         DataType::Dictionary(_key_type, value_type) => *value_type,
-        t @ _ => t
+        t @ _ => t,
     }
 }
-
 
 impl AggregateExpr for DistinctCount {
     /// Return a reference to Any that can be used for downcasting
@@ -92,13 +93,16 @@ impl AggregateExpr for DistinctCount {
 
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(self
-            .input_data_types
+            .state_data_types
             .iter()
-           .map(|input_data_type| {
-               let state_type = state_type(input_data_type.clone());
+            .map(|state_data_type| {
                 Field::new(
                     &format_state_name(&self.name, "count distinct"),
-                    DataType::List(Box::new(Field::new("item", state_type, true))),
+                    DataType::List(Box::new(Field::new(
+                        "item",
+                        state_data_type.clone(),
+                        true,
+                    ))),
                     false,
                 )
             })
@@ -112,7 +116,7 @@ impl AggregateExpr for DistinctCount {
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
         Ok(Box::new(DistinctCountAccumulator {
             values: HashSet::default(),
-            data_types: self.input_data_types.clone(),
+            state_data_types: self.state_data_types.clone(),
             count_data_type: self.data_type.clone(),
         }))
     }
@@ -121,7 +125,7 @@ impl AggregateExpr for DistinctCount {
 #[derive(Debug)]
 struct DistinctCountAccumulator {
     values: HashSet<DistinctScalarValues, RandomState>,
-    data_types: Vec<DataType>,
+    state_data_types: Vec<DataType>,
     count_data_type: DataType,
 }
 
@@ -167,9 +171,11 @@ impl Accumulator for DistinctCountAccumulator {
 
     fn state(&self) -> Result<Vec<ScalarValue>> {
         let mut cols_out = self
-            .data_types
+            .state_data_types
             .iter()
-            .map(|data_type| ScalarValue::List(Some(Vec::new()), state_type(data_type.clone())))
+            .map(|state_data_type| {
+                ScalarValue::List(Some(Vec::new()), state_data_type.clone())
+            })
             .collect::<Vec<_>>();
 
         let mut cols_vec = cols_out

--- a/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/datafusion/src/physical_plan/distinct_expressions.rs
@@ -61,9 +61,6 @@ impl DistinctCount {
         name: String,
         data_type: DataType,
     ) -> Self {
-        println!("creating distinct counts for {:#?}", input_data_types);
-        println!("  name {}, data_type: {:?}", name, data_type);
-
         Self {
             input_data_types,
             exprs,
@@ -99,7 +96,6 @@ impl AggregateExpr for DistinctCount {
             .iter()
            .map(|input_data_type| {
                let state_type = state_type(input_data_type.clone());
-               println!("AAL using state type of {:?}", state_type);
                 Field::new(
                     &format_state_name(&self.name, "count distinct"),
                     DataType::List(Box::new(Field::new("item", state_type, true))),
@@ -136,10 +132,7 @@ impl Accumulator for DistinctCountAccumulator {
             self.values.insert(DistinctScalarValues(
                 values
                     .iter()
-                    .map(|v| {
-                        println!("trying to update from {:?}", v);
-                        GroupByScalar::try_from(v)
-                    })
+                    .map(GroupByScalar::try_from)
                     .collect::<Result<Vec<_>>>()?,
             ));
         }

--- a/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/datafusion/src/physical_plan/distinct_expressions.rs
@@ -77,7 +77,7 @@ fn state_type(data_type: DataType) -> DataType {
     match data_type {
         // when aggregating dictionary values, use the underlying value type
         DataType::Dictionary(_key_type, value_type) => *value_type,
-        t @ _ => t,
+        t => t,
     }
 }
 

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -1070,6 +1070,8 @@ fn dictionary_create_group_by_value<K: ArrowDictionaryKeyType>(
 
 /// Extract the value in `col[row]` as a GroupByScalar
 fn create_group_by_value(col: &ArrayRef, row: usize) -> Result<GroupByScalar> {
+    println!("AAL creating group by value for row {} of type {:?}", row, col);
+
     match col.data_type() {
         DataType::Float32 => {
             let array = col.as_any().downcast_ref::<Float32Array>().unwrap();
@@ -1176,6 +1178,7 @@ pub(crate) fn create_group_by_values(
     row: usize,
     vec: &mut Box<[GroupByScalar]>,
 ) -> Result<()> {
+    println!("AAL creating group by values for row {}", row);
     for (i, col) in group_by_keys.iter().enumerate() {
         vec[i] = create_group_by_value(col, row)?
     }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -1070,8 +1070,6 @@ fn dictionary_create_group_by_value<K: ArrowDictionaryKeyType>(
 
 /// Extract the value in `col[row]` as a GroupByScalar
 fn create_group_by_value(col: &ArrayRef, row: usize) -> Result<GroupByScalar> {
-    println!("AAL creating group by value for row {} of type {:?}", row, col);
-
     match col.data_type() {
         DataType::Float32 => {
             let array = col.as_any().downcast_ref::<Float32Array>().unwrap();
@@ -1178,7 +1176,6 @@ pub(crate) fn create_group_by_values(
     row: usize,
     vec: &mut Box<[GroupByScalar]>,
 ) -> Result<()> {
-    println!("AAL creating group by values for row {}", row);
     for (i, col) in group_by_keys.iter().enumerate() {
         vec[i] = create_group_by_value(col, row)?
     }

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -274,6 +274,7 @@ pub trait AggregateExpr: Send + Sync + Debug {
     /// Returns the aggregate expression as [`Any`](std::any::Any) so that it can be
     /// downcast to a specific implementation.
     fn as_any(&self) -> &dyn Any;
+
     /// the field of the final result of this aggregation.
     fn field(&self) -> Result<Field>;
 
@@ -311,6 +312,9 @@ pub trait Accumulator: Send + Sync + Debug {
         if values.is_empty() {
             return Ok(());
         };
+
+        println!("Accumulator::update_batch for values: {:#?}", values);
+
         (0..values[0].len()).try_for_each(|index| {
             let v = values
                 .iter()

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -312,9 +312,6 @@ pub trait Accumulator: Send + Sync + Debug {
         if values.is_empty() {
             return Ok(());
         };
-
-        println!("Accumulator::update_batch for values: {:#?}", values);
-
         (0..values[0].len()).try_for_each(|index| {
             let v = values
                 .iter()

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -360,10 +360,7 @@ impl ScalarValue {
                 DataType::LargeUtf8 => {
                     build_list!(LargeStringBuilder, LargeUtf8, values, size)
                 }
-                _ => {
-                    println!("list data type was: {}", data_type);
-                    panic!("Unexpected DataType for list")
-                }
+                _ => panic!("Unexpected DataType for list"),
             }),
             ScalarValue::Date32(e) => match e {
                 Some(value) => Arc::new(Date32Array::from_value(*value, size)),

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -19,10 +19,12 @@
 
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
-use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+use arrow::datatypes::{ArrowDictionaryKeyType, DataType, Field, IntervalUnit, TimeUnit};
 use arrow::{
     array::*,
-    datatypes::{ArrowNativeType, Float32Type, TimestampNanosecondType},
+    datatypes::{ArrowNativeType, Float32Type, TimestampNanosecondType,
+                Int16Type, Int32Type, Int64Type,
+                Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type},
 };
 use arrow::{
     array::{
@@ -358,7 +360,10 @@ impl ScalarValue {
                 DataType::LargeUtf8 => {
                     build_list!(LargeStringBuilder, LargeUtf8, values, size)
                 }
-                _ => panic!("Unexpected DataType for list"),
+                _ => {
+                    println!("list data type was: {}", data_type);
+                    panic!("Unexpected DataType for list")
+                }
             }),
             ScalarValue::Date32(e) => match e {
                 Some(value) => Arc::new(Date32Array::from_value(*value, size)),
@@ -443,15 +448,61 @@ impl ScalarValue {
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
                 typed_cast!(array, index, TimestampNanosecondArray, TimestampNanosecond)
+            },
+            DataType::Dictionary(index_type, _) => match **index_type {
+                DataType::Int8 => {
+                    Self::try_from_dict_array::<Int8Type>(array, index)?
+                }
+                DataType::Int16 => {
+                    Self::try_from_dict_array::<Int16Type>(array, index)?
+                }
+                DataType::Int32 => {
+                    Self::try_from_dict_array::<Int32Type>(array, index)?
+                }
+                DataType::Int64 => {
+                    Self::try_from_dict_array::<Int64Type>(array, index)?
+                }
+                DataType::UInt8 => {
+                    Self::try_from_dict_array::<UInt8Type>(array, index)?
+                }
+                DataType::UInt16 => {
+                    Self::try_from_dict_array::<UInt16Type>(array, index)?
+                }
+                DataType::UInt32 => {
+                    Self::try_from_dict_array::<UInt32Type>(array, index)?
+                }
+                DataType::UInt64 => {
+                    Self::try_from_dict_array::<UInt64Type>(array, index)?
+                }
+                _ => return Err(DataFusionError::Internal(format!(
+                    "Index type not supported while creating scalar from dictionary: {}",
+                    array.data_type(),
+                ))),
             }
             other => {
                 return Err(DataFusionError::NotImplemented(format!(
-                    "Can't create a scalar of array of type \"{:?}\"",
+                    "Can't create a scalar from array of type \"{:?}\"",
                     other
                 )))
             }
         })
     }
+
+    fn try_from_dict_array<K: ArrowDictionaryKeyType>(array: &ArrayRef, index: usize) -> Result<Self> {
+        let dict_array = array.as_any().downcast_ref::<DictionaryArray<K>>().unwrap();
+
+        // look up the index in the values dictionary
+        let keys_col = dict_array.keys_array();
+        let values_index = keys_col.value(index).to_usize().ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "Can not convert index to usize in dictionary of type creating group by value {:?}",
+                keys_col.data_type()
+            ))
+        })?;
+        Self::try_from_array(&dict_array.values(), values_index)
+    }
+
+
 }
 
 impl From<f64> for ScalarValue {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/249

# Rationale for this change
I have dictionary encoded data that I want to be able to compute distinct counts

# What changes are included in this PR?
This implementation has the the basic "get it working" version. A more optimized implementation (e.g. only looking at the dictionary contents) is left for a subsequent PR and https://github.com/apache/arrow-datafusion/issues/258 tracks better performance

# Are there any user-facing changes?
queries like `select count(distinct tag_col) from ...` are now supported when `tag_col` is a dictionary encoded column
