### PR TITLE
Add print format param with support for tsv print format to datafusion cli

### DIFF
--- a/datafusion-cli/src/format/print_format.rs
+++ b/datafusion-cli/src/format/print_format.rs
@@ -19,9 +19,7 @@
 use arrow::csv::writer::WriterBuilder;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty;
-use datafusion::error::Result;
 use datafusion::error::{DataFusionError, Result};
-use std::io::{Read, Seek, SeekFrom};
 use std::str::FromStr;
 
 /// Allow records to be printed in different formats

--- a/datafusion-cli/src/format/print_format.rs
+++ b/datafusion-cli/src/format/print_format.rs
@@ -34,11 +34,11 @@ pub enum PrintFormat {
 
 impl FromStr for PrintFormat {
     type Err = ();
-    fn from_str(s: &str) -> std::result::Result<PrintFormat, ()> {
+    fn from_str(s: &str) -> std::result::Result<Self, ()> {
         match s {
-            "csv" => Ok(PrintFormat::Csv),
-            "tsv" => Ok(PrintFormat::Tsv),
-            "table" => Ok(PrintFormat::Table),
+            "csv" => Ok(Self::Csv),
+            "tsv" => Ok(Self::Tsv),
+            "table" => Ok(Self::Table),
             _ => Err(()),
         }
     }
@@ -64,9 +64,9 @@ impl PrintFormat {
     /// print the batches to stdout using the specified format
     pub fn print_batches(&self, batches: &[RecordBatch]) -> Result<()> {
         match self {
-            PrintFormat::Csv => println!("{}", print_batches_with_sep(batches, b',')?),
-            PrintFormat::Tsv => println!("{}", print_batches_with_sep(batches, b'\t')?),
-            PrintFormat::Table => pretty::print_batches(batches)?,
+            Self::Csv => println!("{}", print_batches_with_sep(batches, b',')?),
+            Self::Tsv => println!("{}", print_batches_with_sep(batches, b'\t')?),
+            Self::Table => pretty::print_batches(batches)?,
         }
         Ok(())
     }

--- a/datafusion-cli/src/format/print_format.rs
+++ b/datafusion-cli/src/format/print_format.rs
@@ -28,6 +28,7 @@ use std::str::FromStr;
 #[derive(Debug, Clone)]
 pub enum PrintFormat {
     Csv,
+    Tsv,
     Table,
 }
 
@@ -36,29 +37,35 @@ impl FromStr for PrintFormat {
     fn from_str(s: &str) -> std::result::Result<PrintFormat, ()> {
         match s {
             "csv" => Ok(PrintFormat::Csv),
+            "tsv" => Ok(PrintFormat::Tsv),
             "table" => Ok(PrintFormat::Table),
             _ => Err(()),
         }
     }
 }
 
+fn print_batches_with_sep(batches: &[RecordBatch], delimiter: u8) -> Result<String> {
+    let mut bytes = vec![];
+    {
+        let builder = WriterBuilder::new()
+            .has_headers(true)
+            .with_delimiter(delimiter);
+        let mut writer = builder.build(&mut bytes);
+        for batch in batches {
+            writer.write(batch)?;
+        }
+    }
+    let formatted = String::from_utf8(bytes)
+        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    Ok(formatted)
+}
+
 impl PrintFormat {
     /// print the batches to stdout using the specified format
     pub fn print_batches(&self, batches: &[RecordBatch]) -> Result<()> {
         match self {
-            PrintFormat::Csv => {
-                let mut bytes = vec![];
-                {
-                    let builder = WriterBuilder::new().has_headers(true);
-                    let mut writer = builder.build(&mut bytes);
-                    for batch in batches {
-                        writer.write(batch)?;
-                    }
-                }
-                let csv = String::from_utf8(bytes)
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-                println!("{}", csv);
-            }
+            PrintFormat::Csv => println!("{}", print_batches_with_sep(batches, b',')?),
+            PrintFormat::Tsv => println!("{}", print_batches_with_sep(batches, b'\t')?),
             PrintFormat::Table => pretty::print_batches(batches)?,
         }
         Ok(())

--- a/datafusion-cli/src/format/print_format.rs
+++ b/datafusion-cli/src/format/print_format.rs
@@ -19,7 +19,9 @@
 use arrow::csv::writer::WriterBuilder;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty;
+use datafusion::error::Result;
 use datafusion::error::{DataFusionError, Result};
+use std::io::{Read, Seek, SeekFrom};
 use std::str::FromStr;
 
 /// Allow records to be printed in different formats

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -66,7 +66,7 @@ pub async fn main() {
         )
         .arg(
             Arg::with_name("format")
-                .help("Output format (possible values: table, csv)")
+                .help("Output format (possible values: table, csv, tsv)")
                 .long("format")
                 .default_value("table")
                 .validator(is_valid_format)

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -183,10 +183,10 @@ async fn exec_from_repl(execution_config: ExecutionConfig, print_format: PrintFo
 }
 
 fn is_valid_format(format: String) -> std::result::Result<(), String> {
-    match format.to_lowercase().as_str() {
-        "csv" => Ok(()),
-        "table" => Ok(()),
-        _ => Err(format!("Format '{}' not supported", format)),
+    if format.parse::<PrintFormat>().is_ok() {
+        Ok(())
+    } else {
+        Err(format!("Format '{}' not supported", format))
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #293  .

 # Rationale for this change

Since we now have #289 , we can easily add tsv support

# What changes are included in this PR?

Extending format to include tsv

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `breaking change` label.
