### PR TITLE
Fix display of execution time in datafusion-cli

### DIFF
--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -29,17 +29,16 @@ pub struct PrintOptions {
 
 fn print_timing_info(row_count: usize, now: Instant) {
     println!(
-        "{} {} in set. Query took {} seconds.",
+        "{} {} in set. Query took {:.3} seconds.",
         row_count,
         if row_count == 1 { "row" } else { "rows" },
-        now.elapsed().as_secs()
+        now.elapsed().as_secs_f64()
     );
 }
 
 impl PrintOptions {
     /// print the batches to stdout using the specified format
-    pub fn print_batches(&self, batches: &[RecordBatch]) -> Result<()> {
-        let now = Instant::now();
+    pub fn print_batches(&self, batches: &[RecordBatch], now: Instant) -> Result<()> {
         if batches.is_empty() {
             if !self.quiet {
                 print_timing_info(0, now);

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -30,6 +30,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::Path;
+use std::time::Instant;
 
 #[tokio::main]
 pub async fn main() {
@@ -238,7 +239,9 @@ async fn exec_and_print(
     sql: String,
 ) -> Result<()> {
     let df = ctx.sql(&sql)?;
+    let now = Instant::now();
     let results = df.collect().await?;
-    print_options.print_batches(&results)?;
+
+    print_options.print_batches(&results, now)?;
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #511

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Before this change, starting time was calculated in the printing code, always resulting in `0` seconds.
It also shows the number of seconds with 3 decimals now, which is useful for shorter running queries:

> select l_orderkey from X where l_comment like '1%';
0 rows in set. Query took 0.147 seconds.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
