### PR TITLE
replace once iter chain with array::IntoIter

### DIFF
--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -375,12 +375,10 @@ impl LogicalPlan {
                 {
                     self.using_columns.push(
                         on.iter()
-                            .map(|entry| {
-                                std::iter::once(entry.0.clone())
-                                    .chain(std::iter::once(entry.1.clone()))
-                            })
+                            .map(|entry| std::array::IntoIter::new([&entry.0, &entry.1]))
                             .flatten()
-                            .collect::<HashSet<_>>(),
+                            .cloned()
+                            .collect::<HashSet<Column>>(),
                     );
                 }
                 Ok(true)

--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -375,7 +375,7 @@ impl LogicalPlan {
                 {
                     self.using_columns.push(
                         on.iter()
-                            .map(|entry| std::array::IntoIter::new([&entry.0, &entry.1]))
+                            .map(|entry| [&entry.0, &entry.1])
                             .flatten()
                             .cloned()
                             .collect::<HashSet<Column>>(),

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -97,11 +97,11 @@ fn get_join_predicates<'a>(
         .fields()
         .iter()
         .map(|f| {
-            std::array::IntoIter::new([
+            [
                 f.qualified_column(),
                 // we need to push down filter using unqualified column as well
                 f.unqualified_column(),
-            ])
+            ]
         })
         .flatten()
         .collect::<HashSet<_>>();
@@ -109,11 +109,11 @@ fn get_join_predicates<'a>(
         .fields()
         .iter()
         .map(|f| {
-            std::array::IntoIter::new([
+            [
                 f.qualified_column(),
                 // we need to push down filter using unqualified column as well
                 f.unqualified_column(),
-            ])
+            ]
         })
         .flatten()
         .collect::<HashSet<_>>();

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -97,9 +97,11 @@ fn get_join_predicates<'a>(
         .fields()
         .iter()
         .map(|f| {
-            std::iter::once(f.qualified_column())
+            std::array::IntoIter::new([
+                f.qualified_column(),
                 // we need to push down filter using unqualified column as well
-                .chain(std::iter::once(f.unqualified_column()))
+                f.unqualified_column(),
+            ])
         })
         .flatten()
         .collect::<HashSet<_>>();
@@ -107,8 +109,11 @@ fn get_join_predicates<'a>(
         .fields()
         .iter()
         .map(|f| {
-            std::iter::once(f.qualified_column())
-                .chain(std::iter::once(f.unqualified_column()))
+            std::array::IntoIter::new([
+                f.qualified_column(),
+                // we need to push down filter using unqualified column as well
+                f.unqualified_column(),
+            ])
         })
         .flatten()
         .collect::<HashSet<_>>();


### PR DESCRIPTION
# Rationale for this change

Follow up for #605.

# What changes are included in this PR?

Replace manual once chain iterator with array::IntoIter to make code more readable based on feedback from https://github.com/apache/arrow-datafusion/pull/605#discussion_r664543206.

# Are there any user-facing changes?

no