### PR TITLE
Simplify math expression code (use unary kernel)

### DIFF
--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -631,7 +631,7 @@ async fn sqrt_f32_vs_f64() -> Result<()> {
     // sqrt(f32)'s plan passes
     let sql = "SELECT avg(sqrt(c11)) FROM aggregate_test_100";
     let actual = execute(&mut ctx, sql).await;
-    let expected = vec![vec!["0.6584408485889435"]];
+    let expected = vec![vec!["0.6584407806396484"]];
 
     assert_eq!(actual, expected);
     let sql = "SELECT avg(sqrt(CAST(c11 AS double))) FROM aggregate_test_100";


### PR DESCRIPTION
# Which issue does this PR close?

Closes #308

 # Rationale for this change
Simplifies code, probably is faster too. Also involves one cast less which causes more rounding errors. 

# What changes are included in this PR?

Use `arity::unary` function to simplify math expression code

# Are there any user-facing changes?

No