### PR TITLE
dedup using join column in wildcard expansion

### DIFF
--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -17,7 +17,10 @@
 
 //! This module provides a builder for creating LogicalPlans
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use arrow::{
     datatypes::{Schema, SchemaRef},
@@ -220,10 +223,33 @@ impl LogicalPlanBuilder {
         for e in expr {
             match e {
                 Expr::Wildcard => {
-                    (0..input_schema.fields().len()).for_each(|i| {
-                        projected_expr
-                            .push(Expr::Column(input_schema.field(i).qualified_column()))
-                    });
+                    let columns_to_skip = self
+                        .plan
+                        .using_columns()?
+                        .into_iter()
+                        // For each USING JOIN condition, only expand to one column in projection
+                        .map(|cols| {
+                            let mut cols = cols.into_iter().collect::<Vec<_>>();
+                            // sort join columns to make sure we consistently keep the same
+                            // qualified column
+                            cols.sort();
+                            cols.into_iter().skip(1)
+                        })
+                        .flatten()
+                        .collect::<HashSet<_>>();
+
+                    if columns_to_skip.is_empty() {
+                        input_schema.fields().iter().for_each(|f| {
+                            projected_expr.push(Expr::Column(f.qualified_column()))
+                        })
+                    } else {
+                        input_schema.fields().iter().for_each(|f| {
+                            let col = f.qualified_column();
+                            if !columns_to_skip.contains(&col) {
+                                projected_expr.push(Expr::Column(col))
+                            }
+                        })
+                    }
                 }
                 _ => projected_expr
                     .push(columnize_expr(normalize_col(e, &self.plan)?, input_schema)),
@@ -581,6 +607,27 @@ mod tests {
 
         let expected = "Sort: #employee_csv.state ASC NULLS FIRST, #employee_csv.salary DESC NULLS LAST\
         \n  TableScan: employee_csv projection=Some([3, 4])";
+
+        assert_eq!(expected, format!("{:?}", plan));
+
+        Ok(())
+    }
+
+    #[test]
+    fn plan_using_join_wildcard_projection() -> Result<()> {
+        let t2 = LogicalPlanBuilder::scan_empty(Some("t2"), &employee_schema(), None)?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::scan_empty(Some("t1"), &employee_schema(), None)?
+            .join_using(&t2, JoinType::Inner, vec!["id"])?
+            .project(vec![Expr::Wildcard])?
+            .build()?;
+
+        // id column should only show up once in projection
+        let expected = "Projection: #t1.id, #t1.first_name, #t1.last_name, #t1.state, #t1.salary, #t2.first_name, #t2.last_name, #t2.state, #t2.salary\
+        \n  Join: Using #t1.id = #t2.id\
+        \n    TableScan: t1 projection=None\
+        \n    TableScan: t2 projection=None";
 
         assert_eq!(expected, format!("{:?}", plan));
 

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -34,7 +34,7 @@ use std::fmt;
 use std::sync::Arc;
 
 /// A named reference to a qualified field in a schema.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Column {
     /// relation/table name.
     pub relation: Option<String>,

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -21,7 +21,7 @@
 //! Logical query plans can then be optimized and executed directly, or translated into
 //! physical query plans and executed.
 
-mod builder;
+pub(crate) mod builder;
 mod dfschema;
 mod display;
 mod expr;

--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -25,8 +25,8 @@ use crate::error::DataFusionError;
 use crate::logical_plan::dfschema::DFSchemaRef;
 use crate::sql::parser::FileType;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use std::collections::HashSet;
 use std::{
+    collections::HashSet,
     fmt::{self, Display},
     sync::Arc,
 };

--- a/datafusion/src/sql/utils.rs
+++ b/datafusion/src/sql/utils.rs
@@ -23,16 +23,50 @@ use crate::{
     error::{DataFusionError, Result},
     logical_plan::{Column, ExpressionVisitor, Recursion},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Resolves an `Expr::Wildcard` to a collection of `Expr::Column`'s.
-pub(crate) fn expand_wildcard(expr: &Expr, schema: &DFSchema) -> Vec<Expr> {
+pub(crate) fn expand_wildcard(
+    expr: &Expr,
+    schema: &DFSchema,
+    using_columns: &[HashSet<Column>],
+) -> Vec<Expr> {
     match expr {
-        Expr::Wildcard => schema
-            .fields()
-            .iter()
-            .map(|f| Expr::Column(f.qualified_column()))
-            .collect::<Vec<Expr>>(),
+        Expr::Wildcard => {
+            let columns_to_skip = using_columns
+                .iter()
+                // For each USING JOIN condition, only expand to one column in projection
+                .map(|cols| {
+                    let mut cols = cols.iter().collect::<Vec<_>>();
+                    // sort join columns to make sure we consistently keep the same
+                    // qualified column
+                    cols.sort();
+                    cols.into_iter().skip(1)
+                })
+                .flatten()
+                .collect::<HashSet<_>>();
+
+            if columns_to_skip.is_empty() {
+                schema
+                    .fields()
+                    .iter()
+                    .map(|f| Expr::Column(f.qualified_column()))
+                    .collect::<Vec<Expr>>()
+            } else {
+                schema
+                    .fields()
+                    .iter()
+                    .filter_map(|f| {
+                        let col = f.qualified_column();
+                        if !columns_to_skip.contains(&col) {
+                            Some(Expr::Column(col))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<Expr>>()
+            }
+        }
         _ => vec![expr.clone()],
     }
 }


### PR DESCRIPTION
 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Follow up for https://github.com/apache/arrow-datafusion/pull/605. Please review 605 first.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Duduplicate using join columns in wildcard projection.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Using join wildcard projection now only projects a single join column from one side of the join clause.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
