### PR TITLE
Refactor hash aggregates's planner building code

### DIFF
--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -341,10 +341,8 @@ pub async fn collect_partitioned(
 pub enum Partitioning {
     /// Allocate batches using a round-robin algorithm and the specified number of partitions
     RoundRobinBatch(usize),
-    /// Allocate rows based on a hash of one of more expressions and the specified
-    /// number of partitions
-    /// FIXME: This partitioning scheme is not yet fully supported.
-    /// See https://github.com/apache/arrow-datafusion/issues/131
+    /// Allocate rows based on a hash of one of more expressions and the specified number of
+    /// partitions
     Hash(Vec<Arc<dyn PhysicalExpr>>, usize),
     /// Unknown partitioning scheme with a known number of partitions
     UnknownPartitioning(usize),

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -343,7 +343,8 @@ pub enum Partitioning {
     RoundRobinBatch(usize),
     /// Allocate rows based on a hash of one of more expressions and the specified
     /// number of partitions
-    /// This partitioning scheme is not yet fully supported. See [ARROW-11011](https://issues.apache.org/jira/browse/ARROW-11011)
+    /// FIXME: This partitioning scheme is not yet fully supported.
+    /// See https://github.com/apache/arrow-datafusion/issues/131
     Hash(Vec<Arc<dyn PhysicalExpr>>, usize),
     /// Unknown partitioning scheme with a known number of partitions
     UnknownPartitioning(usize),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #131

 # Rationale for this change

a small refactor to hash aggregate planning phase, to make the code more readable, streamlined.

this shall be covered by the current unit tests.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

no

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
