### PR TITLE
Add missing functions to python

### DIFF
--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -45,9 +45,247 @@ fn lit(value: i32) -> expression::Expression {
 }
 
 #[pyfunction]
+fn array(value: Vec<expression::Expression>) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::array(value.into_iter().map(|x| x.expr).collect::<Vec<_>>()),
+    }
+}
+
+#[pyfunction]
+fn ascii(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::ascii(value.expr),
+    }
+}
+
+#[pyfunction]
 fn sum(value: expression::Expression) -> expression::Expression {
     expression::Expression {
         expr: logical_plan::sum(value.expr),
+    }
+}
+
+#[pyfunction]
+fn bit_length(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::bit_length(value.expr),
+    }
+}
+
+#[pyfunction]
+fn btrim(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::btrim(value.expr),
+    }
+}
+
+#[pyfunction]
+fn character_length(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::character_length(value.expr),
+    }
+}
+
+#[pyfunction]
+fn chr(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::chr(value.expr),
+    }
+}
+
+#[pyfunction]
+fn concat_ws(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::concat_ws(value.expr),
+    }
+}
+
+#[pyfunction]
+fn in_list(expr: expression::Expression, value: Vec<expression::Expression>, negated: bool) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::in_list(expr.expr, value.into_iter().map(|x| x.expr).collect::<Vec<_>>(), negated),
+    }
+}
+
+#[pyfunction]
+fn initcap(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::initcap(value.expr),
+    }
+}
+
+#[pyfunction]
+fn left(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::left(value.expr),
+    }
+}
+
+#[pyfunction]
+fn lower(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::lower(value.expr),
+    }
+}
+
+#[pyfunction]
+fn lpad(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::lpad(value.expr),
+    }
+}
+
+#[pyfunction]
+fn ltrim(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::ltrim(value.expr),
+    }
+}
+
+#[pyfunction]
+fn md5(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::md5(value.expr),
+    }
+}
+
+#[pyfunction]
+fn octet_length(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::octet_length(value.expr),
+    }
+}
+
+#[pyfunction]
+fn regexp_replace(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::regexp_replace(value.expr),
+    }
+}
+
+#[pyfunction]
+fn repeat(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::repeat(value.expr),
+    }
+}
+
+#[pyfunction]
+fn replace(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::replace(value.expr),
+    }
+}
+
+#[pyfunction]
+fn reverse(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::reverse(value.expr),
+    }
+}
+
+#[pyfunction]
+fn right(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::right(value.expr),
+    }
+}
+
+#[pyfunction]
+fn rpad(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::rpad(value.expr),
+    }
+}
+
+#[pyfunction]
+fn rtrim(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::rtrim(value.expr),
+    }
+}
+
+#[pyfunction]
+fn sha224(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::sha224(value.expr),
+    }
+}
+
+#[pyfunction]
+fn sha256(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::sha256(value.expr),
+    }
+}
+
+#[pyfunction]
+fn sha384(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::sha384(value.expr),
+    }
+}
+
+#[pyfunction]
+fn sha512(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::sha512(value.expr),
+    }
+}
+
+#[pyfunction]
+fn split_part(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::split_part(value.expr),
+    }
+}
+
+#[pyfunction]
+fn starts_with(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::starts_with(value.expr),
+    }
+}
+
+#[pyfunction]
+fn strpos(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::strpos(value.expr),
+    }
+}
+
+#[pyfunction]
+fn substr(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::substr(value.expr),
+    }
+}
+
+#[pyfunction]
+fn to_hex(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::to_hex(value.expr),
+    }
+}
+
+#[pyfunction]
+fn translate(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::translate(value.expr),
+    }
+}
+
+#[pyfunction]
+fn trim(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::trim(value.expr),
+    }
+}
+
+#[pyfunction]
+fn upper(value: expression::Expression) -> expression::Expression {
+    expression::Expression {
+        expr: logical_plan::upper(value.expr),
     }
 }
 
@@ -155,6 +393,40 @@ pub fn init(module: &PyModule) -> PyResult<()> {
     // see https://github.com/apache/arrow-datafusion/issues/226
     //module.add_function(wrap_pyfunction!(concat, module)?)?;
     module.add_function(wrap_pyfunction!(udf, module)?)?;
+    module.add_function(wrap_pyfunction!(array, module)?)?;
+    module.add_function(wrap_pyfunction!(ascii, module)?)?;
+    module.add_function(wrap_pyfunction!(bit_length, module)?)?;
+    module.add_function(wrap_pyfunction!(character_length, module)?)?;
+    module.add_function(wrap_pyfunction!(chr, module)?)?;
+    module.add_function(wrap_pyfunction!(btrim, module)?)?;
+    module.add_function(wrap_pyfunction!(concat_ws, module)?)?;
+    module.add_function(wrap_pyfunction!(in_list, module)?)?;
+    module.add_function(wrap_pyfunction!(initcap, module)?)?;
+    module.add_function(wrap_pyfunction!(left, module)?)?;
+    module.add_function(wrap_pyfunction!(lower, module)?)?;
+    module.add_function(wrap_pyfunction!(lpad, module)?)?;
+    module.add_function(wrap_pyfunction!(md5, module)?)?;
+    module.add_function(wrap_pyfunction!(ltrim, module)?)?;
+    module.add_function(wrap_pyfunction!(octet_length, module)?)?;
+    module.add_function(wrap_pyfunction!(regexp_replace, module)?)?;
+    module.add_function(wrap_pyfunction!(repeat, module)?)?;
+    module.add_function(wrap_pyfunction!(replace, module)?)?;
+    module.add_function(wrap_pyfunction!(reverse, module)?)?;
+    module.add_function(wrap_pyfunction!(right, module)?)?;
+    module.add_function(wrap_pyfunction!(rpad, module)?)?;
+    module.add_function(wrap_pyfunction!(rtrim, module)?)?;
+    module.add_function(wrap_pyfunction!(sha224, module)?)?;
+    module.add_function(wrap_pyfunction!(sha256, module)?)?;
+    module.add_function(wrap_pyfunction!(sha384, module)?)?;
+    module.add_function(wrap_pyfunction!(sha512, module)?)?;
+    module.add_function(wrap_pyfunction!(split_part, module)?)?;
+    module.add_function(wrap_pyfunction!(starts_with, module)?)?;
+    module.add_function(wrap_pyfunction!(strpos, module)?)?;
+    module.add_function(wrap_pyfunction!(substr, module)?)?;
+    module.add_function(wrap_pyfunction!(to_hex, module)?)?;
+    module.add_function(wrap_pyfunction!(translate, module)?)?;
+    module.add_function(wrap_pyfunction!(trim, module)?)?;
+    module.add_function(wrap_pyfunction!(upper, module)?)?;
     module.add_function(wrap_pyfunction!(sum, module)?)?;
     module.add_function(wrap_pyfunction!(count, module)?)?;
     module.add_function(wrap_pyfunction!(min, module)?)?;


### PR DESCRIPTION
# Which issue does this PR close?
Tries to implement #374.

 # Rationale for this change
Complete python functions from logical_plan.

# What changes are included in this PR?
Export python functions from logical_plan:

- array
- ascii
- sum
- bit_length
- btrim
- character_length
- chr
- concat_ws
- in_list
- initcap
- left
- lower
- lpad
- ltrim
- md5
- octet_length
- regexp_replace
- repeat
- replace
- reverse
- right
- rpad
- rtrim
- sha224
- sha256
- sha384
- sha512
- split_part
- starts_with
- strpos
- substr
- to_hex
- translate
- trim
- upper

# Are there any user-facing changes?
Update or add python binding docs.
