### PR TITLE
Bump arrow and parquet versions to 4.4

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -46,8 +46,8 @@ unicode_expressions = ["unicode-segmentation"]
 [dependencies]
 ahash = "0.7"
 hashbrown = "0.11"
-arrow = { version = "4.3", features = ["prettyprint"] }
-parquet = { version = "4.3", features = ["arrow"] }
+arrow = { version = "4.4", features = ["prettyprint"] }
+parquet = { version = "4.4", features = ["arrow"] }
 sqlparser = "0.9.0"
 paste = "^1.0"
 num_cpus = "1.13.0"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #653.

 # Rationale for this change

It looks like the interface of `arrow::compute::window::shift` changed from [v4.3](https://docs.rs/arrow/4.3.0/arrow/compute/kernels/window/fn.shift.html) to [v4.4](https://docs.rs/arrow/4.4.0/arrow/compute/kernels/window/fn.shift.html), so this will fix build errors if arrow@4.3.0 is currently in the `Cargo.lock`.

# What changes are included in this PR?
Bumping the `arrow` and `parquet` versions to v4.4

# Are there any user-facing changes?
None
