### PR TITLE
Rename concurrency to partitions in ExecutionContext

### DIFF
--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -230,7 +230,7 @@ pub fn create_datafusion_context() -> ExecutionContext {
     // specify partitions > 1 to enable partitioned joins
     //TODO we need to implement a configuration mechanism for Ballista
     // see https://github.com/apache/arrow-datafusion/issues/682
-    let config = ExecutionConfig::new().with_partitions(2);
+    let config = ExecutionConfig::new().with_default_partitions(2);
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -227,7 +227,10 @@ fn build_exec_plan_diagram(
 
 /// Create a DataFusion context that is compatible with Ballista
 pub fn create_datafusion_context() -> ExecutionContext {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+    // specify partitions > 1 to enable partitioned joins
+    //TODO we need to implement a configuration mechanism for Ballista
+    // see https://github.com/apache/arrow-datafusion/issues/682
+    let config = ExecutionConfig::new().with_partitions(2);
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -29,7 +29,7 @@ pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
     // specify partitions > 1 to enable partitioned joins
     //TODO we need to implement a configuration mechanism for Ballista
     // see https://github.com/apache/arrow-datafusion/issues/682
-    let config = ExecutionConfig::new().with_partitions(2);
+    let config = ExecutionConfig::new().with_default_partitions(2);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,10 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+    // specify partitions > 1 to enable partitioned joins
+    //TODO we need to implement a configuration mechanism for Ballista
+    // see https://github.com/apache/arrow-datafusion/issues/682
+    let config = ExecutionConfig::new().with_partitions(2);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/benchmarks/src/bin/nyctaxi.rs
+++ b/benchmarks/src/bin/nyctaxi.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
     println!("Running benchmarks with the following options: {:?}", opt);
 
     let config = ExecutionConfig::new()
-        .with_partitions(opt.concurrency)
+        .with_default_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/nyctaxi.rs
+++ b/benchmarks/src/bin/nyctaxi.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
     println!("Running benchmarks with the following options: {:?}", opt);
 
     let config = ExecutionConfig::new()
-        .with_concurrency(opt.concurrency)
+        .with_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -201,7 +201,7 @@ async fn main() -> Result<()> {
 async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
-        .with_partitions(opt.concurrency)
+        .with_default_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 
@@ -963,7 +963,7 @@ mod tests {
         // Tests running query with empty tables, to see whether they run succesfully.
 
         let config = ExecutionConfig::new()
-            .with_partitions(1)
+            .with_default_partitions(1)
             .with_batch_size(10);
         let mut ctx = ExecutionContext::with_config(config);
 
@@ -1057,7 +1057,7 @@ mod tests {
 
         fn round_trip_query(n: usize) -> Result<()> {
             let config = ExecutionConfig::new()
-                .with_partitions(1)
+                .with_default_partitions(1)
                 .with_batch_size(10);
             let mut ctx = ExecutionContext::with_config(config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -201,7 +201,7 @@ async fn main() -> Result<()> {
 async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {:?}", opt);
     let config = ExecutionConfig::new()
-        .with_concurrency(opt.concurrency)
+        .with_partitions(opt.concurrency)
         .with_batch_size(opt.batch_size);
     let mut ctx = ExecutionContext::with_config(config);
 
@@ -963,7 +963,7 @@ mod tests {
         // Tests running query with empty tables, to see whether they run succesfully.
 
         let config = ExecutionConfig::new()
-            .with_concurrency(1)
+            .with_partitions(1)
             .with_batch_size(10);
         let mut ctx = ExecutionContext::with_config(config);
 
@@ -1057,7 +1057,7 @@ mod tests {
 
         fn round_trip_query(n: usize) -> Result<()> {
             let config = ExecutionConfig::new()
-                .with_concurrency(1)
+                .with_partitions(1)
                 .with_batch_size(10);
             let mut ctx = ExecutionContext::with_config(config);
 

--- a/datafusion/benches/sort_limit_query_sql.rs
+++ b/datafusion/benches/sort_limit_query_sql.rs
@@ -80,7 +80,7 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
 
         // create local execution context
         let mut ctx = ExecutionContext::new();
-        ctx.state.lock().unwrap().config.concurrency = 1;
+        ctx.state.lock().unwrap().config.default_partitions = 1;
         ctx.register_table("aggregate_test_100", Arc::new(mem_table))
             .unwrap();
         ctx_holder.lock().unwrap().push(Arc::new(Mutex::new(ctx)))

--- a/datafusion/src/datasource/parquet.rs
+++ b/datafusion/src/datasource/parquet.rs
@@ -37,12 +37,12 @@ pub struct ParquetTable {
     path: String,
     schema: SchemaRef,
     statistics: Statistics,
-    max_concurrency: usize,
+    partition_count: usize,
 }
 
 impl ParquetTable {
     /// Attempt to initialize a new `ParquetTable` from a file path.
-    pub fn try_new(path: impl Into<String>, max_concurrency: usize) -> Result<Self> {
+    pub fn try_new(path: impl Into<String>, partition_count: usize) -> Result<Self> {
         let path = path.into();
         let parquet_exec = ParquetExec::try_from_path(&path, None, None, 0, 1, None)?;
         let schema = parquet_exec.schema();
@@ -50,7 +50,7 @@ impl ParquetTable {
             path,
             schema,
             statistics: parquet_exec.statistics().to_owned(),
-            max_concurrency,
+            partition_count,
         })
     }
 
@@ -94,7 +94,7 @@ impl TableProvider for ParquetTable {
             limit
                 .map(|l| std::cmp::min(l, batch_size))
                 .unwrap_or(batch_size),
-            self.max_concurrency,
+            self.partition_count,
             limit,
         )?))
     }

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -675,7 +675,7 @@ impl ExecutionConfig {
     }
 
     /// Customize default_partitions
-    pub fn with_partitions(mut self, n: usize) -> Self {
+    pub fn with_default_partitions(mut self, n: usize) -> Self {
         // number of partitions must be greater than zero
         assert!(n > 0);
         self.default_partitions = n;
@@ -3474,8 +3474,9 @@ mod tests {
 
     /// Generate a partitioned CSV file and register it with an execution context
     fn create_ctx(tmp_dir: &TempDir, partition_count: usize) -> Result<ExecutionContext> {
-        let mut ctx =
-            ExecutionContext::with_config(ExecutionConfig::new().with_partitions(8));
+        let mut ctx = ExecutionContext::with_config(
+            ExecutionConfig::new().with_default_partitions(8),
+        );
 
         let schema = populate_csv_partitions(tmp_dir, partition_count, ".csv")?;
 

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -138,20 +138,20 @@ impl LogicalPlanBuilder {
     pub fn scan_parquet(
         path: impl Into<String>,
         projection: Option<Vec<usize>>,
-        max_concurrency: usize,
+        partition_count: usize,
     ) -> Result<Self> {
         let path = path.into();
-        Self::scan_parquet_with_name(path.clone(), projection, max_concurrency, path)
+        Self::scan_parquet_with_name(path.clone(), projection, partition_count, path)
     }
 
     /// Scan a Parquet data source and register it with a given table name
     pub fn scan_parquet_with_name(
         path: impl Into<String>,
         projection: Option<Vec<usize>>,
-        max_concurrency: usize,
+        partition_count: usize,
         table_name: impl Into<String>,
     ) -> Result<Self> {
-        let provider = Arc::new(ParquetTable::try_new(path, max_concurrency)?);
+        let provider = Arc::new(ParquetTable::try_new(path, partition_count)?);
         Self::scan(table_name, provider, projection)
     }
 

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -135,7 +135,7 @@ mod tests {
 
         let optimized = optimizer.optimize(
             Arc::new(parquet_project),
-            &ExecutionConfig::new().with_partitions(10),
+            &ExecutionConfig::new().with_default_partitions(10),
         )?;
 
         assert_eq!(
@@ -173,7 +173,7 @@ mod tests {
 
         let optimized = optimizer.optimize(
             Arc::new(parquet_project),
-            &ExecutionConfig::new().with_partitions(10),
+            &ExecutionConfig::new().with_default_partitions(10),
         )?;
 
         // RepartitionExec is added to deepest node

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -186,7 +186,7 @@ pub trait ExecutionPlan: Debug + Send + Sync {
 ///
 /// // Hard code partitions as it appears in the RepartitionExec output
 /// let config = ExecutionConfig::new()
-///     .with_partitions(3);
+///     .with_default_partitions(3);
 /// let mut ctx = ExecutionContext::with_config(config);
 ///
 /// // register the a table

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -184,9 +184,9 @@ pub trait ExecutionPlan: Debug + Send + Sync {
 /// use datafusion::prelude::*;
 /// use datafusion::physical_plan::displayable;
 ///
-/// // Hard code concurrency as it appears in the RepartitionExec output
+/// // Hard code partitions as it appears in the RepartitionExec output
 /// let config = ExecutionConfig::new()
-///     .with_concurrency(3);
+///     .with_partitions(3);
 /// let mut ctx = ExecutionContext::with_config(config);
 ///
 /// // register the a table

--- a/datafusion/src/physical_plan/parquet.rs
+++ b/datafusion/src/physical_plan/parquet.rs
@@ -103,7 +103,7 @@ impl ParquetExec {
         projection: Option<Vec<usize>>,
         predicate: Option<Expr>,
         batch_size: usize,
-        max_concurrency: usize,
+        partition_count: usize,
         limit: Option<usize>,
     ) -> Result<Self> {
         // build a list of filenames from the specified path, which could be a single file or
@@ -124,7 +124,7 @@ impl ParquetExec {
                 projection,
                 predicate,
                 batch_size,
-                max_concurrency,
+                partition_count,
                 limit,
             )
         }
@@ -137,15 +137,15 @@ impl ParquetExec {
         projection: Option<Vec<usize>>,
         predicate: Option<Expr>,
         batch_size: usize,
-        max_concurrency: usize,
+        partition_count: usize,
         limit: Option<usize>,
     ) -> Result<Self> {
         // build a list of Parquet partitions with statistics and gather all unique schemas
         // used in this data set
         let mut schemas: Vec<Schema> = vec![];
-        let mut partitions = Vec::with_capacity(max_concurrency);
+        let mut partitions = Vec::with_capacity(partition_count);
         let filenames: Vec<String> = filenames.iter().map(|s| s.to_string()).collect();
-        let chunks = split_files(&filenames, max_concurrency);
+        let chunks = split_files(&filenames, partition_count);
         let mut num_rows = 0;
         let mut total_byte_size = 0;
         let mut null_counts = Vec::new();

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -329,7 +329,7 @@ impl DefaultPhysicalPlanner {
                 let partition_keys = window_expr_common_partition_keys(window_expr)?;
 
                 let can_repartition = !partition_keys.is_empty()
-                    && ctx_state.config.concurrency > 1
+                    && ctx_state.config.default_partitions > 1
                     && ctx_state.config.repartition_windows;
 
                 let input_exec = if can_repartition {
@@ -346,7 +346,10 @@ impl DefaultPhysicalPlanner {
                         .collect::<Result<Vec<Arc<dyn PhysicalExpr>>>>()?;
                     Arc::new(RepartitionExec::try_new(
                         input_exec,
-                        Partitioning::Hash(partition_keys, ctx_state.config.concurrency),
+                        Partitioning::Hash(
+                            partition_keys,
+                            ctx_state.config.default_partitions,
+                        ),
                     )?)
                 } else {
                     input_exec
@@ -480,7 +483,7 @@ impl DefaultPhysicalPlanner {
                     .any(|x| matches!(x, DataType::Dictionary(_, _)));
 
                 let can_repartition = !groups.is_empty()
-                    && ctx_state.config.concurrency > 1
+                    && ctx_state.config.default_partitions > 1
                     && ctx_state.config.repartition_aggregations
                     && !contains_dict;
 
@@ -493,7 +496,7 @@ impl DefaultPhysicalPlanner {
                         initial_aggr,
                         Partitioning::Hash(
                             final_group.clone(),
-                            ctx_state.config.concurrency,
+                            ctx_state.config.default_partitions,
                         ),
                     )?);
                     // Combine hash aggregates within the partition
@@ -679,7 +682,8 @@ impl DefaultPhysicalPlanner {
                     })
                     .collect::<Result<hash_utils::JoinOn>>()?;
 
-                if ctx_state.config.concurrency > 1 && ctx_state.config.repartition_joins
+                if ctx_state.config.default_partitions > 1
+                    && ctx_state.config.repartition_joins
                 {
                     let (left_expr, right_expr) = join_on
                         .iter()
@@ -695,11 +699,17 @@ impl DefaultPhysicalPlanner {
                     Ok(Arc::new(HashJoinExec::try_new(
                         Arc::new(RepartitionExec::try_new(
                             physical_left,
-                            Partitioning::Hash(left_expr, ctx_state.config.concurrency),
+                            Partitioning::Hash(
+                                left_expr,
+                                ctx_state.config.default_partitions,
+                            ),
                         )?),
                         Arc::new(RepartitionExec::try_new(
                             physical_right,
-                            Partitioning::Hash(right_expr, ctx_state.config.concurrency),
+                            Partitioning::Hash(
+                                right_expr,
+                                ctx_state.config.default_partitions,
+                            ),
                         )?),
                         join_on,
                         &physical_join_type,
@@ -1350,7 +1360,7 @@ mod tests {
 
     fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {
         let mut ctx_state = make_ctx_state();
-        ctx_state.config.concurrency = 4;
+        ctx_state.config.default_partitions = 4;
         let planner = DefaultPhysicalPlanner::default();
         planner.create_physical_plan(logical_plan, &ctx_state)
     }

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3796,7 +3796,7 @@ async fn test_cast_expressions_error() -> Result<()> {
 #[tokio::test]
 async fn test_physical_plan_display_indent() {
     // Hard code partitions as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_partitions(3);
+    let config = ExecutionConfig::new().with_default_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     register_aggregate_csv(&mut ctx).unwrap();
     let sql = "SELECT c1, MAX(c12), MIN(c12) as the_min \
@@ -3842,7 +3842,7 @@ async fn test_physical_plan_display_indent() {
 #[tokio::test]
 async fn test_physical_plan_display_indent_multi_children() {
     // Hard code partitions as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_partitions(3);
+    let config = ExecutionConfig::new().with_default_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     // ensure indenting works for nodes with multiple children
     register_aggregate_csv(&mut ctx).unwrap();

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3795,8 +3795,8 @@ async fn test_cast_expressions_error() -> Result<()> {
 
 #[tokio::test]
 async fn test_physical_plan_display_indent() {
-    // Hard code concurrency as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_concurrency(3);
+    // Hard code partitions as it appears in the RepartitionExec output
+    let config = ExecutionConfig::new().with_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     register_aggregate_csv(&mut ctx).unwrap();
     let sql = "SELECT c1, MAX(c12), MIN(c12) as the_min \
@@ -3841,8 +3841,8 @@ async fn test_physical_plan_display_indent() {
 
 #[tokio::test]
 async fn test_physical_plan_display_indent_multi_children() {
-    // Hard code concurrency as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_concurrency(3);
+    // Hard code partitions as it appears in the RepartitionExec output
+    let config = ExecutionConfig::new().with_partitions(3);
     let mut ctx = ExecutionContext::with_config(config);
     // ensure indenting works for nodes with multiple children
     register_aggregate_csv(&mut ctx).unwrap();

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -192,7 +192,7 @@ async fn topk_plan() -> Result<()> {
 fn make_topk_context() -> ExecutionContext {
     let config = ExecutionConfig::new()
         .with_query_planner(Arc::new(TopKQueryPlanner {}))
-        .with_concurrency(48)
+        .with_partitions(48)
         .add_optimizer_rule(Arc::new(TopKOptimizerRule {}));
 
     ExecutionContext::with_config(config)

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -192,7 +192,7 @@ async fn topk_plan() -> Result<()> {
 fn make_topk_context() -> ExecutionContext {
     let config = ExecutionConfig::new()
         .with_query_planner(Arc::new(TopKQueryPlanner {}))
-        .with_partitions(48)
+        .with_default_partitions(48)
         .add_optimizer_rule(Arc::new(TopKOptimizerRule {}));
 
     ExecutionContext::with_config(config)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #684.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #684 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Rename `with_concurrency` to `with_default_partitions` and rename some associated internal attributes

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes! This is a breaking API change, so we should be careful to review the changes and naming to make sure we are happy with them.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
