### PR TITLE
Update ballista.proto link in architecture doc

### DIFF
--- a/ballista/docs/architecture.md
+++ b/ballista/docs/architecture.md
@@ -44,7 +44,7 @@ processes.
 ## Scheduler Process
 
 The scheduler process implements a gRPC interface (defined in
-[ballista.proto](../rust/ballista/proto/ballista.proto)). The interface provides the following methods:
+[ballista.proto](../rust/core/proto/ballista.proto)). The interface provides the following methods:
 
 | Method               | Description                                                          |
 | -------------------- | -------------------------------------------------------------------- |


### PR DESCRIPTION
# Which issue does this PR close?
n/a

 # Rationale for this change
Update docs to point to ballista proto definition file. 





