### PR TITLE
Refactor Ballista executor so that FlightService delegates to an Executor struct

### DIFF
--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -91,8 +91,8 @@ impl Executor {
         let path: ArrayRef = Arc::new(c0.finish());
 
         let stats: ArrayRef = stats.to_arrow_arrayref()?;
-        let results = RecordBatch::try_new(schema, vec![path, stats])?;
-        Ok(results)
+        RecordBatch::try_new(schema, vec![path, stats])
+            .map_err(|e| BallistaError::ArrowError(e))
     }
 
     pub fn work_dir(&self) -> &str {

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -21,11 +21,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
-use arrow::array::{ArrayRef, StringBuilder};
-use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::RecordBatch;
 use ballista_core::error::BallistaError;
 use ballista_core::utils;
+use datafusion::arrow::array::{ArrayRef, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::ExecutionPlan;
 use log::info;
 

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -91,8 +91,7 @@ impl Executor {
         let path: ArrayRef = Arc::new(c0.finish());
 
         let stats: ArrayRef = stats.to_arrow_arrayref()?;
-        RecordBatch::try_new(schema, vec![path, stats])
-            .map_err(|e| BallistaError::ArrowError(e))
+        RecordBatch::try_new(schema, vec![path, stats]).map_err(BallistaError::ArrowError)
     }
 
     pub fn work_dir(&self) -> &str {

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Ballista executor logic
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow::array::{ArrayRef, StringBuilder};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use ballista_core::error::BallistaError;
+use ballista_core::utils;
+use datafusion::physical_plan::ExecutionPlan;
+use log::info;
+
+/// Ballista executor
+pub struct Executor {
+    /// Directory for storing partial results
+    work_dir: String,
+}
+
+impl Executor {
+    /// Create a new executor instance
+    pub fn new(work_dir: &str) -> Self {
+        Self {
+            work_dir: work_dir.to_owned(),
+        }
+    }
+}
+
+impl Executor {
+    /// Execute one partition of a query stage and persist the result to disk in IPC format. On
+    /// success, return a RecordBatch containing metadata about the results, including path
+    /// and statistics.
+    pub async fn execute_partition(
+        &self,
+        job_id: String,
+        stage_id: usize,
+        part: usize,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> Result<RecordBatch, BallistaError> {
+        let mut path = PathBuf::from(&self.work_dir);
+        path.push(&job_id);
+        path.push(&format!("{}", stage_id));
+        path.push(&format!("{}", part));
+        std::fs::create_dir_all(&path)?;
+
+        path.push("data.arrow");
+        let path = path.to_str().unwrap();
+        info!("Writing results to {}", path);
+
+        let now = Instant::now();
+
+        // execute the query partition
+        let mut stream = plan.execute(part).await?;
+
+        // stream results to disk
+        let stats = utils::write_stream_to_disk(&mut stream, &path).await?;
+
+        info!(
+            "Executed partition {} in {} seconds. Statistics: {:?}",
+            part,
+            now.elapsed().as_secs(),
+            stats
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("path", DataType::Utf8, false),
+            stats.arrow_struct_repr(),
+        ]));
+
+        // build result set with summary of the partition execution status
+        let mut c0 = StringBuilder::new(1);
+        c0.append_value(&path).unwrap();
+        let path: ArrayRef = Arc::new(c0.finish());
+
+        let stats: ArrayRef = stats.to_arrow_arrayref()?;
+        let results = RecordBatch::try_new(schema, vec![path, stats])?;
+        Ok(results)
+    }
+
+    pub fn work_dir(&self) -> &str {
+        &self.work_dir
+    }
+}

--- a/ballista/rust/executor/src/lib.rs
+++ b/ballista/rust/executor/src/lib.rs
@@ -18,4 +18,5 @@
 //! Core executor logic for executing queries and storing results in memory.
 
 pub mod collect;
+pub mod executor;
 pub mod flight_service;

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -41,6 +41,7 @@ use ballista_core::{
     print_version, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
+use ballista_executor::executor::Executor;
 use ballista_executor::flight_service::BallistaFlightService;
 use ballista_scheduler::{state::StandaloneClient, SchedulerServer};
 use config::prelude::*;
@@ -166,7 +167,10 @@ async fn main() -> Result<()> {
     let scheduler = SchedulerGrpcClient::connect(scheduler_url)
         .await
         .context("Could not connect to scheduler")?;
-    let service = BallistaFlightService::new(work_dir);
+
+    let executor = Arc::new(Executor::new(&work_dir));
+
+    let service = BallistaFlightService::new(executor);
 
     let server = FlightServiceServer::new(service);
     info!(

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -30,12 +30,9 @@ use tempfile::TempDir;
 use tonic::transport::Server;
 use uuid::Uuid;
 
-use ballista_core::{
-    client::BallistaClient,
-    serde::protobuf::{
-        executor_registration, scheduler_grpc_client::SchedulerGrpcClient,
-        ExecutorRegistration,
-    },
+use ballista_core::serde::protobuf::{
+    executor_registration, scheduler_grpc_client::SchedulerGrpcClient,
+    ExecutorRegistration,
 };
 use ballista_core::{
     print_version, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
@@ -170,7 +167,7 @@ async fn main() -> Result<()> {
 
     let executor = Arc::new(Executor::new(&work_dir));
 
-    let service = BallistaFlightService::new(executor);
+    let service = BallistaFlightService::new(executor.clone());
 
     let server = FlightServiceServer::new(service);
     info!(
@@ -178,19 +175,9 @@ async fn main() -> Result<()> {
         BALLISTA_VERSION, addr
     );
     let server_future = tokio::spawn(Server::builder().add_service(server).serve(addr));
-    let client_host = external_host.as_deref().unwrap_or_else(|| {
-        if bind_host == "0.0.0.0" {
-            // If the executor is being bound to "0.0.0.0" (which means use all ips in all eth devices)
-            // then use "localhost" to connect to itself through the BallistaClient
-            "localhost"
-        } else {
-            &bind_host
-        }
-    });
-    let client = BallistaClient::try_new(client_host, port).await?;
     tokio::spawn(execution_loop::poll_loop(
         scheduler,
-        client,
+        executor,
         executor_meta,
         opt.concurrent_tasks,
     ));

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -52,7 +52,6 @@ tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"
 
-arrow = { version = "4.0"  }
 datafusion = { path = "../../../datafusion" }
 
 [dev-dependencies]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #449 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is fixing some tech debt so that the executor doesn't have to connect to itself over Flight to run queries.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
