### PR TITLE
RepartitionExec should not error if output has hung up

### DIFF
--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -29,7 +29,6 @@ use crate::physical_plan::{DisplayFormatType, ExecutionPlan, Partitioning, SQLMe
 use arrow::record_batch::RecordBatch;
 use arrow::{array::Array, error::Result as ArrowResult};
 use arrow::{compute::take, datatypes::SchemaRef};
-use log::debug;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::{hash_join::create_hashes, RecordBatchStream, SendableRecordBatchStream};
@@ -278,10 +277,6 @@ impl RepartitionExec {
                     if let Some(tx) = txs.get_mut(&output_partition) {
                         if tx.send(Some(result)).is_err() {
                             // If the other end has hung up, it was an early shutdown (e.g. LIMIT)
-                            debug!(
-                                "Repartition RoundRobinBatch receiver {} hung up",
-                                output_partition
-                            );
                             txs.remove(&output_partition);
                         }
                     }
@@ -331,10 +326,6 @@ impl RepartitionExec {
                         if let Some(tx) = txs.get_mut(&num_output_partition) {
                             if tx.send(Some(output_batch)).is_err() {
                                 // If the other end has hung up, it was an early shutdown (e.g. LIMIT)
-                                debug!(
-                                    "Repartition Hash receiver {} hung up",
-                                    num_output_partition
-                                );
                                 txs.remove(&num_output_partition);
                             }
                         }


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/575

 # Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/575 for gory details, but the idea is that an output hanging up is not an error (it is a LIMIT). However, we also should stop repartition exec from reading input that will never be read.

# What changes are included in this PR?
1. Ignore errors when sending to output that has hung up
2. Stop pulling from input if all outputs have hung up.

# Are there any user-facing changes?
Avoid intermittent errors (that probably started appearing after https://github.com/apache/arrow-datafusion/pull/521 as previously runtime errors were ignored)
