### PR TITLE
In list performance improvements

### DIFF
--- a/datafusion/src/physical_plan/expressions/in_list.rs
+++ b/datafusion/src/physical_plan/expressions/in_list.rs
@@ -17,8 +17,8 @@
 
 //! InList expression
 
-use std::sync::Arc;
 use std::{any::Any, collections::HashSet};
+use std::{hash::Hash, sync::Arc};
 
 use arrow::array::{ArrayRef, BooleanArray, StringOffsetSizeTrait};
 use arrow::{
@@ -99,23 +99,69 @@ fn collect_scalar_value<V, F: Fn(&ScalarValue, &mut bool) -> Option<V>>(
         .collect::<Vec<_>>()
 }
 
-//Checks for values in the array of the specified ScalarValue discriminant for  partially ordered that can be totally ordered types like f32 and f64.
-#[allow(clippy::unnecessary_wraps, clippy::too_many_arguments)]
-fn contains_partial_ord_type<A, N, F, V, O>(
+#[allow(clippy::unnecessary_wraps)]
+fn contains_ord_types_it<O, I>(
+    it: I,
+    mut list_values: Vec<O>,
+    negated: bool,
+    contains_null: bool,
+    method_bounds: (usize, usize),
+) -> Result<ColumnarValue>
+where
+    I: Iterator<Item = Option<O>>,
+    O: Ord + Hash + Eq,
+{
+    let num_values = list_values.len();
+    let contains_arr = if num_values <= method_bounds.0 {
+        list_values.sort_unstable();
+        compute_contains_array(it, negated, contains_null, |val| {
+            val.map(|x| {
+                let out_of_bounds = match (list_values.first(), list_values.last()) {
+                    (Some(lowest), Some(highest)) => *lowest > x || *highest < x,
+                    _ => false,
+                };
+                if out_of_bounds {
+                    return false;
+                }
+                list_values.contains(&x)
+            })
+        })
+    } else if num_values <= method_bounds.1 {
+        list_values.sort_unstable();
+        compute_contains_array(it, negated, contains_null, |val| {
+            val.map(|x| {
+                let out_of_bounds = match (list_values.first(), list_values.last()) {
+                    (Some(lowest), Some(highest)) => *lowest > x || *highest < x,
+                    _ => false,
+                };
+                if out_of_bounds {
+                    return false;
+                }
+                list_values.binary_search(&x).is_ok()
+            })
+        })
+    } else {
+        let set = list_values.into_iter().collect::<HashSet<_>>(); // HashSet::with_capacity(values.len());
+        compute_contains_array(it, negated, contains_null, |val| {
+            val.map(|x| set.contains(&x))
+        })
+    };
+    let col_val = ColumnarValue::Array(Arc::new(contains_arr));
+    Ok(col_val)
+}
+
+fn contains_ord_types<A, F>(
     array: Arc<dyn Array>,
     list_values: Vec<ColumnarValue>,
     negated: bool,
     disc: std::mem::Discriminant<ScalarValue>,
-    linear_search_upper_bound: usize,
-    binary_search_upper_bound: usize,
-    make_ord_val: V,
+    method_bounds: (usize, usize),
     scalar_handler: F,
 ) -> Result<ColumnarValue>
 where
-    A: ArrowPrimitiveType<Native = N>,
-    V: Fn(N) -> O + Copy,
-    O: Ord + std::hash::Hash + Eq,
-    F: Fn(&ScalarValue, &mut bool) -> Option<N>,
+    A: ArrowPrimitiveType,
+    A::Native: Ord + Hash + Eq,
+    F: Fn(&ScalarValue, &mut bool) -> Option<A::Native>,
 {
     let arr = array
         .as_ref()
@@ -123,77 +169,44 @@ where
         .downcast_ref::<PrimitiveArray<A>>()
         .unwrap();
     let mut contains_null = false;
-    let handler_wrapper = move |s: &ScalarValue, cont_null: &mut bool| -> Option<O> {
-        let partial_ord_val = scalar_handler(s, cont_null);
-        partial_ord_val.map(make_ord_val)
-    };
-    let mut values =
-        collect_scalar_value(list_values, &mut contains_null, disc, handler_wrapper);
-    let num_values = values.len();
-    let contains_arr = if num_values <= linear_search_upper_bound {
-        values.sort_unstable();
-        compute_contains_array(arr.iter(), negated, contains_null, |val| {
-            val.map(|x| {
-                let ord_val = make_ord_val(x);
-                let out_of_bounds = match (values.first(), values.last()) {
-                    (Some(lowest), Some(highest)) => {
-                        *lowest > ord_val || *highest < ord_val
-                    }
-                    _ => false,
-                };
-                if out_of_bounds {
-                    return false;
-                }
-                values.contains(&ord_val)
-            })
-        })
-    } else if num_values <= binary_search_upper_bound {
-        values.sort_unstable();
-        compute_contains_array(arr.iter(), negated, contains_null, |val| {
-            val.map(|x| {
-                let ord_val = make_ord_val(x);
-                if *values.first().unwrap() > ord_val || *values.last().unwrap() < ord_val
-                {
-                    return false;
-                }
-                values.binary_search(&ord_val).is_ok()
-            })
-        })
-    } else {
-        let set = values.into_iter().collect::<HashSet<_>>(); // HashSet::with_capacity(values.len());
-        compute_contains_array(arr.iter(), negated, contains_null, |val| {
-            val.map(|x| set.contains(&make_ord_val(x)))
-        })
-    };
-    let col_val = ColumnarValue::Array(Arc::new(contains_arr));
-    Ok(col_val)
+    let values =
+        collect_scalar_value(list_values, &mut contains_null, disc, scalar_handler);
+    contains_ord_types_it(arr.iter(), values, negated, contains_null, method_bounds)
 }
 
-//Checks if the values are in the array after downcasting it to the specified Primitive type
-fn contains_ord_types<A, N, F>(
+//Checks for values in the array of the specified ScalarValue discriminant for  partially ordered that can be totally ordered types like f32 and f64.
+fn contains_partial_ord_type<A, F, V, O>(
     array: Arc<dyn Array>,
     list_values: Vec<ColumnarValue>,
     negated: bool,
     disc: std::mem::Discriminant<ScalarValue>,
-    linear_search_upper_bound: usize,
-    binary_search_upper_bound: usize,
+    method_bounds: (usize, usize),
+    make_ord_val: V,
     scalar_handler: F,
 ) -> Result<ColumnarValue>
 where
-    N: Ord + std::hash::Hash,
-    A: ArrowPrimitiveType<Native = N>,
+    A: ArrowPrimitiveType,
+    V: Copy + Fn(A::Native) -> O,
+    O: Ord + Hash + Eq,
     F: Fn(&ScalarValue, &mut bool) -> Option<A::Native>,
 {
-    let make_ord_val = |partial_ord_val: N| -> N { partial_ord_val };
-    contains_partial_ord_type::<A, N, _, _, _>(
-        array,
-        list_values,
+    let arr = array
+        .as_ref()
+        .as_any()
+        .downcast_ref::<PrimitiveArray<A>>()
+        .unwrap();
+    let mut contains_null = false;
+    let handler_wrapper = |s: &ScalarValue, cont_null: &mut bool| {
+        scalar_handler(s, cont_null).map(make_ord_val)
+    };
+    let values =
+        collect_scalar_value(list_values, &mut contains_null, disc, handler_wrapper);
+    contains_ord_types_it(
+        arr.iter().map(|v| v.map(make_ord_val)),
+        values,
         negated,
-        disc,
-        linear_search_upper_bound,
-        binary_search_upper_bound,
-        make_ord_val,
-        scalar_handler,
+        contains_null,
+        method_bounds,
     )
 }
 
@@ -212,14 +225,13 @@ macro_rules! make_ord_contains {
             $LINEAR_SEARCH_BOUND
         )
     }};
-    ($PRIM_TYPE:ty, $ARRAY:expr, $LIST_VALUES:expr, $NEGATED:expr, $SCALAR_VALUE:ident, $LINEAR_SEARCH_BOUND:literal, $BINARY_SEARCH_BOUND:literal) => {{
-        contains_ord_types::<$PRIM_TYPE, <$PRIM_TYPE as ArrowPrimitiveType>::Native, _>(
+    ($ARRAY_TYPE:ty, $ARRAY:expr, $LIST_VALUES:expr, $NEGATED:expr, $SCALAR_VALUE:ident, $LINEAR_SEARCH_BOUND:literal, $BINARY_SEARCH_BOUND:literal) => {{
+        contains_ord_types::<$ARRAY_TYPE, _>(
             $ARRAY,
             $LIST_VALUES,
             $NEGATED,
             std::mem::discriminant(&ScalarValue::$SCALAR_VALUE(None)),
-            $LINEAR_SEARCH_BOUND,
-            $BINARY_SEARCH_BOUND,
+            ($LINEAR_SEARCH_BOUND, $BINARY_SEARCH_BOUND),
             |s, contains_null| match s {
                 ScalarValue::$SCALAR_VALUE(Some(v)) => Some(*v),
                 ScalarValue::$SCALAR_VALUE(None) => {
@@ -274,7 +286,6 @@ impl InListExpr {
             .unwrap();
 
         let mut contains_null = false;
-
         let mut values = list_values
             .iter()
             .flat_map(|expr| match expr {
@@ -296,7 +307,8 @@ impl InListExpr {
                 }
             })
             .collect::<Vec<_>>();
-
+        //TODO: determine better bound for when to switch to hashset
+        // Possibly based off of the number of characters the values in the list have combined with the total length of the list?
         const LINEAR_SEARCH_UPPER_BOUND: usize = 8;
         let contains_arr = match values.len() {
             0..=LINEAR_SEARCH_UPPER_BOUND => {
@@ -360,13 +372,12 @@ impl PhysicalExpr for InListExpr {
         match value_data_type {
             DataType::Float32 => {
                 let disc = std::mem::discriminant(&ScalarValue::Float32(None));
-                contains_partial_ord_type::<Float32Type, f32, _, _, _>(
+                contains_partial_ord_type::<Float32Type, _, _, _>(
                     array,
                     list_values,
                     self.negated,
                     disc,
-                    256,
-                    256,
+                    (256, 256),
                     ordered_float::OrderedFloat::from,
                     |s, contains_null| match s {
                         ScalarValue::Float32(Some(v)) => Some(*v),
@@ -380,13 +391,12 @@ impl PhysicalExpr for InListExpr {
             }
             DataType::Float64 => {
                 let disc = std::mem::discriminant(&ScalarValue::Float64(None));
-                contains_partial_ord_type::<Float64Type, f64, _, _, _>(
+                contains_partial_ord_type::<Float64Type, _, _, _>(
                     array,
                     list_values,
                     self.negated,
                     disc,
-                    128,
-                    128,
+                    (128, 128),
                     ordered_float::OrderedFloat::from,
                     |s, contains_null| match s {
                         ScalarValue::Float64(Some(v)) => Some(*v),
@@ -397,6 +407,9 @@ impl PhysicalExpr for InListExpr {
                         _ => unreachable!(),
                     },
                 )
+            }
+            DataType::Int8 => {
+                make_ord_contains!(Int8Type, array, list_values, self.negated, Int8, 256)
             }
             DataType::Int16 => {
                 make_ord_contains!(
@@ -428,8 +441,15 @@ impl PhysicalExpr for InListExpr {
                     128
                 )
             }
-            DataType::Int8 => {
-                make_ord_contains!(Int8Type, array, list_values, self.negated, Int8, 256)
+            DataType::UInt8 => {
+                make_ord_contains!(
+                    UInt8Type,
+                    array,
+                    list_values,
+                    self.negated,
+                    UInt8,
+                    256
+                )
             }
             DataType::UInt16 => {
                 make_ord_contains!(
@@ -461,16 +481,7 @@ impl PhysicalExpr for InListExpr {
                     128
                 )
             }
-            DataType::UInt8 => {
-                make_ord_contains!(
-                    UInt8Type,
-                    array,
-                    list_values,
-                    self.negated,
-                    UInt8,
-                    256
-                )
-            }
+
             DataType::Boolean => {
                 let mut contains_nulls = false;
                 let bool_disc = std::mem::discriminant(&ScalarValue::Boolean(None));
@@ -487,13 +498,11 @@ impl PhysicalExpr for InListExpr {
                         _ => unreachable!(),
                     },
                 );
-
-                if values.is_empty() {
-                    return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))));
-                }
+                let bool_arr = array.as_any().downcast_ref::<BooleanArray>().unwrap();
                 let mut found_true = false;
                 let mut found_false = false;
-                let exhaustively_true = values.iter().any(|b| {
+                //Check if the list contains both true and false values
+                values.iter().any(|b| {
                     match b {
                         true => {
                             found_true = true;
@@ -504,17 +513,37 @@ impl PhysicalExpr for InListExpr {
                     }
                     found_true && found_false
                 });
-                if exhaustively_true {
-                    return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))));
-                }
-                let match_bool = found_true;
-                let bool_iter = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-                let contains_arr = compute_contains_array(
-                    bool_iter.iter(),
-                    self.negated,
-                    contains_nulls,
-                    |o| o.map(|b| b == match_bool),
-                );
+
+                let contains_arr = match (found_true, found_false, contains_nulls) {
+                    (true, true, false) => {
+                        //If the list contains both true and false but no nulls then fill the array with !negated
+                        let fill_value = !self.negated;
+                        bool_arr
+                            .iter()
+                            .map(|o| o.map(|_| fill_value))
+                            .collect::<BooleanArray>()
+                    }
+                    (true, true, true) => {
+                        //If the list contains both true and false and a null value then fill the array with !negated and map false to null
+                        let fill_value = !self.negated;
+                        bool_arr
+                            .iter()
+                            .map(|o| match o {
+                                Some(true) => Some(fill_value),
+                                Some(false) | None => None,
+                            })
+                            .collect()
+                    }
+                    _ => {
+                        //Otherwise calculate normally
+                        compute_contains_array(
+                            bool_arr.iter(),
+                            self.negated,
+                            contains_nulls,
+                            |o| o.map(|b| (found_false && !b) || (b && found_true)),
+                        )
+                    }
+                };
                 Ok(ColumnarValue::Array(Arc::new(contains_arr)))
             }
             DataType::Utf8 => self.compare_utf8::<i32>(array, list_values),
@@ -681,30 +710,63 @@ mod tests {
     #[test]
     fn in_list_bool() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Boolean, true)]);
-        let a = BooleanArray::from(vec![Some(true), None]);
+        let a = BooleanArray::from(vec![Some(true), None, Some(false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 
         // expression: "a in (true)"
         let list = vec![lit(ScalarValue::Boolean(Some(true)))];
-        in_list!(batch, list, &false, vec![Some(true), None]);
+        in_list!(batch, list, &false, vec![Some(true), None, Some(false)]);
 
         // expression: "a not in (true)"
         let list = vec![lit(ScalarValue::Boolean(Some(true)))];
-        in_list!(batch, list, &true, vec![Some(false), None]);
+        in_list!(batch, list, &true, vec![Some(false), None, Some(true)]);
 
         // expression: "a in (true, NULL)"
         let list = vec![
             lit(ScalarValue::Boolean(Some(true))),
             lit(ScalarValue::Utf8(None)),
         ];
-        in_list!(batch, list, &false, vec![Some(true), None]);
+        in_list!(batch, list, &false, vec![Some(true), None, None]);
 
         // expression: "a not in (true, NULL)"
         let list = vec![
             lit(ScalarValue::Boolean(Some(true))),
             lit(ScalarValue::Utf8(None)),
         ];
-        in_list!(batch, list, &true, vec![Some(false), None]);
+        in_list!(batch, list, &true, vec![Some(false), None, None]);
+
+        // expression: "a in (true, false)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Boolean(Some(false))),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None, Some(true)]);
+
+
+        //expression: "a not in (true, false)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Boolean(Some(false))),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None, Some(false)]);
+
+
+        // expression: "a in (true, false, NULL)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Boolean(Some(false))),
+            lit(ScalarValue::Utf8(None))
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None, None]);
+
+
+        //expression: "a not in (true, false, NULL)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Boolean(Some(false))),
+            lit(ScalarValue::Utf8(None))
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None, None]);
         Ok(())
     }
 }

--- a/datafusion/src/physical_plan/expressions/in_list.rs
+++ b/datafusion/src/physical_plan/expressions/in_list.rs
@@ -99,28 +99,32 @@ fn collect_scalar_value<V, F: Fn(&ScalarValue, &mut bool) -> Option<V>>(
         .collect::<Vec<_>>()
 }
 
-fn contains_sorted<E: Ord>(data: &[E], item: &E)->bool{
-    if data.is_empty(){
+#[allow(clippy::comparison_chain)]
+//Allow comparision chain because sometimes the match solution can be slower due to the
+//cmp call not getting inlined.
+fn contains_sorted<E: Ord>(data: &[E], item: &E) -> bool {
+    if data.is_empty() {
         return false;
     }
     //At this point slice is not empty so it will never panic
     let lowest = data.first().unwrap();
     let highest = data.last().unwrap();
 
-    if item < lowest || highest < item{
-        return false
+    if item < lowest || highest < item {
+        return false;
     }
 
-    for elem in data.iter(){
-        if *elem == *item{
+    for elem in data.iter() {
+        if *elem == *item {
             return true;
-        }else if *elem > *item{
+        } else if *elem > *item {
             return false;
         }
     }
     false
 }
 
+//Allow unnecessary_wraps to avoid wrapping with result every time this is invoked since this is a fairly specialized function
 #[allow(clippy::unnecessary_wraps)]
 fn contains_ord_types_it<O, I>(
     it: I,
@@ -134,14 +138,12 @@ where
     O: Ord + Hash + Eq,
 {
     let num_values = list_values.len();
-    let contains_arr = if num_values == 0{
-        compute_contains_array(it, negated, contains_null, |val| {
-            val.map(|_x| false)
-        })
+    let contains_arr = if num_values == 0 {
+        compute_contains_array(it, negated, contains_null, |val| val.map(|_x| false))
     } else if num_values <= linear_search_bound {
         list_values.sort_unstable();
         compute_contains_array(it, negated, contains_null, |val| {
-            val.map(|x|  contains_sorted(list_values.as_slice(), &x))
+            val.map(|x| contains_sorted(list_values.as_slice(), &x))
         })
     } else {
         let set = list_values.into_iter().collect::<HashSet<_>>(); // HashSet::with_capacity(values.len());
@@ -309,11 +311,9 @@ impl InListExpr {
         // Possibly based off of the number of characters the values in the list have combined with the total length of the list?
         const LINEAR_SEARCH_UPPER_BOUND: usize = 8;
         let contains_arr = match values.len() {
-            0 =>{
-                compute_contains_array(array.iter(), self.negated, contains_null, |x| {
-                    x.map(|_x| false)
-                })
-            }
+            0 => compute_contains_array(array.iter(), self.negated, contains_null, |x| {
+                x.map(|_x| false)
+            }),
             1..=LINEAR_SEARCH_UPPER_BOUND => {
                 values.sort_unstable();
                 compute_contains_array(array.iter(), self.negated, contains_null, |x| {

--- a/datafusion/src/physical_plan/expressions/in_list.rs
+++ b/datafusion/src/physical_plan/expressions/in_list.rs
@@ -99,6 +99,28 @@ fn collect_scalar_value<V, F: Fn(&ScalarValue, &mut bool) -> Option<V>>(
         .collect::<Vec<_>>()
 }
 
+fn contains_sorted<E: Ord>(data: &[E], item: &E)->bool{
+    if data.is_empty(){
+        return false;
+    }
+    //At this point slice is not empty so it will never panic
+    let lowest = data.first().unwrap();
+    let highest = data.last().unwrap();
+
+    if item < lowest || highest < item{
+        return false
+    }
+
+    for elem in data.iter(){
+        if *elem == *item{
+            return true;
+        }else if *elem > *item{
+            return false;
+        }
+    }
+    false
+}
+
 #[allow(clippy::unnecessary_wraps)]
 fn contains_ord_types_it<O, I>(
     it: I,
@@ -112,19 +134,14 @@ where
     O: Ord + Hash + Eq,
 {
     let num_values = list_values.len();
-    let contains_arr = if num_values <= linear_search_bound {
+    let contains_arr = if num_values == 0{
+        compute_contains_array(it, negated, contains_null, |val| {
+            val.map(|_x| false)
+        })
+    } else if num_values <= linear_search_bound {
         list_values.sort_unstable();
         compute_contains_array(it, negated, contains_null, |val| {
-            val.map(|x| {
-                let out_of_bounds = match (list_values.first(), list_values.last()) {
-                    (Some(lowest), Some(highest)) => *lowest > x || *highest < x,
-                    _ => false,
-                };
-                if out_of_bounds {
-                    return false;
-                }
-                list_values.contains(&x)
-            })
+            val.map(|x|  contains_sorted(list_values.as_slice(), &x))
         })
     } else {
         let set = list_values.into_iter().collect::<HashSet<_>>(); // HashSet::with_capacity(values.len());
@@ -292,10 +309,15 @@ impl InListExpr {
         // Possibly based off of the number of characters the values in the list have combined with the total length of the list?
         const LINEAR_SEARCH_UPPER_BOUND: usize = 8;
         let contains_arr = match values.len() {
-            0..=LINEAR_SEARCH_UPPER_BOUND => {
+            0 =>{
+                compute_contains_array(array.iter(), self.negated, contains_null, |x| {
+                    x.map(|_x| false)
+                })
+            }
+            1..=LINEAR_SEARCH_UPPER_BOUND => {
                 values.sort_unstable();
                 compute_contains_array(array.iter(), self.negated, contains_null, |x| {
-                    x.map(|x| values.contains(&x))
+                    x.map(|x| contains_sorted(values.as_slice(), &x))
                 })
             }
             _ => {

--- a/datafusion/src/physical_plan/expressions/in_list.rs
+++ b/datafusion/src/physical_plan/expressions/in_list.rs
@@ -705,12 +705,6 @@ mod tests {
             lit(ScalarValue::Utf8(None)),
         ];
         in_list!(batch, list, &true, vec![Some(false), None]);
-        ////Expression "a in true (NULL, true)"
-        //let list=vec![
-        //    lit(ScalarValue::Utf8(None)),
-        //];
-        ////let batch = BooleanArray::from(vec![Some(true), None]);
-        //in_list!(batch, list, &false, vec![Some(false), None]);
         Ok(())
     }
 }

--- a/datafusion/src/physical_plan/expressions/in_list.rs
+++ b/datafusion/src/physical_plan/expressions/in_list.rs
@@ -513,8 +513,13 @@ impl PhysicalExpr for InListExpr {
                     }
                     found_true && found_false
                 });
-                
-                let contains_arr = compute_contains_array(bool_arr.iter(), self.negated, contains_null, |o| o.map(|b| (found_true && b) || (found_false && !b)));
+
+                let contains_arr = compute_contains_array(
+                    bool_arr.iter(),
+                    self.negated,
+                    contains_null,
+                    |o| o.map(|b| (found_true && b) || (found_false && !b)),
+                );
                 Ok(ColumnarValue::Array(Arc::new(contains_arr)))
             }
             DataType::Utf8 => self.compare_utf8::<i32>(array, list_values),
@@ -713,7 +718,6 @@ mod tests {
         ];
         in_list!(batch, list, &false, vec![Some(true), None, Some(true)]);
 
-
         //expression: "a not in (true, false)"
         let list = vec![
             lit(ScalarValue::Boolean(Some(true))),
@@ -721,21 +725,19 @@ mod tests {
         ];
         in_list!(batch, list, &true, vec![Some(false), None, Some(false)]);
 
-
         // expression: "a in (true, false, NULL)"
         let list = vec![
             lit(ScalarValue::Boolean(Some(true))),
             lit(ScalarValue::Boolean(Some(false))),
-            lit(ScalarValue::Utf8(None))
+            lit(ScalarValue::Utf8(None)),
         ];
         in_list!(batch, list, &false, vec![Some(true), None, Some(true)]);
-
 
         //expression: "a not in (true, false, NULL)"
         let list = vec![
             lit(ScalarValue::Boolean(Some(true))),
             lit(ScalarValue::Boolean(Some(false))),
-            lit(ScalarValue::Utf8(None))
+            lit(ScalarValue::Utf8(None)),
         ];
         in_list!(batch, list, &true, vec![Some(false), None, Some(false)]);
         Ok(())


### PR DESCRIPTION
Added short circuiting extreme values check on list.

# Which issue does this PR close?

fixes #145 

# What changes are included in this PR?
Various changes to the InList physical expression.

Macro based solution was replaced with generic functions, which ended up being a little symbol soupy. If the macro based solution is preferred I'd be happy to switch it to use a macro instead. 

List of optimizations:
- Using a HashSet to check for values in the list for large lists
- For numeric lists sort the list of values:
    - Check that value falls within extreme values of list to enable 
    - Short circuits the linear search
- Explicitly lift check for negated and contains_null to outside of the loop. It probably doesn't matter and if it did the compiler probably already does this,  but I thought it made sense to be explicit. 

The thresholds for selecting whether to do a scan or use a HashSet could  be tuned more.

# Are there any user-facing changes?
No