### PR TITLE
Fix indented display for multi-child nodes

### DIFF
--- a/datafusion/src/physical_plan/display.rs
+++ b/datafusion/src/physical_plan/display.rs
@@ -87,4 +87,9 @@ impl<'a, 'b> ExecutionPlanVisitor for IndentVisitor<'a, 'b> {
         self.indent += 1;
         Ok(true)
     }
+
+    fn post_visit(&mut self, _plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
+        self.indent -= 1;
+        Ok(true)
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #345 

 # Rationale for this change
When generating display output, the indent level of nodes with more than one child input was not correct.

Note the code with the bug has not yet been released yet