### PR TITLE
remove redundant `into_iter()` calls

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -914,13 +914,11 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                     .partition_by
                     .iter()
                     .map(|e| e.try_into())
-                    .into_iter()
                     .collect::<Result<Vec<_>, _>>()?;
                 let order_by = expr
                     .order_by
                     .iter()
                     .map(|e| e.try_into())
-                    .into_iter()
                     .collect::<Result<Vec<_>, _>>()?;
                 let window_frame = expr
                     .window_frame

--- a/datafusion/src/physical_plan/windows.rs
+++ b/datafusion/src/physical_plan/windows.rs
@@ -348,7 +348,6 @@ fn window_aggregate_batch(
                 .collect::<Result<Vec<_>>>()?;
             window_acc.scan_batch(batch.num_rows(), values)
         })
-        .into_iter()
         .collect::<Result<Vec<_>>>()
 }
 

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -713,7 +713,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let select_exprs = select_exprs
             .iter()
             .map(|expr| rebase_expr(expr, &window_exprs, &plan))
-            .into_iter()
             .collect::<Result<Vec<_>>>()?;
         Ok((plan, select_exprs))
     }
@@ -810,7 +809,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let order_by_rex = order_by
             .iter()
             .map(|e| self.order_by_to_sort_expr(e))
-            .into_iter()
             .collect::<Result<Vec<_>>>()?;
 
         LogicalPlanBuilder::from(&plan).sort(order_by_rex)?.build()
@@ -1126,13 +1124,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .partition_by
                         .iter()
                         .map(|e| self.sql_expr_to_logical_expr(e))
-                        .into_iter()
                         .collect::<Result<Vec<_>>>()?;
                     let order_by = window
                         .order_by
                         .iter()
                         .map(|e| self.order_by_to_sort_expr(e))
-                        .into_iter()
                         .collect::<Result<Vec<_>>>()?;
                     let window_frame = window
                         .window_frame


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

remove redundant `into_iter` calls because `Vec<Result<_>>` can automatically be transposed to `Result<Vec<_>>` - there is no need for additional `into_iter` calls

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
