### PR TITLE
Constant fold / optimize `to_timestamp` function during planning

### DIFF
--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -700,10 +700,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected = format!(
-            "Projection: totimestamp(Utf8(\"I\'M NOT A TIMESTAMP\"))\
-            \n  TableScan: test projection=None",
-        );
+        let expected = "Projection: totimestamp(Utf8(\"I\'M NOT A TIMESTAMP\"))\
+            \n  TableScan: test projection=None";
         let actual = get_optimized_plan_formatted(&plan, &chrono::Utc::now());
         assert_eq!(expected, actual);
     }
@@ -721,10 +719,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected = format!(
-            "Projection: totimestamp()\
-            \n  TableScan: test projection=None",
-        );
+        let expected = "Projection: totimestamp()\
+            \n  TableScan: test projection=None";
         let actual = get_optimized_plan_formatted(&plan, &chrono::Utc::now());
         assert_eq!(expected, actual);
     }

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -29,6 +29,10 @@ use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
 use crate::physical_plan::functions::BuiltinScalarFunction;
 use crate::scalar::ScalarValue;
+use crate::physical_plan::datetime_expressions::to_timestamp;
+use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
+use std::convert::TryInto;
+use crate::scalar::ScalarValue::Utf8;
 
 /// Optimizer that simplifies comparison expressions involving boolean literals.
 ///
@@ -142,23 +146,23 @@ impl<'a> ExprRewriter for ConstantRewriter<'a> {
                         _ => Expr::Literal(ScalarValue::Boolean(None)),
                     },
                     (Expr::Literal(ScalarValue::Boolean(b)), _)
-                        if self.is_boolean_type(&right) =>
-                    {
-                        match b {
-                            Some(true) => *right,
-                            Some(false) => Expr::Not(right),
-                            None => Expr::Literal(ScalarValue::Boolean(None)),
+                    if self.is_boolean_type(&right) =>
+                        {
+                            match b {
+                                Some(true) => *right,
+                                Some(false) => Expr::Not(right),
+                                None => Expr::Literal(ScalarValue::Boolean(None)),
+                            }
                         }
-                    }
                     (_, Expr::Literal(ScalarValue::Boolean(b)))
-                        if self.is_boolean_type(&left) =>
-                    {
-                        match b {
-                            Some(true) => *left,
-                            Some(false) => Expr::Not(left),
-                            None => Expr::Literal(ScalarValue::Boolean(None)),
+                    if self.is_boolean_type(&left) =>
+                        {
+                            match b {
+                                Some(true) => *left,
+                                Some(false) => Expr::Not(left),
+                                None => Expr::Literal(ScalarValue::Boolean(None)),
+                            }
                         }
-                    }
                     _ => Expr::BinaryExpr {
                         left,
                         op: Operator::Eq,
@@ -176,23 +180,23 @@ impl<'a> ExprRewriter for ConstantRewriter<'a> {
                         _ => Expr::Literal(ScalarValue::Boolean(None)),
                     },
                     (Expr::Literal(ScalarValue::Boolean(b)), _)
-                        if self.is_boolean_type(&right) =>
-                    {
-                        match b {
-                            Some(true) => Expr::Not(right),
-                            Some(false) => *right,
-                            None => Expr::Literal(ScalarValue::Boolean(None)),
+                    if self.is_boolean_type(&right) =>
+                        {
+                            match b {
+                                Some(true) => Expr::Not(right),
+                                Some(false) => *right,
+                                None => Expr::Literal(ScalarValue::Boolean(None)),
+                            }
                         }
-                    }
                     (_, Expr::Literal(ScalarValue::Boolean(b)))
-                        if self.is_boolean_type(&left) =>
-                    {
-                        match b {
-                            Some(true) => Expr::Not(left),
-                            Some(false) => *left,
-                            None => Expr::Literal(ScalarValue::Boolean(None)),
+                    if self.is_boolean_type(&left) =>
+                        {
+                            match b {
+                                Some(true) => Expr::Not(left),
+                                Some(false) => *left,
+                                None => Expr::Literal(ScalarValue::Boolean(None)),
+                            }
                         }
-                    }
                     _ => Expr::BinaryExpr {
                         left,
                         op: Operator::NotEq,
@@ -217,6 +221,23 @@ impl<'a> ExprRewriter for ConstantRewriter<'a> {
                     .query_execution_start_time
                     .timestamp_nanos(),
             ))),
+            Expr::ScalarFunction {
+                fun: BuiltinScalarFunction::ToTimestamp,
+                args,
+            } => {
+                if args.len() > 0 {
+                    match &args[0] {
+                        Expr::Literal(ScalarValue::Utf8(Some(val))) => {
+                            Expr::Literal(ScalarValue::TimestampNanosecond(
+                                string_to_timestamp_nanos(val).ok()
+                            ))
+                        }
+                        _ => Expr::ScalarFunction { fun: BuiltinScalarFunction::ToTimestamp, args }
+                    }
+                } else {
+                    Expr::ScalarFunction { fun: BuiltinScalarFunction::ToTimestamp, args }
+                }
+            }
             expr => {
                 // no rewrite possible
                 expr
@@ -252,7 +273,7 @@ mod tests {
                 DFField::new(None, "c1", DataType::Utf8, true),
                 DFField::new(None, "c2", DataType::Boolean, true),
             ])
-            .unwrap(),
+                .unwrap(),
         )
     }
 
@@ -319,7 +340,7 @@ mod tests {
         assert_eq!(col("c2").get_type(&schema)?, DataType::Boolean);
 
         // true = ture -> true
-        assert_eq!((lit(true).eq(lit(true))).rewrite(&mut rewriter)?, lit(true),);
+        assert_eq!((lit(true).eq(lit(true))).rewrite(&mut rewriter)?, lit(true), );
 
         // true = false -> false
         assert_eq!(
@@ -328,7 +349,7 @@ mod tests {
         );
 
         // c2 = true -> c2
-        assert_eq!((col("c2").eq(lit(true))).rewrite(&mut rewriter)?, col("c2"),);
+        assert_eq!((col("c2").eq(lit(true))).rewrite(&mut rewriter)?, col("c2"), );
 
         // c2 = false => !c2
         assert_eq!(
@@ -468,7 +489,7 @@ mod tests {
                 )],
                 else_expr: Some(Box::new(col("c2").eq(lit(true)))),
             }))
-            .rewrite(&mut rewriter)?,
+                .rewrite(&mut rewriter)?,
             Expr::Case {
                 expr: None,
                 when_then_expr: vec![(

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -27,12 +27,9 @@ use crate::execution::context::ExecutionProps;
 use crate::logical_plan::{DFSchemaRef, Expr, ExprRewriter, LogicalPlan, Operator};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
-use crate::physical_plan::datetime_expressions::to_timestamp;
 use crate::physical_plan::functions::BuiltinScalarFunction;
 use crate::scalar::ScalarValue;
-use crate::scalar::ScalarValue::Utf8;
 use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
-use std::convert::TryInto;
 
 /// Optimizer that simplifies comparison expressions involving boolean literals.
 ///
@@ -225,7 +222,7 @@ impl<'a> ExprRewriter for ConstantRewriter<'a> {
                 fun: BuiltinScalarFunction::ToTimestamp,
                 args,
             } => {
-                if args.len() > 0 {
+                if !args.is_empty() {
                     match &args[0] {
                         Expr::Literal(ScalarValue::Utf8(Some(val))) => {
                             Expr::Literal(ScalarValue::TimestampNanosecond(

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -686,6 +686,50 @@ mod tests {
     }
 
     #[test]
+    fn to_timestamp_expr_wrong_arg() {
+        let table_scan = test_table_scan().unwrap();
+        let proj = vec![Expr::ScalarFunction {
+            args: vec![Expr::Literal(ScalarValue::Utf8(Some(
+                "I'M NOT A TIMESTAMP".to_string(),
+            )))],
+            fun: BuiltinScalarFunction::ToTimestamp,
+        }];
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .project(proj)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let expected = format!(
+            "Projection: totimestamp(Utf8(\"I\'M NOT A TIMESTAMP\"))\
+            \n  TableScan: test projection=None",
+        );
+        let actual = get_optimized_plan_formatted(&plan, &chrono::Utc::now());
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn to_timestamp_expr_no_arg() {
+        let table_scan = test_table_scan().unwrap();
+        let proj = vec![Expr::ScalarFunction {
+            args: vec![],
+            fun: BuiltinScalarFunction::ToTimestamp,
+        }];
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .project(proj)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let expected = format!(
+            "Projection: totimestamp()\
+            \n  TableScan: test projection=None",
+        );
+        let actual = get_optimized_plan_formatted(&plan, &chrono::Utc::now());
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn single_now_expr() {
         let table_scan = test_table_scan().unwrap();
         let proj = vec![Expr::ScalarFunction {

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -677,10 +677,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected = format!(
-            "Projection: TimestampNanosecond(1599566400000000000)\
-            \n  TableScan: test projection=None",
-        );
+        let expected = "Projection: TimestampNanosecond(1599566400000000000)\
+            \n  TableScan: test projection=None"
+            .to_string();
         let actual = get_optimized_plan_formatted(&plan, &chrono::Utc::now());
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
# Which issue does this PR close?

Fixes #383 

 # Rationale for this change
Optimize to_timestamp function

# What changes are included in this PR?
Optimize to_timestamp function

# Are there any user-facing changes?
N/A
