### PR TITLE
Support statistics pruning for formats other than parquet

### DIFF
--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -571,7 +571,7 @@ mod tests {
         let batch = build_statistics_record_batch(&statistics, &stat_column_req).unwrap();
         let expected = vec![
             "+--------+--------+--------+--------+",
-            "| s1_min | s2_min | s3_max | s3_min |",
+            "| s1_min | s2_max | s3_max | s3_min |",
             "+--------+--------+--------+--------+",
             "|        | 20     | q      | a      |",
             "|        |        |        |        |",

--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -28,20 +28,12 @@
 //! https://github.com/apache/arrow-datafusion/issues/363 it will
 //! be genericized.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, convert::TryInto, sync::Arc};
 
 use arrow::{
-    array::{
-        make_array, new_null_array, ArrayData, ArrayRef, BooleanArray,
-        BooleanBufferBuilder,
-    },
-    buffer::MutableBuffer,
-    datatypes::{DataType, Field, Schema},
+    array::{ArrayRef, BooleanArray},
+    datatypes::{Field, Schema, SchemaRef},
     record_batch::RecordBatch,
-};
-
-use parquet::file::{
-    metadata::RowGroupMetaData, statistics::Statistics as ParquetStatistics,
 };
 
 use crate::{
@@ -50,28 +42,61 @@ use crate::{
     logical_plan::{Expr, Operator},
     optimizer::utils,
     physical_plan::{planner::DefaultPhysicalPlanner, ColumnarValue, PhysicalExpr},
+    scalar::ScalarValue,
 };
 
+/// Interface to pass statistics information to [`PruningPredicates`]
+pub trait PruningStatistics {
+    /// return the minimum value for the named column, if known
+    fn min_value(&self, column: &str) -> Option<ScalarValue>;
+
+    /// return the maximum value for the named column, if known
+    fn max_value(&self, column: &str) -> Option<ScalarValue>;
+}
+
+/// Evaluates filter expressions on statistics in order to
+/// prune data containers (e.g. parquet row group)
+///
+/// See [`try_new`] for more information.
 #[derive(Debug, Clone)]
-/// Builder used for generating predicate functions that can be used
-/// to prune data based on statistics (e.g. parquet row group metadata)
-pub struct PruningPredicateBuilder {
-    schema: Schema,
+pub struct PruningPredicate {
+    /// The input schema against which the predicate will be evaluated
+    schema: SchemaRef,
+    /// Actual pruning predicate (rewritten in terms of column min/max statistics)
     predicate_expr: Arc<dyn PhysicalExpr>,
+    /// The statistics required to evaluate this predicate:
+    /// * The column name in the input schema
+    /// * Statstics type (e.g. Min or Ma)
+    /// * The field the statistics value should be placed in for
+    ///   pruning predicate evaluation
     stat_column_req: Vec<(String, StatisticsType, Field)>,
 }
 
-impl PruningPredicateBuilder {
-    /// Try to create a new instance of [`PruningPredicateBuilder`]
+impl PruningPredicate {
+    /// Try to create a new instance of [`PruningPredicate`]
     ///
-    /// This will translate the filter expression into a statistics predicate expression
+    /// This will translate the provided `expr` filter expression into
+    /// a *pruning predicate*.
     ///
-    /// For example,  `(column / 2) = 4` becomes `(column_min / 2) <= 4 && 4 <= (column_max / 2))`
-    pub fn try_new(expr: &Expr, schema: Schema) -> Result<Self> {
+    /// A pruning predicate is one that has been rewritten in terms of
+    /// the min and max values of column references and that evaluates
+    /// to FALSE if the filter predicate would evaluate FALSE *for
+    /// every row* whose values fell within the min / max ranges (aka
+    /// could be pruned).
+    ///
+    /// The pruning predicate evaluates to TRUE or NULL
+    /// if the filter predicate *might* evaluate to TRUE for at least
+    /// one row whose vaules fell within the min/max ranges (in other
+    /// words they might pass the predicate)
+    ///
+    /// For example, the filter expression `(column / 2) = 4` becomes
+    /// the pruning predicate
+    /// `(column_min / 2) <= 4 && 4 <= (column_max / 2))`
+    pub fn try_new(expr: &Expr, schema: SchemaRef) -> Result<Self> {
         // build predicate expression once
         let mut stat_column_req = Vec::<(String, StatisticsType, Field)>::new();
         let logical_predicate_expr =
-            build_predicate_expression(expr, &schema, &mut stat_column_req)?;
+            build_predicate_expression(expr, schema.as_ref(), &mut stat_column_req)?;
         let stat_fields = stat_column_req
             .iter()
             .map(|(_, _, f)| f.clone())
@@ -90,37 +115,31 @@ impl PruningPredicateBuilder {
         })
     }
 
-    /// For each set of statistics, evalates the predicate in this
-    /// builder and returns a `bool` with the following meaning for a
-    /// container with those statistics:
+    /// For each set of statistics, evalates the pruning predicate
+    /// and returns a `bool` with the following meaning for a
+    /// all rows whose values match the statistics:
     ///
-    /// `true`: The container MAY contain rows that match the predicate
+    /// `true`: There MAY be rows that match the predicate
     ///
-    /// `false`: The container MUST NOT contain rows that match the predicate
+    /// `false`: There are no rows that could match the predicate
     ///
     /// Note this function takes a slice of statistics as a parameter
     /// to amortize the cost of the evaluation of the predicate
     /// against a single record batch.
-    pub fn build_pruning_predicate(
-        &self,
-        statistics: &[RowGroupMetaData],
-    ) -> Result<Vec<bool>> {
+    pub fn prune<S: PruningStatistics>(&self, statistics: &[S]) -> Result<Vec<bool>> {
         // build statistics record batch
-        let predicate_array = build_statistics_record_batch(
-            statistics,
-            &self.schema,
-            &self.stat_column_req,
-        )
-        .and_then(|statistics_batch| {
-            // execute predicate expression
-            self.predicate_expr.evaluate(&statistics_batch)
-        })
-        .and_then(|v| match v {
-            ColumnarValue::Array(array) => Ok(array),
-            ColumnarValue::Scalar(_) => Err(DataFusionError::Internal(
-                "predicate expression didn't return an array".to_string(),
-            )),
-        })?;
+        let predicate_array =
+            build_statistics_record_batch(statistics, &self.stat_column_req)
+                .and_then(|statistics_batch| {
+                    // execute predicate expression
+                    self.predicate_expr.evaluate(&statistics_batch)
+                })
+                .and_then(|v| match v {
+                    ColumnarValue::Array(array) => Ok(array),
+                    ColumnarValue::Scalar(_) => Err(DataFusionError::Internal(
+                        "predicate expression didn't return an array".to_string(),
+                    )),
+                })?;
 
         let predicate_array = predicate_array
             .as_any()
@@ -141,39 +160,87 @@ impl PruningPredicateBuilder {
             .map(|x| x.unwrap_or(true))
             .collect::<Vec<_>>())
     }
+
+    /// Return a reference to the input schema
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
 }
 
-/// Build a RecordBatch from a list of statistics (currently parquet
-/// [`RowGroupMetadata`] structs), creating arrays, one for each
-/// statistics column, as requested in the stat_column_req parameter.
-fn build_statistics_record_batch(
-    statistics: &[RowGroupMetaData],
-    schema: &Schema,
+/// Build a RecordBatch from a list of statistics, creating arrays,
+/// with one row for each PruningStatistics and columns specified in
+/// in the stat_column_req parameter.
+///
+/// For example, if the requested columns are
+/// ```text
+/// ("s1", Min, Field:s1_min)
+/// ("s2", Max, field:s2_maxx)
+///```
+///
+/// And the input statistics had
+/// ```text
+/// S1(Min: 5, Max: 10)
+/// S2(Min: 99, Max: 1000)
+/// S3(Min: 1, Max: 2)
+/// ```
+///
+/// Then this function would build a record batch with 2 columns and
+/// one row s1_min and s2_maxx as follows (s3 is not requested):
+///
+/// ```text
+/// s1_min | s2_maxx
+/// -------+--------
+///   5    | 10
+/// ```
+fn build_statistics_record_batch<S: PruningStatistics>(
+    statistics: &[S],
     stat_column_req: &[(String, StatisticsType, Field)],
 ) -> Result<RecordBatch> {
     let mut fields = Vec::<Field>::new();
     let mut arrays = Vec::<ArrayRef>::new();
+    // For each needed statistics column:
     for (column_name, statistics_type, stat_field) in stat_column_req {
-        if let Some((column_index, _)) = schema.column_with_name(column_name) {
-            let statistics = statistics
-                .iter()
-                .map(|g| g.column(column_index).statistics())
-                .collect::<Vec<_>>();
-            let array = build_statistics_array(
-                &statistics,
-                *statistics_type,
-                stat_field.data_type(),
-            );
-            fields.push(stat_field.clone());
-            arrays.push(array);
-        }
+        // Create a None value of the appropriate scalar type
+        let data_type = stat_field.data_type();
+        let null_scalar: ScalarValue = data_type.try_into()?;
+
+        let array = match statistics_type {
+            StatisticsType::Min => {
+                let values: Vec<_> = statistics
+                    .iter()
+                    .map(|s| {
+                        s.min_value(&column_name)
+                            .unwrap_or_else(|| null_scalar.clone())
+                    })
+                    .collect();
+                ScalarValue::iter_to_array(values.iter())?
+            }
+            StatisticsType::Max => {
+                let values: Vec<_> = statistics
+                    .iter()
+                    .map(|s| {
+                        s.max_value(&column_name)
+                            .unwrap_or_else(|| null_scalar.clone())
+                    })
+                    .collect();
+                ScalarValue::iter_to_array(values.iter())?
+            }
+        };
+
+        // cast statistics array to required data type (e.g. parquet
+        // provides timestamp statistics as "Int64")
+        let array = arrow::compute::cast(&array, data_type)?;
+
+        fields.push(stat_field.clone());
+        arrays.push(array);
     }
+
     let schema = Arc::new(Schema::new(fields));
     RecordBatch::try_new(schema, arrays)
         .map_err(|err| DataFusionError::Plan(err.to_string()))
 }
 
-struct StatisticsExpressionBuilder<'a> {
+struct PruningExpressionBuilder<'a> {
     column_name: String,
     column_expr: &'a Expr,
     scalar_expr: &'a Expr,
@@ -182,7 +249,7 @@ struct StatisticsExpressionBuilder<'a> {
     reverse_operator: bool,
 }
 
-impl<'a> StatisticsExpressionBuilder<'a> {
+impl<'a> PruningExpressionBuilder<'a> {
     fn try_new(
         left: &'a Expr,
         right: &'a Expr,
@@ -303,7 +370,11 @@ fn rewrite_column_expr(
     utils::rewrite_expression(&expr, &expressions)
 }
 
-/// Translate logical filter expression into statistics predicate expression
+/// Translate logical filter expression into pruning predicate
+/// expression that will evaluate to FALSE if it can be determined no
+/// rows between the min/max values could pass the predicates.
+///
+/// Returns the pruning predicate as an [`Expr`]
 fn build_predicate_expression(
     expr: &Expr,
     schema: &Schema,
@@ -328,7 +399,7 @@ fn build_predicate_expression(
     }
 
     let expr_builder =
-        StatisticsExpressionBuilder::try_new(left, right, schema, stat_column_req);
+        PruningExpressionBuilder::try_new(left, right, schema, stat_column_req);
     let mut expr_builder = match expr_builder {
         Ok(builder) => builder,
         // allow partial failure in predicate expression generation
@@ -384,210 +455,218 @@ enum StatisticsType {
     Max,
 }
 
-fn build_statistics_array(
-    statistics: &[Option<&ParquetStatistics>],
-    statistics_type: StatisticsType,
-    data_type: &DataType,
-) -> ArrayRef {
-    let statistics_count = statistics.len();
-    let first_group_stats = statistics.iter().find(|s| s.is_some());
-    let first_group_stats = if let Some(Some(statistics)) = first_group_stats {
-        // found first row group with statistics defined
-        statistics
-    } else {
-        // no row group has statistics defined
-        return new_null_array(data_type, statistics_count);
-    };
-
-    let (data_size, arrow_type) = match first_group_stats {
-        ParquetStatistics::Int32(_) => (std::mem::size_of::<i32>(), DataType::Int32),
-        ParquetStatistics::Int64(_) => (std::mem::size_of::<i64>(), DataType::Int64),
-        ParquetStatistics::Float(_) => (std::mem::size_of::<f32>(), DataType::Float32),
-        ParquetStatistics::Double(_) => (std::mem::size_of::<f64>(), DataType::Float64),
-        ParquetStatistics::ByteArray(_) if data_type == &DataType::Utf8 => {
-            (0, DataType::Utf8)
-        }
-        _ => {
-            // type of statistics not supported
-            return new_null_array(data_type, statistics_count);
-        }
-    };
-
-    let statistics = statistics.iter().map(|s| {
-        s.filter(|s| s.has_min_max_set())
-            .map(|s| match statistics_type {
-                StatisticsType::Min => s.min_bytes(),
-                StatisticsType::Max => s.max_bytes(),
-            })
-    });
-
-    if arrow_type == DataType::Utf8 {
-        let data_size = statistics
-            .clone()
-            .map(|x| x.map(|b| b.len()).unwrap_or(0))
-            .sum();
-        let mut builder =
-            arrow::array::StringBuilder::with_capacity(statistics_count, data_size);
-        let string_statistics =
-            statistics.map(|x| x.and_then(|bytes| std::str::from_utf8(bytes).ok()));
-        for maybe_string in string_statistics {
-            match maybe_string {
-                Some(string_value) => builder.append_value(string_value).unwrap(),
-                None => builder.append_null().unwrap(),
-            };
-        }
-        return Arc::new(builder.finish());
-    }
-
-    let mut data_buffer = MutableBuffer::new(statistics_count * data_size);
-    let mut bitmap_builder = BooleanBufferBuilder::new(statistics_count);
-    let mut null_count = 0;
-    for s in statistics {
-        if let Some(stat_data) = s {
-            bitmap_builder.append(true);
-            data_buffer.extend_from_slice(stat_data);
-        } else {
-            bitmap_builder.append(false);
-            data_buffer.resize(data_buffer.len() + data_size, 0);
-            null_count += 1;
-        }
-    }
-
-    let mut builder = ArrayData::builder(arrow_type)
-        .len(statistics_count)
-        .add_buffer(data_buffer.into());
-    if null_count > 0 {
-        builder = builder.null_bit_buffer(bitmap_builder.finish());
-    }
-    let array_data = builder.build();
-    let statistics_array = make_array(array_data);
-    if statistics_array.data_type() == data_type {
-        return statistics_array;
-    }
-    // cast statistics array to required data type
-    arrow::compute::cast(&statistics_array, data_type)
-        .unwrap_or_else(|_| new_null_array(data_type, statistics_count))
-}
-
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
-    use crate::physical_optimizer::pruning::StatisticsType;
-    use arrow::{
-        array::{Int32Array, StringArray},
-        datatypes::DataType,
-    };
-    use parquet::file::statistics::Statistics as ParquetStatistics;
+    use crate::logical_plan::{col, lit};
+    use crate::{assert_batches_eq, physical_optimizer::pruning::StatisticsType};
+    use arrow::datatypes::{DataType, TimeUnit};
 
-    #[test]
-    fn build_statistics_array_int32() {
-        // build row group metadata array
-        let s1 = ParquetStatistics::int32(None, Some(10), None, 0, false);
-        let s2 = ParquetStatistics::int32(Some(2), Some(20), None, 0, false);
-        let s3 = ParquetStatistics::int32(Some(3), Some(30), None, 0, false);
-        let statistics = vec![Some(&s1), Some(&s2), Some(&s3)];
-
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Min, &DataType::Int32);
-        let int32_array = statistics_array
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-        let int32_vec = int32_array.into_iter().collect::<Vec<_>>();
-        assert_eq!(int32_vec, vec![None, Some(2), Some(3)]);
-
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Max, &DataType::Int32);
-        let int32_array = statistics_array
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-        let int32_vec = int32_array.into_iter().collect::<Vec<_>>();
-        // here the first max value is None and not the Some(10) value which was actually set
-        // because the min value is None
-        assert_eq!(int32_vec, vec![None, Some(20), Some(30)]);
+    #[derive(Debug, Default)]
+    struct MinMax {
+        min: Option<ScalarValue>,
+        max: Option<ScalarValue>,
     }
 
-    #[test]
-    fn build_statistics_array_utf8() {
-        // build row group metadata array
-        let s1 = ParquetStatistics::byte_array(None, Some("10".into()), None, 0, false);
-        let s2 = ParquetStatistics::byte_array(
-            Some("2".into()),
-            Some("20".into()),
-            None,
-            0,
-            false,
-        );
-        let s3 = ParquetStatistics::byte_array(
-            Some("3".into()),
-            Some("30".into()),
-            None,
-            0,
-            false,
-        );
-        let statistics = vec![Some(&s1), Some(&s2), Some(&s3)];
-
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Min, &DataType::Utf8);
-        let string_array = statistics_array
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let string_vec = string_array.into_iter().collect::<Vec<_>>();
-        assert_eq!(string_vec, vec![None, Some("2"), Some("3")]);
-
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Max, &DataType::Utf8);
-        let string_array = statistics_array
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let string_vec = string_array.into_iter().collect::<Vec<_>>();
-        // here the first max value is None and not the Some("10") value which was actually set
-        // because the min value is None
-        assert_eq!(string_vec, vec![None, Some("20"), Some("30")]);
+    impl MinMax {
+        fn new(min: Option<ScalarValue>, max: Option<ScalarValue>) -> Self {
+            Self { min, max }
+        }
     }
 
-    #[test]
-    fn build_statistics_array_empty_stats() {
-        let data_type = DataType::Int32;
-        let statistics = vec![];
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Min, &data_type);
-        assert_eq!(statistics_array.len(), 0);
+    #[derive(Debug, Default)]
+    struct TestStatistics {
+        // key: column name
+        stats: HashMap<String, MinMax>,
+    }
 
-        let statistics = vec![None, None];
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Min, &data_type);
-        assert_eq!(statistics_array.len(), statistics.len());
-        assert_eq!(statistics_array.data_type(), &data_type);
-        for i in 0..statistics_array.len() {
-            assert_eq!(statistics_array.is_null(i), true);
-            assert_eq!(statistics_array.is_valid(i), false);
+    impl TestStatistics {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn with(mut self, name: impl Into<String>, min_max: MinMax) -> Self {
+            self.stats.insert(name.into(), min_max);
+            self
+        }
+    }
+
+    impl PruningStatistics for TestStatistics {
+        fn min_value(&self, column: &str) -> Option<ScalarValue> {
+            self.stats
+                .get(column)
+                .map(|s| s.min.clone())
+                .unwrap_or(None)
+        }
+
+        fn max_value(&self, column: &str) -> Option<ScalarValue> {
+            self.stats
+                .get(column)
+                .map(|s| s.max.clone())
+                .unwrap_or(None)
         }
     }
 
     #[test]
-    fn build_statistics_array_unsupported_type() {
-        // boolean is not currently a supported type for statistics
-        let s1 = ParquetStatistics::boolean(Some(false), Some(true), None, 0, false);
-        let s2 = ParquetStatistics::boolean(Some(false), Some(true), None, 0, false);
-        let statistics = vec![Some(&s1), Some(&s2)];
-        let data_type = DataType::Boolean;
-        let statistics_array =
-            build_statistics_array(&statistics, StatisticsType::Min, &data_type);
-        assert_eq!(statistics_array.len(), statistics.len());
-        assert_eq!(statistics_array.data_type(), &data_type);
-        for i in 0..statistics_array.len() {
-            assert_eq!(statistics_array.is_null(i), true);
-            assert_eq!(statistics_array.is_valid(i), false);
-        }
+    fn test_build_statistics_record_batch() {
+        // Request a record batch with of s1_min, s2_max, s3_max, s3_min
+        let stat_column_req = vec![
+            // min of original column s1, named s1_min
+            (
+                "s1".to_string(),
+                StatisticsType::Min,
+                Field::new("s1_min", DataType::Int32, true),
+            ),
+            // max of original column s2, named s2_max
+            (
+                "s2".to_string(),
+                StatisticsType::Max,
+                Field::new("s2_min", DataType::Int32, true),
+            ),
+            // max of original column s3, named s3_max
+            (
+                "s3".to_string(),
+                StatisticsType::Max,
+                Field::new("s3_max", DataType::Utf8, true),
+            ),
+            // min of original column s3, named s3_min
+            (
+                "s3".to_string(),
+                StatisticsType::Min,
+                Field::new("s3_min", DataType::Utf8, true),
+            ),
+        ];
+
+        // s1: [None, 10]
+        // s2: [2, 20]
+        // s2: ["a", "q"]
+        let stats1 = TestStatistics::new()
+            .with("s1", MinMax::new(None, Some(10i32.into())))
+            .with("s2", MinMax::new(Some(2i32.into()), Some(20i32.into())))
+            .with("s3", MinMax::new(Some("a".into()), Some("q".into())));
+
+        // s1: [None, None]
+        // s2: [None, None]
+        // s2: [None, None]
+        let stats2 = TestStatistics::new()
+            .with("s1", MinMax::new(None, None))
+            .with("s2", MinMax::new(None, None))
+            .with("s3", MinMax::new(None, None));
+
+        // s1: [9, None]
+        // s2: None
+        // s2: [None, "r"]
+        let stats3 = TestStatistics::new()
+            .with("s1", MinMax::new(Some(9i32.into()), None))
+            .with("s3", MinMax::new(None, Some("r".into())));
+
+        // This one returns a statistics value, but the value itself is NULL
+        // s1: [Some(None), None]
+        let stats4 = TestStatistics::new()
+            .with("s1", MinMax::new(Some(ScalarValue::Int32(None)), None));
+
+        let statistics = [stats1, stats2, stats3, stats4];
+        let batch = build_statistics_record_batch(&statistics, &stat_column_req).unwrap();
+        let expected = vec![
+            "+--------+--------+--------+--------+",
+            "| s1_min | s2_min | s3_max | s3_min |",
+            "+--------+--------+--------+--------+",
+            "|        | 20     | q      | a      |",
+            "|        |        |        |        |",
+            "| 9      |        | r      |        |",
+            "|        |        |        |        |",
+            "+--------+--------+--------+--------+",
+        ];
+
+        assert_batches_eq!(expected, &[batch]);
+    }
+
+    #[test]
+    fn test_build_statistics_casting() {
+        // Test requesting a Timestamp column, but getting statistics as Int64
+        // which is what Parquet does
+
+        // Request a record batch with of s1_min as a timestamp
+        let stat_column_req = vec![(
+            "s1".to_string(),
+            StatisticsType::Min,
+            Field::new(
+                "s1_min",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        )];
+
+        // Note the statistics pass back i64 (not timestamp)
+        // s1: [None, 10]
+        let stats1 = TestStatistics::new()
+            .with("s1", MinMax::new(Some(10i64.into()), Some(20i32.into())));
+
+        let statistics = [stats1];
+        let batch = build_statistics_record_batch(&statistics, &stat_column_req).unwrap();
+        let expected = vec![
+            "+-------------------------------+",
+            "| s1_min                        |",
+            "+-------------------------------+",
+            "| 1970-01-01 00:00:00.000000010 |",
+            "+-------------------------------+",
+        ];
+
+        assert_batches_eq!(expected, &[batch]);
+    }
+
+    #[test]
+    fn test_build_statistics_no_stats() {
+        let stat_column_req = vec![];
+
+        let stats1 = TestStatistics::new()
+            .with("s1", MinMax::new(Some(10i64.into()), Some(20i32.into())));
+
+        let statistics = [stats1];
+        let result =
+            build_statistics_record_batch(&statistics, &stat_column_req).unwrap_err();
+        assert!(
+            result.to_string().contains("Invalid argument error"),
+            "{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_build_statistics_inconsistent_types() {
+        // Test requesting a Utf8 column when the stats return some other type
+
+        // Request a record batch with of s1_min as a timestamp
+        let stat_column_req = vec![(
+            "s1".to_string(),
+            StatisticsType::Min,
+            Field::new("s1_min", DataType::Utf8, true),
+        )];
+
+        // Note the statistics return binary (which can't be cast to string)
+        // s1: [0x255, None]
+        let stats1 = TestStatistics::new().with(
+            "s1",
+            MinMax::new(Some(ScalarValue::Binary(Some(vec![255]))), None),
+        );
+
+        let statistics = [stats1];
+        let batch = build_statistics_record_batch(&statistics, &stat_column_req).unwrap();
+        let expected = vec![
+            "+--------+",
+            "| s1_min |",
+            "+--------+",
+            "|        |",
+            "+--------+",
+        ];
+
+        assert_batches_eq!(expected, &[batch]);
     }
 
     #[test]
     fn row_group_predicate_eq() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "#c1_min LtEq Int32(1) And Int32(1) LtEq #c1_max";
 
@@ -606,7 +685,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_gt() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "#c1_max Gt Int32(1)";
 
@@ -625,7 +703,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_gt_eq() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "#c1_max GtEq Int32(1)";
 
@@ -643,7 +720,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_lt() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "#c1_min Lt Int32(1)";
 
@@ -662,7 +738,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_lt_eq() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "#c1_min LtEq Int32(1)";
 
@@ -680,7 +755,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_and() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Int32, false),
             Field::new("c2", DataType::Int32, false),
@@ -697,7 +771,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_or() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Int32, false),
             Field::new("c2", DataType::Int32, false),
@@ -713,7 +786,6 @@ mod tests {
 
     #[test]
     fn row_group_predicate_stat_column_req() -> Result<()> {
-        use crate::logical_plan::{col, lit};
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Int32, false),
             Field::new("c2", DataType::Int32, false),
@@ -748,5 +820,41 @@ mod tests {
         assert_eq!(stat_column_req.len(), 3);
 
         Ok(())
+    }
+
+    #[test]
+    fn prune_api() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("s1", DataType::Utf8, false),
+            Field::new("s2", DataType::Int32, false),
+        ]));
+
+        // Prune using s2 > 5
+        let expr = col("s2").gt(lit(5));
+
+        // s2 [0, 5] ==> no rows should pass
+        let stats1 = TestStatistics::new()
+            .with("s1", MinMax::new(None, None))
+            .with("s2", MinMax::new(Some(0i32.into()), Some(5i32.into())));
+
+        // s2 [4, 6] ==> some rows could pass
+        let stats2 = TestStatistics::new()
+            .with("s1", MinMax::new(None, None))
+            .with("s2", MinMax::new(Some(4i32.into()), Some(6i32.into())));
+
+        // No stats for s2 ==> some rows could pass
+        let stats3 = TestStatistics::new();
+
+        // s2 [3, None] (null max) ==> some rows could pass
+        let stats4 = TestStatistics::new().with(
+            "s2",
+            MinMax::new(Some(3i32.into()), Some(ScalarValue::Int32(None))),
+        );
+
+        let p = PruningPredicate::try_new(&expr, schema).unwrap();
+        let result = p.prune(&[stats1, stats2, stats3, stats4]).unwrap();
+        let expected = vec![false, true, true, true];
+
+        assert_eq!(result, expected);
     }
 }

--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -190,7 +190,7 @@ impl PruningPredicate {
 /// ```text
 /// s1_min | s2_maxx
 /// -------+--------
-///   5    | 10
+///   5    | 1000
 /// ```
 fn build_statistics_record_batch<S: PruningStatistics>(
     statistics: &[S],

--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -86,7 +86,7 @@ impl PruningPredicate {
     ///
     /// The pruning predicate evaluates to TRUE or NULL
     /// if the filter predicate *might* evaluate to TRUE for at least
-    /// one row whose vaules fell within the min/max ranges (in other
+    /// one row whose values fell within the min/max ranges (in other
     /// words they might pass the predicate)
     ///
     /// For example, the filter expression `(column / 2) = 4` becomes

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -115,6 +115,7 @@ mod tests {
 
     #[test]
     fn added_repartition_to_single_partition() -> Result<()> {
+        let schema = Arc::new(Schema::empty());
         let parquet_project = ProjectionExec::try_new(
             vec![],
             Arc::new(ParquetExec::new(
@@ -122,7 +123,7 @@ mod tests {
                     filenames: vec!["x".to_string()],
                     statistics: Statistics::default(),
                 }],
-                Schema::empty(),
+                schema,
                 None,
                 None,
                 2048,
@@ -149,6 +150,7 @@ mod tests {
 
     #[test]
     fn repartition_deepest_node() -> Result<()> {
+        let schema = Arc::new(Schema::empty());
         let parquet_project = ProjectionExec::try_new(
             vec![],
             Arc::new(ProjectionExec::try_new(
@@ -158,7 +160,7 @@ mod tests {
                         filenames: vec!["x".to_string()],
                         statistics: Statistics::default(),
                     }],
-                    Schema::empty(),
+                    schema,
                     None,
                     None,
                     2048,


### PR DESCRIPTION
Closes #363

Edit: **Note**: There is an alternate API in https://github.com/apache/arrow-datafusion/pull/426

# Rationale
As explained on #363 the high level goal is to make the parquet row group pruning logic generic to any types of min/max statistics (not just parquet metadata)

# Changes:
1. Introduce a new `PruningStatistics` trait
2. Refactor `PruningPredicateBuilder` to be generic in terms of `PruningStatistics`
3. Add documentation and tests

# Example

Here is a brief snippet of one of the tests that shows the new API:
```rust
        // Prune using s2 > 5
        let expr = col("s2").gt(lit(5));

        // s2 [0, 5] ==> no rows should pass
        let stats1 = TestStatistics::new()
            .with("s1", MinMax::new(None, None))
            .with("s2", MinMax::new(Some(0i32.into()), Some(5i32.into())));

        // s2 [4, 6] ==> some rows could pass
        let stats2 = TestStatistics::new()
            .with("s1", MinMax::new(None, None))
            .with("s2", MinMax::new(Some(4i32.into()), Some(6i32.into())));

        let p = PruningPredicate::try_new(&expr, schema).unwrap();
        let result = p.prune(&[stats1, stats2]).unwrap();

        // false means no rows could possibly match (can prune)
        // true means some rows might match (can not prune)
        let expected = vec![false, true];

        assert_eq!(expected, result);
```

# Sequence:

I am trying to do this in a few small PRs to reduce review burden; Here is how connect together:

Planned changes:
- [x] Refactor code into a new module (https://github.com/apache/arrow-datafusion/pull/365)
- [x] Return bool rather than parquet specific output (https://github.com/apache/arrow-datafusion/pull/370)
- [x] Add `ScalarValue::iter_to_array` (https://github.com/apache/arrow-datafusion/pull/381)
- [ ] Add `PruningStatstics` Trait (this PR)
