### PR TITLE
Add print format param and support for csv print format to datafusion cli

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -32,4 +32,3 @@ rustyline = "8.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 datafusion = { path = "../datafusion" }
 arrow = { git = "https://github.com/apache/arrow-rs", rev = "508f25c10032857da34ea88cc8166f0741616a32" }
-tempfile = "3.2.0"

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -31,3 +31,5 @@ clap = "2.33"
 rustyline = "8.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 datafusion = { path = "../datafusion" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "508f25c10032857da34ea88cc8166f0741616a32" }
+tempfile = "3.2.0"

--- a/datafusion-cli/src/format.rs
+++ b/datafusion-cli/src/format.rs
@@ -1,1 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 pub mod print_format;

--- a/datafusion-cli/src/format.rs
+++ b/datafusion-cli/src/format.rs
@@ -1,0 +1,1 @@
+pub mod print_format;

--- a/datafusion-cli/src/format/print_format.rs
+++ b/datafusion-cli/src/format/print_format.rs
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Print format variants
+use arrow::csv::writer::WriterBuilder;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty;
+use datafusion::error::Result;
+use std::io::{Read, Seek, SeekFrom};
+use tempfile::tempfile;
+
+/// Allow records to be printed in different formats
+#[derive(Debug, Clone)]
+pub enum PrintFormat {
+    Csv,
+    Aligned,
+}
+
+impl PrintFormat {
+    /// print the batches to stdout using the specified format
+    pub fn print_batches(&self, batches: &[RecordBatch]) -> Result<()> {
+        match self {
+            PrintFormat::Csv => {
+                // utilizing a temp file so that we can leverage the arrow csv writer
+                // ideally the upstream shall take a more generic trait
+                let mut file = tempfile()?;
+                {
+                    let builder = WriterBuilder::new().has_headers(true);
+                    let mut writer = builder.build(&file);
+                    batches
+                        .iter()
+                        .for_each(|batch| writer.write(batch).unwrap());
+                }
+                let mut data = String::new();
+                file.seek(SeekFrom::Start(0))?;
+                file.read_to_string(&mut data)?;
+                println!("{}", data);
+            }
+            PrintFormat::Aligned => pretty::print_batches(batches)?,
+        }
+        Ok(())
+    }
+}

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -66,7 +66,7 @@ pub async fn main() {
         )
         .arg(
             Arg::with_name("format")
-                .help("Output format")
+                .help("Output format (possible values: table, csv)")
                 .long("format")
                 .default_value("table")
                 .validator(is_valid_format)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #290.

This shall be merged after https://github.com/apache/arrow-datafusion/pull/285

 # Rationale for this change

Printing results in CSV mode allows for better parsing, e.g. in automatic systems.

# What changes are included in this PR?

- adding arrow deps
~- adding tmpfile deps~
- taking additional `--format` flag

# Are there any user-facing changes?

- additional feature, no breaking changes.
