### PR TITLE
Add some resiliency to lost executors

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -610,10 +610,10 @@ message ExecutorRegistration {
   uint32 port = 3;
 }
 
-message GetExecutorMetadataParams {}
-
-message GetExecutorMetadataResult {
-  repeated ExecutorMetadata metadata = 1;
+message ExecutorHeartbeat {
+  ExecutorMetadata meta = 1;
+  // Unix epoch-based timestamp in seconds
+  uint64 timestamp = 2;
 }
 
 message RunningTask {
@@ -712,8 +712,6 @@ message FilePartitionMetadata {
 }
 
 service SchedulerGrpc {
-  rpc GetExecutorsMetadata (GetExecutorMetadataParams) returns (GetExecutorMetadataResult) {}
-
   // Executors must poll the scheduler for heartbeat and to receive tasks
   rpc PollWork (PollWorkParams) returns (PollWorkResult) {}
 

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -90,10 +90,14 @@ async fn run_received_tasks(
     task_status_sender: Sender<TaskStatus>,
     task: TaskDefinition,
 ) {
-    info!("Received task {:?}", task.task_id.as_ref().unwrap());
+    let task_id = task.task_id.unwrap();
+    let task_id_log = format!(
+        "{}/{}/{}",
+        task_id.job_id, task_id.stage_id, task_id.partition_id
+    );
+    info!("Received task {}", task_id_log);
     available_tasks_slots.fetch_sub(1, Ordering::SeqCst);
     let plan: Arc<dyn ExecutionPlan> = (&task.plan.unwrap()).try_into().unwrap();
-    let task_id = task.task_id.unwrap();
 
     tokio::spawn(async move {
         let execution_result = executor
@@ -104,7 +108,8 @@ async fn run_received_tasks(
                 plan,
             )
             .await;
-        info!("DONE WITH TASK: {:?}", execution_result);
+        info!("Done with task {}", task_id_log);
+        debug!("Statistics: {:?}", execution_result);
         available_tasks_slots.fetch_add(1, Ordering::SeqCst);
         let _ = task_status_sender.send(as_task_status(
             execution_result.map(|_| ()),

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -30,10 +30,10 @@ use std::{fmt, net::IpAddr};
 use ballista_core::serde::protobuf::{
     execute_query_params::Query, executor_registration::OptionalHost, job_status,
     scheduler_grpc_server::SchedulerGrpc, ExecuteQueryParams, ExecuteQueryResult,
-    FailedJob, FilePartitionMetadata, FileType, GetExecutorMetadataParams,
-    GetExecutorMetadataResult, GetFileMetadataParams, GetFileMetadataResult,
-    GetJobStatusParams, GetJobStatusResult, JobStatus, PartitionId, PollWorkParams,
-    PollWorkResult, QueuedJob, RunningJob, TaskDefinition, TaskStatus,
+    FailedJob, FilePartitionMetadata, FileType, GetFileMetadataParams,
+    GetFileMetadataResult, GetJobStatusParams, GetJobStatusResult, JobStatus,
+    PartitionId, PollWorkParams, PollWorkResult, QueuedJob, RunningJob, TaskDefinition,
+    TaskStatus,
 };
 use ballista_core::serde::scheduler::ExecutorMeta;
 
@@ -72,9 +72,8 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 #[derive(Clone)]
 pub struct SchedulerServer {
     caller_ip: IpAddr,
-    state: Arc<SchedulerState>,
+    pub(crate) state: Arc<SchedulerState>,
     start_time: u128,
-    version: String,
 }
 
 impl SchedulerServer {
@@ -83,7 +82,6 @@ impl SchedulerServer {
         namespace: String,
         caller_ip: IpAddr,
     ) -> Self {
-        const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
         let state = Arc::new(SchedulerState::new(config, namespace));
         let state_clone = state.clone();
 
@@ -97,35 +95,12 @@ impl SchedulerServer {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis(),
-            version: VERSION.unwrap_or("Unknown").to_string(),
         }
     }
 }
 
 #[tonic::async_trait]
 impl SchedulerGrpc for SchedulerServer {
-    async fn get_executors_metadata(
-        &self,
-        _request: Request<GetExecutorMetadataParams>,
-    ) -> std::result::Result<Response<GetExecutorMetadataResult>, tonic::Status> {
-        info!("Received get_executors_metadata request");
-        let result = self
-            .state
-            .get_executors_metadata()
-            .await
-            .map_err(|e| {
-                let msg = format!("Error reading executors metadata: {}", e);
-                error!("{}", msg);
-                tonic::Status::internal(msg)
-            })?
-            .into_iter()
-            .map(|meta| meta.into())
-            .collect();
-        Ok(Response::new(GetExecutorMetadataResult {
-            metadata: result,
-        }))
-    }
-
     async fn poll_work(
         &self,
         request: Request<PollWorkParams>,
@@ -275,13 +250,6 @@ impl SchedulerGrpc for SchedulerServer {
                 }
             };
             debug!("Received plan for execution: {:?}", plan);
-            let executors = self.state.get_executors_metadata().await.map_err(|e| {
-                let msg = format!("Error reading executors metadata: {}", e);
-                error!("{}", msg);
-                tonic::Status::internal(msg)
-            })?;
-            debug!("Found executors: {:?}", executors);
-
             let job_id: String = {
                 let mut rng = thread_rng();
                 std::iter::repeat(())

--- a/dev/docker/ballista-base.dockerfile
+++ b/dev/docker/ballista-base.dockerfile
@@ -23,7 +23,7 @@
 
 
 # Base image extends debian:buster-slim
-FROM rust:1.51.0-buster AS builder
+FROM rust:1.52.1-buster AS builder
 
 RUN apt update && apt -y install musl musl-dev musl-tools libssl-dev openssl
 


### PR DESCRIPTION
 # Rationale for this change

If an executor dies, the current behavior is that the job will fail or it might get stuck forever. This PR is a first step towards making it possible to recover from lost executors: if an executor is dead and it was running tasks or contained materialized partitions that need to be read, we just re-schedule the task.

There are many many more failure cases that the ones covered in this PR. I'll probably start opening issues with the different failure cases so we can track them.

# What changes are included in this PR?
`assign_next_schedulable_task` will not re-schedule any tasks that were handled by executors that died.

I have tested this manually by killing an executor while running tpch query 12, and the query was able to finish and produce the correct result.

# Are there any user-facing changes?
No
