### PR TITLE
Added composite identifiers to get field of struct.

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -1201,7 +1201,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
             Expr::Wildcard => Ok(protobuf::LogicalExprNode {
                 expr_type: Some(protobuf::logical_expr_node::ExprType::Wildcard(true)),
             }),
-            Expr::TryCast { .. } => unimplemented!(),
+            _ => unimplemented!(),
         }
     }
 }

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -224,6 +224,7 @@ pub mod physical_plan;
 pub mod prelude;
 pub mod scalar;
 pub mod sql;
+mod utils;
 pub mod variable;
 
 // re-export dependencies from arrow-rs to minimise version maintenance for crate users

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -82,6 +82,7 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
             Expr::AggregateUDF { .. } => {}
             Expr::InList { .. } => {}
             Expr::Wildcard => {}
+            Expr::GetField { .. } => {}
         }
         Ok(Recursion::Continue(self))
     }
@@ -329,6 +330,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
         Expr::Wildcard { .. } => Err(DataFusionError::Internal(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
+        Expr::GetField { expr, .. } => Ok(vec![expr.as_ref().to_owned()]),
     }
 }
 
@@ -344,6 +346,10 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
         }),
         Expr::IsNull(_) => Ok(Expr::IsNull(Box::new(expressions[0].clone()))),
         Expr::IsNotNull(_) => Ok(Expr::IsNotNull(Box::new(expressions[0].clone()))),
+        Expr::GetField { expr: _, name } => Ok(Expr::GetField {
+            expr: Box::new(expressions[0].clone()),
+            name: name.clone(),
+        }),
         Expr::ScalarFunction { fun, .. } => Ok(Expr::ScalarFunction {
             fun: fun.clone(),
             args: expressions.to_vec(),

--- a/datafusion/src/physical_plan/expressions/get_field.rs
+++ b/datafusion/src/physical_plan/expressions/get_field.rs
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! get field of a struct array
+
+use std::{any::Any, sync::Arc};
+
+use arrow::{
+    array::StructArray,
+    datatypes::{DataType, Schema},
+    record_batch::RecordBatch,
+};
+
+use crate::{
+    error::DataFusionError,
+    error::Result,
+    physical_plan::{ColumnarValue, PhysicalExpr},
+    utils::get_field as get_data_type_field,
+};
+
+/// expression to get a field of a struct array.
+#[derive(Debug)]
+pub struct GetFieldExpr {
+    arg: Arc<dyn PhysicalExpr>,
+    name: String,
+}
+
+impl GetFieldExpr {
+    /// Create new get field expression
+    pub fn new(arg: Arc<dyn PhysicalExpr>, name: String) -> Self {
+        Self { arg, name }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
+    }
+}
+
+impl std::fmt::Display for GetFieldExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "({}).{}", self.arg, self.name)
+    }
+}
+
+impl PhysicalExpr for GetFieldExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
+        let data_type = self.arg.data_type(input_schema)?;
+        get_data_type_field(&data_type, &self.name).map(|f| f.data_type().clone())
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        let data_type = self.arg.data_type(input_schema)?;
+        get_data_type_field(&data_type, &self.name).map(|f| f.is_nullable())
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let arg = self.arg.evaluate(batch)?;
+        match arg {
+            ColumnarValue::Array(array) => Ok(ColumnarValue::Array(
+                array
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .unwrap()
+                    .column_by_name(&self.name)
+                    .unwrap()
+                    .clone(),
+            )),
+            ColumnarValue::Scalar(_) => Err(DataFusionError::NotImplemented(
+                "field is not yet implemented for scalar values".to_string(),
+            )),
+        }
+    }
+}
+
+/// Create an `.field` expression
+pub fn get_field(
+    arg: Arc<dyn PhysicalExpr>,
+    name: String,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    Ok(Arc::new(GetFieldExpr::new(arg, name)))
+}

--- a/datafusion/src/physical_plan/expressions/mod.rs
+++ b/datafusion/src/physical_plan/expressions/mod.rs
@@ -33,6 +33,7 @@ mod cast;
 mod coercion;
 mod column;
 mod count;
+mod get_field;
 mod in_list;
 mod is_not_null;
 mod is_null;
@@ -54,6 +55,7 @@ pub use cast::{
 };
 pub use column::{col, Column};
 pub use count::Count;
+pub use get_field::{get_field, GetFieldExpr};
 pub use in_list::{in_list, InListExpr};
 pub use is_not_null::{is_not_null, IsNotNullExpr};
 pub use is_null::{is_null, IsNullExpr};

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -128,6 +128,10 @@ fn physical_name(e: &Expr, input_schema: &DFSchema) -> Result<String> {
             let expr = physical_name(expr, input_schema)?;
             Ok(format!("{} IS NOT NULL", expr))
         }
+        Expr::GetField { expr, name } => {
+            let expr = physical_name(expr, input_schema)?;
+            Ok(format!("{}.{}", expr, name))
+        }
         Expr::ScalarFunction { fun, args, .. } => {
             create_function_physical_name(&fun.to_string(), false, args, input_schema)
         }
@@ -870,6 +874,10 @@ impl DefaultPhysicalPlanner {
             )?),
             Expr::IsNotNull(expr) => expressions::is_not_null(
                 self.create_physical_expr(expr, input_dfschema, input_schema, ctx_state)?,
+            ),
+            Expr::GetField { expr, name } => expressions::get_field(
+                self.create_physical_expr(expr, input_dfschema, input_schema, ctx_state)?,
+                name.clone(),
             ),
             Expr::ScalarFunction { fun, args } => {
                 let physical_args = args

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -79,6 +79,22 @@ pub struct SqlToRel<'a, S: ContextProvider> {
     schema_provider: &'a S,
 }
 
+fn plan_compound(mut identifiers: Vec<String>) -> Expr {
+    if &identifiers[0][0..1] == "@" {
+        Expr::ScalarVariable(identifiers)
+    } else if identifiers.len() == 2 {
+        // "table.column"
+        let name = identifiers.pop().unwrap();
+        let relation = Some(identifiers.pop().unwrap());
+        Expr::Column(Column { relation, name })
+    } else {
+        // "table.column.field..."
+        let name = identifiers.pop().unwrap();
+        let expr = Box::new(plan_compound(identifiers));
+        Expr::GetField { expr, name }
+    }
+}
+
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Create a new query planner
     pub fn new(schema_provider: &'a S) -> Self {
@@ -916,23 +932,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
 
             SQLExpr::CompoundIdentifier(ids) => {
-                let mut var_names = vec![];
-                for id in ids {
-                    var_names.push(id.value.clone());
-                }
-                if &var_names[0][0..1] == "@" {
-                    Ok(Expr::ScalarVariable(var_names))
-                } else if var_names.len() == 2 {
-                    // table.column identifier
-                    let name = var_names.pop().unwrap();
-                    let relation = Some(var_names.pop().unwrap());
-                    Ok(Expr::Column(Column { relation, name }))
-                } else {
-                    Err(DataFusionError::NotImplemented(format!(
-                        "Unsupported compound identifier '{:?}'",
-                        var_names,
-                    )))
-                }
+                let var_names = ids.iter().map(|x| x.value.clone()).collect::<Vec<_>>();
+                Ok(plan_compound(var_names))
             }
 
             SQLExpr::Wildcard => Ok(Expr::Wildcard),

--- a/datafusion/src/sql/utils.rs
+++ b/datafusion/src/sql/utils.rs
@@ -380,6 +380,10 @@ where
                 Ok(expr.clone())
             }
             Expr::Wildcard => Ok(Expr::Wildcard),
+            Expr::GetField { expr, name } => Ok(Expr::GetField {
+                expr: Box::new(clone_with_replacement(expr.as_ref(), replacement_fn)?),
+                name: name.clone(),
+            }),
         },
     }
 }

--- a/datafusion/src/utils.rs
+++ b/datafusion/src/utils.rs
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, Field};
+
+use crate::error::{DataFusionError, Result};
+
+/// Returns the first field named `name` from the fields of a [`DataType::Struct`].
+/// # Error
+/// Errors iff
+/// * the `data_type` is not a Struct or,
+/// * there is no field named `name`
+pub fn get_field<'a>(data_type: &'a DataType, name: &str) -> Result<&'a Field> {
+    if let DataType::Struct(fields) = data_type {
+        let maybe_field = fields.iter().find(|x| x.name() == name);
+        if let Some(field) = maybe_field {
+            Ok(field)
+        } else {
+            Err(DataFusionError::Plan(format!(
+                "The `Struct` has no field named \"{}\"",
+                name
+            )))
+        }
+    } else {
+        Err(DataFusionError::Plan(
+            "The expression to get a field is only valid for `Struct`".to_string(),
+        ))
+    }
+}

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -24,14 +24,8 @@ use chrono::Duration;
 extern crate arrow;
 extern crate datafusion;
 
-use arrow::{array::*, datatypes::TimeUnit};
-use arrow::{datatypes::Int32Type, datatypes::Int64Type, record_batch::RecordBatch};
 use arrow::{
-    datatypes::{
-        ArrowNativeType, ArrowPrimitiveType, ArrowTimestampType, DataType, Field, Schema,
-        SchemaRef, TimestampMicrosecondType, TimestampMillisecondType,
-        TimestampNanosecondType, TimestampSecondType,
-    },
+    array::*, datatypes::*, record_batch::RecordBatch,
     util::display::array_value_to_string,
 };
 
@@ -2855,6 +2849,31 @@ async fn query_is_not_null() -> Result<()> {
     let sql = "SELECT c1 IS NOT NULL FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["true"], vec!["false"], vec!["true"]];
+
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_get_field() -> Result<()> {
+    let inner_field = Field::new("inner", DataType::Float64, true);
+    let field = Field::new("c1", DataType::Struct(vec![inner_field.clone()]), true);
+    let schema = Arc::new(Schema::new(vec![field]));
+
+    let array = Arc::new(Float64Array::from(vec![Some(1.1), None])) as ArrayRef;
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(StructArray::from(vec![(inner_field, array)]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let mut ctx = ExecutionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT test.c1.inner FROM test";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["1.1"], vec!["NULL"]];
 
     assert_eq!(expected, actual);
     Ok(())


### PR DESCRIPTION
Closes #603

Note that this only works with full identifiers, i.e. `SELECT test.c1.field FROM test`.

The DataFrame API is named `Expr::get_field`, just to make it explicit. We could add `col("c1")["field"]` or something.