### PR TITLE
Derive PartialEq for datasource enums

### DIFF
--- a/datafusion/src/datasource/datasource.rs
+++ b/datafusion/src/datasource/datasource.rs
@@ -27,7 +27,7 @@ use crate::{arrow::datatypes::SchemaRef, scalar::ScalarValue};
 
 /// This table statistics are estimates.
 /// It can not be used directly in the precise compute
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Statistics {
     /// The number of table rows
     pub num_rows: Option<usize>,
@@ -51,7 +51,7 @@ pub struct ColumnStatistics {
 
 /// Indicates whether and how a filter expression can be handled by a
 /// TableProvider for table scans.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TableProviderFilterPushDown {
     /// The expression cannot be used by the provider.
     Unsupported,
@@ -67,7 +67,7 @@ pub enum TableProviderFilterPushDown {
 }
 
 /// Indicates the type of this table for metadata/catalog purposes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TableType {
     /// An ordinary physical table.
     Base,


### PR DESCRIPTION
# Rationale
I was trying to write a test for IOx (see https://github.com/influxdata/influxdb_iox/pull/2038) but it was a bit awkward without this derivation

# Changes
Derive `PartialEq`  on Statistics, as well as some other enums in datasource

