### PR TITLE
Allow non-equijoin filters in join condition

### DIFF
--- a/benchmarks/queries/q13.sql
+++ b/benchmarks/queries/q13.sql
@@ -5,7 +5,7 @@ from
     (
         select
             c_custkey,
-            count(o_orderkey) c_count
+            count(o_orderkey)
         from
             customer left outer join orders on
                         c_custkey = o_custkey

--- a/benchmarks/queries/q13.sql
+++ b/benchmarks/queries/q13.sql
@@ -5,7 +5,7 @@ from
     (
         select
             c_custkey,
-            count(o_orderkey)
+            count(o_orderkey) c_count
         from
             customer left outer join orders on
                         c_custkey = o_custkey

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1568,12 +1568,14 @@ fn remove_join_expressions(
     }
 }
 
-/// Parse equijoin ON condition which could be a single Eq or multiple conjunctive Eqs
+/// Extracts equijoin ON condition be a single Eq or multiple conjunctive Eqs
+/// Filters matching this pattern are added to `accum`
+/// Filters that don't match this pattern are added to `accum_filter`
+/// Examples:
 ///
-/// Examples
-///
-/// foo = bar
-/// foo = bar AND bar = baz AND ...
+/// foo = bar => accum=[(foo, bar)] accum_filter=[]
+/// foo = bar AND bar = baz => accum=[(foo, bar), (bar, baz)] accum_filter=[]
+/// foo = bar AND baz > 1 => accum=[(foo, bar)] accum_filter=[baz > 1]
 ///
 fn extract_join_keys(
     expr: &Expr,

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1695,7 +1695,7 @@ async fn equijoin() -> Result<()> {
 }
 
 #[tokio::test]
-async fn equijoin_unsuppored_condition() -> Result<()> {
+async fn equijoin_and_other_condition() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id AND t2_name >= 'y' ORDER BY t1_id";

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1706,6 +1706,17 @@ async fn equijoin_and_other_condition() -> Result<()> {
 }
 
 #[tokio::test]
+async fn equijoin_and_unsupported_condition() -> Result<()> {
+    let ctx = create_join_context("t1_id", "t2_id")?;
+    let sql =
+        "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id AND t2_name >= 'y' ORDER BY t1_id";
+    let res = ctx.create_logical_plan(sql);
+    assert!(res.is_err());
+    assert_eq!(format!("{}", res.unwrap_err()), "This feature is not implemented: Unsupported expressions in Left JOIN: [#t2.t2_name GtEq Utf8(\"y\")]");
+    Ok(())
+}
+
+#[tokio::test]
 async fn left_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let sql = "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id";

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1695,6 +1695,17 @@ async fn equijoin() -> Result<()> {
 }
 
 #[tokio::test]
+async fn equijoin_unsuppored_condition() -> Result<()> {
+    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let sql =
+        "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id AND t2_name >= 'y' ORDER BY t1_id";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["11", "a", "z"], vec!["22", "b", "y"]];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn left_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let sql = "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id";


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #659

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
In queries, some expressions can be added that can not be handled by a equi-join. Those should be supported by moving them to a filter instead. 
This is only done for inner join for now, supporting this for other (left/right) joins will require a bit more work.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Changes the planner to add the unsupported expressions to a filter instead of returning an error.
This almost makes TPC-H query 13 pass, except from some small unsupported / ignored syntax.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No, should just be a bit more flexible.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
