### PR TITLE
Improve error message and comments

### DIFF
--- a/datafusion/src/logical_plan/dfschema.rs
+++ b/datafusion/src/logical_plan/dfschema.rs
@@ -158,8 +158,8 @@ impl DFSchema {
             }
         }
         Err(DataFusionError::Plan(format!(
-            "No field matches column '{}'",
-            col,
+            "No field matches column '{}'. Available fields: {}",
+            col, self
         )))
     }
 

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -83,7 +83,12 @@ impl Column {
         }
     }
 
-    /// Normalize Column with qualifier based on provided dataframe schemas.
+    /// Normalizes `self` if is unqualified (has no relation name)
+    /// with an explicit qualifier from the first matching input
+    /// schemas.
+    ///
+    /// For example, `foo` will be normalized to `t.foo` if there is a
+    /// column named `foo` in a relation named `t` found in `schemas`
     pub fn normalize(self, schemas: &[&DFSchemaRef]) -> Result<Self> {
         if self.relation.is_some() {
             return Ok(self);
@@ -1113,7 +1118,8 @@ pub fn columnize_expr(e: Expr, input_schema: &DFSchema) -> Expr {
     }
 }
 
-/// Recursively normalize all Column expressions in a given expression tree
+/// Recursively call [`Column::normalize`] on all Column expressions
+/// in the `expr` expression tree.
 pub fn normalize_col(e: Expr, schemas: &[&DFSchemaRef]) -> Result<Expr> {
     struct ColumnNormalizer<'a, 'b> {
         schemas: &'a [&'b DFSchemaRef],


### PR DESCRIPTION
 # Rationale for this change

I am working through errors while integrating the new qualified identifiers in DataFusion and a few things are confusing:
1. What exactly `normalize*` was normalizing (I found the comments slightly vague)
2. When I got an error (due to a problem I am debugging), it would have helped me debug the issue more to know what the valid fields were.



# What changes are included in this PR?
Changes:
1. Add some comments to `Column::normalize` and `normalize_expr`
2. Print out the available schema in error message


# Are there any user-facing changes?
Previously the error message looked like this

```
thread 'frontend::reorg::test::test_split_plan' panicked at 'called `Result::unwrap()` on an `Err` value: Plan("No field matches column \'#t.time\'")', query/src/frontend/reorg.rs:372:78
```

Now the error looks like:
```
thread 'frontend::reorg::test::test_split_plan' panicked at 'called `Result::unwrap()` on an `Err` value: Plan("No field matches column \'#t.time\'. Available fields: foo.field_int, foo.field_int2, foo.tag1, foo.time")', query/src/frontend/reorg.rs:373:78
```

