### PR TITLE
Use NullArray to Pass row count to ScalarFunctions that take 0 arguments 

### DIFF
--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -43,6 +43,13 @@ pub struct ScalarUDF {
     /// Return type
     pub return_type: ReturnTypeFunction,
     /// actual implementation
+    ///
+    /// The fn param is the wrapped function but be aware that the function will
+    /// be passed with the slice / vec of columnar values (either scalar or array)
+    /// with the exception of zero param function, where a singular element vec
+    /// will be passed. In that case the single element is a null array to indicate
+    /// the batch's row count (so that the generative zero-argument function can know
+    /// the result array size).
     pub fun: ScalarFunctionImplementation,
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

fix 305 by using a null array as param for zero param functions

Closes #305

 # Rationale for this change

in case of a zero param function we'll have a rather hacky way to pass in the batch num_rows param so that the functions wrapped can be generative the correct result

# What changes are included in this PR?

Similar to #307 but use a null array instead

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
