### PR TITLE
add `order by` construct in window function and logical plans

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -174,6 +174,12 @@ message WindowExprNode {
     // udaf = 3
   }
   LogicalExprNode expr = 4;
+  // repeated LogicalExprNode partition_by = 5;
+  repeated LogicalExprNode order_by = 6;
+  // repeated LogicalExprNode filter = 7;
+  // oneof window_frame {
+  //   WindowFrame frame = 8;
+  // }
 }
 
 message BetweenNode {
@@ -317,14 +323,6 @@ message AggregateNode {
 message WindowNode {
   LogicalPlanNode input = 1;
   repeated LogicalExprNode window_expr = 2;
-  repeated LogicalExprNode partition_by_expr = 3;
-  repeated LogicalExprNode order_by_expr = 4;
-  // "optional" keyword is stable in protoc 3.15 but prost is still on 3.14 (see https://github.com/danburkert/prost/issues/430)
-  // this syntax is ugly but is binary compatible with the "optional" keyword (see https://stackoverflow.com/questions/42622015/how-to-define-an-optional-field-in-protobuf-3)
-  oneof window_frame {
-    WindowFrame frame = 5;
-  }
-  // TODO add filter by expr
 }
 
 enum WindowFrameUnits {

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -297,23 +297,7 @@ impl LogicalPlanBuilder {
     /// - https://github.com/apache/arrow-datafusion/issues/299 with partition clause
     /// - https://github.com/apache/arrow-datafusion/issues/360 with order by
     /// - https://github.com/apache/arrow-datafusion/issues/361 with window frame
-    pub fn window(
-        &self,
-        window_expr: impl IntoIterator<Item = Expr>,
-        // FIXME: implement next
-        // filter_by_expr: impl IntoIterator<Item = Expr>,
-        // FIXME: implement next
-        // partition_by_expr: impl IntoIterator<Item = Expr>,
-        // FIXME: implement next
-        // order_by_expr: impl IntoIterator<Item = Expr>,
-        // FIXME: implement next
-        // window_frame: Option<WindowFrame>,
-    ) -> Result<Self> {
-        let window_expr = window_expr.into_iter().collect::<Vec<_>>();
-        // FIXME: implement next
-        // let partition_by_expr = partition_by_expr.into_iter().collect::<Vec<Expr>>();
-        // FIXME: implement next
-        // let order_by_expr = order_by_expr.into_iter().collect::<Vec<Expr>>();
+    pub fn window(&self, window_expr: Vec<Expr>) -> Result<Self> {
         let all_expr = window_expr.iter();
         validate_unique_names("Windows", all_expr.clone(), self.plan.schema())?;
 
@@ -323,12 +307,6 @@ impl LogicalPlanBuilder {
 
         Ok(Self::from(&LogicalPlan::Window {
             input: Arc::new(self.plan.clone()),
-            // FIXME implement next
-            // partition_by_expr,
-            // FIXME implement next
-            // order_by_expr,
-            // FIXME implement next
-            // window_frame,
             window_expr,
             schema: Arc::new(DFSchema::new(window_fields)?),
         }))

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -746,13 +746,18 @@ impl DefaultPhysicalPlanner {
         };
 
         match e {
-            Expr::WindowFunction { fun, args } => {
+            Expr::WindowFunction { fun, args, .. } => {
                 let args = args
                     .iter()
                     .map(|e| {
                         self.create_physical_expr(e, physical_input_schema, ctx_state)
                     })
                     .collect::<Result<Vec<_>>>()?;
+                // if !order_by.is_empty() {
+                //     return Err(DataFusionError::NotImplemented(
+                //         "Window function with order by is not yet implemented".to_owned(),
+                //     ));
+                // }
                 windows::create_window_expr(fun, &args, physical_input_schema, name)
             }
             other => Err(DataFusionError::Internal(format!(

--- a/datafusion/src/sql/mod.rs
+++ b/datafusion/src/sql/mod.rs
@@ -20,4 +20,4 @@
 
 pub mod parser;
 pub mod planner;
-mod utils;
+pub(crate) mod utils;


### PR DESCRIPTION
# Which issue does this PR close?

add sort_by construct in window function and logical plans.

Related and partly implements #360 



 # Rationale for this change

Implementing `order by` constructs and its logical planning by following a similar approach to PostgreSQL.

Coming up: [adding window frame unit][1] and type defs, and allow window functions to operate differently depending on `RANGE` or `ROW` window frame spec.

# What changes are included in this PR?

- update to ballista proto
- add logical plan for window functions with `order by`
- add unit test

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

[1]: https://github.com/apache/arrow-datafusion/pull/492
