### PR TITLE
Enable redundant_field_names clippy lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cargo clippy --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
+          cargo clippy --all-targets --workspace -- -D warnings
 
   miri-checks:
     name: MIRI


### PR DESCRIPTION
# Which issue does this PR close?

Closes #260

 # Rationale for this change
This lint doesn't seem to cause warnings in our code. If we have some false positives, we should not put it here but on a more granular (line/code block/module/project) level, so the warnings locally reflect the CI.
I am not sure why it was configured like this, maybe because of some false positives.

# What changes are included in this PR?

Remove the "allow" on the lint

# Are there any user-facing changes?

No