### PR TITLE
Remove reundant filters (e.g. c> 5 AND c>5 --> c>5)

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -57,9 +57,9 @@ use crate::logical_plan::{
 use crate::optimizer::constant_folding::ConstantFolding;
 use crate::optimizer::filter_push_down::FilterPushDown;
 use crate::optimizer::limit_push_down::LimitPushDown;
-use crate::optimizer::remove_duplicate_filters::RemoveDuplicateFilters;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
+use crate::optimizer::remove_duplicate_filters::RemoveDuplicateFilters;
 use crate::physical_optimizer::coalesce_batches::CoalesceBatches;
 use crate::physical_optimizer::merge_exec::AddMergeExec;
 use crate::physical_optimizer::repartition::Repartition;

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -59,7 +59,7 @@ use crate::optimizer::filter_push_down::FilterPushDown;
 use crate::optimizer::limit_push_down::LimitPushDown;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
-use crate::optimizer::remove_duplicate_filters::RemoveDuplicateFilters;
+use crate::optimizer::simplify_expressions::SimplifyExpressions;
 use crate::physical_optimizer::coalesce_batches::CoalesceBatches;
 use crate::physical_optimizer::merge_exec::AddMergeExec;
 use crate::physical_optimizer::repartition::Repartition;
@@ -653,7 +653,7 @@ impl ExecutionConfig {
                 Arc::new(EliminateLimit::new()),
                 Arc::new(ProjectionPushDown::new()),
                 Arc::new(FilterPushDown::new()),
-                Arc::new(RemoveDuplicateFilters::new()),
+                Arc::new(SimplifyExpressions::new()),
                 Arc::new(HashBuildProbeOrder::new()),
                 Arc::new(LimitPushDown::new()),
             ],

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -57,6 +57,7 @@ use crate::logical_plan::{
 use crate::optimizer::constant_folding::ConstantFolding;
 use crate::optimizer::filter_push_down::FilterPushDown;
 use crate::optimizer::limit_push_down::LimitPushDown;
+use crate::optimizer::remove_duplicate_filters::RemoveDuplicateFilters;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
 use crate::physical_optimizer::coalesce_batches::CoalesceBatches;
@@ -652,6 +653,7 @@ impl ExecutionConfig {
                 Arc::new(EliminateLimit::new()),
                 Arc::new(ProjectionPushDown::new()),
                 Arc::new(FilterPushDown::new()),
+                Arc::new(RemoveDuplicateFilters::new()),
                 Arc::new(HashBuildProbeOrder::new()),
                 Arc::new(LimitPushDown::new()),
             ],

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -25,4 +25,5 @@ pub mod hash_build_probe_order;
 pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod remove_duplicate_filters;
 pub mod utils;

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -25,5 +25,5 @@ pub mod hash_build_probe_order;
 pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
-pub mod remove_duplicate_filters;
+pub mod simplify_expressions;
 pub mod utils;

--- a/datafusion/src/optimizer/remove_duplicate_filters.rs
+++ b/datafusion/src/optimizer/remove_duplicate_filters.rs
@@ -1,0 +1,257 @@
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Remove duplicate filters optimizer rule
+
+use crate::execution::context::ExecutionProps;
+use crate::logical_plan::Expr;
+use crate::logical_plan::LogicalPlan;
+use crate::optimizer::optimizer::OptimizerRule;
+use crate::optimizer::utils;
+use crate::optimizer::utils::optimize_explain;
+use crate::{error::Result, logical_plan::Operator};
+
+/// Remove duplicate filters optimizer
+/// # Introduction
+pub struct RemoveDuplicateFilters {}
+
+fn expr_contains<'a>(expr: &'a Expr, needle: &'a Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        } => expr_contains(left, needle) || expr_contains(right, needle),
+        Expr::BinaryExpr {
+            left,
+            op: Operator::Or,
+            right,
+        } => expr_contains(left, needle) || expr_contains(right, needle),
+        _ => expr == needle,
+    }
+}
+
+fn as_binary_expr<'a>(expr: &'a Expr) -> Option<&'a Expr> {
+    match expr {
+        Expr::BinaryExpr { .. } => Some(expr),
+        _ => None,
+    }
+}
+
+fn simplify<'a>(expr: &'a Expr) -> Expr {
+    match expr {
+        Expr::BinaryExpr { left, op: _, right } if left == right => simplify(left),
+        Expr::BinaryExpr {
+            left,
+            op: Operator::Or,
+            right,
+        } if expr_contains(left, right) => as_binary_expr(left)
+            .map(|x| match x {
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::Or,
+                    right: _,
+                } => x.clone(),
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::And,
+                    right: _,
+                } => *right.clone(),
+                _ => expr.clone(),
+            })
+            .unwrap_or(expr.clone()),
+        Expr::BinaryExpr {
+            left,
+            op: Operator::Or,
+            right,
+        } if expr_contains(right, left) => as_binary_expr(right)
+            .map(|x| match x {
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::Or,
+                    right: _,
+                } => *right.clone(),
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::And,
+                    right: _,
+                } => x.clone(),
+                _ => expr.clone(),
+            })
+            .unwrap_or(expr.clone()),
+        Expr::BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        } if expr_contains(left, right) => as_binary_expr(left)
+            .map(|x| match x {
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::Or,
+                    right: _,
+                } => *right.clone(),
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::And,
+                    right: _,
+                } => x.clone(),
+                _ => expr.clone(),
+            })
+            .unwrap_or(expr.clone()),
+        Expr::BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        } if expr_contains(right, left) => as_binary_expr(right)
+            .map(|x| match x {
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::Or,
+                    right: _,
+                } => *left.clone(),
+                Expr::BinaryExpr {
+                    left: _,
+                    op: Operator::And,
+                    right: _,
+                } => x.clone(),
+                _ => expr.clone(),
+            })
+            .unwrap_or(expr.clone()),
+        Expr::BinaryExpr { left, op, right } => Expr::BinaryExpr {
+            left: Box::new(simplify(&left)),
+            op: *op,
+            right: Box::new(simplify(right)),
+        },
+        _ => expr.clone(),
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct State {
+    filters: Vec<Expr>,
+}
+
+fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+    match plan {
+        LogicalPlan::Filter { input, predicate } => Ok(LogicalPlan::Filter {
+            input: input.clone(),
+            predicate: simplify(predicate),
+        }),
+        _ => {
+            let new_inputs = plan
+                .inputs()
+                .iter()
+                .map(|input| optimize(input))
+                .collect::<Result<Vec<_>>>()?;
+
+            let expr = plan.expressions();
+            utils::from_plan(&plan, &expr, &new_inputs)
+        }
+    }
+}
+
+impl OptimizerRule for RemoveDuplicateFilters {
+    fn name(&self) -> &str {
+        "remove_duplicate_filters"
+    }
+
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
+        match plan {
+            LogicalPlan::Explain {
+                verbose,
+                plan,
+                stringified_plans,
+                schema,
+            } => {
+                let schema = schema.as_ref().to_owned().into();
+                optimize_explain(
+                    self,
+                    *verbose,
+                    &*plan,
+                    stringified_plans,
+                    &schema,
+                    execution_props,
+                )
+            }
+            _ => optimize(plan),
+        }
+    }
+}
+
+impl RemoveDuplicateFilters {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical_plan::{and, col, lit, LogicalPlanBuilder};
+    use crate::test::*;
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = RemoveDuplicateFilters::new();
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    #[test]
+    fn remove_duplicate_and() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .project(vec![col("a")])?
+            .filter(and(col("b").gt(lit(1)), col("b").gt(lit(1))))?
+            .build()?;
+
+        assert_optimized_plan_eq(
+            &plan,
+            "\
+	        Filter: #b Gt Int32(1)\
+            \n  Projection: #a\
+            \n    TableScan: test projection=None",
+        );
+        Ok(())
+    }
+
+    // ((c > 5) AND (d < 6)) AND (c > 5) --> (c > 5) AND (d < 6)
+    #[test]
+    fn remove_composed_and() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .project(vec![col("a")])?
+            .filter(and(
+                and(col("a").gt(lit(5)), col("b").lt(lit(6))),
+                col("a").gt(lit(5)),
+            ))?
+            .build()?;
+
+        assert_optimized_plan_eq(
+            &plan,
+            "\
+            Filter: #a Gt Int32(5) And #b Lt Int32(6)\
+            \n  Projection: #a\
+	        \n    TableScan: test projection=None",
+        );
+        Ok(())
+    }
+}

--- a/datafusion/src/optimizer/remove_duplicate_filters.rs
+++ b/datafusion/src/optimizer/remove_duplicate_filters.rs
@@ -25,7 +25,7 @@ use crate::{error::Result, logical_plan::Operator};
 /// Remove duplicate filters optimizer.
 /// # Introduction
 /// It uses boolean algebra laws to simplify or reduce the number of terms in expressions.
-/// 
+///
 /// Filter: #b Gt Int32(2) And #b Gt Int32(2)
 /// is optimized to
 /// Filter: #b Gt Int32(2)

--- a/datafusion/src/optimizer/remove_duplicate_filters.rs
+++ b/datafusion/src/optimizer/remove_duplicate_filters.rs
@@ -61,14 +61,14 @@ fn operator_is_boolean(op: Operator) -> bool {
 
 fn is_one(s: &Expr) -> bool {
     match s {
-        Expr::Literal(ScalarValue::Int8(Some(1))) => true,
-        Expr::Literal(ScalarValue::Int16(Some(1))) => true,
-        Expr::Literal(ScalarValue::Int32(Some(1))) => true,
-        Expr::Literal(ScalarValue::Int64(Some(1))) => true,
-        Expr::Literal(ScalarValue::UInt8(Some(1))) => true,
-        Expr::Literal(ScalarValue::UInt16(Some(1))) => true,
-        Expr::Literal(ScalarValue::UInt32(Some(1))) => true,
-        Expr::Literal(ScalarValue::UInt64(Some(1))) => true,
+        Expr::Literal(ScalarValue::Int8(Some(1)))
+        | Expr::Literal(ScalarValue::Int16(Some(1)))
+        | Expr::Literal(ScalarValue::Int32(Some(1)))
+        | Expr::Literal(ScalarValue::Int64(Some(1)))
+        | Expr::Literal(ScalarValue::UInt8(Some(1)))
+        | Expr::Literal(ScalarValue::UInt16(Some(1)))
+        | Expr::Literal(ScalarValue::UInt32(Some(1)))
+        | Expr::Literal(ScalarValue::UInt64(Some(1))) => true,
         Expr::Literal(ScalarValue::Float32(Some(v))) if *v == 1. => true,
         Expr::Literal(ScalarValue::Float64(Some(v))) if *v == 1. => true,
         _ => false,

--- a/datafusion/src/optimizer/remove_duplicate_filters.rs
+++ b/datafusion/src/optimizer/remove_duplicate_filters.rs
@@ -54,9 +54,17 @@ fn as_binary_expr<'a>(expr: &'a Expr) -> Option<&'a Expr> {
     }
 }
 
+fn operator_is_boolean(op: &Operator) -> bool {
+    op == &Operator::And || op == &Operator::Or
+}
+
 fn simplify<'a>(expr: &'a Expr) -> Expr {
     match expr {
-        Expr::BinaryExpr { left, op: _, right } if left == right => simplify(left),
+        Expr::BinaryExpr { left, op, right }
+            if left == right && operator_is_boolean(op) =>
+        {
+            simplify(left)
+        }
         Expr::BinaryExpr {
             left,
             op: Operator::Or,
@@ -265,6 +273,17 @@ mod tests {
         let expected = col("c").gt(lit(5));
 
         assert_eq!(simplify(&expr), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_do_not_simplify_arithmetic_expr() -> Result<()> {
+        let expr_plus = binary_expr(lit(1), Operator::Plus, lit(1));
+        let expr_eq = binary_expr(lit(1), Operator::Eq, lit(1));
+
+        assert_eq!(simplify(&expr_plus), expr_plus);
+        assert_eq!(simplify(&expr_eq), expr_eq);
+
         Ok(())
     }
 

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -23,14 +23,14 @@ use crate::optimizer::utils::optimize_explain;
 use crate::scalar::ScalarValue;
 use crate::{error::Result, logical_plan::Operator};
 
-/// Remove duplicate filters optimizer.
+/// Simplify expressions optimizer.
 /// # Introduction
 /// It uses boolean algebra laws to simplify or reduce the number of terms in expressions.
 ///
 /// Filter: b > 2 AND b > 2
 /// is optimized to
 /// Filter: b > 2
-pub struct RemoveDuplicateFilters {}
+pub struct SimplifyExpressions {}
 
 fn expr_contains(expr: &Expr, needle: &Expr) -> bool {
     match expr {
@@ -255,9 +255,9 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
     utils::from_plan(&plan, &expr, &new_inputs)
 }
 
-impl OptimizerRule for RemoveDuplicateFilters {
+impl OptimizerRule for SimplifyExpressions {
     fn name(&self) -> &str {
-        "remove_duplicate_filters"
+        "simplify_expressions"
     }
 
     fn optimize(
@@ -287,7 +287,7 @@ impl OptimizerRule for RemoveDuplicateFilters {
     }
 }
 
-impl RemoveDuplicateFilters {
+impl SimplifyExpressions {
     #[allow(missing_docs)]
     pub fn new() -> Self {
         Self {}
@@ -301,7 +301,7 @@ mod tests {
     use crate::test::*;
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
-        let rule = RemoveDuplicateFilters::new();
+        let rule = SimplifyExpressions::new();
         let optimized_plan = rule
             .optimize(plan, &ExecutionProps::new())
             .expect("failed to optimize plan");

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn test_simplify_or_and() -> Result<()> {
-        // (c > 5) OR ((d < 6) AND (c > 5) -- can't remove
+        // (c > 5) OR ((d < 6) AND (c > 5) -- can remove
         let expr = binary_expr(
             col("c").gt(lit(5)),
             Operator::Or,

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_simplify_or_true() -> Result<()> {
-        let expr_a = binary_expr(col("c"), Operator::Or, lit(true));
+        let expr_a = col("c").or(lit(true)));
         let expr_b = binary_expr(lit(true), Operator::Or, col("c"));
         let expected = lit(true);
 

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -326,8 +326,8 @@ mod tests {
 
     #[test]
     fn test_simplify_or_true() -> Result<()> {
-        let expr_a = col("c").or(lit(true)));
-        let expr_b = binary_expr(lit(true), Operator::Or, col("c"));
+        let expr_a = col("c").or(lit(true));
+        let expr_b = lit(true).or(col("c"));
         let expected = lit(true);
 
         assert_eq!(simplify(&expr_a), expected);
@@ -337,8 +337,8 @@ mod tests {
 
     #[test]
     fn test_simplify_or_false() -> Result<()> {
-        let expr_a = binary_expr(lit(false), Operator::Or, col("c"));
-        let expr_b = binary_expr(col("c"), Operator::Or, lit(false));
+        let expr_a = lit(false).or(col("c"));
+        let expr_b = col("c").or(lit(false));
         let expected = col("c");
 
         assert_eq!(simplify(&expr_a), expected);
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_simplify_or_same() -> Result<()> {
-        let expr = binary_expr(col("c"), Operator::Or, col("c"));
+        let expr = col("c").or(col("c"));
         let expected = col("c");
 
         assert_eq!(simplify(&expr), expected);
@@ -357,8 +357,8 @@ mod tests {
 
     #[test]
     fn test_simplify_and_false() -> Result<()> {
-        let expr_a = binary_expr(lit(false), Operator::And, col("c"));
-        let expr_b = binary_expr(col("c"), Operator::And, lit(false));
+        let expr_a = lit(false).and(col("c"));
+        let expr_b = col("c").and(lit(false));
         let expected = lit(false);
 
         assert_eq!(simplify(&expr_a), expected);
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_simplify_and_same() -> Result<()> {
-        let expr = binary_expr(col("c"), Operator::And, col("c"));
+        let expr = col("c").and(col("c"));
         let expected = col("c");
 
         assert_eq!(simplify(&expr), expected);
@@ -377,8 +377,8 @@ mod tests {
 
     #[test]
     fn test_simplify_and_true() -> Result<()> {
-        let expr_a = binary_expr(lit(true), Operator::And, col("c"));
-        let expr_b = binary_expr(col("c"), Operator::And, lit(true));
+        let expr_a = lit(true).and(col("c"));
+        let expr_b = col("c").and(lit(true));
         let expected = col("c");
 
         assert_eq!(simplify(&expr_a), expected);
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn test_simplify_simple_and() -> Result<()> {
         // (c > 5) AND (c > 5)
-        let expr = binary_expr(col("c").gt(lit(5)), Operator::And, col("c").gt(lit(5)));
+        let expr = (col("c").gt(lit(5))).and(col("c").gt(lit(5)));
         let expected = col("c").gt(lit(5));
 
         assert_eq!(simplify(&expr), expected);

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -91,7 +91,7 @@ fn is_null(expr: &Expr) -> bool {
 
 fn is_false(expr: &Expr) -> bool {
     match expr {
-        Expr::Literal(ScalarValue::Boolean(Some(v))) => *v == false,
+        Expr::Literal(ScalarValue::Boolean(Some(v))) => !(*v),
         _ => false,
     }
 }
@@ -186,7 +186,7 @@ fn simplify(expr: &Expr) -> Expr {
                 } => simplify(&*right.clone()),
                 _ => expr.clone(),
             })
-            .unwrap_or(expr.clone()),
+            .unwrap_or_else(|| expr.clone()),
         Expr::BinaryExpr {
             left,
             op: Operator::Or,
@@ -205,7 +205,7 @@ fn simplify(expr: &Expr) -> Expr {
                 } => simplify(&*left.clone()),
                 _ => expr.clone(),
             })
-            .unwrap_or(expr.clone()),
+            .unwrap_or_else(|| expr.clone()),
         Expr::BinaryExpr {
             left,
             op: Operator::And,
@@ -224,7 +224,7 @@ fn simplify(expr: &Expr) -> Expr {
                 } => simplify(&x.clone()),
                 _ => expr.clone(),
             })
-            .unwrap_or(expr.clone()),
+            .unwrap_or_else(|| expr.clone()),
         Expr::BinaryExpr {
             left,
             op: Operator::And,
@@ -243,7 +243,7 @@ fn simplify(expr: &Expr) -> Expr {
                 } => simplify(&x.clone()),
                 _ => expr.clone(),
             })
-            .unwrap_or(expr.clone()),
+            .unwrap_or_else(|| expr.clone()),
         Expr::BinaryExpr { left, op, right } => Expr::BinaryExpr {
             left: Box::new(simplify(&left)),
             op: *op,
@@ -467,7 +467,8 @@ mod tests {
 
     #[test]
     fn test_simplify_and_and_false() -> Result<()> {
-        let expr = binary_expr(lit(ScalarValue::Boolean(None)), Operator::And, lit(false));
+        let expr =
+            binary_expr(lit(ScalarValue::Boolean(None)), Operator::And, lit(false));
         let expr_eq = lit(false);
 
         assert_eq!(simplify(&expr), expr_eq);

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Remove duplicate filters optimizer rule
+//! Simplify expressions optimizer rule
 
 use crate::execution::context::ExecutionProps;
 use crate::logical_plan::LogicalPlan;


### PR DESCRIPTION
# Which issue does this PR close?
Closes #410.

 # Rationale for this change
Uses boolean algebra laws to simplify binary boolean expressions.

# What changes are included in this PR?
New RemoveDuplicateFilters optimizer.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
