### PR TITLE
Remove qualifiers on pushed down predicates / Fix parquet pruning

### DIFF
--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -43,7 +43,8 @@ pub use expr::{
     min, normalize_col, normalize_cols, now, octet_length, or, random, regexp_match,
     regexp_replace, repeat, replace, replace_col, reverse, right, round, rpad, rtrim,
     sha224, sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos,
-    substr, sum, tan, to_hex, translate, trim, trunc, upper, when, Column, Expr,
+    substr, sum, tan, to_hex, translate, trim, trunc, unnormalize_col, unnormalize_cols,
+    upper, when, Column, Expr,
     ExprRewriter, ExpressionVisitor, Literal, Recursion,
 };
 pub use extension::UserDefinedLogicalNode;

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -44,8 +44,7 @@ pub use expr::{
     regexp_replace, repeat, replace, replace_col, reverse, right, round, rpad, rtrim,
     sha224, sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos,
     substr, sum, tan, to_hex, translate, trim, trunc, unnormalize_col, unnormalize_cols,
-    upper, when, Column, Expr,
-    ExprRewriter, ExpressionVisitor, Literal, Recursion,
+    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/tests/parquet_pruning.rs
+++ b/datafusion/tests/parquet_pruning.rs
@@ -44,9 +44,9 @@ async fn prune_timestamps_nanos() {
         .query("SELECT * FROM t where nanos < to_timestamp('2020-01-02 01:01:11Z')")
         .await;
     println!("{}", output.description());
-    // TODO This should prune one metrics without error
-    assert_eq!(output.predicate_evaluation_errors(), Some(1));
-    assert_eq!(output.row_groups_pruned(), Some(0));
+    // This should prune one metrics without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(1));
     assert_eq!(output.result_rows, 10, "{}", output.description());
 }
 
@@ -59,9 +59,9 @@ async fn prune_timestamps_micros() {
         )
         .await;
     println!("{}", output.description());
-    // TODO This should prune one metrics without error
-    assert_eq!(output.predicate_evaluation_errors(), Some(1));
-    assert_eq!(output.row_groups_pruned(), Some(0));
+    // This should prune one metrics without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(1));
     assert_eq!(output.result_rows, 10, "{}", output.description());
 }
 
@@ -74,9 +74,9 @@ async fn prune_timestamps_millis() {
         )
         .await;
     println!("{}", output.description());
-    // TODO This should prune one metrics without error
-    assert_eq!(output.predicate_evaluation_errors(), Some(1));
-    assert_eq!(output.row_groups_pruned(), Some(0));
+    // This should prune one metrics without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(1));
     assert_eq!(output.result_rows, 10, "{}", output.description());
 }
 
@@ -89,9 +89,9 @@ async fn prune_timestamps_seconds() {
         )
         .await;
     println!("{}", output.description());
-    // TODO This should prune one metrics without error
-    assert_eq!(output.predicate_evaluation_errors(), Some(1));
-    assert_eq!(output.row_groups_pruned(), Some(0));
+    // This should prune one metrics without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(1));
     assert_eq!(output.result_rows, 10, "{}", output.description());
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #https://github.com/apache/arrow-datafusion/issues/656

Based on https://github.com/apache/arrow-datafusion/pull/657 (test for parquet pruning) so review that first

 # Rationale for this change
Predicate pushdown for parquet is currently broken because the filtering logic gets columns that refer to `foo.bar` but the table provider only knows about columns (e.g. only about `bar)`

# What changes are included in this PR?
1. `unnormalize_expr` function to remove qualifiers from expressions
2.  tests


# Are there any user-facing changes?
Pruning works again
