### PR TITLE
add random SQL function

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -65,9 +65,9 @@ unicode-segmentation = { version = "^1.7.1", optional = true }
 regex = { version = "^1.4.3", optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 smallvec = { version = "1.6", features = ["union"] }
+rand = "0.8"
 
 [dev-dependencies]
-rand = "0.8"
 criterion = "0.3"
 tempfile = "3"
 doc-comment = "0.3"

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -221,7 +221,10 @@ impl BuiltinScalarFunction {
     /// an allowlist of functions to take zero arguments, so that they will get special treatment
     /// while executing.
     fn supports_zero_argument(&self) -> bool {
-        matches!(self, BuiltinScalarFunction::Now)
+        matches!(
+            self,
+            BuiltinScalarFunction::Random | BuiltinScalarFunction::Now
+        )
     }
 }
 

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -169,6 +169,8 @@ pub enum BuiltinScalarFunction {
     NullIf,
     /// octet_length
     OctetLength,
+    /// random
+    Random,
     /// regexp_replace
     RegexpReplace,
     /// repeat
@@ -275,6 +277,7 @@ impl FromStr for BuiltinScalarFunction {
             "md5" => BuiltinScalarFunction::MD5,
             "nullif" => BuiltinScalarFunction::NullIf,
             "octet_length" => BuiltinScalarFunction::OctetLength,
+            "random" => BuiltinScalarFunction::Random,
             "regexp_replace" => BuiltinScalarFunction::RegexpReplace,
             "repeat" => BuiltinScalarFunction::Repeat,
             "replace" => BuiltinScalarFunction::Replace,
@@ -438,6 +441,7 @@ pub fn return_type(
                 ));
             }
         }),
+        BuiltinScalarFunction::Random => Ok(DataType::Float64),
         BuiltinScalarFunction::RegexpReplace => Ok(match arg_types[0] {
             DataType::LargeUtf8 => DataType::LargeUtf8,
             DataType::Utf8 => DataType::Utf8,
@@ -742,6 +746,7 @@ pub fn create_physical_expr(
         BuiltinScalarFunction::Ln => math_expressions::ln,
         BuiltinScalarFunction::Log10 => math_expressions::log10,
         BuiltinScalarFunction::Log2 => math_expressions::log2,
+        BuiltinScalarFunction::Random => math_expressions::random,
         BuiltinScalarFunction::Round => math_expressions::round,
         BuiltinScalarFunction::Signum => math_expressions::signum,
         BuiltinScalarFunction::Sin => math_expressions::sin,
@@ -1307,6 +1312,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
             Signature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Utf8]),
             Signature::Exact(vec![DataType::LargeUtf8, DataType::Utf8, DataType::Utf8]),
         ]),
+        BuiltinScalarFunction::Random => Signature::Exact(vec![]),
         // math expressions expect 1 argument of type f64 or f32
         // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
         // return the best approximation for it (in f64).

--- a/datafusion/src/physical_plan/type_coercion.rs
+++ b/datafusion/src/physical_plan/type_coercion.rs
@@ -75,7 +75,6 @@ pub fn data_types(
     if current_types.is_empty() {
         return Ok(vec![]);
     }
-
     let valid_types = get_valid_types(signature, current_types)?;
 
     if valid_types

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2906,7 +2906,16 @@ async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
     let t2 = t2_naive.timestamp();
     assert!(t1 <= t2 && t2 <= t3);
     assert_eq!(res2, res1);
+}
 
+#[tokio::test]
+async fn test_random_expression() -> Result<()> {
+    let mut ctx = create_ctx()?;
+    let sql = format!("SELECT random() r1");
+    let actual = execute(&mut ctx, sql.as_str()).await;
+    let r1 = actual[0][0].parse::<f64>().unwrap();
+    assert!(0.0 <= r1);
+    assert!(r1 < 1.0);
     Ok(())
 }
 

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2906,13 +2906,15 @@ async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
     let t2 = t2_naive.timestamp();
     assert!(t1 <= t2 && t2 <= t3);
     assert_eq!(res2, res1);
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_random_expression() -> Result<()> {
     let mut ctx = create_ctx()?;
-    let sql = format!("SELECT random() r1");
-    let actual = execute(&mut ctx, sql.as_str()).await;
+    let sql = "SELECT random() r1";
+    let actual = execute(&mut ctx, sql).await;
     let r1 = actual[0][0].parse::<f64>().unwrap();
     assert!(0.0 <= r1);
     assert!(r1 < 1.0);


### PR DESCRIPTION
# Which issue does this PR close?

add random SQL function. unlike the `now()` function, each row shall be individually generated.

Closes #304

based on #307 

 # Rationale for this change
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

# What changes are included in this PR?

There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `breaking change` label.
