### PR TITLE
[fix] select * on empty table

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -893,7 +893,7 @@ mod tests {
         logical_plan::{col, create_udf, sum, Expr},
     };
     use crate::{
-        datasource::{MemTable, TableType},
+        datasource::{empty::EmptyTable, MemTable, TableType},
         logical_plan::create_udaf,
         physical_plan::expressions::AvgAccumulator,
     };
@@ -3330,6 +3330,19 @@ mod tests {
             "| Jorge  | 2018-12-13 12:12:10.011 |",
             "+--------+-------------------------+",
         ];
+        assert_batches_sorted_eq!(expected, &result);
+    }
+
+    #[tokio::test]
+    async fn query_empty_table() {
+        let mut ctx = ExecutionContext::new();
+        let empty_table = Arc::new(EmptyTable::new(Arc::new(Schema::empty())));
+        ctx.register_table("test_tbl", empty_table).unwrap();
+        let sql = "SELECT * FROM test_tbl";
+        let result = plan_and_collect(&mut ctx, sql)
+            .await
+            .expect("Query empty table");
+        let expected = vec!["++", "++"];
         assert_batches_sorted_eq!(expected, &result);
     }
 

--- a/datafusion/src/optimizer/projection_push_down.rs
+++ b/datafusion/src/optimizer/projection_push_down.rs
@@ -83,9 +83,10 @@ fn get_projected_schema(
         .collect();
 
     if projection.is_empty() {
-        if has_projection {
+        if has_projection && schema.fields().len() > 0 {
             // Ensure that we are reading at least one column from the table in case the query
-            // does not reference any columns directly such as "SELECT COUNT(1) FROM table"
+            // does not reference any columns directly such as "SELECT COUNT(1) FROM table",
+            // except when the table is empty (no column)
             projection.push(0);
         } else {
             // for table scan without projection, we default to return all columns

--- a/datafusion/src/optimizer/projection_push_down.rs
+++ b/datafusion/src/optimizer/projection_push_down.rs
@@ -83,7 +83,7 @@ fn get_projected_schema(
         .collect();
 
     if projection.is_empty() {
-        if has_projection && schema.fields().len() > 0 {
+        if has_projection && !schema.fields().is_empty() {
             // Ensure that we are reading at least one column from the table in case the query
             // does not reference any columns directly such as "SELECT COUNT(1) FROM table",
             // except when the table is empty (no column)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #612.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The pushdown is forced even for `select *` in https://github.com/apache/arrow-datafusion/blob/20f6f21ec551f066fd9ff228cc5221f1068c8b03/datafusion/src/optimizer/projection_push_down.rs#L164-L170. In that case, we should ensure that no column is artificially added if the table is empty.

# What changes are included in this PR?
I added the test at the context level because it allows it to have a wider coverage of this corner case.

# Are there any user-facing changes?
No
