### PR TITLE
Implement fmt_as for ShuffleReaderExec

### DIFF
--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -24,7 +24,7 @@ use crate::serde::scheduler::PartitionLocation;
 
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use datafusion::physical_plan::{ExecutionPlan, Partitioning, DisplayFormatType};
+use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan, Partitioning};
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::RecordBatchStream,
@@ -112,19 +112,23 @@ impl ExecutionPlan for ShuffleReaderExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                let loc_str = self.partition_location.iter()
-                    .map(|l| format!("[executor={} part={}:{}:{} stats={:?}]",
-                                     l.executor_meta.id,
-                                     l.partition_id.job_id,
-                                     l.partition_id.stage_id,
-                                     l.partition_id.partition_id,
-                                     l.partition_stats))
-                    .collect::<Vec<String>>().join(",");
-                write!(f, "ShuffleReaderExec: partition_locations={}",
-                       loc_str)
-
+                let loc_str = self
+                    .partition_location
+                    .iter()
+                    .map(|l| {
+                        format!(
+                            "[executor={} part={}:{}:{} stats={:?}]",
+                            l.executor_meta.id,
+                            l.partition_id.job_id,
+                            l.partition_id.stage_id,
+                            l.partition_id.partition_id,
+                            l.partition_stats
+                        )
+                    })
+                    .collect::<Vec<String>>()
+                    .join(",");
+                write!(f, "ShuffleReaderExec: partition_locations={}", loc_str)
             }
         }
     }
-
 }

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -24,12 +24,13 @@ use crate::serde::scheduler::PartitionLocation;
 
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use datafusion::physical_plan::{ExecutionPlan, Partitioning};
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, DisplayFormatType};
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::RecordBatchStream,
 };
 use log::info;
+use std::fmt::Formatter;
 
 /// ShuffleReaderExec reads partitions that have already been materialized by an executor.
 #[derive(Debug, Clone)]
@@ -103,4 +104,27 @@ impl ExecutionPlan for ShuffleReaderExec {
             .await
             .map_err(|e| DataFusionError::Execution(format!("Ballista Error: {:?}", e)))
     }
+
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                let loc_str = self.partition_location.iter()
+                    .map(|l| format!("executor={} part={}:{}:{} stats={:?}",
+                                     l.executor_meta.id,
+                                     l.partition_id.job_id,
+                                     l.partition_id.stage_id,
+                                     l.partition_id.partition_id,
+                                     l.partition_stats))
+                    .collect::<Vec<String>>().join(",");
+                write!(f, "ShuffleReaderExec: partition_locations={}",
+                       loc_str)
+
+            }
+        }
+    }
+
 }

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -113,7 +113,7 @@ impl ExecutionPlan for ShuffleReaderExec {
         match t {
             DisplayFormatType::Default => {
                 let loc_str = self.partition_location.iter()
-                    .map(|l| format!("executor={} part={}:{}:{} stats={:?}",
+                    .map(|l| format!("[executor={} part={}:{}:{} stats={:?}]",
                                      l.executor_meta.id,
                                      l.partition_id.job_id,
                                      l.partition_id.stage_id,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Before:

```
SortExec: [revenue DESC]
  ProjectionExec: expr=[n_name, SUM(l_extendedprice Multiply Int64(1) Minus l_discount) as revenue]
    HashAggregateExec: mode=Final, gby=[n_name], aggr=[SUM(l_extendedprice Multiply Int64(1) Minus l_discount)]
      ExecutionPlan(PlaceHolder)
```

After:

```
SortExec: [revenue DESC]
  ProjectionExec: expr=[n_name, SUM(l_extendedprice Multiply Int64(1) Minus l_discount) as revenue]
    HashAggregateExec: mode=Final, gby=[n_name], aggr=[SUM(l_extendedprice Multiply Int64(1) Minus l_discount)]
      ShuffleReaderExec: partition_locations=[executor=cb5f9a3b-69ed-4261-b3b5-38ba74ba7e30 part=50ELpmq:1:0 stats=PartitionStats { num_rows: None, num_batches: None, num_bytes: None }]
```

Closes #399.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
