### PR TITLE
Improve column naming by aliasing with expression name

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1188,7 +1188,7 @@ fn fmt_function(
 impl fmt::Debug for Expr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Expr::Alias(expr, alias) => write!(f, "{:?} AS {}", expr, alias),
+            Expr::Alias(expr, _alias) => write!(f, "{:?}", expr),
             Expr::Column(name) => write!(f, "#{}", name),
             Expr::ScalarVariable(var_names) => write!(f, "{}", var_names.join(".")),
             Expr::Literal(v) => write!(f, "{:?}", v),

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -810,7 +810,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Generate a relational expression from a select SQL expression
     fn sql_select_to_rex(&self, sql: &SelectItem, schema: &DFSchema) -> Result<Expr> {
         match sql {
-            SelectItem::UnnamedExpr(expr) => self.sql_to_rex(expr, schema),
+            SelectItem::UnnamedExpr(sql_expr) => {
+                let expr = self.sql_to_rex(sql_expr, schema)?;
+                Ok(expr.alias(&format!("{}", sql_expr)))
+            }
             SelectItem::ExprWithAlias { expr, alias } => Ok(Alias(
                 Box::new(self.sql_to_rex(&expr, schema)?),
                 alias.value.clone(),


### PR DESCRIPTION
# Which issue does this PR close?


Closes #279

 # Rationale for this change
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

# What changes are included in this PR?

* Wrap unnamed expressions in a `alias`.
* Don't display alias in logical plan (as it otherwise will be added to every expression) - still not so sure about this one.

# Are there any user-facing changes?

Yes, column names will be different.