### PR TITLE
Expose DataFrame::sort in the python bindings

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -27,9 +27,10 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+libc = "0.2"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 rand = "0.7"
-pyo3 = { version = "0.12.1", features = ["extension-module"] }
+pyo3 = { version = "0.13.2", features = ["extension-module"] }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "2423ff0d" }
 
 [lib]

--- a/python/src/dataframe.rs
+++ b/python/src/dataframe.rs
@@ -93,6 +93,18 @@ impl DataFrame {
         })
     }
 
+    /// Sort by specified sorting expressions
+    fn sort(&self, exprs: Vec<expression::Expression>) -> PyResult<Self> {
+        let exprs = exprs.into_iter().map(|e| e.expr);
+        let builder = LogicalPlanBuilder::from(&self.plan);
+        let builder = errors::wrap(builder.sort(exprs))?;
+        let plan = errors::wrap(builder.build())?;
+        Ok(DataFrame {
+            ctx_state: self.ctx_state.clone(),
+            plan,
+        })
+    }
+
     /// Limits the plan to return at most `count` rows
     fn limit(&self, count: usize) -> PyResult<Self> {
         let builder = LogicalPlanBuilder::from(&self.plan);

--- a/python/src/expression.rs
+++ b/python/src/expression.rs
@@ -117,6 +117,14 @@ impl Expression {
             expr: self.expr.clone().alias(name),
         })
     }
+
+    /// Create a sort expression from an existing expression.
+    #[args(ascending = true, nulls_first = true)]
+    pub fn sort(&self, ascending: bool, nulls_first: bool) -> PyResult<Expression> {
+        Ok(Expression {
+            expr: self.expr.clone().sort(ascending, nulls_first),
+        })
+    }
 }
 
 /// Represents a ScalarUDF

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -101,9 +101,17 @@ fn concat_ws(value: expression::Expression) -> expression::Expression {
 }
 
 #[pyfunction]
-fn in_list(expr: expression::Expression, value: Vec<expression::Expression>, negated: bool) -> expression::Expression {
+fn in_list(
+    expr: expression::Expression,
+    value: Vec<expression::Expression>,
+    negated: bool,
+) -> expression::Expression {
     expression::Expression {
-        expr: logical_plan::in_list(expr.expr, value.into_iter().map(|x| x.expr).collect::<Vec<_>>(), negated),
+        expr: logical_plan::in_list(
+            expr.expr,
+            value.into_iter().map(|x| x.expr).collect::<Vec<_>>(),
+            negated,
+        ),
     }
 }
 

--- a/python/src/to_py.rs
+++ b/python/src/to_py.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use libc::uintptr_t;
 use pyo3::prelude::*;
-use pyo3::{libc::uintptr_t, PyErr};
+use pyo3::PyErr;
 
 use std::convert::From;
 

--- a/python/src/to_rust.rs
+++ b/python/src/to_rust.rs
@@ -25,7 +25,8 @@ use datafusion::arrow::{
     record_batch::RecordBatch,
 };
 use datafusion::scalar::ScalarValue;
-use pyo3::{libc::uintptr_t, prelude::*};
+use libc::uintptr_t;
+use pyo3::prelude::*;
 
 use crate::{errors, types::PyDataType};
 


### PR DESCRIPTION
# Which issue does this PR close?

When I tried to execute the python unittests I got two recordbatches instead of a single one in the join test, so I exposed the sort method to resolve that.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #468

# What changes are included in this PR?

- upgrade PyO3 to 0.13
- expose DataFrame::sort
- fix join test case
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

