### PR TITLE
make `VOLUME` declaration in tpch datagen docker absolute

### DIFF
--- a/benchmarks/tpchgen.dockerfile
+++ b/benchmarks/tpchgen.dockerfile
@@ -27,6 +27,6 @@ RUN git clone https://github.com/databricks/tpch-dbgen.git && \
 WORKDIR /tpch-dbgen
 ADD entrypoint.sh /tpch-dbgen/
 
-VOLUME data
+VOLUME /data
 
 ENTRYPOINT [ "bash", "./entrypoint.sh" ]


### PR DESCRIPTION
Otherwise some docker versions complain about:

```text
docker: Error response from daemon: failed to create shim: OCI runtime create failed: invalid mount {Destination:data Type:bind Source:/var/lib/docker/volumes/8c57860badfdf66bd32f64fe4b22970bcbb1f0f13a5d134ec451458a823dec6f/_data Options:[rbind]}: mount destination data not absolute: unknown.
```

Also see docs for `VOLUME` which suggest this path should be absolute: https://docs.docker.com/engine/reference/builder/#volume

Fixes #465.