### PR TITLE
Move ballista standalone mode to client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
           cargo test
           # test datafusion examples
           cd datafusion-examples
-          cargo test --no-default-features
+          cargo test --no-default-features --features sled
           cargo run --example csv_sql
           cargo run --example parquet_sql
         env:
@@ -131,7 +131,7 @@ jobs:
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
           cd ballista/rust
           # snmalloc requires cmake so build without default features
-          cargo test --no-default-features
+          cargo test --no-default-features --features sled
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd ballista/rust
           # snmalloc requires cmake so build without default features
-          cargo build --no-default-features
+          cargo build --no-default-features --features sled
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
           cargo test
           # test datafusion examples
           cd datafusion-examples
-          cargo test --no-default-features --features sled
+          cargo test --no-default-features
           cargo run --example csv_sql
           cargo run --example parquet_sql
         env:

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -27,8 +27,14 @@ edition = "2018"
 
 [dependencies]
 ballista-core = { path = "../core" }
+ballista-executor = { path = "../executor", optional = true }
+ballista-scheduler = { path = "../scheduler", optional = true }
 futures = "0.3"
 log = "0.4"
 tokio = "1.0"
 
 datafusion = { path = "../../../datafusion" }
+
+[features]
+default = []
+standalone = ["ballista-executor", "ballista-scheduler"]

--- a/ballista/rust/client/src/columnar_batch.rs
+++ b/ballista/rust/client/src/columnar_batch.rs
@@ -29,9 +29,7 @@ use datafusion::scalar::ScalarValue;
 pub type MaybeColumnarBatch = Result<Option<ColumnarBatch>>;
 
 /// Batch of columnar data.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
-
 pub struct ColumnarBatch {
     schema: Arc<Schema>,
     columns: HashMap<String, ColumnarValue>,
@@ -112,9 +110,7 @@ impl ColumnarBatch {
 }
 
 /// A columnar value can either be a scalar value or an Arrow array.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
-
 pub enum ColumnarValue {
     Scalar(ScalarValue, usize),
     Columnar(ArrayRef),

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4"
 snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -32,7 +32,6 @@ snmalloc = ["snmalloc-rs"]
 anyhow = "1"
 async-trait = "0.1.36"
 ballista-core = { path = "../core" }
-ballista-scheduler = { path = "../scheduler" }
 configure_me = "0.4.0"
 env_logger = "0.8"
 futures = "0.3"

--- a/ballista/rust/executor/executor_config_spec.toml
+++ b/ballista/rust/executor/executor_config_spec.toml
@@ -36,10 +36,6 @@ type = "u16"
 default = "50050"
 doc = "scheduler port"
 
-[[switch]]
-name = "local"
-doc = "Running in local mode will launch a standalone scheduler inside the executor process. This will create a single-executor cluster, and is useful for development scenarios."
-
 [[param]]
 name = "bind_host"
 type = "String"
@@ -69,8 +65,3 @@ name = "concurrent_tasks"
 type = "usize"
 default = "4"
 doc = "Max concurrent tasks."
-
-[[param]]
-name = "scheduler_data_path"
-type = "String"
-doc = "Path for standalone data"

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -29,8 +29,9 @@ use ballista_core::serde::protobuf::{
     self, scheduler_grpc_client::SchedulerGrpcClient, task_status, FailedTask,
     PartitionId, PollWorkParams, PollWorkResult, TaskDefinition, TaskStatus,
 };
-use ballista_executor::executor::Executor;
 use protobuf::CompletedTask;
+
+use crate::executor::Executor;
 
 pub async fn poll_loop(
     mut scheduler: SchedulerGrpcClient<Channel>,

--- a/ballista/rust/executor/src/lib.rs
+++ b/ballista/rust/executor/src/lib.rs
@@ -18,5 +18,9 @@
 //! Core executor logic for executing queries and storing results in memory.
 
 pub mod collect;
+pub mod execution_loop;
 pub mod executor;
 pub mod flight_service;
+
+mod standalone;
+pub use standalone::new_standalone_executor;

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -17,14 +17,11 @@
 
 //! Ballista Rust executor binary.
 
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arrow_flight::flight_service_server::FlightServiceServer;
-use futures::future::MaybeDone;
+use ballista_executor::execution_loop;
 use log::info;
 use tempfile::TempDir;
 use tonic::transport::Server;
@@ -34,16 +31,10 @@ use ballista_core::serde::protobuf::{
     executor_registration, scheduler_grpc_client::SchedulerGrpcClient,
     ExecutorRegistration,
 };
-use ballista_core::{
-    print_version, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
-    BALLISTA_VERSION,
-};
+use ballista_core::{print_version, BALLISTA_VERSION};
 use ballista_executor::executor::Executor;
 use ballista_executor::flight_service::BallistaFlightService;
-use ballista_scheduler::{state::StandaloneClient, SchedulerServer};
 use config::prelude::*;
-
-mod execution_loop;
 
 #[macro_use]
 extern crate configure_me;
@@ -82,11 +73,7 @@ async fn main() -> Result<()> {
         .parse()
         .with_context(|| format!("Could not parse address: {}", addr))?;
 
-    let scheduler_host = if opt.local {
-        "localhost".to_string()
-    } else {
-        opt.scheduler_host
-    };
+    let scheduler_host = opt.scheduler_host;
     let scheduler_port = opt.scheduler_port;
     let scheduler_url = format!("http://{}:{}", scheduler_host, scheduler_port);
 
@@ -108,58 +95,6 @@ async fn main() -> Result<()> {
             .map(executor_registration::OptionalHost::Host),
         port: port as u32,
     };
-
-    if opt.local {
-        info!("Running in local mode. Scheduler will be run in-proc");
-
-        let client = match opt.scheduler_data_path {
-            Some(v) => StandaloneClient::try_new(v)
-                .context("Could not create standalone config backend")?,
-            None => StandaloneClient::try_new_temporary()
-                .context("Could not create standalone config backend")?,
-        };
-
-        let server = SchedulerGrpcServer::new(SchedulerServer::new(
-            Arc::new(client),
-            "ballista".to_string(),
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-        ));
-        let addr = format!("localhost:{}", scheduler_port);
-        let addr = addr
-            .parse()
-            .with_context(|| format!("Could not parse {}", addr))?;
-        info!(
-            "Ballista v{} Rust Scheduler listening on {:?}",
-            BALLISTA_VERSION, addr
-        );
-        let scheduler_future =
-            tokio::spawn(Server::builder().add_service(server).serve(addr));
-        let mut scheduler_result = futures::future::maybe_done(scheduler_future);
-
-        // Ensure scheduler is ready to receive connections
-        while SchedulerGrpcClient::connect(scheduler_url.clone())
-            .await
-            .is_err()
-        {
-            let scheduler_future = match scheduler_result {
-                MaybeDone::Future(f) => f,
-                MaybeDone::Done(Err(e)) => return Err(e).context("Tokio error"),
-                MaybeDone::Done(Ok(Err(e))) => {
-                    return Err(e).context("Scheduler failed to initialize correctly")
-                }
-                MaybeDone::Done(Ok(Ok(()))) => {
-                    return Err(anyhow::format_err!(
-                        "Scheduler unexpectedly finished successfully"
-                    ))
-                }
-                MaybeDone::Gone => {
-                    panic!("Received Gone from recently created MaybeDone")
-                }
-            };
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            scheduler_result = futures::future::maybe_done(scheduler_future);
-        }
-    }
 
     let scheduler = SchedulerGrpcClient::connect(scheduler_url)
         .await

--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use arrow_flight::flight_service_server::FlightServiceServer;
+use ballista_core::{
+    error::Result,
+    serde::protobuf::{scheduler_grpc_client::SchedulerGrpcClient, ExecutorRegistration},
+    BALLISTA_VERSION,
+};
+use log::info;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tonic::transport::{Channel, Server};
+use uuid::Uuid;
+
+use crate::{execution_loop, executor::Executor, flight_service::BallistaFlightService};
+
+pub async fn new_standalone_executor(
+    scheduler: SchedulerGrpcClient<Channel>,
+    concurrent_tasks: usize,
+) -> Result<()> {
+    let work_dir = TempDir::new()?
+        .into_path()
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    let executor = Arc::new(Executor::new(&work_dir));
+
+    let service = BallistaFlightService::new(executor.clone());
+
+    let server = FlightServiceServer::new(service);
+    // Let the OS assign a random, free port
+    let listener = TcpListener::bind("localhost:0").await?;
+    let addr = listener.local_addr()?;
+    info!(
+        "Ballista v{} Rust Executor listening on {:?}",
+        BALLISTA_VERSION, addr
+    );
+    tokio::spawn(
+        Server::builder().add_service(server).serve_with_incoming(
+            tokio_stream::wrappers::TcpListenerStream::new(listener),
+        ),
+    );
+    let executor_meta = ExecutorRegistration {
+        id: Uuid::new_v4().to_string(), // assign this executor a unique ID
+        optional_host: None,
+        port: addr.port() as u32,
+    };
+    tokio::spawn(execution_loop::poll_loop(
+        scheduler,
+        executor,
+        executor_meta,
+        concurrent_tasks,
+    ));
+    Ok(())
+}

--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::sync::Arc;
 
 use arrow_flight::flight_service_server::FlightServiceServer;

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -28,7 +28,7 @@ edition = "2018"
 [features]
 default = ["etcd", "sled"]
 etcd = ["etcd-client"]
-sled = ["sled_package"]
+sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
@@ -48,6 +48,7 @@ rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"], optional = true }
 tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -19,7 +19,10 @@
 
 pub mod api;
 pub mod planner;
+mod standalone;
 pub mod state;
+#[cfg(feature = "sled")]
+pub use standalone::new_standalone_scheduler;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod api;
 pub mod planner;
+#[cfg(feature = "sled")]
 mod standalone;
 pub mod state;
 #[cfg(feature = "sled")]

--- a/ballista/rust/scheduler/src/standalone.rs
+++ b/ballista/rust/scheduler/src/standalone.rs
@@ -29,7 +29,6 @@ use tonic::transport::Server;
 
 use crate::{state::StandaloneClient, SchedulerServer};
 
-#[cfg(feature = "sled")]
 pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
     let client = StandaloneClient::try_new_temporary()?;
 

--- a/ballista/rust/scheduler/src/standalone.rs
+++ b/ballista/rust/scheduler/src/standalone.rs
@@ -1,0 +1,38 @@
+use ballista_core::{
+    error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
+    BALLISTA_VERSION,
+};
+use log::info;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+use crate::{state::StandaloneClient, SchedulerServer};
+
+#[cfg(feature = "sled")]
+pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
+    let client = StandaloneClient::try_new_temporary()?;
+
+    let server = SchedulerGrpcServer::new(SchedulerServer::new(
+        Arc::new(client),
+        "ballista".to_string(),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+    ));
+    // Let the OS assign a random, free port
+    let listener = TcpListener::bind("localhost:0").await?;
+    let addr = listener.local_addr()?;
+    info!(
+        "Ballista v{} Rust Scheduler listening on {:?}",
+        BALLISTA_VERSION, addr
+    );
+    tokio::spawn(
+        Server::builder().add_service(server).serve_with_incoming(
+            tokio_stream::wrappers::TcpListenerStream::new(listener),
+        ),
+    );
+
+    Ok(addr)
+}

--- a/ballista/rust/scheduler/src/standalone.rs
+++ b/ballista/rust/scheduler/src/standalone.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -18,7 +18,6 @@
 //! Benchmark derived from TPC-H. This is not an official TPC-H benchmark.
 
 use std::{
-    collections::HashMap,
     fs,
     iter::Iterator,
     path::{Path, PathBuf},
@@ -252,11 +251,7 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
 async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     println!("Running benchmarks with the following options: {:?}", opt);
 
-    let mut settings = HashMap::new();
-    settings.insert("batch.size".to_owned(), format!("{}", opt.batch_size));
-
-    let ctx =
-        BallistaContext::remote(opt.host.unwrap().as_str(), opt.port.unwrap(), settings);
+    let ctx = BallistaContext::remote(opt.host.unwrap().as_str(), opt.port.unwrap());
 
     // register tables with Ballista context
     let path = opt.path.to_str().unwrap();

--- a/dev/docker/ballista-base.dockerfile
+++ b/dev/docker/ballista-base.dockerfile
@@ -23,7 +23,7 @@
 
 
 # Base image extends debian:buster-slim
-FROM rust:1.51.0-buster AS builder
+FROM rust:1.52.1-buster AS builder
 
 RUN apt update && apt -y install musl musl-dev musl-tools libssl-dev openssl
 

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -91,4 +91,4 @@ COPY benchmarks/queries/ /queries/
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-CMD ["/executor", "--local"]
+CMD ["/executor"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #588.

# What changes are included in this PR?
- Standalone feature in client lib
- Removed --local param in executor

# Are there any user-facing changes?
Yes, the executor no longer has a --local mode.