### PR TITLE
Make AggregateFunction take a single argument

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -976,7 +976,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
 
                 Ok(Expr::AggregateFunction {
                     fun,
-                    args: vec![parse_required_expr(&expr.expr)?],
+                    arg: Box::new(parse_required_expr(&expr.expr)?),
                     distinct: false, //TODO
                 })
             }

--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -1062,7 +1062,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                 })
             }
             Expr::AggregateFunction {
-                ref fun, ref args, ..
+                ref fun, arg: ref args, ..
             } => {
                 let aggr_function = match fun {
                     AggregateFunction::Min => protobuf::AggregateFunction::Min,
@@ -1072,7 +1072,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                     AggregateFunction::Count => protobuf::AggregateFunction::Count,
                 };
 
-                let arg = &args[0];
+                let arg = &**args;
                 let aggregate_expr = Box::new(protobuf::AggregateExprNode {
                     aggr_function: aggr_function.into(),
                     expr: Some(Box::new(arg.try_into()?)),

--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -1062,7 +1062,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                 })
             }
             Expr::AggregateFunction {
-                ref fun, arg: ref args, ..
+                ref fun, ref arg, ..
             } => {
                 let aggr_function = match fun {
                     AggregateFunction::Min => protobuf::AggregateFunction::Min,
@@ -1072,7 +1072,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                     AggregateFunction::Count => protobuf::AggregateFunction::Count,
                 };
 
-                let arg = &**args;
+                let arg = &**arg;
                 let aggregate_expr = Box::new(protobuf::AggregateExprNode {
                     aggr_function: aggr_function.into(),
                     expr: Some(Box::new(arg.try_into()?)),

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -325,10 +325,10 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                 let df_planner = DefaultPhysicalPlanner::default();
                 for (expr, name) in &logical_agg_expr {
                     match expr {
-                        Expr::AggregateFunction { fun, args, .. } => {
+                        Expr::AggregateFunction { fun, arg, .. } => {
                             let arg = df_planner
                                 .create_physical_expr(
-                                    &args[0],
+                                    &**arg,
                                     &physical_schema,
                                     &ctx_state,
                                 )

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1271,9 +1271,9 @@ impl fmt::Debug for Expr {
             Expr::AggregateFunction {
                 fun,
                 distinct,
-                arg: ref args,
+                ref arg,
                 ..
-            } => fmt_function(f, &fun.to_string(), *distinct, &[*args.clone()]),
+            } => fmt_function(f, &fun.to_string(), *distinct, &[*arg.clone()]),
             Expr::AggregateUDF { fun, ref args, .. } => {
                 fmt_function(f, &fun.name, false, args)
             }

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -259,8 +259,8 @@ impl Expr {
                     .collect::<Result<Vec<_>>>()?;
                 window_functions::return_type(fun, &data_types)
             }
-            Expr::AggregateFunction { fun, arg: args, .. } => {
-                let data_type = args.get_type(schema)?;
+            Expr::AggregateFunction { fun, arg, .. } => {
+                let data_type = arg.get_type(schema)?;
                 aggregates::return_type(fun, &[data_type])
             }
             Expr::AggregateUDF { fun, args, .. } => {
@@ -587,7 +587,7 @@ impl Expr {
             Expr::WindowFunction { args, .. } => args
                 .iter()
                 .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
-            Expr::AggregateFunction { arg: args, .. } => args.accept(visitor),
+            Expr::AggregateFunction { arg, .. } => arg.accept(visitor),
             Expr::AggregateUDF { args, .. } => args
                 .iter()
                 .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
@@ -723,11 +723,11 @@ impl Expr {
                 fun,
             },
             Expr::AggregateFunction {
-                arg: args,
+                arg,
                 fun,
                 distinct,
             } => Expr::AggregateFunction {
-                arg: rewrite_boxed(args, rewriter)?,
+                arg: rewrite_boxed(arg, rewriter)?,
                 fun,
                 distinct,
             },
@@ -1389,9 +1389,9 @@ fn create_name(e: &Expr, input_schema: &DFSchema) -> Result<String> {
         Expr::AggregateFunction {
             fun,
             distinct,
-            arg: args,
+            arg,
             ..
-        } => create_function_name(&fun.to_string(), *distinct, &[*args.clone()], input_schema),
+        } => create_function_name(&fun.to_string(), *distinct, &[*arg.clone()], input_schema),
         Expr::AggregateUDF { fun, args } => {
             let mut names = Vec::with_capacity(args.len());
             for e in args {

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -266,7 +266,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
         Expr::ScalarFunction { args, .. } => Ok(args.clone()),
         Expr::ScalarUDF { args, .. } => Ok(args.clone()),
         Expr::WindowFunction { args, .. } => Ok(args.clone()),
-        Expr::AggregateFunction { arg: args, .. } => Ok(vec![args.as_ref().to_owned()]),
+        Expr::AggregateFunction { arg, .. } => Ok(vec![arg.as_ref().to_owned()]),
         Expr::AggregateUDF { args, .. } => Ok(args.clone()),
         Expr::Case {
             expr,

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -266,7 +266,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
         Expr::ScalarFunction { args, .. } => Ok(args.clone()),
         Expr::ScalarUDF { args, .. } => Ok(args.clone()),
         Expr::WindowFunction { args, .. } => Ok(args.clone()),
-        Expr::AggregateFunction { args, .. } => Ok(args.clone()),
+        Expr::AggregateFunction { arg: args, .. } => Ok(vec![args.as_ref().to_owned()]),
         Expr::AggregateUDF { args, .. } => Ok(args.clone()),
         Expr::Case {
             expr,
@@ -344,7 +344,7 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
         }),
         Expr::AggregateFunction { fun, distinct, .. } => Ok(Expr::AggregateFunction {
             fun: fun.clone(),
-            args: expressions.to_vec(),
+            arg: Box::new(expressions[0].clone()),
             distinct: *distinct,
         }),
         Expr::AggregateUDF { fun, .. } => Ok(Expr::AggregateUDF {

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -779,19 +779,14 @@ impl DefaultPhysicalPlanner {
             Expr::AggregateFunction {
                 fun,
                 distinct,
-                args,
+                arg: args,
                 ..
             } => {
-                let args = args
-                    .iter()
-                    .map(|e| {
-                        self.create_physical_expr(e, physical_input_schema, ctx_state)
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+                let args = self.create_physical_expr(args, physical_input_schema, ctx_state)?;
                 aggregates::create_aggregate_expr(
                     fun,
                     *distinct,
-                    &args,
+                    &[args],
                     physical_input_schema,
                     name,
                 )

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -779,10 +779,10 @@ impl DefaultPhysicalPlanner {
             Expr::AggregateFunction {
                 fun,
                 distinct,
-                arg: args,
+                arg,
                 ..
             } => {
-                let args = self.create_physical_expr(args, physical_input_schema, ctx_state)?;
+                let args = self.create_physical_expr(arg, physical_input_schema, ctx_state)?;
                 aggregates::create_aggregate_expr(
                     fun,
                     *distinct,

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1136,7 +1136,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return Ok(Expr::AggregateFunction {
                         fun,
                         distinct: function.distinct,
-                        args,
+                        arg: Box::new(args[0].clone()),
                     });
                 };
 

--- a/datafusion/src/sql/utils.rs
+++ b/datafusion/src/sql/utils.rs
@@ -215,11 +215,11 @@ where
         None => match expr {
             Expr::AggregateFunction {
                 fun,
-                arg: args,
+                arg,
                 distinct,
             } => Ok(Expr::AggregateFunction {
                 fun: fun.clone(),
-                arg: Box::new(clone_with_replacement(args, replacement_fn)?),
+                arg: Box::new(clone_with_replacement(arg, replacement_fn)?),
                 distinct: *distinct,
             }),
             Expr::WindowFunction { fun, args } => Ok(Expr::WindowFunction {

--- a/datafusion/src/sql/utils.rs
+++ b/datafusion/src/sql/utils.rs
@@ -215,14 +215,11 @@ where
         None => match expr {
             Expr::AggregateFunction {
                 fun,
-                args,
+                arg: args,
                 distinct,
             } => Ok(Expr::AggregateFunction {
                 fun: fun.clone(),
-                args: args
-                    .iter()
-                    .map(|e| clone_with_replacement(e, replacement_fn))
-                    .collect::<Result<Vec<Expr>>>()?,
+                arg: Box::new(clone_with_replacement(args, replacement_fn)?),
                 distinct: *distinct,
             }),
             Expr::WindowFunction { fun, args } => Ok(Expr::WindowFunction {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #444

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This makes the representation of aggregate functions more correct, makes code dealing with aggregate functions more simple (by not having to assume that the arguments are of length 1 but encode it in the enum).
This came up while working on https://github.com/apache/arrow-datafusion/pull/441

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change type from `Vec<Expr>` to `Box<Expr>`
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, this is a breaking change to the `Expr` enum.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
