### PR TITLE
Add metrics to RepartitionExec

### DIFF
--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -36,12 +36,12 @@ use async_trait::async_trait;
 
 use futures::stream::Stream;
 use futures::StreamExt;
+use hashbrown::HashMap;
 use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     Mutex,
 };
 use tokio::task::JoinHandle;
-use hashbrown::HashMap;
 
 type MaybeBatch = Option<ArrowResult<RecordBatch>>;
 
@@ -65,7 +65,7 @@ pub struct RepartitionExec {
     /// Time in nanos to perform repartitioning
     repart_time_nanos: Arc<SQLMetric>,
     /// Time in nanos for sending resulting batches to channels
-    send_time_nanos: Arc<SQLMetric>
+    send_time_nanos: Arc<SQLMetric>,
 }
 
 impl RepartitionExec {
@@ -162,7 +162,6 @@ impl ExecutionPlan for RepartitionExec {
                     let hashes_buf = &mut vec![];
 
                     loop {
-
                         // fetch the next batch
                         let now = Instant::now();
                         let result = stream.next().await;
@@ -273,7 +272,10 @@ impl ExecutionPlan for RepartitionExec {
     fn metrics(&self) -> HashMap<String, SQLMetric> {
         let mut metrics = HashMap::new();
         metrics.insert("fetchTime".to_owned(), (*self.fetch_time_nanos).clone());
-        metrics.insert("repartitionTime".to_owned(), (*self.repart_time_nanos).clone());
+        metrics.insert(
+            "repartitionTime".to_owned(),
+            (*self.repart_time_nanos).clone(),
+        );
         metrics.insert("sendTime".to_owned(), (*self.send_time_nanos).clone());
         metrics
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Adds metrics to `RepartitionExec`. Example output (with local hack to display metrics in query plan):

```
RepartitionExec: partitioning=Hash([Column { name: "o_custkey" }], 24) metrics=[repartitionTime=19390949,fetchTime=1354115582,sendTime=1642636]
  CoalesceBatchesExec: target_batch_size=4096 metrics=[]
    FilterExec: o_orderdate >= CAST(1994-01-01 AS Date32) AND o_orderdate < CAST(1995-01-01 AS Date32) metrics=[]
      RepartitionExec: partitioning=RoundRobinBatch(24) metrics=[fetchTime=56873223,sendTime=125282,repartitionTime=0]
        ParquetExec: batch_size=8192, limit=None, partitions=[/mnt/tpch/parquet-sf1//orders/part-0.parquet] metrics=[]
```

Closes #397 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Help debug performance issues in queries.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds metrics to `RepartitionExec`.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No. The metrics are not shown by default.

<!--
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
