### PR TITLE
[fix] benchmark run with compose

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -140,7 +140,7 @@ docker-compose up
 Then you can run the benchmark with:
 
 ```bash
-docker-compose run ballista-client cargo run benchmark ballista --host ballista-scheduler --port 50050 --query 1 --path /data --format tbl
+docker-compose run ballista-client bash -c '/tpch benchmark ballista --host ballista-scheduler --port 50050 --query 1 --path /data --format tbl'
 ```
 
 ## Expected output

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -41,12 +41,10 @@ services:
   ballista-client:
     image: ballista:0.5.0-SNAPSHOT
     command: "/bin/sh" # do nothing
-    working_dir: /ballista/benchmarks/tpch
     environment:
       - RUST_LOG=info
     volumes:
       - ./data:/data
-      - ../..:/ballista
     depends_on:
       - ballista-scheduler
       - ballista-executor


### PR DESCRIPTION
# Which issue does this PR close?

Closes #665.

 # Rationale for this change
The the following command from the README:
```bash
docker-compose run ballista-client cargo run benchmark ballista --host ballista-scheduler --port 50050 --query 1 --path /data --format tbl
```
was failing because `--host` was taken as an option for `docker-compose` instead of `cargo run benchmark`. 

Also binding to a folder outside the project folder:
```yaml
  volumes:
    - ../..:/ballista
```
is dangerous as you might end up overriding random files on the host filesystem.

# What changes are included in this PR?
Removed the binding to `../..` and documentation update.

# Are there any user-facing changes?
No
