### PR TITLE
Ballista: Make shuffle partitions configurable in benchmarks

### DIFF
--- a/ballista/rust/client/src/prelude.rs
+++ b/ballista/rust/client/src/prelude.rs
@@ -18,6 +18,8 @@
 //! Ballista Prelude (common imports)
 
 pub use crate::context::BallistaContext;
+pub use ballista_core::config::BallistaConfig;
+pub use ballista_core::config::BALLISTA_DEFAULT_SHUFFLE_PARTITIONS;
 pub use ballista_core::error::{BallistaError, Result};
 
 pub use futures::StreamExt;

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -803,7 +803,9 @@ message ExecuteQueryParams {
   oneof query {
     LogicalPlanNode logical_plan = 1;
     string sql = 2;
-  }}
+  }
+  repeated KeyValuePair settings = 3;
+}
 
 message ExecuteSqlParams {
   string sql = 1;

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -60,12 +60,13 @@ pub struct BallistaConfigBuilder {
 impl Default for BallistaConfigBuilder {
     /// Create a new config builder
     fn default() -> Self {
-        Self { settings: HashMap::new() }
+        Self {
+            settings: HashMap::new(),
+        }
     }
 }
 
 impl BallistaConfigBuilder {
-
     /// Create a new config with an additional setting
     pub fn set(&self, k: &str, v: &str) -> Self {
         let mut settings = self.settings.clone();
@@ -86,7 +87,6 @@ pub struct BallistaConfig {
 }
 
 impl BallistaConfig {
-
     /// Create a default configuration
     pub fn new() -> Result<Self> {
         Self::with_settings(HashMap::new())
@@ -174,7 +174,8 @@ mod tests {
     #[test]
     fn custom_config_invalid() -> Result<()> {
         let config = BallistaConfig::builder()
-            .set(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, "true").build();
+            .set(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, "true")
+            .build();
         assert!(config.is_err());
         assert_eq!("General(\"Failed to parse user-supplied value 'ballista.shuffle.partitions' for configuration setting 'true': ParseIntError { kind: InvalidDigit }\")", format!("{:?}", config.unwrap_err()));
         Ok(())

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -20,9 +20,37 @@
 
 use std::collections::HashMap;
 
+use crate::error::{BallistaError, Result};
+
+use datafusion::arrow::datatypes::DataType;
 use log::warn;
 
 pub const BALLISTA_DEFAULT_SHUFFLE_PARTITIONS: &str = "ballista.shuffle.partitions";
+
+/// Configuration option meta-data
+#[derive(Debug, Clone)]
+pub struct ConfigEntry {
+    name: String,
+    description: String,
+    data_type: DataType,
+    default_value: Option<String>,
+}
+
+impl ConfigEntry {
+    fn new(
+        name: String,
+        description: String,
+        data_type: DataType,
+        default_value: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            description,
+            data_type,
+            default_value,
+        }
+    }
+}
 
 /// Ballista configuration
 #[derive(Debug, Clone)]
@@ -33,8 +61,36 @@ pub struct BallistaConfig {
 
 impl BallistaConfig {
     /// Create a new configuration based on key-value pairs
-    pub fn new(settings: HashMap<String, String>) -> Self {
-        Self { settings }
+    pub fn new(settings: HashMap<String, String>) -> Result<Self> {
+        let supported_entries = BallistaConfig::valid_entries();
+        for (name, entry) in &supported_entries {
+            if let Some(v) = settings.get(name) {
+                // validate that we can parse the user-supplied value
+                let _ = v.parse::<usize>().map_err(|e| BallistaError::General(format!("Failed to parse user-supplied value '{}' for configuration setting '{}': {:?}", name, v, e)))?;
+            } else if let Some(v) = entry.default_value.clone() {
+                let _ = v.parse::<usize>().map_err(|e| BallistaError::General(format!("Failed to parse default value '{}' for configuration setting '{}': {:?}", name, v, e)))?;
+            } else {
+                return Err(BallistaError::General(format!(
+                    "No value specified for mandatory configuration setting '{}'",
+                    name
+                )));
+            }
+        }
+
+        Ok(Self { settings })
+    }
+
+    /// All available configuration options
+    pub fn valid_entries() -> HashMap<String, ConfigEntry> {
+        let entries = vec![
+            ConfigEntry::new(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_string(),
+                "Sets the default number of partitions to create when repartitioning query stages".to_string(),
+                DataType::UInt16, Some("2".to_string())),
+        ];
+        entries
+            .iter()
+            .map(|e| (e.name.clone(), e.clone()))
+            .collect::<HashMap<_, _>>()
     }
 
     pub fn settings(&self) -> &HashMap<String, String> {
@@ -42,15 +98,55 @@ impl BallistaConfig {
     }
 
     pub fn default_shuffle_partitions(&self) -> usize {
-        self.get_usize_setting(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, 2)
+        self.get_usize_setting(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS)
     }
 
-    fn get_usize_setting(&self, key: &str, default_value: usize) -> usize {
+    fn get_usize_setting(&self, key: &str) -> usize {
         if let Some(v) = self.settings.get(key) {
-            //TODO error handling
+            // infallible because we validate all configs in the constructor
             v.parse().unwrap()
         } else {
-            default_value
+            let entries = Self::valid_entries();
+            // infallible because we validate all configs in the constructor
+            let v = entries.get(key).unwrap().default_value.as_ref().unwrap();
+            v.parse().unwrap()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() -> Result<()> {
+        let config = BallistaConfig::new(HashMap::new())?;
+        assert_eq!(2, config.default_shuffle_partitions());
+        Ok(())
+    }
+
+    #[test]
+    fn custom_config() -> Result<()> {
+        let mut settings = HashMap::new();
+        settings.insert(
+            BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_string(),
+            "123".to_string(),
+        );
+        let config = BallistaConfig::new(settings)?;
+        assert_eq!(123, config.default_shuffle_partitions());
+        Ok(())
+    }
+
+    #[test]
+    fn custom_config_invalid() -> Result<()> {
+        let mut settings = HashMap::new();
+        settings.insert(
+            BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_string(),
+            "true".to_string(),
+        );
+        let config = BallistaConfig::new(settings);
+        assert!(config.is_err());
+        assert_eq!("General(\"Failed to parse user-supplied value 'ballista.shuffle.partitions' for configuration setting 'true': ParseIntError { kind: InvalidDigit }\")", format!("{:?}", config.unwrap_err()));
+        Ok(())
     }
 }

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+//! Ballista configuration
+
+use std::collections::HashMap;
+
+use log::warn;
+
+pub const BALLISTA_DEFAULT_SHUFFLE_PARTITIONS: &str = "ballista.shuffle.partitions";
+
+/// Ballista configuration
+#[derive(Debug, Clone)]
+pub struct BallistaConfig {
+    /// Settings stored in map for easy serde
+    settings: HashMap<String, String>,
+}
+
+impl BallistaConfig {
+    /// Create a new configuration based on key-value pairs
+    pub fn new(settings: HashMap<String, String>) -> Self {
+        Self { settings }
+    }
+
+    pub fn settings(&self) -> &HashMap<String, String> {
+        &self.settings
+    }
+
+    pub fn default_shuffle_partitions(&self) -> usize {
+        self.get_usize_setting(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, 2)
+    }
+
+    fn get_usize_setting(&self, key: &str, default_value: usize) -> usize {
+        if let Some(v) = self.settings.get(key) {
+            //TODO error handling
+            v.parse().unwrap()
+        } else {
+            default_value
+        }
+    }
+}

--- a/ballista/rust/core/src/lib.rs
+++ b/ballista/rust/core/src/lib.rs
@@ -24,6 +24,7 @@ pub fn print_version() {
 }
 
 pub mod client;
+pub mod config;
 pub mod datasource;
 pub mod error;
 pub mod execution_plans;

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -27,6 +27,7 @@ use crate::execution_plans::{ShuffleWriterExec, UnresolvedShuffleExec};
 use crate::memory_stream::MemoryStream;
 use crate::serde::scheduler::PartitionStats;
 
+use crate::config::BallistaConfig;
 use datafusion::arrow::error::Result as ArrowResult;
 use datafusion::arrow::{
     array::{
@@ -233,8 +234,9 @@ fn build_exec_plan_diagram(
 }
 
 /// Create a DataFusion context that is compatible with Ballista
-pub fn create_datafusion_context() -> ExecutionContext {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+pub fn create_datafusion_context(config: &BallistaConfig) -> ExecutionContext {
+    let config =
+        ExecutionConfig::new().with_concurrency(config.default_shuffle_partitions());
     ExecutionContext::with_config(config)
 }
 

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -302,7 +302,11 @@ impl SchedulerGrpc for SchedulerServer {
             for kv_pair in &settings {
                 config.insert(kv_pair.key.clone(), kv_pair.value.clone());
             }
-            let config = BallistaConfig::new(config);
+            let config = BallistaConfig::new(config).map_err(|e| {
+                let msg = format!("Could not parse configs: {}", e);
+                error!("{}", msg);
+                tonic::Status::internal(msg)
+            })?;
 
             let plan = match query {
                 Query::LogicalPlan(logical_plan) => {

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -82,7 +82,6 @@ use self::state::{ConfigBackendClient, SchedulerState};
 use ballista_core::config::BallistaConfig;
 use ballista_core::utils::create_datafusion_context;
 use datafusion::physical_plan::parquet::ParquetExec;
-use std::collections::HashMap;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
@@ -298,11 +297,11 @@ impl SchedulerGrpc for SchedulerServer {
         } = request.into_inner()
         {
             // parse config
-            let mut config = HashMap::new();
+            let mut config_builder = BallistaConfig::builder();
             for kv_pair in &settings {
-                config.insert(kv_pair.key.clone(), kv_pair.value.clone());
+                config_builder = config_builder.set(&kv_pair.key, &kv_pair.value);
             }
-            let config = BallistaConfig::new(config).map_err(|e| {
+            let config = config_builder.build().map_err(|e| {
                 let msg = format!("Could not parse configs: {}", e);
                 error!("{}", msg);
                 tonic::Status::internal(msg)

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,8 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let config = ExecutionConfig::new().with_concurrency(2); // TODO: this is hack to enable partitioned joins
+    let default_shuffle_partitions = 2;
+    let config = ExecutionConfig::new().with_concurrency(default_shuffle_partitions);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -262,7 +262,8 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
         BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_owned(),
         format!("{}", opt.shuffle_partitions),
     );
-    let config = BallistaConfig::new(config);
+    let config = BallistaConfig::new(config)
+        .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
     let ctx =
         BallistaContext::remote(opt.host.unwrap().as_str(), opt.port.unwrap(), &config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -18,7 +18,6 @@
 //! Benchmark derived from TPC-H. This is not an official TPC-H benchmark.
 
 use std::{
-    collections::HashMap,
     fs,
     iter::Iterator,
     path::{Path, PathBuf},
@@ -257,13 +256,14 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
 async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     println!("Running benchmarks with the following options: {:?}", opt);
 
-    let mut config = HashMap::new();
-    config.insert(
-        BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_owned(),
-        format!("{}", opt.shuffle_partitions),
-    );
-    let config = BallistaConfig::new(config)
+    let config = BallistaConfig::builder()
+        .set(
+            BALLISTA_DEFAULT_SHUFFLE_PARTITIONS,
+            &format!("{}", opt.shuffle_partitions),
+        )
+        .build()
         .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
+
     let ctx =
         BallistaContext::remote(opt.host.unwrap().as_str(), opt.port.unwrap(), &config);
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -95,6 +95,10 @@ struct BallistaBenchmarkOpt {
     /// Ballista executor port
     #[structopt(long = "port")]
     port: Option<u16>,
+
+    /// Number of shuffle partitions
+    #[structopt(short, long, default_value = "2")]
+    shuffle_partitions: usize,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -256,7 +260,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     let mut config = HashMap::new();
     config.insert(
         BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_owned(),
-        "4".to_owned(),
+        format!("{}", opt.shuffle_partitions),
     );
     let config = BallistaConfig::new(config);
     let ctx =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #701

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We shouldn't hard-code configuration settings. User should be able to specify configuration.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This introduces a configuration mechanism for a Ballista context based on key-value pairs that can be sent over protobuf to the scheduler. There is one configuration option supported so far, for default number of shuffle partitions.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes. The API for creating a Ballista context has changed.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
