### PR TITLE
Avoid warnings in tests when compiling without default features

### DIFF
--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -1275,7 +1275,7 @@ mod tests {
     use arrow::{
         array::{
             Array, ArrayRef, BinaryArray, BooleanArray, FixedSizeListArray, Float64Array,
-            Int32Array, ListArray, StringArray, UInt32Array, UInt64Array,
+            Int32Array, StringArray, UInt32Array, UInt64Array,
         },
         datatypes::Field,
         record_batch::RecordBatch,
@@ -3555,6 +3555,7 @@ mod tests {
     #[test]
     #[cfg(feature = "regex_expressions")]
     fn test_regexp_match() -> Result<()> {
+        use arrow::array::ListArray;
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
         let ctx_state = ExecutionContextState::new();
 
@@ -3594,6 +3595,7 @@ mod tests {
     #[test]
     #[cfg(feature = "regex_expressions")]
     fn test_regexp_match_all_literals() -> Result<()> {
+        use arrow::array::ListArray;
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let ctx_state = ExecutionContextState::new();
 


### PR DESCRIPTION
When testing with

```shell
cargo test -p datafusion --no-default-features   -- pruning
```

I get this warning:
```
warning: unused import: `ListArray`
    --> datafusion/src/physical_plan/functions.rs:1278:25
     |
1278 |             Int32Array, ListArray, StringArray, UInt32Array, UInt64Array,
     |                         ^^^^^^^^^
     |
     = note: `#[warn(unused_imports)]` on by default
```

Because the test that uses it is not being compiled without the default features.  

Thus move the `use` to the tests that need them. 