### PR TITLE
fix clippy lint

### DIFF
--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -389,7 +389,7 @@ impl ExecutionPlan for HashJoinExec {
             num_output_rows: 0,
             join_time: 0,
             random_state: self.random_state.clone(),
-            visited_left_side: visited_left_side,
+            visited_left_side,
             is_exhausted: false,
         }))
     }


### PR DESCRIPTION


 # Rationale for this change

When I run clippy locally, I get the following warning. This PR fixes it.

```
error: redundant field names in struct initialization
   --> datafusion/src/physical_plan/hash_join.rs:392:13
    |
392 |             visited_left_side: visited_left_side,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `visited_left_side`
    |
    = note: `-D clippy::redundant-field-names` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
```


# What changes are included in this PR?

fix clippy lint error

# Are there any user-facing changes?

no