### PR TITLE
reuse datafusion physical planner in ballista building from protobuf

### DIFF
--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -36,7 +36,7 @@ use datafusion::execution::context::{
     ExecutionConfig, ExecutionContextState, ExecutionProps,
 };
 use datafusion::logical_plan::{DFSchema, Expr};
-use datafusion::physical_plan::aggregates::{create_aggregate_expr, AggregateFunction};
+use datafusion::physical_plan::aggregates::AggregateFunction;
 use datafusion::physical_plan::expressions::col;
 use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
 use datafusion::physical_plan::hash_join::PartitionMode;
@@ -45,7 +45,6 @@ use datafusion::physical_plan::planner::DefaultPhysicalPlanner;
 use datafusion::physical_plan::window_functions::{
     BuiltInWindowFunction, WindowFunction,
 };
-use datafusion::physical_plan::windows::create_window_expr;
 use datafusion::physical_plan::windows::WindowAggExec;
 use datafusion::physical_plan::{
     coalesce_batches::CoalesceBatchesExec,
@@ -205,10 +204,8 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                         )
                     })?
                     .clone();
-
                 let physical_schema: SchemaRef =
                     SchemaRef::new((&input_schema).try_into()?);
-
                 let catalog_list =
                     Arc::new(MemoryCatalogList::new()) as Arc<dyn CatalogList>;
                 let ctx_state = ExecutionContextState {
@@ -219,62 +216,24 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                     config: ExecutionConfig::new(),
                     execution_props: ExecutionProps::new(),
                 };
-
                 let window_agg_expr: Vec<(Expr, String)> = window_agg
                     .window_expr
                     .iter()
                     .zip(window_agg.window_expr_name.iter())
                     .map(|(expr, name)| expr.try_into().map(|expr| (expr, name.clone())))
                     .collect::<Result<Vec<_>, _>>()?;
-
-                let mut physical_window_expr = vec![];
-
                 let df_planner = DefaultPhysicalPlanner::default();
-
-                for (expr, name) in &window_agg_expr {
-                    match expr {
-                        Expr::WindowFunction {
-                            fun,
-                            args,
-                            partition_by,
-                            order_by,
-                            window_frame,
-                            ..
-                        } => {
-                            let arg = df_planner
-                                .create_physical_expr(
-                                    &args[0],
-                                    &physical_schema,
-                                    &ctx_state,
-                                )
-                                .map_err(|e| {
-                                    BallistaError::General(format!("{:?}", e))
-                                })?;
-                            if !partition_by.is_empty() {
-                                return Err(BallistaError::NotImplemented("Window function with partition by is not yet implemented".to_owned()));
-                            }
-                            if !order_by.is_empty() {
-                                return Err(BallistaError::NotImplemented("Window function with order by is not yet implemented".to_owned()));
-                            }
-                            if window_frame.is_some() {
-                                return Err(BallistaError::NotImplemented("Window function with window frame is not yet implemented".to_owned()));
-                            }
-                            let window_expr = create_window_expr(
-                                &fun,
-                                &[arg],
-                                &physical_schema,
-                                name.to_owned(),
-                            )?;
-                            physical_window_expr.push(window_expr);
-                        }
-                        _ => {
-                            return Err(BallistaError::General(
-                                "Invalid expression for WindowAggrExec".to_string(),
-                            ));
-                        }
-                    }
-                }
-
+                let physical_window_expr = window_agg_expr
+                    .iter()
+                    .map(|(expr, name)| {
+                        df_planner.create_window_expr_with_name(
+                            expr,
+                            name.to_string(),
+                            &physical_schema,
+                            &ctx_state,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(Arc::new(WindowAggExec::try_new(
                     physical_window_expr,
                     input,
@@ -336,37 +295,18 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                     .clone();
                 let physical_schema: SchemaRef =
                     SchemaRef::new((&input_schema).try_into()?);
-
-                let mut physical_aggr_expr = vec![];
-
                 let df_planner = DefaultPhysicalPlanner::default();
-                for (expr, name) in &logical_agg_expr {
-                    match expr {
-                        Expr::AggregateFunction { fun, args, .. } => {
-                            let arg = df_planner
-                                .create_physical_expr(
-                                    &args[0],
-                                    &physical_schema,
-                                    &ctx_state,
-                                )
-                                .map_err(|e| {
-                                    BallistaError::General(format!("{:?}", e))
-                                })?;
-                            physical_aggr_expr.push(create_aggregate_expr(
-                                &fun,
-                                false,
-                                &[arg],
-                                &physical_schema,
-                                name.to_string(),
-                            )?);
-                        }
-                        _ => {
-                            return Err(BallistaError::General(
-                                "Invalid expression for HashAggregateExec".to_string(),
-                            ))
-                        }
-                    }
-                }
+                let physical_aggr_expr = logical_agg_expr
+                    .iter()
+                    .map(|(expr, name)| {
+                        df_planner.create_aggregate_expr_with_name(
+                            expr,
+                            name.to_string(),
+                            &physical_schema,
+                            &ctx_state,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(Arc::new(HashAggregateExec::try_new(
                     agg_mode,
                     group,

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -22,7 +22,6 @@ use super::{
     functions, hash_join::PartitionMode, udaf, union::UnionExec, windows,
 };
 use crate::execution::context::ExecutionContextState;
-use crate::logical_plan::window_frames::WindowFrame;
 use crate::logical_plan::{
     DFSchema, Expr, LogicalPlan, Operator, Partitioning as LogicalPartitioning, PlanType,
     StringifiedPlan, UserDefinedLogicalNode,
@@ -781,14 +780,31 @@ impl DefaultPhysicalPlanner {
                         )),
                     })
                     .collect::<Result<Vec<_>>>()?;
-                let window_frame = window_frame.unwrap_or_else(WindowFrame::default);
+                if !partition_by.is_empty() {
+                    return Err(DataFusionError::NotImplemented(
+                            "window expression with non-empty partition by clause is not yet supported"
+                                .to_owned(),
+                        ));
+                }
+                if !order_by.is_empty() {
+                    return Err(DataFusionError::NotImplemented(
+                            "window expression with non-empty order by clause is not yet supported"
+                                .to_owned(),
+                        ));
+                }
+                if window_frame.is_some() {
+                    return Err(DataFusionError::NotImplemented(
+                            "window expression with window frame definition is not yet supported"
+                                .to_owned(),
+                        ));
+                }
                 windows::create_window_expr(
                     fun,
                     name,
                     &args,
                     &partition_by,
                     &order_by,
-                    window_frame,
+                    *window_frame,
                     physical_input_schema,
                 )
             }

--- a/datafusion/src/physical_plan/windows.rs
+++ b/datafusion/src/physical_plan/windows.rs
@@ -18,9 +18,11 @@
 //! Execution plan for window functions
 
 use crate::error::{DataFusionError, Result};
+
+use crate::logical_plan::window_frames::WindowFrame;
 use crate::physical_plan::{
     aggregates, common,
-    expressions::{Literal, NthValue, RowNumber},
+    expressions::{Literal, NthValue, PhysicalSortExpr, RowNumber},
     type_coercion::coerce,
     window_functions::signature_for_built_in,
     window_functions::BuiltInWindowFunctionExpr,
@@ -61,12 +63,15 @@ pub struct WindowAggExec {
 /// Create a physical expression for window function
 pub fn create_window_expr(
     fun: &WindowFunction,
-    args: &[Arc<dyn PhysicalExpr>],
-    input_schema: &Schema,
     name: String,
+    args: &[Arc<dyn PhysicalExpr>],
+    _partition_by: &[Arc<dyn PhysicalExpr>],
+    _order_by: &[PhysicalSortExpr],
+    _window_frame: WindowFrame,
+    input_schema: &Schema,
 ) -> Result<Arc<dyn WindowExpr>> {
-    match fun {
-        WindowFunction::AggregateFunction(fun) => Ok(Arc::new(AggregateWindowExpr {
+    Ok(match fun {
+        WindowFunction::AggregateFunction(fun) => Arc::new(AggregateWindowExpr {
             aggregate: aggregates::create_aggregate_expr(
                 fun,
                 false,
@@ -74,11 +79,11 @@ pub fn create_window_expr(
                 input_schema,
                 name,
             )?,
-        })),
-        WindowFunction::BuiltInWindowFunction(fun) => Ok(Arc::new(BuiltInWindowExpr {
+        }),
+        WindowFunction::BuiltInWindowFunction(fun) => Arc::new(BuiltInWindowExpr {
             window: create_built_in_window_expr(fun, args, input_schema, name)?,
-        })),
-    }
+        }),
+    })
 }
 
 fn create_built_in_window_expr(
@@ -537,9 +542,12 @@ mod tests {
         let window_exec = Arc::new(WindowAggExec::try_new(
             vec![create_window_expr(
                 &WindowFunction::AggregateFunction(AggregateFunction::Count),
-                &[col("c3")],
-                schema.as_ref(),
                 "count".to_owned(),
+                &[col("c3")],
+                &[],
+                &[],
+                WindowFrame::default(),
+                schema.as_ref(),
             )?],
             input,
             schema.clone(),
@@ -567,21 +575,30 @@ mod tests {
             vec![
                 create_window_expr(
                     &WindowFunction::AggregateFunction(AggregateFunction::Count),
-                    &[col("c3")],
-                    schema.as_ref(),
                     "count".to_owned(),
+                    &[col("c3")],
+                    &[],
+                    &[],
+                    WindowFrame::default(),
+                    schema.as_ref(),
                 )?,
                 create_window_expr(
                     &WindowFunction::AggregateFunction(AggregateFunction::Max),
-                    &[col("c3")],
-                    schema.as_ref(),
                     "max".to_owned(),
+                    &[col("c3")],
+                    &[],
+                    &[],
+                    WindowFrame::default(),
+                    schema.as_ref(),
                 )?,
                 create_window_expr(
                     &WindowFunction::AggregateFunction(AggregateFunction::Min),
-                    &[col("c3")],
-                    schema.as_ref(),
                     "min".to_owned(),
+                    &[col("c3")],
+                    &[],
+                    &[],
+                    WindowFrame::default(),
+                    schema.as_ref(),
                 )?,
             ],
             input,

--- a/datafusion/src/physical_plan/windows.rs
+++ b/datafusion/src/physical_plan/windows.rs
@@ -65,9 +65,12 @@ pub fn create_window_expr(
     fun: &WindowFunction,
     name: String,
     args: &[Arc<dyn PhysicalExpr>],
+    // https://github.com/apache/arrow-datafusion/issues/299
     _partition_by: &[Arc<dyn PhysicalExpr>],
+    // https://github.com/apache/arrow-datafusion/issues/360
     _order_by: &[PhysicalSortExpr],
-    _window_frame: WindowFrame,
+    // https://github.com/apache/arrow-datafusion/issues/361
+    _window_frame: Option<WindowFrame>,
     input_schema: &Schema,
 ) -> Result<Arc<dyn WindowExpr>> {
     Ok(match fun {
@@ -546,7 +549,7 @@ mod tests {
                 &[col("c3")],
                 &[],
                 &[],
-                WindowFrame::default(),
+                Some(WindowFrame::default()),
                 schema.as_ref(),
             )?],
             input,
@@ -579,7 +582,7 @@ mod tests {
                     &[col("c3")],
                     &[],
                     &[],
-                    WindowFrame::default(),
+                    Some(WindowFrame::default()),
                     schema.as_ref(),
                 )?,
                 create_window_expr(
@@ -588,7 +591,7 @@ mod tests {
                     &[col("c3")],
                     &[],
                     &[],
-                    WindowFrame::default(),
+                    Some(WindowFrame::default()),
                     schema.as_ref(),
                 )?,
                 create_window_expr(
@@ -597,7 +600,7 @@ mod tests {
                     &[col("c3")],
                     &[],
                     &[],
-                    WindowFrame::default(),
+                    Some(WindowFrame::default()),
                     schema.as_ref(),
                 )?,
             ],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

reuse datafusion physical planner in ballista building from protobuf.

so far there are duplicated code within ballista and datafusion planner because the latter needs to handle alias but for ballista the expr name is flattened in protobuf, resulting two similar codepath in building the aggregation exec.

this tries to unify both and reuse code.

# What changes are included in this PR?

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
