### PR TITLE
add postgres comparison to python test

### DIFF
--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -21,38 +21,57 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: db_test
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Rust toolchain
-      run: |
-        rustup toolchain install nightly-2021-01-06
-        rustup default nightly-2021-01-06
-        rustup component add rustfmt
-    - name: Cache Cargo
-      uses: actions/cache@v2
-      with:
-        path: /home/runner/.cargo
-        key: cargo-maturin-cache-
-    - name: Cache Rust dependencies
-      uses: actions/cache@v2
-      with:
-        path: /home/runner/target
-        key: target-maturin-cache-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-    - name: Install Python dependencies
-      run: python -m pip install --upgrade pip setuptools wheel
-    - name: Run tests
-      run: |
-        cd python/
-        export CARGO_HOME="/home/runner/.cargo"
-        export CARGO_TARGET_DIR="/home/runner/target"
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install nightly-2021-01-06
+          rustup default nightly-2021-01-06
+          rustup component add rustfmt
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.cargo
+          key: cargo-maturin-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/target
+          key: target-maturin-cache-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Run tests
+        run: |
+          cd python/
+          export CARGO_HOME="/home/runner/.cargo"
+          export CARGO_TARGET_DIR="/home/runner/target"
 
-        python -m venv venv
-        source venv/bin/activate
+          python -m venv venv
+          source venv/bin/activate
 
-        pip install maturin==0.10.4 toml==0.10.1 pyarrow==4.0.0
-        maturin develop
+          # TODO move to use poetry
+          pip install maturin==0.10.4 toml==0.10.2 pyarrow==4.0.0 psycopg2==2.8.6
+          maturin develop
 
-        python -m unittest discover tests
+          python -m unittest discover tests
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_DB: db_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/python/README.md
+++ b/python/README.md
@@ -135,7 +135,7 @@ cd arrow-datafusion/python
 
 # prepare development environment (used to build wheel / install in development)
 python3 -m venv venv
-pip install maturin==0.10.4 toml==0.10.1 pyarrow==1.0.0
+pip install maturin==0.10.4 toml==0.10.2 pyarrow==4.0.0 psycopg2==2.8.6
 ```
 
 Whenever rust code changes (your changes or via git pull):

--- a/python/tests/generic.py
+++ b/python/tests/generic.py
@@ -15,18 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
-import tempfile
 import datetime
 import os.path
 import shutil
+import tempfile
+import unittest
 
 import numpy
 import pyarrow
-import datafusion
 
 # used to write parquet files
 import pyarrow.parquet
+
+import datafusion
 
 
 def data():

--- a/python/tests/test_df.py
+++ b/python/tests/test_df.py
@@ -18,12 +18,12 @@
 import unittest
 
 import pyarrow
+
 import datafusion
-f = datafusion.functions
+from datafusion import functions as f
 
 
 class TestCase(unittest.TestCase):
-
     def _prepare(self):
         ctx = datafusion.ExecutionContext()
 
@@ -51,12 +51,10 @@ class TestCase(unittest.TestCase):
     def test_filter(self):
         df = self._prepare()
 
-        df = df \
-            .select(
-                f.col("a") + f.col("b"),
-                f.col("a") - f.col("b"),
-            ) \
-            .filter(f.col("a") > f.lit(2))
+        df = df.select(
+            f.col("a") + f.col("b"),
+            f.col("a") - f.col("b"),
+        ).filter(f.col("a") > f.lit(2))
 
         # execute and collect the first (and only) batch
         result = df.collect()[0]
@@ -83,7 +81,9 @@ class TestCase(unittest.TestCase):
 
         df = df.select(udf(f.col("a")))
 
-        self.assertEqual(df.collect()[0].column(0), pyarrow.array([False, False, False]))
+        self.assertEqual(
+            df.collect()[0].column(0), pyarrow.array([False, False, False])
+        )
 
     def test_join(self):
         ctx = datafusion.ExecutionContext()

--- a/python/tests/test_postgres_parity.py
+++ b/python/tests/test_postgres_parity.py
@@ -68,7 +68,7 @@ class PostgresComparisonTestCase(unittest.TestCase):
                 self.assertEqual(expected, got)
             else:
                 for i, j in zip(got, expected):
-                    self.assertAlmostEqual(Decimal(i), Decimal(j), delta)
+                    self.assertAlmostEqual(Decimal(i), Decimal(j), delta=delta)
 
     def test_simple_select_1(self):
         sql = "SELECT 1"

--- a/python/tests/test_postgres_parity.py
+++ b/python/tests/test_postgres_parity.py
@@ -29,6 +29,9 @@ from tests.generic import *
 import datafusion
 
 
+@unittest.skipUnless(
+    os.environ.get("POSTGRES_PASSWORD") is not None, "requires Postgres environment"
+)
 class PostgresComparisonTestCase(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory

--- a/python/tests/test_postgres_parity.py
+++ b/python/tests/test_postgres_parity.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy
+import psycopg2
+from tests.generic import *
+
+import datafusion
+
+
+class PostgresComparisonTestCase(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+        self.pg_conn = psycopg2.connect(
+            user="postgres",
+            password=os.environ.get("POSTGRES_PASSWORD"),
+            database=os.environ.get("POSTGRES_DB"),
+            host=os.environ.get("POSTGRES_HOST"),
+            port=os.environ.get("POSTGRES_PORT"),
+        )
+        numpy.random.seed(1)
+
+    def tearDown(self):
+        self.pg_conn.close()
+        # Remove the directory after the test
+        shutil.rmtree(self.test_dir)
+
+    def _query_and_compare(self, sql: str):
+        ctx = datafusion.ExecutionContext()
+        batches = ctx.sql(sql).collect()
+
+        # shall only return a single batch
+        (batch,) = batches
+
+        with self.pg_conn.cursor() as cur:
+            cur.execute(sql)
+            fetched = cur.fetchall()
+
+        self.assertEqual(batch.num_rows, len(fetched), msg="result size should match")
+
+        # RecordBatch is column oriented, in order to compare, we'll need to transpose it
+        batch = zip(*[i.tolist() for i in batch])
+
+        for got, expected in zip(batch, fetched):
+            self.assertEqual(expected, got)
+
+    def test_simple_select_1(self):
+        sql = "SELECT 1"
+        self._query_and_compare(sql)
+
+    def test_simple_select_scalars(self):
+        sql = "SELECT 1, 2, 3"
+        self._query_and_compare(sql)
+
+    def test_simple_select_math_expressions(self):
+        sql = """SELECT
+        1 + 2,
+        1 - 2,
+        1 * 2,
+        1 / 2,
+        +1,
+        -1
+        """
+        self._query_and_compare(sql)
+
+    def test_simple_select_math_functions(self):
+        sql = """SELECT
+        sqrt(3.0),
+        sin(1.0),
+        cos(1.0),
+        tan(2.0),
+        exp(2.0),
+        abs(-1.0)
+        """
+        self._query_and_compare(sql)
+
+    def test_simple_select_string_functions(self):
+        sql = """SELECT
+        ascii('x'),
+        btrim('xyxtrimyyx', 'xyz'),
+        chr(65),
+        concat('abcde', 2, NULL, 22),
+        concat_ws(',', 'abcde', 2, NULL, 22),
+        initcap('hi THOMAS'),
+        lower('TOM'),
+        ltrim('zzzytest', 'xyz'),
+        repeat('Pg', 4),
+        replace('abcdefabcdef', 'cd', 'XX'),
+        rtrim('testxxzx', 'xyz'),
+        split_part('abc~@~def~@~ghi', '~@~', 2),
+        starts_with('alphabet', 'alph')
+        """
+        self._query_and_compare(sql)

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -15,20 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
-import tempfile
 import datetime
 import os.path
 import shutil
+import tempfile
+import unittest
 
 import numpy
 import pyarrow
-import datafusion
 
 # used to write parquet files
 import pyarrow.parquet
-
 from tests.generic import *
+
+import datafusion
 
 
 class TestCase(unittest.TestCase):

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -16,12 +16,13 @@
 # under the License.
 
 import unittest
+from typing import List
 
 import pyarrow
 import pyarrow.compute
-import datafusion
 
-f = datafusion.functions
+import datafusion
+from datafusion import functions as f
 
 
 class Accumulator:
@@ -32,7 +33,7 @@ class Accumulator:
     def __init__(self):
         self._sum = pyarrow.scalar(0.0)
 
-    def to_scalars(self) -> [pyarrow.Scalar]:
+    def to_scalars(self) -> List[pyarrow.Scalar]:
         return [self._sum]
 
     def update(self, values: pyarrow.Array) -> None:


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.

Closes #276.

 # Rationale for this change
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

# What changes are included in this PR?

_There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR._

- update the python test CI to use Python 3.8
- use `isort` and `black` to clean up Python test functions
- setup Postgres database in CI environment for Python tests
- add a postgres comparison test case suite for side by side comparison

# Are there any user-facing changes?

NO user facing changes

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `breaking change` label.
