### PR TITLE
Ballista: Finish implementing shuffle mechanism [DRAFT]

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -223,7 +223,7 @@ impl BallistaContext {
                 &partition_id.job_id,
                 partition_id.stage_id as usize,
                 partition_id.partition_id as usize,
-                &partition_id.path,
+                &location.path,
             )
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?)

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -223,6 +223,7 @@ impl BallistaContext {
                 &partition_id.job_id,
                 partition_id.stage_id as usize,
                 partition_id.partition_id as usize,
+                &partition_id.path,
             )
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?)

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -542,7 +542,7 @@ message PhysicalNegativeNode {
 }
 
 message UnresolvedShuffleExecNode {
-  repeated uint32 query_stage_ids = 1;
+  uint32 query_stage_ids = 1;
   Schema schema = 2;
   uint32 partition_count = 3;
 }
@@ -706,7 +706,7 @@ message Action {
     ExecutePartition execute_partition = 2;
 
     // Fetch a partition from an executor
-    PartitionId fetch_partition = 3;
+    FetchPartition fetch_partition = 3;
   }
 
   // configuration settings
@@ -722,11 +722,19 @@ message ExecutePartition {
   repeated PartitionLocation partition_location = 5;
 }
 
+message FetchPartition {
+  string job_id = 1;
+  uint32 stage_id = 2;
+  uint32 partition_id = 3;
+  string path = 4;
+}
+
 // Mapping from partition id to executor id
 message PartitionLocation {
   PartitionId partition_id = 1;
   ExecutorMetadata executor_meta = 2;
   PartitionStats partition_stats = 3;
+  string path = 4;
 }
 
 // Unique identifier for a materialized partition of data
@@ -734,7 +742,7 @@ message PartitionId {
   string job_id = 1;
   uint32 stage_id = 2;
   uint32 partition_id = 4;
-  string path = 5;
+//  string path = 5;
 }
 
 message PartitionStats {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -789,7 +789,7 @@ message CompletedTask {
 }
 
 message ShuffleWritePartition {
-  uint64 output_partition_id = 1;
+  uint64 partition_id = 1;
   string path = 2;
   uint64 num_batches = 3;
   uint64 num_rows = 4;

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -424,6 +424,7 @@ message PhysicalPlanNode {
     UnresolvedShuffleExecNode unresolved = 15;
     RepartitionExecNode repartition = 16;
     WindowAggExecNode window = 17;
+    ShuffleWriterExecNode shuffle_writer = 18;
   }
 }
 
@@ -629,6 +630,15 @@ message HashAggregateExecNode {
   Schema input_schema = 7;
 }
 
+message ShuffleWriterExecNode {
+  //TODO it seems redundant to provide job and stage id here since we also have them
+  // in the TaskDefinition that wraps this plan
+  string job_id = 1;
+  uint32 stage_id = 2;
+  PhysicalPlanNode input = 3;
+  PhysicalHashRepartition output_partitioning = 4;
+}
+
 message ShuffleReaderExecNode {
   repeated ShuffleReaderPartition partition = 1;
   Schema schema = 2;
@@ -793,6 +803,9 @@ message PollWorkParams {
 message TaskDefinition {
   PartitionId task_id = 1;
   PhysicalPlanNode plan = 2;
+  // TODO tasks are currently always shuffle writes but this will not always be the case
+  // so we might want to think about some refactoring of the task definition
+  PhysicalHashRepartition shuffle_output_partitioning = 3;
 }
 
 message PollWorkResult {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -734,6 +734,7 @@ message PartitionId {
   string job_id = 1;
   uint32 stage_id = 2;
   uint32 partition_id = 4;
+  string path = 5;
 }
 
 message PartitionStats {
@@ -782,6 +783,17 @@ message FailedTask {
 
 message CompletedTask {
   string executor_id = 1;
+  // TODO tasks are currently always shuffle writes but this will not always be the case
+  // so we might want to think about some refactoring of the task definitions
+  repeated ShuffleWritePartition partitions = 2;
+}
+
+message ShuffleWritePartition {
+  uint64 output_partition_id = 1;
+  string path = 2;
+  uint64 num_batches = 3;
+  uint64 num_rows = 4;
+  uint64 num_bytes = 5;
 }
 
 message TaskStatus {
@@ -804,7 +816,7 @@ message TaskDefinition {
   PartitionId task_id = 1;
   PhysicalPlanNode plan = 2;
   // TODO tasks are currently always shuffle writes but this will not always be the case
-  // so we might want to think about some refactoring of the task definition
+  // so we might want to think about some refactoring of the task definitions
   PhysicalHashRepartition shuffle_output_partitioning = 3;
 }
 

--- a/ballista/rust/core/src/client.rs
+++ b/ballista/rust/core/src/client.rs
@@ -132,9 +132,14 @@ impl BallistaClient {
         job_id: &str,
         stage_id: usize,
         partition_id: usize,
+        path: &str,
     ) -> Result<SendableRecordBatchStream> {
-        let action =
-            Action::FetchPartition(PartitionId::new(job_id, stage_id, partition_id));
+        let action = Action::FetchPartition(PartitionId::new(
+            job_id,
+            stage_id,
+            partition_id,
+            path,
+        ));
         self.execute_action(&action).await
     }
 

--- a/ballista/rust/core/src/client.rs
+++ b/ballista/rust/core/src/client.rs
@@ -134,12 +134,12 @@ impl BallistaClient {
         partition_id: usize,
         path: &str,
     ) -> Result<SendableRecordBatchStream> {
-        let action = Action::FetchPartition(PartitionId::new(
-            job_id,
+        let action = Action::FetchPartition {
+            job_id: job_id.to_string(),
             stage_id,
             partition_id,
-            path,
-        ));
+            path: path.to_owned(),
+        };
         self.execute_action(&action).await
     }
 

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -166,6 +166,7 @@ async fn fetch_partition(
             &partition_id.job_id,
             partition_id.stage_id as usize,
             partition_id.partition_id as usize,
+            &partition_id.path,
         )
         .await
         .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?)

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -126,7 +126,10 @@ impl ExecutionPlan for ShuffleWriterExec {
     }
 
     fn output_partitioning(&self) -> Partitioning {
-        self.plan.output_partitioning()
+        match &self.shuffle_output_partitioning {
+            Some(p) => p.clone(),
+            _ => Partitioning::UnknownPartitioning(1),
+        }
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
@@ -143,7 +146,7 @@ impl ExecutionPlan for ShuffleWriterExec {
             self.stage_id,
             children[0].clone(),
             self.work_dir.clone(),
-            None,
+            self.shuffle_output_partitioning.clone(),
         )?))
     }
 

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -45,6 +45,8 @@ use datafusion::arrow::ipc::writer::FileWriter;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::hash_join::create_hashes;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::Partitioning::RoundRobinBatch;
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream, SQLMetric,
 };
@@ -52,8 +54,6 @@ use futures::StreamExt;
 use hashbrown::HashMap;
 use log::{debug, info};
 use uuid::Uuid;
-use datafusion::physical_plan::repartition::RepartitionExec;
-use datafusion::physical_plan::Partitioning::RoundRobinBatch;
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
 /// can be executed as one unit with each partition being executed in parallel. The output of each
@@ -342,54 +342,52 @@ impl ExecutionPlan for ShuffleWriterExec {
 
     async fn execute(
         &self,
-        _input_partition: usize,
+        input_partition: usize,
     ) -> Result<Pin<Box<dyn RecordBatchStream + Send + Sync>>> {
-        // let part_loc = self.execute_shuffle(input_partition).await?;
-        //
-        // // build metadata result batch
-        // let num_writers = part_loc.len();
-        // let mut partition_builder = UInt32Builder::new(num_writers);
-        // let mut path_builder = StringBuilder::new(num_writers);
-        // let mut num_rows_builder = UInt64Builder::new(num_writers);
-        // let mut num_batches_builder = UInt64Builder::new(num_writers);
-        // let mut num_bytes_builder = UInt64Builder::new(num_writers);
-        //
-        // for loc in &part_loc {
-        //     path_builder.append_value(loc.path.clone())?;
-        //     partition_builder.append_value(loc.partition_id as u32)?;
-        //     num_rows_builder.append_value(loc.num_rows)?;
-        //     num_batches_builder.append_value(loc.num_batches)?;
-        //     num_bytes_builder.append_value(loc.num_bytes)?;
-        // }
-        //
-        // // build arrays
-        // let partition_num: ArrayRef = Arc::new(partition_builder.finish());
-        // let path: ArrayRef = Arc::new(path_builder.finish());
-        // let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
-        //     Box::new(num_rows_builder),
-        //     Box::new(num_batches_builder),
-        //     Box::new(num_bytes_builder),
-        // ];
-        // let mut stats_builder = StructBuilder::new(
-        //     PartitionStats::default().arrow_struct_fields(),
-        //     field_builders,
-        // );
-        // for _ in 0..num_writers {
-        //     stats_builder.append(true)?;
-        // }
-        // let stats = Arc::new(stats_builder.finish());
-        //
-        // // build result batch containing metadata
-        // let schema = result_schema();
-        // let batch =
-        //     RecordBatch::try_new(schema.clone(), vec![partition_num, path, stats])
-        //         .map_err(DataFusionError::ArrowError)?;
-        //
-        // debug!("RESULTS METADATA:\n{:?}", batch);
-        //
-        // Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
+        let part_loc = self.execute_shuffle(input_partition).await?;
 
-        unimplemented!()
+        // build metadata result batch
+        let num_writers = part_loc.len();
+        let mut partition_builder = UInt32Builder::new(num_writers);
+        let mut path_builder = StringBuilder::new(num_writers);
+        let mut num_rows_builder = UInt64Builder::new(num_writers);
+        let mut num_batches_builder = UInt64Builder::new(num_writers);
+        let mut num_bytes_builder = UInt64Builder::new(num_writers);
+
+        for loc in &part_loc {
+            path_builder.append_value(loc.path.clone())?;
+            partition_builder.append_value(loc.partition_id as u32)?;
+            num_rows_builder.append_value(loc.num_rows)?;
+            num_batches_builder.append_value(loc.num_batches)?;
+            num_bytes_builder.append_value(loc.num_bytes)?;
+        }
+
+        // build arrays
+        let partition_num: ArrayRef = Arc::new(partition_builder.finish());
+        let path: ArrayRef = Arc::new(path_builder.finish());
+        let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
+            Box::new(num_rows_builder),
+            Box::new(num_batches_builder),
+            Box::new(num_bytes_builder),
+        ];
+        let mut stats_builder = StructBuilder::new(
+            PartitionStats::default().arrow_struct_fields(),
+            field_builders,
+        );
+        for _ in 0..num_writers {
+            stats_builder.append(true)?;
+        }
+        let stats = Arc::new(stats_builder.finish());
+
+        // build result batch containing metadata
+        let schema = result_schema();
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![partition_num, path, stats])
+                .map_err(DataFusionError::ArrowError)?;
+
+        debug!("RESULTS METADATA:\n{:?}", batch);
+
+        Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
     }
 
     fn metrics(&self) -> HashMap<String, SQLMetric> {
@@ -417,14 +415,14 @@ impl ExecutionPlan for ShuffleWriterExec {
     }
 }
 
-// fn result_schema() -> SchemaRef {
-//     let stats = PartitionStats::default();
-//     Arc::new(Schema::new(vec![
-//         Field::new("partition", DataType::UInt32, false),
-//         Field::new("path", DataType::Utf8, false),
-//         stats.arrow_struct_repr(),
-//     ]))
-// }
+fn result_schema() -> SchemaRef {
+    let stats = PartitionStats::default();
+    Arc::new(Schema::new(vec![
+        Field::new("partition", DataType::UInt32, false),
+        Field::new("path", DataType::Utf8, false),
+        stats.arrow_struct_repr(),
+    ]))
+}
 
 struct ShuffleWriter {
     path: String,
@@ -511,13 +509,13 @@ mod tests {
 
         let file0 = path.value(0);
         assert!(
-            file0.ends_with("/jobOne/1/0/data.arrow")
-                || file0.ends_with("\\jobOne\\1\\0\\data.arrow")
+            file0.ends_with("/jobOne/1/0/data-0.arrow")
+                || file0.ends_with("\\jobOne\\1\\0\\data-0.arrow")
         );
         let file1 = path.value(1);
         assert!(
-            file1.ends_with("/jobOne/1/1/data.arrow")
-                || file1.ends_with("\\jobOne\\1\\1\\data.arrow")
+            file1.ends_with("/jobOne/1/1/data-0.arrow")
+                || file1.ends_with("\\jobOne\\1\\1\\data-0.arrow")
         );
 
         let stats = batch.columns()[2]

--- a/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
@@ -31,14 +31,14 @@ use datafusion::{
 use log::info;
 use std::fmt::Formatter;
 
-/// UnresolvedShuffleExec represents a dependency on the results of several ShuffleWriterExec nodes which haven't been computed yet.
+/// UnresolvedShuffleExec represents a dependency on the results of a ShuffleWriterExec node which haven't been computed yet.
 ///
 /// An ExecutionPlan that contains an UnresolvedShuffleExec isn't ready for execution. The presence of this ExecutionPlan
 /// is used as a signal so the scheduler knows it can't start computation on a specific ShuffleWriterExec.
 #[derive(Debug, Clone)]
 pub struct UnresolvedShuffleExec {
     // The query stage ids which needs to be computed
-    pub query_stage_ids: Vec<usize>,
+    pub query_stage_ids: usize,
 
     // The schema this node will have once it is replaced with a ShuffleReaderExec
     pub schema: SchemaRef,
@@ -50,7 +50,7 @@ pub struct UnresolvedShuffleExec {
 impl UnresolvedShuffleExec {
     /// Create a new UnresolvedShuffleExec
     pub fn new(
-        query_stage_ids: Vec<usize>,
+        query_stage_ids: usize,
         schema: SchemaRef,
         partition_count: usize,
     ) -> Self {

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -22,7 +22,9 @@ use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
 use crate::error::BallistaError;
-use crate::execution_plans::{ShuffleReaderExec, UnresolvedShuffleExec};
+use crate::execution_plans::{
+    ShuffleReaderExec, ShuffleWriterExec, UnresolvedShuffleExec,
+};
 use crate::serde::protobuf::repartition_exec_node::PartitionMethod;
 use crate::serde::protobuf::ShuffleReaderPartition;
 use crate::serde::scheduler::PartitionLocation;
@@ -368,6 +370,34 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                     on,
                     &join_type.into(),
                     partition_mode,
+                )?))
+            }
+            PhysicalPlanType::ShuffleWriter(shuffle_writer) => {
+                let input: Arc<dyn ExecutionPlan> =
+                    convert_box_required!(shuffle_writer.input)?;
+
+                let output_partitioning = match &shuffle_writer.output_partitioning {
+                    Some(hash_part) => {
+                        let expr = hash_part
+                            .hash_expr
+                            .iter()
+                            .map(|e| e.try_into())
+                            .collect::<Result<Vec<Arc<dyn PhysicalExpr>>, _>>()?;
+
+                        Some(Partitioning::Hash(
+                            expr,
+                            hash_part.partition_count.try_into().unwrap(),
+                        ))
+                    }
+                    None => None,
+                };
+
+                Ok(Arc::new(ShuffleWriterExec::try_new(
+                    shuffle_writer.job_id.clone(),
+                    shuffle_writer.stage_id as usize,
+                    input,
+                    "".to_string(), // this is intentional but hacky - the executor will fill this in
+                    output_partitioning,
                 )?))
             }
             PhysicalPlanType::ShuffleReader(shuffle_reader) => {

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -464,11 +464,7 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
             PhysicalPlanType::Unresolved(unresolved_shuffle) => {
                 let schema = Arc::new(convert_required!(unresolved_shuffle.schema)?);
                 Ok(Arc::new(UnresolvedShuffleExec {
-                    query_stage_ids: unresolved_shuffle
-                        .query_stage_ids
-                        .iter()
-                        .map(|id| *id as usize)
-                        .collect(),
+                    query_stage_ids: unresolved_shuffle.query_stage_ids as usize,
                     schema,
                     partition_count: unresolved_shuffle.partition_count as usize,
                 }))

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -55,7 +55,9 @@ use datafusion::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr};
 use datafusion::physical_plan::hash_aggregate::HashAggregateExec;
 use protobuf::physical_plan_node::PhysicalPlanType;
 
-use crate::execution_plans::{ShuffleReaderExec, UnresolvedShuffleExec};
+use crate::execution_plans::{
+    ShuffleReaderExec, ShuffleWriterExec, UnresolvedShuffleExec,
+};
 use crate::serde::protobuf::repartition_exec_node::PartitionMethod;
 use crate::serde::scheduler::PartitionLocation;
 use crate::serde::{protobuf, BallistaError};
@@ -353,6 +355,36 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                     protobuf::SortExecNode {
                         input: Some(Box::new(input)),
                         expr,
+                    },
+                ))),
+            })
+        } else if let Some(exec) = plan.downcast_ref::<ShuffleWriterExec>() {
+            let input: protobuf::PhysicalPlanNode =
+                exec.children()[0].to_owned().try_into()?;
+            Ok(protobuf::PhysicalPlanNode {
+                physical_plan_type: Some(PhysicalPlanType::ShuffleWriter(Box::new(
+                    protobuf::ShuffleWriterExecNode {
+                        job_id: exec.job_id().to_string(),
+                        stage_id: exec.stage_id() as u32,
+                        input: Some(Box::new(input)),
+                        output_partitioning: match exec.output_partitioning() {
+                            Partitioning::Hash(exprs, partition_count) => {
+                                Some(protobuf::PhysicalHashRepartition {
+                                    hash_expr: exprs
+                                        .iter()
+                                        .map(|expr| expr.clone().try_into())
+                                        .collect::<Result<Vec<_>, BallistaError>>()?,
+                                    partition_count: partition_count as u64,
+                                })
+                            }
+                            Partitioning::UnknownPartitioning(1) => None,
+                            other => {
+                                return Err(BallistaError::General(format!(
+                                    "physical_plan::to_proto() invalid partitioning for ShuffleWriterExec: {:?}",
+                                    other
+                                )))
+                            }
+                        },
                     },
                 ))),
             })

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -392,11 +392,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::Unresolved(
                     protobuf::UnresolvedShuffleExecNode {
-                        query_stage_ids: exec
-                            .query_stage_ids
-                            .iter()
-                            .map(|id| *id as u32)
-                            .collect(),
+                        query_stage_ids: exec.query_stage_ids as u32,
                         schema: Some(exec.schema().as_ref().into()),
                         partition_count: exec.partition_count as u32,
                     },

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -68,6 +68,7 @@ impl TryInto<PartitionId> for protobuf::PartitionId {
             &self.job_id,
             self.stage_id as usize,
             self.partition_id as usize,
+            &self.path,
         ))
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -50,9 +50,12 @@ impl TryInto<Action> for protobuf::Action {
                     HashMap::new(),
                 )))
             }
-            Some(ActionType::FetchPartition(partition)) => {
-                Ok(Action::FetchPartition(partition.try_into()?))
-            }
+            Some(ActionType::FetchPartition(fetch)) => Ok(Action::FetchPartition {
+                job_id: fetch.job_id.to_string(),
+                stage_id: fetch.stage_id as usize,
+                partition_id: fetch.partition_id as usize,
+                path: fetch.path.to_string(),
+            }),
             _ => Err(BallistaError::General(
                 "scheduler::from_proto(Action) invalid or missing action".to_owned(),
             )),
@@ -68,7 +71,7 @@ impl TryInto<PartitionId> for protobuf::PartitionId {
             &self.job_id,
             self.stage_id as usize,
             self.partition_id as usize,
-            &self.path,
+            // &self.path,
         ))
     }
 }
@@ -121,6 +124,7 @@ impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
                     )
                 })?
                 .into(),
+            path: self.path,
         })
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -51,10 +51,10 @@ impl TryInto<Action> for protobuf::Action {
                 )))
             }
             Some(ActionType::FetchPartition(fetch)) => Ok(Action::FetchPartition {
-                job_id: fetch.job_id.to_string(),
+                job_id: fetch.job_id,
                 stage_id: fetch.stage_id as usize,
                 partition_id: fetch.partition_id as usize,
-                path: fetch.path.to_string(),
+                path: fetch.path,
             }),
             _ => Err(BallistaError::General(
                 "scheduler::from_proto(Action) invalid or missing action".to_owned(),

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -46,6 +46,7 @@ pub enum Action {
 pub struct PartitionId {
     pub job_id: String,
     pub stage_id: usize,
+    /// Output partition
     pub partition_id: usize,
     pub path: String,
 }
@@ -100,9 +101,9 @@ impl From<protobuf::ExecutorMetadata> for ExecutorMeta {
 /// Summary of executed partition
 #[derive(Debug, Copy, Clone)]
 pub struct PartitionStats {
-    num_rows: Option<u64>,
-    num_batches: Option<u64>,
-    num_bytes: Option<u64>,
+    pub(crate) num_rows: Option<u64>,
+    pub(crate) num_batches: Option<u64>,
+    pub(crate) num_bytes: Option<u64>,
 }
 
 impl Default for PartitionStats {

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -38,7 +38,12 @@ pub enum Action {
     /// Execute a query and store the results in memory
     ExecutePartition(ExecutePartition),
     /// Collect a shuffle partition
-    FetchPartition(PartitionId),
+    FetchPartition {
+        job_id: String,
+        stage_id: usize,
+        partition_id: usize,
+        path: String,
+    },
 }
 
 /// Unique identifier for the output partition of an operator.
@@ -46,18 +51,15 @@ pub enum Action {
 pub struct PartitionId {
     pub job_id: String,
     pub stage_id: usize,
-    /// Output partition
     pub partition_id: usize,
-    pub path: String,
 }
 
 impl PartitionId {
-    pub fn new(job_id: &str, stage_id: usize, partition_id: usize, path: &str) -> Self {
+    pub fn new(job_id: &str, stage_id: usize, partition_id: usize) -> Self {
         Self {
             job_id: job_id.to_string(),
             stage_id,
             partition_id,
-            path: path.to_owned(),
         }
     }
 }
@@ -67,6 +69,7 @@ pub struct PartitionLocation {
     pub partition_id: PartitionId,
     pub executor_meta: ExecutorMeta,
     pub partition_stats: PartitionStats,
+    pub path: String,
 }
 
 /// Meta-data for an executor, used when fetching shuffle partitions from other executors

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -47,14 +47,16 @@ pub struct PartitionId {
     pub job_id: String,
     pub stage_id: usize,
     pub partition_id: usize,
+    pub path: String,
 }
 
 impl PartitionId {
-    pub fn new(job_id: &str, stage_id: usize, partition_id: usize) -> Self {
+    pub fn new(job_id: &str, stage_id: usize, partition_id: usize, path: &str) -> Self {
         Self {
             job_id: job_id.to_string(),
             stage_id,
             partition_id,
+            path: path.to_owned(),
         }
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -40,10 +40,10 @@ impl TryInto<protobuf::Action> for Action {
                 path,
             } => Ok(protobuf::Action {
                 action_type: Some(ActionType::FetchPartition(protobuf::FetchPartition {
-                    job_id: job_id.to_string(),
+                    job_id: job_id,
                     stage_id: stage_id as u32,
                     partition_id: partition_id as u32,
-                    path: path.to_string(),
+                    path: path,
                 })),
                 settings: vec![],
             }),

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -62,7 +62,7 @@ impl Into<protobuf::PartitionId> for PartitionId {
             job_id: self.job_id,
             stage_id: self.stage_id as u32,
             partition_id: self.partition_id as u32,
-            path: self.path.clone(),
+            path: self.path,
         }
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -33,8 +33,18 @@ impl TryInto<protobuf::Action> for Action {
                 action_type: Some(ActionType::ExecutePartition(partition.try_into()?)),
                 settings: vec![],
             }),
-            Action::FetchPartition(partition_id) => Ok(protobuf::Action {
-                action_type: Some(ActionType::FetchPartition(partition_id.into())),
+            Action::FetchPartition {
+                job_id,
+                stage_id,
+                partition_id,
+                path,
+            } => Ok(protobuf::Action {
+                action_type: Some(ActionType::FetchPartition(protobuf::FetchPartition {
+                    job_id: job_id.to_string(),
+                    stage_id: stage_id as u32,
+                    partition_id: partition_id as u32,
+                    path: path.to_string(),
+                })),
                 settings: vec![],
             }),
         }
@@ -62,7 +72,6 @@ impl Into<protobuf::PartitionId> for PartitionId {
             job_id: self.job_id,
             stage_id: self.stage_id as u32,
             partition_id: self.partition_id as u32,
-            path: self.path,
         }
     }
 }
@@ -75,6 +84,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
             partition_stats: Some(self.partition_stats.into()),
+            path: self.path.to_string(),
         })
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -62,6 +62,7 @@ impl Into<protobuf::PartitionId> for PartitionId {
             job_id: self.job_id,
             stage_id: self.stage_id as u32,
             partition_id: self.partition_id as u32,
+            path: self.path.clone(),
         }
     }
 }

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -209,13 +209,13 @@ fn build_exec_plan_diagram(
     for child in plan.children() {
         if let Some(shuffle) = child.as_any().downcast_ref::<UnresolvedShuffleExec>() {
             if !draw_entity {
-                for y in &shuffle.query_stage_ids {
+                //for y in &shuffle.query_stage_ids {
                     writeln!(
                         w,
                         "\tstage_{}_exec_1 -> stage_{}_exec_{};",
-                        y, stage_id, node_id
+                        shuffle.query_stage_ids, stage_id, node_id
                     )?;
-                }
+                //}
             }
         } else {
             // relationships within same entity

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -210,11 +210,11 @@ fn build_exec_plan_diagram(
         if let Some(shuffle) = child.as_any().downcast_ref::<UnresolvedShuffleExec>() {
             if !draw_entity {
                 //for y in &shuffle.query_stage_ids {
-                    writeln!(
-                        w,
-                        "\tstage_{}_exec_1 -> stage_{}_exec_{};",
-                        shuffle.query_stage_ids, stage_id, node_id
-                    )?;
+                writeln!(
+                    w,
+                    "\tstage_{}_exec_1 -> stage_{}_exec_{};",
+                    shuffle.query_stage_ids, stage_id, node_id
+                )?;
                 //}
             }
         } else {

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -114,11 +114,12 @@ async fn run_received_tasks(
                 .hash_expr
                 .iter()
                 .map(|e| e.try_into())
-                .collect::<Result<Vec<Arc<dyn PhysicalExpr>>, _>>().unwrap(); //TODO err handling
+                .collect::<Result<Vec<Arc<dyn PhysicalExpr>>, _>>()
+                .unwrap(); //TODO err handling
 
             Some(Partitioning::Hash(expr, hash_part.partition_count as usize))
-        },
-        _ => None
+        }
+        _ => None,
     };
 
     tokio::spawn(async move {

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -156,6 +156,7 @@ fn as_task_status(
                 partition_id: Some(task_id),
                 status: Some(task_status::Status::Completed(CompletedTask {
                     executor_id,
+                    partitions: vec![], // TODO populate
                 })),
             }
         }

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -53,7 +53,7 @@ impl Executor {
         shuffle_output_partitioning: Option<Partitioning>,
     ) -> Result<Vec<ShuffleWritePartition>, BallistaError> {
         let exec = ShuffleWriterExec::try_new(
-            job_id,
+            job_id.clone(),
             stage_id,
             plan,
             self.work_dir.clone(),
@@ -62,7 +62,9 @@ impl Executor {
         let partitions = exec.execute_shuffle(part).await?;
 
         println!(
-            "=== Physical plan with metrics ===\n{}\n",
+            "=== Job {} stage {} physical plan with metrics ===\n{}\n",
+            job_id,
+            stage_id,
             DisplayableExecutionPlan::with_metrics(&exec)
                 .indent()
                 .to_string()

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -107,11 +107,12 @@ impl FlightService for BallistaFlightService {
                     let executor = self.executor.clone();
                     tasks.push(tokio::spawn(async move {
                         let results = executor
-                            .execute_partition(
+                            .execute_shuffle_write(
                                 partition.job_id.clone(),
                                 partition.stage_id,
                                 part,
                                 partition.plan.clone(),
+                                None //TODO
                             )
                             .await?;
                         let results = vec![results];

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -112,7 +112,7 @@ impl FlightService for BallistaFlightService {
                                 partition.stage_id,
                                 part,
                                 partition.plan.clone(),
-                                None //TODO
+                                None, //TODO
                             )
                             .await?;
                         let results = vec![results];

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::executor::Executor;
 use ballista_core::error::BallistaError;
 use ballista_core::serde::decode_protobuf;
-use ballista_core::serde::scheduler::{Action as BallistaAction, PartitionStats};
+use ballista_core::serde::scheduler::Action as BallistaAction;
 
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty,
@@ -33,18 +33,13 @@ use arrow_flight::{
     PutResult, SchemaResult, Ticket,
 };
 use datafusion::arrow::{
-    datatypes::{DataType, Field, Schema},
-    error::ArrowError,
-    ipc::reader::FileReader,
-    ipc::writer::IpcWriteOptions,
+    error::ArrowError, ipc::reader::FileReader, ipc::writer::IpcWriteOptions,
     record_batch::RecordBatch,
 };
-use datafusion::physical_plan::displayable;
 use futures::{Stream, StreamExt};
 use log::{info, warn};
 use std::io::{Read, Seek};
 use tokio::sync::mpsc::channel;
-use tokio::task::JoinHandle;
 use tokio::{
     sync::mpsc::{Receiver, Sender},
     task,
@@ -92,80 +87,6 @@ impl FlightService for BallistaFlightService {
             decode_protobuf(&ticket.ticket).map_err(|e| from_ballista_err(&e))?;
 
         match &action {
-            BallistaAction::ExecutePartition(partition) => {
-                info!(
-                    "ExecutePartition: job={}, stage={}, partition={:?}\n{}",
-                    partition.job_id,
-                    partition.stage_id,
-                    partition.partition_id,
-                    displayable(partition.plan.as_ref()).indent().to_string()
-                );
-
-                let mut tasks: Vec<JoinHandle<Result<_, BallistaError>>> = vec![];
-                for &part in &partition.partition_id {
-                    let partition = partition.clone();
-                    let executor = self.executor.clone();
-                    tasks.push(tokio::spawn(async move {
-                        let results = executor
-                            .execute_shuffle_write(
-                                partition.job_id.clone(),
-                                partition.stage_id,
-                                part,
-                                partition.plan.clone(),
-                                None, //TODO
-                            )
-                            .await?;
-                        let results = vec![results];
-
-                        let mut flights: Vec<Result<FlightData, Status>> = vec![];
-                        let options = arrow::ipc::writer::IpcWriteOptions::default();
-
-                        let mut batches: Vec<Result<FlightData, Status>> = results
-                            .iter()
-                            .flat_map(|batch| create_flight_iter(batch, &options))
-                            .collect();
-
-                        // append batch vector to schema vector, so that the first message sent is the schema
-                        flights.append(&mut batches);
-
-                        Ok(flights)
-                    }));
-                }
-
-                // wait for all partitions to complete
-                let results = futures::future::join_all(tasks).await;
-
-                // get results
-                let mut flights: Vec<Result<FlightData, Status>> = vec![];
-
-                // add an initial FlightData message that sends schema
-                let options = arrow::ipc::writer::IpcWriteOptions::default();
-                let stats = PartitionStats::default();
-                let schema = Arc::new(Schema::new(vec![
-                    Field::new("path", DataType::Utf8, false),
-                    stats.arrow_struct_repr(),
-                ]));
-                let schema_flight_data =
-                    arrow_flight::utils::flight_data_from_arrow_schema(
-                        schema.as_ref(),
-                        &options,
-                    );
-                flights.push(Ok(schema_flight_data));
-
-                // collect statistics from each executed partition
-                for result in results {
-                    let result = result.map_err(|e| {
-                        Status::internal(format!("Ballista Error: {:?}", e))
-                    })?;
-                    let batches = result.map_err(|e| {
-                        Status::internal(format!("Ballista Error: {:?}", e))
-                    })?;
-                    flights.extend_from_slice(&batches);
-                }
-
-                let output = futures::stream::iter(flights);
-                Ok(Response::new(Box::pin(output) as Self::DoGetStream))
-            }
             BallistaAction::FetchPartition(partition_id) => {
                 // fetch a partition that was previously executed by this executor
                 info!("FetchPartition {:?}", partition_id);
@@ -202,6 +123,7 @@ impl FlightService for BallistaFlightService {
                     Box::pin(ReceiverStream::new(rx)) as Self::DoGetStream
                 ))
             }
+            _ => unreachable!(),
         }
     }
 

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -307,8 +307,8 @@ where
         let batch_flight_data: Vec<_> = batch
             .map(|b| create_flight_iter(&b, &options).collect())
             .map_err(|e| from_arrow_err(&e))?;
-        for batch in &batch_flight_data {
-            send_response(&tx, batch.clone()).await?;
+        for flight_data in &batch_flight_data {
+            send_response(&tx, flight_data.clone()).await?;
         }
     }
     Ok(())

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -95,7 +95,7 @@ impl FlightService for BallistaFlightService {
                 path.push(&partition_id.job_id);
                 path.push(&format!("{}", partition_id.stage_id));
                 path.push(&format!("{}", partition_id.partition_id));
-                path.push("data.arrow");
+                path.push(&partition_id.path);
                 let path = path.to_str().unwrap();
 
                 info!("FetchPartition {:?} reading {}", partition_id, path);

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -18,7 +18,6 @@
 //! Implementation of the Apache Arrow Flight protocol that wraps an executor.
 
 use std::fs::File;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -81,24 +80,11 @@ impl FlightService for BallistaFlightService {
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         let ticket = request.into_inner();
-        info!("Received do_get request");
-
         let action =
             decode_protobuf(&ticket.ticket).map_err(|e| from_ballista_err(&e))?;
-
         match &action {
-            BallistaAction::FetchPartition(partition_id) => {
-                // fetch a partition that was previously executed by this executor
-                info!("FetchPartition {:?}", partition_id);
-
-                let mut path = PathBuf::from(self.executor.work_dir());
-                path.push(&partition_id.job_id);
-                path.push(&format!("{}", partition_id.stage_id));
-                path.push(&format!("{}", partition_id.partition_id));
-                path.push(&partition_id.path);
-                let path = path.to_str().unwrap();
-
-                info!("FetchPartition {:?} reading {}", partition_id, path);
+            BallistaAction::FetchPartition { path, .. } => {
+                info!("FetchPartition reading {}", &path);
                 let file = File::open(&path)
                     .map_err(|e| {
                         BallistaError::General(format!(

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -488,8 +488,9 @@ impl SchedulerGrpc for SchedulerServer {
 
                     // note that we execute INPUT partitions on the shuffle, which is
                     // different from other operators
-                    let num_partitions =
-                        shuffle_writer.children()[0].output_partitioning().partition_count();
+                    let num_partitions = shuffle_writer.children()[0]
+                        .output_partitioning()
+                        .partition_count();
                     println!("shuffle writer has {} input partitions", num_partitions);
 
                     for partition_id in 0..num_partitions {

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -80,12 +80,12 @@ use tonic::{Request, Response};
 
 use self::state::{ConfigBackendClient, SchedulerState};
 use ballista_core::config::BallistaConfig;
+use ballista_core::execution_plans::ShuffleWriterExec;
 use ballista_core::serde::protobuf;
 use ballista_core::utils::create_datafusion_context;
+use datafusion::physical_plan::expressions::Column;
 use datafusion::physical_plan::parquet::ParquetExec;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
-use ballista_core::execution_plans::ShuffleWriterExec;
-use datafusion::physical_plan::expressions::Column;
 
 #[derive(Clone)]
 pub struct SchedulerServer {
@@ -485,7 +485,8 @@ impl SchedulerGrpc for SchedulerServer {
                             error!("{}", msg);
                             tonic::Status::internal(msg)
                         }));
-                    let num_partitions = shuffle_writer.output_partitioning().partition_count();
+                    let num_partitions =
+                        shuffle_writer.output_partitioning().partition_count();
                     for partition_id in 0..num_partitions {
                         let pending_status = TaskStatus {
                             partition_id: Some(PartitionId {

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -485,15 +485,19 @@ impl SchedulerGrpc for SchedulerServer {
                             error!("{}", msg);
                             tonic::Status::internal(msg)
                         }));
+
+                    // note that we execute INPUT partitions on the shuffle, which is
+                    // different from other operators
                     let num_partitions =
-                        shuffle_writer.output_partitioning().partition_count();
+                        shuffle_writer.children()[0].output_partitioning().partition_count();
+                    println!("shuffle writer has {} input partitions", num_partitions);
+
                     for partition_id in 0..num_partitions {
                         let pending_status = TaskStatus {
                             partition_id: Some(PartitionId {
                                 job_id: job_id_spawn.clone(),
                                 stage_id: shuffle_writer.stage_id() as u32,
                                 partition_id: partition_id as u32,
-                                path: "tbd".to_owned(),
                             }),
                             status: None,
                         };

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -493,6 +493,7 @@ impl SchedulerGrpc for SchedulerServer {
                                 job_id: job_id_spawn.clone(),
                                 stage_id: shuffle_writer.stage_id() as u32,
                                 partition_id: partition_id as u32,
+                                path: "".to_owned(),
                             }),
                             status: None,
                         };

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -493,7 +493,7 @@ impl SchedulerGrpc for SchedulerServer {
                                 job_id: job_id_spawn.clone(),
                                 stage_id: shuffle_writer.stage_id() as u32,
                                 partition_id: partition_id as u32,
-                                path: "".to_owned(),
+                                path: "tbd".to_owned(),
                             }),
                             status: None,
                         };

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -166,7 +166,8 @@ pub fn remove_unresolved_shuffles(
             child.as_any().downcast_ref::<UnresolvedShuffleExec>()
         {
             let mut relevant_locations = vec![];
-            let p = partition_locations.get(&unresolved_shuffle.query_stage_ids)
+            let p = partition_locations
+                .get(&unresolved_shuffle.query_stage_ids)
                 .ok_or_else(|| {
                     BallistaError::General(
                         "Missing partition location. Could not remove unresolved shuffles"
@@ -182,7 +183,14 @@ pub fn remove_unresolved_shuffles(
                     relevant_locations.push(vec![]);
                 }
             }
-            println!("create shuffle reader with {:?}", relevant_locations.iter().map(|c| format!("{:?}", c)).collect::<Vec<_>>().join("\n"));
+            println!(
+                "create shuffle reader with {:?}",
+                relevant_locations
+                    .iter()
+                    .map(|c| format!("{:?}", c))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
             new_children.push(Arc::new(ShuffleReaderExec::try_new(
                 relevant_locations,
                 unresolved_shuffle.schema().clone(),
@@ -261,7 +269,7 @@ mod test {
 
         /* Expected result:
 
-        ShuffleWriterExec: Some(Hash([Column { name: "l_returnflag", index: 0 }], 4))
+        ShuffleWriterExec: Some(Hash([Column { name: "l_returnflag", index: 0 }], 2))
           HashAggregateExec: mode=Partial, gby=[l_returnflag@1 as l_returnflag], aggr=[SUM(l_extendedprice Multiply Int64(1))]
             CsvExec: source=Path(testdata/lineitem: [testdata/lineitem/partition0.tbl,testdata/lineitem/partition1.tbl]), has_header=false
 

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -296,11 +296,13 @@ impl SchedulerState {
                 let unresolved_shuffles = find_unresolved_shuffles(&plan)?;
                 let mut partition_locations: HashMap<
                     usize, // stage id
-                    HashMap<usize, // partition id
-                        Vec<ballista_core::serde::scheduler::PartitionLocation>>,
+                    HashMap<
+                        usize, // partition id
+                        Vec<ballista_core::serde::scheduler::PartitionLocation>,
+                    >,
                 > = HashMap::new();
                 for unresolved_shuffle in unresolved_shuffles {
-                    let stage_id= unresolved_shuffle.query_stage_ids;
+                    let stage_id = unresolved_shuffle.query_stage_ids;
                     for partition_id in 0..unresolved_shuffle.partition_count {
                         let referenced_task = tasks
                             .get(&get_task_status_key(
@@ -322,33 +324,38 @@ impl SchedulerState {
                             },
                         )) = &referenced_task.status
                         {
-                            let locations =
-                                partition_locations.entry(stage_id).or_insert(HashMap::new());
+                            let locations = partition_locations
+                                .entry(stage_id)
+                                .or_insert_with(HashMap::new);
                             let executor_meta = executors
                                 .iter()
                                 .find(|exec| exec.id == *executor_id)
                                 .unwrap()
                                 .clone();
 
-                            let temp = locations.entry(partition_id).or_insert(vec![]);
+                            let temp =
+                                locations.entry(partition_id).or_insert_with(Vec::new);
                             for p in partitions {
                                 let executor_meta = executor_meta.clone();
-                                let partition_location = ballista_core::serde::scheduler::PartitionLocation {
+                                let partition_location =
+                                    ballista_core::serde::scheduler::PartitionLocation {
                                         partition_id:
-                                        ballista_core::serde::scheduler::PartitionId {
-                                            job_id: partition.job_id.clone(),
-                                            stage_id,
-                                            partition_id,
-                                        },
+                                            ballista_core::serde::scheduler::PartitionId {
+                                                job_id: partition.job_id.clone(),
+                                                stage_id,
+                                                partition_id,
+                                            },
                                         executor_meta,
-                                        partition_stats: PartitionStats::new(Some(p.num_rows), Some(p.num_batches), Some(p.num_bytes)),
+                                        partition_stats: PartitionStats::new(
+                                            Some(p.num_rows),
+                                            Some(p.num_batches),
+                                            Some(p.num_bytes),
+                                        ),
                                         path: p.path.clone(),
                                     };
                                 info!(
                                     "Scheduler storing stage {} partition {} path: {}",
-                                    stage_id,
-                                    partition_id,
-                                    partition_location.path
+                                    stage_id, partition_id, partition_location.path
                                 );
                                 temp.push(partition_location);
                             }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -336,20 +336,20 @@ impl SchedulerState {
                                 //TODO review this
                                 for p in partitions {
                                     let executor_meta = executor_meta.clone();
-                                    if p.output_partition_id as usize == partition_id {
-                                        locations.push(vec![
-                                            ballista_core::serde::scheduler::PartitionLocation {
-                                                partition_id:
-                                                ballista_core::serde::scheduler::PartitionId {
-                                                    job_id: partition.job_id.clone(),
-                                                    stage_id,
-                                                    partition_id,
-                                                    path: p.path.clone(),
-                                                },
-                                                executor_meta,
-                                                partition_stats: PartitionStats::new(Some(p.num_rows), Some(p.num_batches), Some(p.num_bytes)),
+                                    if p.partition_id as usize == partition_id {
+                                        let partition_location = ballista_core::serde::scheduler::PartitionLocation {
+                                            partition_id:
+                                            ballista_core::serde::scheduler::PartitionId {
+                                                job_id: partition.job_id.clone(),
+                                                stage_id,
+                                                partition_id,
+                                                path: p.path.clone(),
                                             },
-                                        ]);
+                                            executor_meta,
+                                            partition_stats: PartitionStats::new(Some(p.num_rows), Some(p.num_batches), Some(p.num_bytes)),
+                                        };
+                                        println!("Scheduler storing partition location: {:?}", partition_location);
+                                        locations.push(vec![partition_location]);
                                     }
                                 }
                             } else {

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,7 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let default_shuffle_partitions = 2;
+    let default_shuffle_partitions = 4;
     let config = ExecutionConfig::new().with_concurrency(default_shuffle_partitions);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -26,7 +26,7 @@ pub const TPCH_TABLES: &[&str] = &[
 ];
 
 pub fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
-    let default_shuffle_partitions = 4;
+    let default_shuffle_partitions = 2;
     let config = ExecutionConfig::new().with_concurrency(default_shuffle_partitions);
     let mut ctx = ExecutionContext::with_config(config);
     for table in TPCH_TABLES {

--- a/datafusion/src/physical_plan/parquet.rs
+++ b/datafusion/src/physical_plan/parquet.rs
@@ -501,9 +501,10 @@ impl ExecutionPlan for ParquetExec {
 
                 write!(
                     f,
-                    "ParquetExec: batch_size={}, limit={:?}, partitions=[{}]",
+                    "ParquetExec: batch_size={}, limit={:?}, partitions({})=[{}]",
                     self.batch_size,
                     self.limit,
+                    self.partitions.len(),
                     files.join(", ")
                 )
             }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #707 but is actually much larger than one issue because it turns out that the shuffle mechanism wasn't fully implemented and wasn't really being used.

With this PR, I now see the executors using hash partitioning in the shuffle writes.
```
=== Physical plan with metrics ===
ShuffleWriterExec: Some(Hash([Column { name: "l_orderkey", index: 0 }], 2)), metrics=[writeTime=21538883]
  CoalesceBatchesExec: target_batch_size=4096, metrics=[]
```

Other changes:

- Fixed bug where all shuffle tasks within the same query stage were writing to the same output files, causing corruption
- TaskStatus now includes task meta-data so that that the scheduler can pass the correct partition meta-data to shuffle readers (and skip empty partitions)

Remaining work:

- Get it all working

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Shuffles were broken. The executor always ran the shuffle writes with partioning of `None` instead of the hash partitioning they were supposed to use. This information was never sent as part of the protobuf. Queries still worked correctly but this was not scaling since there was always a single partition.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
