### PR TITLE
allow datafusion cli to take -- comments

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -114,6 +114,9 @@ async fn exec_from_lines(
 
     for line in reader.lines() {
         match line {
+            Ok(line) if line.starts_with("--") => {
+                continue;
+            }
             Ok(line) => {
                 let line = line.trim_end();
                 query.push_str(line);
@@ -153,6 +156,9 @@ async fn exec_from_repl(execution_config: ExecutionConfig, print_format: PrintFo
         match rl.readline("> ") {
             Ok(ref line) if is_exit_command(line) && query.is_empty() => {
                 break;
+            }
+            Ok(ref line) if line.starts_with("--") => {
+                continue;
             }
             Ok(ref line) if line.trim_end().ends_with(';') => {
                 query.push_str(line.trim_end());

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -127,7 +127,7 @@ async fn exec_from_lines(
                     }
                     query = "".to_owned();
                 } else {
-                    query.push(' ');
+                    query.push('\n');
                 }
             }
             _ => {
@@ -171,7 +171,7 @@ async fn exec_from_repl(execution_config: ExecutionConfig, print_format: PrintFo
             }
             Ok(ref line) => {
                 query.push_str(line);
-                query.push(' ');
+                query.push('\n');
             }
             Err(_) => {
                 break;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #297.

# Rationale for this change

`--` comments shall be respected in parsing command line input

# What changes are included in this PR?

- adding support for `--` for both file and cli mode

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `breaking change` label.
