### PR TITLE
Improve "field not found" error messages

### DIFF
--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1650,7 +1650,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'doesnotexist'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'doesnotexist'"),
         ));
     }
 
@@ -1708,7 +1708,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'doesnotexist'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'doesnotexist'"),
         ));
     }
 
@@ -1718,7 +1718,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'x'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'x'"),
         ));
     }
 
@@ -2189,7 +2189,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'doesnotexist'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'doesnotexist'"),
         ));
     }
 
@@ -2279,7 +2279,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'doesnotexist'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'doesnotexist'"),
         ));
     }
 
@@ -2289,7 +2289,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert!(matches!(
             err,
-            DataFusionError::Plan(msg) if msg == "No field with unqualified name 'doesnotexist'",
+            DataFusionError::Plan(msg) if msg.contains("No field with unqualified name 'doesnotexist'"),
         ));
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #624 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Better UX.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

"Field 'X' not found" error messages now include list of valid fields.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, better error messages.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
