### PR TITLE
MINOR: Remove unused Ballista query execution code path

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -700,10 +700,10 @@ message Action {
 
   oneof ActionType {
     // Execute a logical query plan
-    LogicalPlanNode query = 1;
+    //LogicalPlanNode query = 1;
 
     // Execute one partition of a physical query plan
-    ExecutePartition execute_partition = 2;
+    //ExecutePartition execute_partition = 2;
 
     // Fetch a partition from an executor
     PartitionId fetch_partition = 3;

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -699,12 +699,6 @@ message KeyValuePair {
 message Action {
 
   oneof ActionType {
-    // Execute a logical query plan
-    //LogicalPlanNode query = 1;
-
-    // Execute one partition of a physical query plan
-    //ExecutePartition execute_partition = 2;
-
     // Fetch a partition from an executor
     PartitionId fetch_partition = 3;
   }

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -32,24 +32,6 @@ impl TryInto<Action> for protobuf::Action {
 
     fn try_into(self) -> Result<Action, Self::Error> {
         match self.action_type {
-            Some(ActionType::ExecutePartition(partition)) => {
-                Ok(Action::ExecutePartition(ExecutePartition::new(
-                    partition.job_id,
-                    partition.stage_id as usize,
-                    partition.partition_id.iter().map(|n| *n as usize).collect(),
-                    partition
-                        .plan
-                        .as_ref()
-                        .ok_or_else(|| {
-                            BallistaError::General(
-                                "PhysicalPlanNode in ExecutePartition is missing"
-                                    .to_owned(),
-                            )
-                        })?
-                        .try_into()?,
-                    HashMap::new(),
-                )))
-            }
             Some(ActionType::FetchPartition(partition)) => {
                 Ok(Action::FetchPartition(partition.try_into()?))
             }

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -35,8 +35,6 @@ pub mod to_proto;
 /// Action that can be sent to an executor
 #[derive(Debug, Clone)]
 pub enum Action {
-    /// Execute a query and store the results in memory
-    ExecutePartition(ExecutePartition),
     /// Collect a shuffle partition
     FetchPartition(PartitionId),
 }

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -29,10 +29,6 @@ impl TryInto<protobuf::Action> for Action {
 
     fn try_into(self) -> Result<protobuf::Action, Self::Error> {
         match self {
-            Action::ExecutePartition(partition) => Ok(protobuf::Action {
-                action_type: Some(ActionType::ExecutePartition(partition.try_into()?)),
-                settings: vec![],
-            }),
             Action::FetchPartition(partition_id) => Ok(protobuf::Action {
                 action_type: Some(ActionType::FetchPartition(partition_id.into())),
                 settings: vec![],


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

There are no functional change sin this PR. It just removes some unused code paths. 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Originally queries were executed by sending them to the executors flight service but now the executor pulls query plans from the scheduler.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove some code.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.