### PR TITLE
Introduce (default) number of partitions option, use it in DataFusion/Ballista

### DIFF
--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -236,7 +236,7 @@ fn build_exec_plan_diagram(
 pub fn create_datafusion_context() -> ExecutionContext {
     let config = ExecutionConfig::new()
         .with_concurrency(1)
-        .with_partitions(4); // TODO: make it easier to configure from Ballista
+        .with_default_partitions(4); // TODO: make it easier to configure from Ballista
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -234,7 +234,9 @@ fn build_exec_plan_diagram(
 
 /// Create a DataFusion context that is compatible with Ballista
 pub fn create_datafusion_context() -> ExecutionContext {
-    let config = ExecutionConfig::new().with_concurrency(1).with_partitions(4); // TODO: make it easier to configure from Ballista
+    let config = ExecutionConfig::new()
+        .with_concurrency(1)
+        .with_partitions(4); // TODO: make it easier to configure from Ballista
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -234,7 +234,7 @@ fn build_exec_plan_diagram(
 
 /// Create a DataFusion context that is compatible with Ballista
 pub fn create_datafusion_context() -> ExecutionContext {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+    let config = ExecutionConfig::new().with_concurrency(1).with_partitions(4); // TODO: make it easier to configure from Ballista
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,9 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let config = ExecutionConfig::new().with_concurrency(1).with_partitions(4);
+    let config = ExecutionConfig::new()
+        .with_concurrency(1)
+        .with_partitions(4);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -28,7 +28,7 @@ pub const TPCH_TABLES: &[&str] = &[
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
     let config = ExecutionConfig::new()
         .with_concurrency(1)
-        .with_partitions(4);
+        .with_partitions(2);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,7 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+    let config = ExecutionConfig::new().with_concurrency(1).with_partitions(4);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -28,7 +28,7 @@ pub const TPCH_TABLES: &[&str] = &[
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
     let config = ExecutionConfig::new()
         .with_concurrency(1)
-        .with_partitions(2);
+        .with_default_partitions(2);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/benchmarks/src/bin/nyctaxi.rs
+++ b/benchmarks/src/bin/nyctaxi.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
 
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
+        .with_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/nyctaxi.rs
+++ b/benchmarks/src/bin/nyctaxi.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
 
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
-        .with_partitions(opt.concurrency)
+        .with_default_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -202,6 +202,7 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
+        .with_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -202,7 +202,7 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
         .with_concurrency(opt.concurrency)
-        .with_partitions(opt.concurrency)
+        .with_default_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -608,7 +608,7 @@ pub struct ExecutionConfig {
     /// Number of concurrent threads for query execution.
     pub concurrency: usize,
     /// Number of default partitions to use for repartioning data
-    pub partitions: usize,
+    pub partition_count: usize,
     /// Default batch size when reading data sources
     pub batch_size: usize,
     /// Responsible for optimizing a logical plan
@@ -641,7 +641,7 @@ impl Default for ExecutionConfig {
     fn default() -> Self {
         Self {
             concurrency: num_cpus::get(),
-            partitions: num_cpus::get(),
+            partition_count: num_cpus::get(),
             batch_size: 8192,
             optimizers: vec![
                 Arc::new(ConstantFolding::new()),
@@ -685,10 +685,10 @@ impl ExecutionConfig {
     }
 
     /// Customize default number of partitions being used in repartioning
-    pub fn with_partitions(mut self, n: usize) -> Self {
-        // partitions must be greater than zero
+    pub fn with_default_partitions(mut self, n: usize) -> Self {
+        // partition count must be greater than zero
         assert!(n > 0);
-        self.partitions = n;
+        self.partition_count = n;
         self
     }
 
@@ -3484,8 +3484,9 @@ mod tests {
 
     /// Generate a partitioned CSV file and register it with an execution context
     fn create_ctx(tmp_dir: &TempDir, partition_count: usize) -> Result<ExecutionContext> {
-        let mut ctx =
-            ExecutionContext::with_config(ExecutionConfig::new().with_concurrency(8));
+        let mut ctx = ExecutionContext::with_config(
+            ExecutionConfig::new().with_default_partitions(8),
+        );
 
         let schema = populate_csv_partitions(tmp_dir, partition_count, ".csv")?;
 

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -607,6 +607,8 @@ impl QueryPlanner for DefaultQueryPlanner {
 pub struct ExecutionConfig {
     /// Number of concurrent threads for query execution.
     pub concurrency: usize,
+    /// Number of partitions for query execution.
+    pub partitions: usize,
     /// Default batch size when reading data sources
     pub batch_size: usize,
     /// Responsible for optimizing a logical plan
@@ -639,6 +641,7 @@ impl Default for ExecutionConfig {
     fn default() -> Self {
         Self {
             concurrency: num_cpus::get(),
+            partitions: num_cpus::get(),
             batch_size: 8192,
             optimizers: vec![
                 Arc::new(ConstantFolding::new()),
@@ -678,6 +681,14 @@ impl ExecutionConfig {
         // concurrency must be greater than zero
         assert!(n > 0);
         self.concurrency = n;
+        self
+    }
+
+    /// Customize default number of partitions being created
+    pub fn with_partitions(mut self, n: usize) -> Self {
+        // partitions must be greater than zero
+        assert!(n > 0);
+        self.partitions = n;
         self
     }
 

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -607,7 +607,7 @@ impl QueryPlanner for DefaultQueryPlanner {
 pub struct ExecutionConfig {
     /// Number of concurrent threads for query execution.
     pub concurrency: usize,
-    /// Number of partitions for query execution.
+    /// Number of default partitions to use for repartioning data
     pub partitions: usize,
     /// Default batch size when reading data sources
     pub batch_size: usize,
@@ -684,7 +684,7 @@ impl ExecutionConfig {
         self
     }
 
-    /// Customize default number of partitions being created
+    /// Customize default number of partitions being used in repartioning
     pub fn with_partitions(mut self, n: usize) -> Self {
         // partitions must be greater than zero
         assert!(n > 0);

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -329,7 +329,7 @@ impl DefaultPhysicalPlanner {
                 let partition_keys = window_expr_common_partition_keys(window_expr)?;
 
                 let can_repartition = !partition_keys.is_empty()
-                    && ctx_state.config.partitions > 1
+                    && ctx_state.config.partition_count > 1
                     && ctx_state.config.repartition_windows;
 
                 let input_exec = if can_repartition {
@@ -346,7 +346,7 @@ impl DefaultPhysicalPlanner {
                         .collect::<Result<Vec<Arc<dyn PhysicalExpr>>>>()?;
                     Arc::new(RepartitionExec::try_new(
                         input_exec,
-                        Partitioning::Hash(partition_keys, ctx_state.config.partitions),
+                        Partitioning::Hash(partition_keys, ctx_state.config.partition_count),
                     )?)
                 } else {
                     input_exec
@@ -480,7 +480,7 @@ impl DefaultPhysicalPlanner {
                     .any(|x| matches!(x, DataType::Dictionary(_, _)));
 
                 let can_repartition = !groups.is_empty()
-                    && ctx_state.config.partitions > 1
+                    && ctx_state.config.partition_count > 1
                     && ctx_state.config.repartition_aggregations
                     && !contains_dict;
 
@@ -493,7 +493,7 @@ impl DefaultPhysicalPlanner {
                         initial_aggr,
                         Partitioning::Hash(
                             final_group.clone(),
-                            ctx_state.config.partitions,
+                            ctx_state.config.partition_count,
                         ),
                     )?);
                     // Combine hash aggregates within the partition
@@ -679,7 +679,7 @@ impl DefaultPhysicalPlanner {
                     })
                     .collect::<Result<hash_utils::JoinOn>>()?;
 
-                if ctx_state.config.partitions > 1 && ctx_state.config.repartition_joins {
+                if ctx_state.config.partition_count > 1 && ctx_state.config.repartition_joins {
                     let (left_expr, right_expr) = join_on
                         .iter()
                         .map(|(l, r)| {
@@ -694,11 +694,11 @@ impl DefaultPhysicalPlanner {
                     Ok(Arc::new(HashJoinExec::try_new(
                         Arc::new(RepartitionExec::try_new(
                             physical_left,
-                            Partitioning::Hash(left_expr, ctx_state.config.partitions),
+                            Partitioning::Hash(left_expr, ctx_state.config.partition_count),
                         )?),
                         Arc::new(RepartitionExec::try_new(
                             physical_right,
-                            Partitioning::Hash(right_expr, ctx_state.config.partitions),
+                            Partitioning::Hash(right_expr, ctx_state.config.partition_count),
                         )?),
                         join_on,
                         &physical_join_type,
@@ -1350,7 +1350,7 @@ mod tests {
     fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {
         let mut ctx_state = make_ctx_state();
         ctx_state.config.concurrency = 4;
-        ctx_state.config.partitions = 4;
+        ctx_state.config.partition_count = 4;
 
         let planner = DefaultPhysicalPlanner::default();
         planner.create_physical_plan(logical_plan, &ctx_state)

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -346,7 +346,10 @@ impl DefaultPhysicalPlanner {
                         .collect::<Result<Vec<Arc<dyn PhysicalExpr>>>>()?;
                     Arc::new(RepartitionExec::try_new(
                         input_exec,
-                        Partitioning::Hash(partition_keys, ctx_state.config.partition_count),
+                        Partitioning::Hash(
+                            partition_keys,
+                            ctx_state.config.partition_count,
+                        ),
                     )?)
                 } else {
                     input_exec
@@ -679,7 +682,9 @@ impl DefaultPhysicalPlanner {
                     })
                     .collect::<Result<hash_utils::JoinOn>>()?;
 
-                if ctx_state.config.partition_count > 1 && ctx_state.config.repartition_joins {
+                if ctx_state.config.partition_count > 1
+                    && ctx_state.config.repartition_joins
+                {
                     let (left_expr, right_expr) = join_on
                         .iter()
                         .map(|(l, r)| {
@@ -694,11 +699,17 @@ impl DefaultPhysicalPlanner {
                     Ok(Arc::new(HashJoinExec::try_new(
                         Arc::new(RepartitionExec::try_new(
                             physical_left,
-                            Partitioning::Hash(left_expr, ctx_state.config.partition_count),
+                            Partitioning::Hash(
+                                left_expr,
+                                ctx_state.config.partition_count,
+                            ),
                         )?),
                         Arc::new(RepartitionExec::try_new(
                             physical_right,
-                            Partitioning::Hash(right_expr, ctx_state.config.partition_count),
+                            Partitioning::Hash(
+                                right_expr,
+                                ctx_state.config.partition_count,
+                            ),
                         )?),
                         join_on,
                         &physical_join_type,

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -679,8 +679,7 @@ impl DefaultPhysicalPlanner {
                     })
                     .collect::<Result<hash_utils::JoinOn>>()?;
 
-                if ctx_state.config.partitions > 1 && ctx_state.config.repartition_joins
-                {
+                if ctx_state.config.partitions > 1 && ctx_state.config.repartition_joins {
                     let (left_expr, right_expr) = join_on
                         .iter()
                         .map(|(l, r)| {

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3796,7 +3796,7 @@ async fn test_cast_expressions_error() -> Result<()> {
 #[tokio::test]
 async fn test_physical_plan_display_indent() {
     // Hard code concurrency as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_concurrency(3);
+    let config = ExecutionConfig::new().with_default_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     register_aggregate_csv(&mut ctx).unwrap();
     let sql = "SELECT c1, MAX(c12), MIN(c12) as the_min \
@@ -3842,7 +3842,7 @@ async fn test_physical_plan_display_indent() {
 #[tokio::test]
 async fn test_physical_plan_display_indent_multi_children() {
     // Hard code concurrency as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_concurrency(3);
+    let config = ExecutionConfig::new().with_default_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     // ensure indenting works for nodes with multiple children
     register_aggregate_csv(&mut ctx).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #661

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently we have `concurrency=partitions` which makes sense for good use of parallelism when you can load results of a single partition in memory, but is not what you want in a distributed / big data setting.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds a new option to DataFusion `partitions` and `with_partitions` that is used for the default number of partitions in a `Hash` or `RoundRobin` repartitioning, or a shuffle in Ballista.

I experimented a bit with setting the number of partitions in Ballista a bit higher, but it seems the writing / reading of small partition has quite a bit of overhead and maybe picking up the tasks in the executors too (?), for a small dataset this is very slow.
I used a couple of executors too.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Added members to `ExecutionConfig`.

As the `ExecutionConfig` is public and a field `partitions` has been added it is technically an `api change`
