### PR TITLE
add support for ndjson for datafusion-cli

### DIFF
--- a/datafusion/docs/cli.md
+++ b/datafusion/docs/cli.md
@@ -61,7 +61,7 @@ OPTIONS:
     -c, --batch-size <batch-size>    The batch size of each query, or use DataFusion default
     -p, --data-path <data-path>      Path to your data, default to current directory
     -f, --file <file>                Execute commands from file, then exit
-        --format <format>            Output format (possible values: table, csv, tsv, json) [default: table]
+        --format <format>            Output format [default: table]  [possible values: csv, tsv, table, json, ndjson]
 ```
 
 Type `exit` or `quit` to exit the CLI.


### PR DESCRIPTION
# Which issue does this PR close?

add support for ndjson for datafusion-cli

Closes #.

 # Rationale for this change

add support for ndjson for datafusion-cli 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

```
❯ cargo run --bin datafusion-cli -q -- -f integration-tests/create_test_table.sql -f integration-tests/sqls/simple_group_by.sql -q --format ndjson
{"c2":1,"sum_c3":367,"avg_c3":16.681818181818183,"max_c3":125,"min_c3":-99,"count_c3":22}
{"c2":2,"sum_c3":184,"avg_c3":8.363636363636363,"max_c3":122,"min_c3":-117,"count_c3":22}
{"c2":3,"sum_c3":395,"avg_c3":20.789473684210527,"max_c3":123,"min_c3":-101,"count_c3":19}
{"c2":4,"sum_c3":29,"avg_c3":1.2608695652173914,"max_c3":123,"min_c3":-117,"count_c3":23}
{"c2":5,"sum_c3":-194,"avg_c3":-13.857142857142858,"max_c3":118,"min_c3":-101,"count_c3":14}
```

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
