### PR TITLE
#554: Lead/lag window function with offset and default value arguments

### DIFF
--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -201,10 +201,16 @@ pub(super) fn signature_for_built_in(fun: &BuiltInWindowFunction) -> Signature {
         | BuiltInWindowFunction::DenseRank
         | BuiltInWindowFunction::PercentRank
         | BuiltInWindowFunction::CumeDist => Signature::Any(0),
-        BuiltInWindowFunction::Lag
-        | BuiltInWindowFunction::Lead
-        | BuiltInWindowFunction::FirstValue
-        | BuiltInWindowFunction::LastValue => Signature::Any(1),
+        BuiltInWindowFunction::Lag | BuiltInWindowFunction::Lead => {
+            Signature::OneOf(vec![
+                Signature::Any(1),
+                Signature::Any(2),
+                Signature::Any(3),
+            ])
+        }
+        BuiltInWindowFunction::FirstValue | BuiltInWindowFunction::LastValue => {
+            Signature::Any(1)
+        }
         BuiltInWindowFunction::Ntile => Signature::Exact(vec![DataType::UInt64]),
         BuiltInWindowFunction::NthValue => Signature::Any(2),
     }

--- a/integration-tests/sqls/simple_window_lead_built_in_functions.sql
+++ b/integration-tests/sqls/simple_window_lead_built_in_functions.sql
@@ -1,0 +1,27 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT
+  c8,
+  LEAD(c8) OVER () next_c8,
+  LEAD(c8, 10, 10) OVER() next_10_c8,
+  LEAD(c8, 100, 10) OVER() next_out_of_bounds_c8,
+  LAG(c8) OVER() prev_c8,
+  LAG(c8, -2, 0) OVER() AS prev_2_c8,
+  LAG(c8, -200, 10) OVER() AS prev_out_of_bounds_c8
+
+FROM test
+ORDER BY c8;

--- a/integration-tests/test_psql_parity.py
+++ b/integration-tests/test_psql_parity.py
@@ -77,7 +77,7 @@ test_files = set(root.glob("*.sql"))
 
 class TestPsqlParity:
     def test_tests_count(self):
-        assert len(test_files) == 14, "tests are missed"
+        assert len(test_files) == 15, "tests are missed"
 
     @pytest.mark.parametrize("fname", test_files)
     def test_sql_file(self, fname):


### PR DESCRIPTION
# Which issue does this PR close?
#Closes #554.

 # Rationale for this change
Implement offset and default value optional arguments in lead/lag window functions.

# What changes are included in this PR?
Changes in lead/lag pub fn signatures.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
