### PR TITLE
Cleanup Repartition Exec code

### DIFF
--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -107,6 +107,11 @@ impl SQLMetric {
         self.value.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Add elapsed nanoseconds since `start`to self
+    pub fn add_elapsed(&self, start: std::time::Instant) {
+        self.add(start.elapsed().as_nanos() as usize)
+    }
+
     /// Get the current value
     pub fn value(&self) -> usize {
         self.value.load(Ordering::Relaxed)


### PR DESCRIPTION
 # Rationale for this change
The body of RepartitionExec::execute is long and highly indented, and has a bunch of metrics related code that obscures how it works, in my opinion. 

# What changes are included in this PR?

As suggested by @tustvold  in https://github.com/apache/arrow-datafusion/pull/521#discussion_r646611109, attempt to make the code clearer and error conditions easier to reason about by:

Changes:
1. Factor the body of the repartition into its own async function
2. Grouped the metrics into a `RepartitionMetrics` struct for convenience
3. Refactored repeated code into `SQLMetric::add_elapsed` and reduced duplication

I still think the metrics could still be made better, and I hope to work on that at a later date.



# Are there any user-facing changes?
No

