### PR TITLE
Benchmark subcommand to distinguish between DataFusion and Ballista

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,13 +44,13 @@ to the `.gitignore` file.
 The benchmark can then be run (assuming the data created from `dbgen` is in `./data`) with a command such as:
 
 ```bash
-cargo run --release --bin tpch -- benchmark --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
+cargo run --release --bin tpch -- benchmark datafusion --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
 ```
 
 You can enable the features `simd` (to use SIMD instructions) and/or `mimalloc` or `snmalloc` (to use either the mimalloc or snmalloc allocator) as features by passing them in as `--features`:
 
 ```
-cargo run --release --features "simd mimalloc" --bin tpch -- benchmark --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
+cargo run --release --features "simd mimalloc" --bin tpch -- benchmark datafusion --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
 ```
 
 The benchmark program also supports CSV and Parquet input file formats and a utility is provided to convert from `tbl`
@@ -123,7 +123,7 @@ To run the benchmarks:
 
 ```bash
 cd $ARROW_HOME/ballista/rust/benchmarks/tpch
-cargo run --release benchmark --host localhost --port 50050 --query 1 --path $(pwd)/data --format tbl
+cargo run --release benchmark ballista --host localhost --port 50050 --query 1 --path $(pwd)/data --format tbl
 ```
 
 ## Running the Ballista Benchmarks on docker-compose
@@ -140,7 +140,7 @@ docker-compose up
 Then you can run the benchmark with:
 
 ```bash
-docker-compose run ballista-client cargo run benchmark --host ballista-scheduler --port 50050 --query 1 --path /data --format tbl
+docker-compose run ballista-client cargo run benchmark ballista --host ballista-scheduler --port 50050 --query 1 --path /data --format tbl
 ```
 
 ## Expected output

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -22,5 +22,5 @@ set -e
 cd /
 for query in 1 3 5 6 10 12
 do
-  /tpch benchmark --host ballista-scheduler --port 50050 --query $query --path /data --format tbl --iterations 1 --debug
+  /tpch benchmark ballista --host ballista-scheduler --port 50050 --query $query --path /data --format tbl --iterations 1 --debug
 done

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -53,7 +53,6 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-
 #[derive(Debug, StructOpt, Clone)]
 struct BallistaBenchmarkOpt {
     /// Query number
@@ -191,10 +190,10 @@ async fn main() -> Result<()> {
     match TpchOpt::from_args() {
         TpchOpt::Benchmark(BallistaBenchmark(opt)) => {
             benchmark_ballista(opt).await.map(|_| ())
-        },
+        }
         TpchOpt::Benchmark(DatafusionBenchmark(opt)) => {
             benchmark_datafusion(opt).await.map(|_| ())
-        },
+        }
         TpchOpt::Convert(opt) => convert_tbl(opt).await,
     }
 }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -53,8 +53,52 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+
 #[derive(Debug, StructOpt, Clone)]
-struct BenchmarkOpt {
+struct BallistaBenchmarkOpt {
+    /// Query number
+    #[structopt(short, long)]
+    query: usize,
+
+    /// Activate debug mode to see query results
+    #[structopt(short, long)]
+    debug: bool,
+
+    /// Number of iterations of each test run
+    #[structopt(short = "i", long = "iterations", default_value = "3")]
+    iterations: usize,
+
+    /// Batch size when reading CSV or Parquet files
+    #[structopt(short = "s", long = "batch-size", default_value = "8192")]
+    batch_size: usize,
+
+    /// Path to data files
+    #[structopt(parse(from_os_str), required = true, short = "p", long = "path")]
+    path: PathBuf,
+
+    /// File format: `csv` or `parquet`
+    #[structopt(short = "f", long = "format", default_value = "csv")]
+    file_format: String,
+
+    /// Load the data into a MemTable before executing the query
+    #[structopt(short = "m", long = "mem-table")]
+    mem_table: bool,
+
+    /// Number of partitions to create when using MemTable as input
+    #[structopt(short = "n", long = "partitions", default_value = "8")]
+    partitions: usize,
+
+    /// Ballista executor host
+    #[structopt(long = "host")]
+    host: Option<String>,
+
+    /// Ballista executor port
+    #[structopt(long = "port")]
+    port: Option<u16>,
+}
+
+#[derive(Debug, StructOpt, Clone)]
+struct DatafusionBenchmarkOpt {
     /// Query number
     #[structopt(short, long)]
     query: usize,
@@ -90,14 +134,6 @@ struct BenchmarkOpt {
     /// Number of partitions to create when using MemTable as input
     #[structopt(short = "n", long = "partitions", default_value = "8")]
     partitions: usize,
-
-    /// Ballista executor host
-    #[structopt(long = "host")]
-    host: Option<String>,
-
-    /// Ballista executor port
-    #[structopt(long = "port")]
-    port: Option<u16>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -128,9 +164,18 @@ struct ConvertOpt {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(about = "benchmark command")]
+enum SubCommandOpt {
+    #[structopt(name = "ballista")]
+    BallistaBenchmark(BallistaBenchmarkOpt),
+    #[structopt(name = "datafusion")]
+    DatafusionBenchmark(DatafusionBenchmarkOpt),
+}
+
+#[derive(Debug, StructOpt)]
 #[structopt(name = "TPC-H", about = "TPC-H Benchmarks.")]
 enum TpchOpt {
-    Benchmark(BenchmarkOpt),
+    Benchmark(SubCommandOpt),
     Convert(ConvertOpt),
 }
 
@@ -140,20 +185,21 @@ const TABLES: &[&str] = &[
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    use SubCommandOpt::*;
+
     env_logger::init();
     match TpchOpt::from_args() {
-        TpchOpt::Benchmark(opt) => {
-            if opt.host.is_some() && opt.port.is_some() {
-                benchmark_ballista(opt).await.map(|_| ())
-            } else {
-                benchmark_datafusion(opt).await.map(|_| ())
-            }
-        }
+        TpchOpt::Benchmark(BallistaBenchmark(opt)) => {
+            benchmark_ballista(opt).await.map(|_| ())
+        },
+        TpchOpt::Benchmark(DatafusionBenchmark(opt)) => {
+            benchmark_datafusion(opt).await.map(|_| ())
+        },
         TpchOpt::Convert(opt) => convert_tbl(opt).await,
     }
 }
 
-async fn benchmark_datafusion(opt: BenchmarkOpt) -> Result<Vec<RecordBatch>> {
+async fn benchmark_datafusion(opt: DatafusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
@@ -204,7 +250,7 @@ async fn benchmark_datafusion(opt: BenchmarkOpt) -> Result<Vec<RecordBatch>> {
     Ok(result)
 }
 
-async fn benchmark_ballista(opt: BenchmarkOpt) -> Result<()> {
+async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     println!("Running benchmarks with the following options: {:?}", opt);
 
     let mut settings = HashMap::new();

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -97,7 +97,7 @@ struct BallistaBenchmarkOpt {
 }
 
 #[derive(Debug, StructOpt, Clone)]
-struct DatafusionBenchmarkOpt {
+struct DataFusionBenchmarkOpt {
     /// Query number
     #[structopt(short, long)]
     query: usize,
@@ -168,7 +168,7 @@ enum BenchmarkSubCommandOpt {
     #[structopt(name = "ballista")]
     BallistaBenchmark(BallistaBenchmarkOpt),
     #[structopt(name = "datafusion")]
-    DatafusionBenchmark(DatafusionBenchmarkOpt),
+    DataFusionBenchmark(DataFusionBenchmarkOpt),
 }
 
 #[derive(Debug, StructOpt)]
@@ -191,14 +191,14 @@ async fn main() -> Result<()> {
         TpchOpt::Benchmark(BallistaBenchmark(opt)) => {
             benchmark_ballista(opt).await.map(|_| ())
         }
-        TpchOpt::Benchmark(DatafusionBenchmark(opt)) => {
+        TpchOpt::Benchmark(DataFusionBenchmark(opt)) => {
             benchmark_datafusion(opt).await.map(|_| ())
         }
         TpchOpt::Convert(opt) => convert_tbl(opt).await,
     }
 }
 
-async fn benchmark_datafusion(opt: DatafusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
+async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
@@ -995,7 +995,7 @@ mod tests {
             let expected = df.collect().await?;
 
             // run the query to compute actual results of the query
-            let opt = DatafusionBenchmarkOpt {
+            let opt = DataFusionBenchmarkOpt {
                 query: n,
                 debug: false,
                 iterations: 1,

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -165,7 +165,7 @@ struct ConvertOpt {
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "benchmark command")]
-enum SubCommandOpt {
+enum BenchmarkSubCommandOpt {
     #[structopt(name = "ballista")]
     BallistaBenchmark(BallistaBenchmarkOpt),
     #[structopt(name = "datafusion")]
@@ -175,7 +175,7 @@ enum SubCommandOpt {
 #[derive(Debug, StructOpt)]
 #[structopt(name = "TPC-H", about = "TPC-H Benchmarks.")]
 enum TpchOpt {
-    Benchmark(SubCommandOpt),
+    Benchmark(BenchmarkSubCommandOpt),
     Convert(ConvertOpt),
 }
 
@@ -185,7 +185,7 @@ const TABLES: &[&str] = &[
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    use SubCommandOpt::*;
+    use BenchmarkSubCommandOpt::*;
 
     env_logger::init();
     match TpchOpt::from_args() {

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -995,7 +995,7 @@ mod tests {
             let expected = df.collect().await?;
 
             // run the query to compute actual results of the query
-            let opt = BenchmarkOpt {
+            let opt = DatafusionBenchmarkOpt {
                 query: n,
                 debug: false,
                 iterations: 1,
@@ -1005,8 +1005,6 @@ mod tests {
                 file_format: "tbl".to_string(),
                 mem_table: false,
                 partitions: 16,
-                host: None,
-                port: None,
             };
             let actual = benchmark_datafusion(opt).await?;
 

--- a/docs/user-guide/src/distributed/raspberrypi.md
+++ b/docs/user-guide/src/distributed/raspberrypi.md
@@ -114,7 +114,7 @@ Run the benchmarks:
 
 ```bash
 docker run -it myrepo/ballista-arm64 \
-  /tpch benchmark --query=1 --path=/path/to/data --format=parquet \
+  /tpch benchmark datafusion --query=1 --path=/path/to/data --format=parquet \
   --concurrency=24 --iterations=1 --debug --host=ballista-scheduler --port=50050
 ```
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #401.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
It defines a BenchmarkSubCommandOpt to allow different arguments depending on whether it is run against ballista or datafusion.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
It changes tpch bin arugments generated by benchmarks project.
It contains changes in benchmarks/README.md and benchmars/run.sh files.

<!--
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
