### PR TITLE
MINOR: Fix integration tests by adding datafusion-cli module to docker image

### DIFF
--- a/dev/docker/rust.dockerfile
+++ b/dev/docker/rust.dockerfile
@@ -35,6 +35,7 @@ RUN mkdir /tmp/ballista/datafusion-examples
 ADD Cargo.toml .
 COPY benchmarks ./benchmarks/
 COPY datafusion ./datafusion/
+COPY datafusion-cli ./datafusion-cli/
 COPY datafusion-examples ./datafusion-examples/
 COPY ballista ./ballista/
 RUN cargo chef prepare --recipe-path recipe.json
@@ -47,11 +48,13 @@ FROM base as builder
 RUN mkdir /tmp/ballista/ballista
 RUN mkdir /tmp/ballista/benchmarks
 RUN mkdir /tmp/ballista/datafusion
+RUN mkdir /tmp/ballista/datafusion-cli
 RUN mkdir /tmp/ballista/datafusion-examples
 ADD Cargo.toml .
 COPY benchmarks ./benchmarks/
 COPY datafusion ./datafusion/
 COPY ballista ./ballista/
+COPY datafusion-cli ./datafusion-cli/
 COPY datafusion-examples ./datafusion-examples/
 COPY --from=cacher /tmp/ballista/target target
 ARG RELEASE_FLAG=--release


### PR DESCRIPTION
The recent changes to move DataFusion CLI to a separate crate broke the Ballista integration tests. This PR simply adds this crate to the Docker image used by the integration tests.

For anyone that is interested, integration tests can be run with this command:

```bash
./dev/integration-tests.sh
```

I filed https://github.com/apache/arrow-datafusion/issues/321 for adding these tests to CI
