### PR TITLE
Update TPC-H benchmark to show physical plan when debug mode is enabled

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -108,7 +108,7 @@ To run the executor from source:
 
 ```bash
 cd $ARROW_HOME/ballista/rust/executor
-RUST_LOG=info cargo run --release -- --concurrency 4
+RUST_LOG=info cargo run --release
 ```
 
 By default the executor will bind to `0.0.0.0` and listen on port 50051.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -108,7 +108,7 @@ To run the executor from source:
 
 ```bash
 cd $ARROW_HOME/ballista/rust/executor
-RUST_LOG=info cargo run --release
+RUST_LOG=info cargo run --release -- --concurrency 4
 ```
 
 By default the executor will bind to `0.0.0.0` and listen on port 50051.

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -38,7 +38,7 @@ use datafusion::datasource::parquet::ParquetTable;
 use datafusion::datasource::{CsvFile, MemTable, TableProvider};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_plan::LogicalPlan;
-use datafusion::physical_plan::collect;
+use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
 
 use datafusion::parquet::basic::Compression;
@@ -310,6 +310,12 @@ async fn execute_query(
         println!("Optimized logical plan:\n{:?}", plan);
     }
     let physical_plan = ctx.create_physical_plan(&plan)?;
+    if debug {
+        println!(
+            "Physical plan:\n{}",
+            displayable(physical_plan.as_ref()).indent().to_string()
+        );
+    }
     let result = collect(physical_plan).await?;
     if debug {
         pretty::print_batches(&result)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #385 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When we run the benchmarks with `--debug` we see the logical plan and optimized logical plan but we do not see the physical plan. This PR updates debug mode to also show the physical plan.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
