### PR TITLE
Refactor QueryStageExec in preparation for implementing map-side shuffle

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -45,6 +45,7 @@ arrow-flight = { version = "4.0"  }
 datafusion = { path = "../../../datafusion" }
 
 [dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = { version = "0.4" }

--- a/ballista/rust/core/src/execution_plans/query_stage.rs
+++ b/ballista/rust/core/src/execution_plans/query_stage.rs
@@ -15,13 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! QueryStageExec represents a section of a query plan that has consistent partitioning and
+//! can be executed as one unit with each partition being executed in parallel. The output of
+//! a query stage either forms the input of another query stage or can be the final result of
+//! a query.
+
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use std::{any::Any, pin::Pin};
 
+use crate::error::BallistaError;
+use crate::memory_stream::MemoryStream;
+use crate::utils;
+
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::physical_plan::{ExecutionPlan, Partitioning};
-use datafusion::{error::Result, physical_plan::RecordBatchStream};
+use datafusion::arrow::array::{ArrayRef, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, RecordBatchStream};
+use log::info;
 use uuid::Uuid;
 
 /// QueryStageExec represents a section of a query plan that has consistent partitioning and
@@ -36,6 +50,10 @@ pub struct QueryStageExec {
     pub stage_id: usize,
     /// Physical execution plan for this query stage
     pub child: Arc<dyn ExecutionPlan>,
+    /// Path to write output streams to
+    work_dir: String,
+    /// Optional shuffle output partitioning
+    shuffle_output_partitioning: Option<Partitioning>,
 }
 
 impl QueryStageExec {
@@ -44,11 +62,15 @@ impl QueryStageExec {
         job_id: String,
         stage_id: usize,
         child: Arc<dyn ExecutionPlan>,
+        work_dir: String,
+        shuffle_output_partitioning: Option<Partitioning>,
     ) -> Result<Self> {
         Ok(Self {
             job_id,
             stage_id,
             child,
+            work_dir,
+            shuffle_output_partitioning,
         })
     }
 }
@@ -80,6 +102,8 @@ impl ExecutionPlan for QueryStageExec {
             self.job_id.clone(),
             self.stage_id,
             children[0].clone(),
+            self.work_dir.clone(),
+            None,
         )?))
     }
 
@@ -87,6 +111,64 @@ impl ExecutionPlan for QueryStageExec {
         &self,
         partition: usize,
     ) -> Result<Pin<Box<dyn RecordBatchStream + Send + Sync>>> {
-        self.child.execute(partition).await
+        let now = Instant::now();
+
+        let mut stream = self.child.execute(partition).await?;
+
+        let mut path = PathBuf::from(&self.work_dir);
+        path.push(&self.job_id);
+        path.push(&format!("{}", self.stage_id));
+
+        match &self.shuffle_output_partitioning {
+            None => {
+                path.push(&format!("{}", partition));
+                std::fs::create_dir_all(&path)?;
+
+                path.push("data.arrow");
+                let path = path.to_str().unwrap();
+                info!("Writing results to {}", path);
+
+                // stream results to disk
+                let stats = utils::write_stream_to_disk(&mut stream, &path)
+                    .await
+                    .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
+
+                info!(
+                    "Executed partition {} in {} seconds. Statistics: {:?}",
+                    partition,
+                    now.elapsed().as_secs(),
+                    stats
+                );
+
+                let schema = Arc::new(Schema::new(vec![
+                    Field::new("path", DataType::Utf8, false),
+                    stats.arrow_struct_repr(),
+                ]));
+
+                // build result set with summary of the partition execution status
+                let mut c0 = StringBuilder::new(1);
+                c0.append_value(&path).unwrap();
+                let path: ArrayRef = Arc::new(c0.finish());
+
+                let stats: ArrayRef = stats
+                    .to_arrow_arrayref()
+                    .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
+                let batch = RecordBatch::try_new(schema.clone(), vec![path, stats])
+                    .map_err(DataFusionError::ArrowError)?;
+
+                Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
+            }
+
+            Some(Partitioning::Hash(_, _)) => {
+                //TODO re-use code from RepartitionExec to split each batch into
+                // partitions and write to one IPC file per partition
+                // See https://github.com/apache/arrow-datafusion/issues/456
+                unimplemented!()
+            }
+
+            _ => Err(DataFusionError::Execution(
+                "Invalid shuffle partitioning scheme".to_owned(),
+            )),
+        }
     }
 }

--- a/ballista/rust/core/src/execution_plans/query_stage.rs
+++ b/ballista/rust/core/src/execution_plans/query_stage.rs
@@ -188,11 +188,19 @@ mod tests {
     use super::*;
     use datafusion::arrow::array::{StringArray, StructArray, UInt32Array, UInt64Array};
     use datafusion::physical_plan::memory::MemoryExec;
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test() -> Result<()> {
         let input_plan = create_input_plan()?;
-        let query_stage = QueryStageExec::try_new("jobOne", 1, input_plan, "", None)?;
+        let work_dir = TempDir::new()?;
+        let query_stage = QueryStageExec::try_new(
+            "jobOne",
+            1,
+            input_plan,
+            work_dir.into_path().to_str().unwrap(),
+            None,
+        )?;
         let mut stream = query_stage.execute(0).await?;
         let batches = utils::collect_stream(&mut stream)
             .await

--- a/ballista/rust/core/src/execution_plans/query_stage.rs
+++ b/ballista/rust/core/src/execution_plans/query_stage.rs
@@ -216,7 +216,7 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         let file = path.value(0);
-        assert!(file.ends_with("/data.arrow"));
+        assert!(file.ends_with("data.arrow"));
         let stats = batch.columns()[1]
             .as_any()
             .downcast_ref::<StructArray>()

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -112,13 +112,13 @@ pub fn produce_diagram(filename: &str, stages: &[Arc<QueryStageExec>]) -> Result
 
     // draw stages and entities
     for stage in stages {
-        writeln!(w, "\tsubgraph cluster{} {{", stage.stage_id)?;
-        writeln!(w, "\t\tlabel = \"Stage {}\";", stage.stage_id)?;
+        writeln!(w, "\tsubgraph cluster{} {{", stage.stage_id())?;
+        writeln!(w, "\t\tlabel = \"Stage {}\";", stage.stage_id())?;
         let mut id = AtomicUsize::new(0);
         build_exec_plan_diagram(
             &mut w,
-            stage.child.as_ref(),
-            stage.stage_id,
+            stage.children()[0].as_ref(),
+            stage.stage_id(),
             &mut id,
             true,
         )?;
@@ -130,8 +130,8 @@ pub fn produce_diagram(filename: &str, stages: &[Arc<QueryStageExec>]) -> Result
         let mut id = AtomicUsize::new(0);
         build_exec_plan_diagram(
             &mut w,
-            stage.child.as_ref(),
-            stage.stage_id,
+            stage.children()[0].as_ref(),
+            stage.stage_id(),
             &mut id,
             false,
         )?;

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -55,6 +55,7 @@ impl Executor {
             QueryStageExec::try_new(job_id, stage_id, plan, self.work_dir.clone(), None)?;
         let mut stream = exec.execute(part).await?;
         let batches = utils::collect_stream(&mut stream).await?;
+        // the output should be a single batch containing metadata (path and statistics)
         assert!(batches.len() == 1);
         Ok(batches[0].clone())
     }

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -52,7 +52,7 @@ impl Executor {
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<RecordBatch, BallistaError> {
         let exec =
-            QueryStageExec::try_new(job_id, stage_id, plan, self.work_dir.clone(), None)?;
+            QueryStageExec::try_new(&job_id, stage_id, plan, &self.work_dir, None)?;
         let mut stream = exec.execute(part).await?;
         let batches = utils::collect_stream(&mut stream).await?;
         // the output should be a single batch containing metadata (path and statistics)

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -17,17 +17,13 @@
 
 //! Ballista executor logic
 
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 
 use ballista_core::error::BallistaError;
+use ballista_core::execution_plans::QueryStageExec;
 use ballista_core::utils;
-use datafusion::arrow::array::{ArrayRef, StringBuilder};
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::ExecutionPlan;
-use log::info;
 
 /// Ballista executor
 pub struct Executor {
@@ -55,43 +51,12 @@ impl Executor {
         part: usize,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<RecordBatch, BallistaError> {
-        let mut path = PathBuf::from(&self.work_dir);
-        path.push(&job_id);
-        path.push(&format!("{}", stage_id));
-        path.push(&format!("{}", part));
-        std::fs::create_dir_all(&path)?;
-
-        path.push("data.arrow");
-        let path = path.to_str().unwrap();
-        info!("Writing results to {}", path);
-
-        let now = Instant::now();
-
-        // execute the query partition
-        let mut stream = plan.execute(part).await?;
-
-        // stream results to disk
-        let stats = utils::write_stream_to_disk(&mut stream, &path).await?;
-
-        info!(
-            "Executed partition {} in {} seconds. Statistics: {:?}",
-            part,
-            now.elapsed().as_secs(),
-            stats
-        );
-
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("path", DataType::Utf8, false),
-            stats.arrow_struct_repr(),
-        ]));
-
-        // build result set with summary of the partition execution status
-        let mut c0 = StringBuilder::new(1);
-        c0.append_value(&path).unwrap();
-        let path: ArrayRef = Arc::new(c0.finish());
-
-        let stats: ArrayRef = stats.to_arrow_arrayref()?;
-        RecordBatch::try_new(schema, vec![path, stats]).map_err(BallistaError::ArrowError)
+        let exec =
+            QueryStageExec::try_new(job_id, stage_id, plan, self.work_dir.clone(), None)?;
+        let mut stream = exec.execute(part).await?;
+        let batches = utils::collect_stream(&mut stream).await?;
+        assert!(batches.len() == 1);
+        Ok(batches[0].clone())
     }
 
     pub fn work_dir(&self) -> &str {

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -52,7 +52,7 @@ impl Executor {
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<RecordBatch, BallistaError> {
         let exec =
-            QueryStageExec::try_new(&job_id, stage_id, plan, &self.work_dir, None)?;
+            QueryStageExec::try_new(job_id, stage_id, plan, self.work_dir.clone(), None)?;
         let mut stream = exec.execute(part).await?;
         let batches = utils::collect_stream(&mut stream).await?;
         // the output should be a single batch containing metadata (path and statistics)

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -388,8 +388,8 @@ impl SchedulerGrpc for SchedulerServer {
                     fail_job!(state
                         .save_stage_plan(
                             &job_id_spawn,
-                            stage.stage_id,
-                            stage.child.clone()
+                            stage.stage_id(),
+                            stage.children()[0].clone()
                         )
                         .await
                         .map_err(|e| {
@@ -402,7 +402,7 @@ impl SchedulerGrpc for SchedulerServer {
                         let pending_status = TaskStatus {
                             partition_id: Some(PartitionId {
                                 job_id: job_id_spawn.clone(),
-                                stage_id: stage.stage_id as u32,
+                                stage_id: stage.stage_id() as u32,
                                 partition_id: partition_id as u32,
                             }),
                             status: None,

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -117,7 +117,7 @@ impl DistributedPlanner {
                 merge.children()[0].clone(),
             )?;
             let unresolved_shuffle = Arc::new(UnresolvedShuffleExec::new(
-                vec![query_stage.stage_id],
+                vec![query_stage.stage_id()],
                 query_stage.schema(),
                 query_stage.output_partitioning().partition_count(),
             ));
@@ -138,7 +138,7 @@ impl DistributedPlanner {
                             child.clone(),
                         )?;
                         new_children.push(Arc::new(UnresolvedShuffleExec::new(
-                            vec![new_stage.stage_id],
+                            vec![new_stage.stage_id()],
                             new_stage.schema().clone(),
                             new_stage.output_partitioning().partition_count(),
                         )));
@@ -171,7 +171,7 @@ impl DistributedPlanner {
                         child.clone(),
                     )?;
                     new_children.push(Arc::new(UnresolvedShuffleExec::new(
-                        vec![new_stage.stage_id],
+                        vec![new_stage.stage_id()],
                         new_stage.schema().clone(),
                         new_stage.output_partitioning().partition_count(),
                     )));

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -227,7 +227,10 @@ fn create_query_stage(
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<Arc<QueryStageExec>> {
     Ok(Arc::new(QueryStageExec::try_new(
-        job_id, stage_id, plan, "", // executor will decide on the work_dir path
+        job_id.to_owned(),
+        stage_id,
+        plan,
+        "".to_owned(), // executor will decide on the work_dir path
         None,
     )?))
 }

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -233,7 +233,13 @@ fn create_query_stage(
     stage_id: usize,
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<Arc<QueryStageExec>> {
-    Ok(Arc::new(QueryStageExec::try_new(job_id, stage_id, plan)?))
+    Ok(Arc::new(QueryStageExec::try_new(
+        job_id,
+        stage_id,
+        plan,
+        "TBD".to_owned(),
+        None,
+    )?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #458 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Moves logic from Ballista executor to `QueryStageExec` (which we can potentially move to DataFusion later on)
- Puts some plumbing in place in preparation for supporting map-side shuffle
- Implements a unit test

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
