### PR TITLE
[TEST]Update Rust version to 1.53.0 for integration test

### DIFF
--- a/dev/docker/ballista-base.dockerfile
+++ b/dev/docker/ballista-base.dockerfile
@@ -96,4 +96,6 @@ RUN cargo install cargo-build-deps
 
 # prepare toolchain
 RUN rustup update && \
+    rustup toolchain install nightly-2021-05-10 && \
+    rustup default nightly-2021-05-10 && \
     rustup component add rustfmt

--- a/dev/docker/ballista-base.dockerfile
+++ b/dev/docker/ballista-base.dockerfile
@@ -23,7 +23,7 @@
 
 
 # Base image extends debian:buster-slim
-FROM rust:1.51.0-buster AS builder
+FROM rust:1.53.0-buster AS builder
 
 RUN apt update && apt -y install musl musl-dev musl-tools libssl-dev openssl
 
@@ -96,6 +96,4 @@ RUN cargo install cargo-build-deps
 
 # prepare toolchain
 RUN rustup update && \
-    rustup toolchain install nightly-2021-05-10 && \
-    rustup default nightly-2021-05-10 && \
     rustup component add rustfmt


### PR DESCRIPTION
# Which issue does this PR close?

Closes #596.

 # Rationale for this change
[partition_point](https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point) is stabilized in 1.52.0, we should update the rust docker image used in the integration test to fix the broken test.

# What changes are included in this PR?
Update rust docker image version

# Are there any user-facing changes?

No.
