### PR TITLE
Add PartialOrd and Ord to GroupByScalar (#364)

### DIFF
--- a/datafusion/src/physical_plan/group_scalar.rs
+++ b/datafusion/src/physical_plan/group_scalar.rs
@@ -24,7 +24,7 @@ use crate::error::{DataFusionError, Result};
 use crate::scalar::ScalarValue;
 
 /// Enumeration of types that can be used in a GROUP BY expression
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub(crate) enum GroupByScalar {
     Float32(OrderedFloat<f32>),
     Float64(OrderedFloat<f64>),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #364.

 # Rationale for this change

Allows comparing GroupByScalar values

# What changes are included in this PR?

Adds PartialOrd and Ord derives to GroupByScalar

# Are there any user-facing changes?

No, only changes a crate-local. There didn't seem to be consensus on the ticket as to whether I should make this enum public
