### PR TITLE
Wrong aggregation arguments error.

### DIFF
--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -116,7 +116,7 @@ pub fn create_aggregate_expr(
     let arg = coerce(args, input_schema, &signature(fun))?;
     if arg.len() == 0 {
         return Err(DataFusionError::Plan(format!(
-            "Aggregate error: Invalid or wrong number of arguments passed to aggregate: '{}'",
+            "Aggregate error. Invalid or wrong number of arguments passed to aggregate: '{}'",
             name,
         )));
     }

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -116,7 +116,7 @@ pub fn create_aggregate_expr(
     let arg = coerce(args, input_schema, &signature(fun))?;
     if arg.len() == 0 {
         return Err(DataFusionError::Plan(format!(
-            "Invalid aggregation '{}'",
+            "Aggregate error: Invalid or wrong number of arguments passed to aggregate: '{}'",
             name,
         )));
     }

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -113,7 +113,14 @@ pub fn create_aggregate_expr(
     name: String,
 ) -> Result<Arc<dyn AggregateExpr>> {
     // coerce
-    let arg = coerce(args, input_schema, &signature(fun))?[0].clone();
+    let arg = coerce(args, input_schema, &signature(fun))?;
+    if arg.len() == 0 {
+        return Err(DataFusionError::Plan(format!(
+            "Invalid aggregation '{}'",
+            name,
+        )));
+    }
+    let arg = arg[0].clone();
 
     let arg_types = args
         .iter()


### PR DESCRIPTION
# Which issue does this PR close?
Closes #496.

 # Rationale for this change
Check the arguments coerced to an aggregation and return a DataFusionError::Plan if no arguments can be associated with the function call.
Error message will display something like
```
Aggregate error. Invalid or wrong number of arguments passed to aggregate 'COUNT(DISTINCT )'
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Checks if there are some valid coerced arguments to call an aggregation function in create_aggregate_expr (datafusion/src/physical_plan/aggregates.rs)

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
