### PR TITLE
Fix Date32 and Date64 parquet row group pruning

### DIFF
--- a/datafusion/src/physical_plan/expressions/binary.rs
+++ b/datafusion/src/physical_plan/expressions/binary.rs
@@ -269,6 +269,9 @@ macro_rules! binary_array_op_scalar {
             DataType::Date32 => {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, Date32Array)
             }
+            DataType::Date64 => {
+                compute_op_scalar!($LEFT, $RIGHT, $OP, Date64Array)
+            }
             other => Err(DataFusionError::Internal(format!(
                 "Data type {:?} not supported for scalar operation on dyn array",
                 other

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -900,6 +900,7 @@ impl TryFrom<ScalarValue> for i64 {
     fn try_from(value: ScalarValue) -> Result<Self> {
         match value {
             ScalarValue::Int64(Some(inner_value))
+            | ScalarValue::Date64(Some(inner_value))
             | ScalarValue::TimestampNanosecond(Some(inner_value))
             | ScalarValue::TimestampMicrosecond(Some(inner_value))
             | ScalarValue::TimestampMillisecond(Some(inner_value))
@@ -939,6 +940,8 @@ impl TryFrom<&DataType> for ScalarValue {
             DataType::UInt64 => ScalarValue::UInt64(None),
             DataType::Utf8 => ScalarValue::Utf8(None),
             DataType::LargeUtf8 => ScalarValue::LargeUtf8(None),
+            DataType::Date32 => ScalarValue::Date32(None),
+            DataType::Date64 => ScalarValue::Date64(None),
             DataType::Timestamp(TimeUnit::Second, _) => {
                 ScalarValue::TimestampSecond(None)
             }


### PR DESCRIPTION
# Which issue does this PR close?

Fixes: https://github.com/apache/arrow-datafusion/issues/649 as found by @yordan-pavlov 

~Build on https://github.com/apache/arrow-datafusion/pull/657 and https://github.com/apache/arrow-datafusion/pull/689 so please review them first~

 # Rationale for this change
Parquet pruning is not working for `Date32` or `Date64`

# What changes are included in this PR?
Fixes parquet pruning on `Date32` and `Date64` columns by adding the appropriate expression evaluation machinery for Date32 and Date64. Creating arrays for testing I found super awkward and I filed https://github.com/apache/arrow-rs/issues/527 to try and track improving that situation 