### PR TITLE
Fix build with 1.52.1

### DIFF
--- a/datafusion/src/physical_plan/parquet.rs
+++ b/datafusion/src/physical_plan/parquet.rs
@@ -514,7 +514,7 @@ impl ExecutionPlan for ParquetExec {
         self.partitions
             .iter()
             .flat_map(|p| {
-                [
+                vec![
                     (
                         format!(
                             "numPredicateEvaluationErrors for {}",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/695

 # Rationale for this change
We use a slightly older version of Rust in IOn (1.52.1) and it does not compile HEAD of datafusion

# What changes are included in this PR?
Add a `vec!` to make 1.52.1 happy

# Are there any user-facing changes?
No
