### PR TITLE
Support COUNT(DISTINCT timestamps) 

### DIFF
--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -104,6 +104,73 @@ macro_rules! typed_cast {
     }};
 }
 
+macro_rules! build_values_list {
+    ($VALUE_BUILDER_TY:ident, $SCALAR_TY:ident, $VALUES:expr, $SIZE:expr) => {{
+        let mut builder = ListBuilder::new($VALUE_BUILDER_TY::new($VALUES.len()));
+
+        for _ in 0..$SIZE {
+            for scalar_value in $VALUES {
+                match scalar_value {
+                    ScalarValue::$SCALAR_TY(Some(v)) => {
+                        builder.values().append_value(v.clone()).unwrap()
+                    }
+                    ScalarValue::$SCALAR_TY(None) => {
+                        builder.values().append_null().unwrap();
+                    }
+                    _ => panic!("Incompatible ScalarValue for list"),
+                };
+            }
+            builder.append(true).unwrap();
+        }
+
+        builder.finish()
+    }};
+}
+
+macro_rules! build_timestamp_list {
+    ($TIME_UNIT:expr, $TIME_ZONE:expr, $VALUES:expr, $SIZE:expr) => {{
+        match $VALUES {
+            // the return on the macro is necessary, to short-circuit and return ArrayRef
+            None => {
+                return new_null_array(
+                    &DataType::List(Box::new(Field::new(
+                        "item",
+                        DataType::Timestamp($TIME_UNIT, $TIME_ZONE),
+                        true,
+                    ))),
+                    $SIZE,
+                )
+            }
+            Some(values) => match $TIME_UNIT {
+                TimeUnit::Second => build_values_list!(
+                    TimestampSecondBuilder,
+                    TimestampSecond,
+                    values,
+                    $SIZE
+                ),
+                TimeUnit::Microsecond => build_values_list!(
+                    TimestampMillisecondBuilder,
+                    TimestampMillisecond,
+                    values,
+                    $SIZE
+                ),
+                TimeUnit::Millisecond => build_values_list!(
+                    TimestampMicrosecondBuilder,
+                    TimestampMicrosecond,
+                    values,
+                    $SIZE
+                ),
+                TimeUnit::Nanosecond => build_values_list!(
+                    TimestampNanosecondBuilder,
+                    TimestampNanosecond,
+                    values,
+                    $SIZE
+                ),
+            },
+        }
+    }};
+}
+
 macro_rules! build_list {
     ($VALUE_BUILDER_TY:ident, $SCALAR_TY:ident, $VALUES:expr, $SIZE:expr) => {{
         match $VALUES {
@@ -360,10 +427,13 @@ impl ScalarValue {
                 DataType::Utf8 => build_list!(StringBuilder, Utf8, values, size),
                 DataType::Float32 => build_list!(Float32Builder, Float32, values, size),
                 DataType::Float64 => build_list!(Float64Builder, Float64, values, size),
+                DataType::Timestamp(unit, tz) => {
+                    build_timestamp_list!(unit.clone(), tz.clone(), values, size)
+                }
                 DataType::LargeUtf8 => {
                     build_list!(LargeStringBuilder, LargeUtf8, values, size)
                 }
-                _ => panic!("Unexpected DataType for list"),
+                dt => panic!("Unexpected DataType for list {:?}", dt),
             }),
             ScalarValue::Date32(e) => match e {
                 Some(value) => Arc::new(Date32Array::from_value(*value, size)),

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1960,6 +1960,19 @@ async fn to_timestamp() -> Result<()> {
 }
 
 #[tokio::test]
+async fn count_distinct_timestamps() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
+
+    let sql = "SELECT COUNT(DISTINCT(ts)) FROM ts_data";
+    let actual = execute(&mut ctx, sql).await;
+
+    let expected = vec![vec!["3"]];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_is_null() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Float64, true)]));
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #314 .

# What changes are included in this PR?

Handles `DataType::Timestamp` in `ScalarValue::List` with a custom macro `build_timestamp_list` that takes the time unit and timezone. 

# Are there any user-facing changes?


