### PR TITLE
Ballista: Prep for fixing shuffle mechansim, part 1

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -776,6 +776,17 @@ message FailedTask {
 
 message CompletedTask {
   string executor_id = 1;
+  // TODO tasks are currently always shuffle writes but this will not always be the case
+  // so we might want to think about some refactoring of the task definitions
+  repeated ShuffleWritePartition partitions = 2;
+}
+
+message ShuffleWritePartition {
+  uint64 partition_id = 1;
+  string path = 2;
+  uint64 num_batches = 3;
+  uint64 num_rows = 4;
+  uint64 num_bytes = 5;
 }
 
 message TaskStatus {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -721,6 +721,7 @@ message PartitionLocation {
   PartitionId partition_id = 1;
   ExecutorMetadata executor_meta = 2;
   PartitionStats partition_stats = 3;
+  string path = 4;
 }
 
 // Unique identifier for a materialized partition of data

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -31,7 +31,8 @@ use crate::error::BallistaError;
 use crate::memory_stream::MemoryStream;
 use crate::utils;
 
-use crate::serde::scheduler::PartitionStats;
+use crate::serde::protobuf::ShuffleWritePartition;
+use crate::serde::scheduler::{PartitionLocation, PartitionStats};
 use async_trait::async_trait;
 use datafusion::arrow::array::{
     Array, ArrayBuilder, ArrayRef, StringBuilder, StructBuilder, UInt32Builder,
@@ -39,16 +40,19 @@ use datafusion::arrow::array::{
 };
 use datafusion::arrow::compute::take;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::ipc::reader::FileReader;
 use datafusion::arrow::ipc::writer::FileWriter;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::hash_join::create_hashes;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::Partitioning::RoundRobinBatch;
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream, SQLMetric,
 };
 use futures::StreamExt;
 use hashbrown::HashMap;
-use log::info;
+use log::{debug, info};
 use uuid::Uuid;
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
@@ -75,12 +79,16 @@ pub struct ShuffleWriterExec {
 struct ShuffleWriteMetrics {
     /// Time spend writing batches to shuffle files
     write_time: Arc<SQLMetric>,
+    input_rows: Arc<SQLMetric>,
+    output_rows: Arc<SQLMetric>,
 }
 
 impl ShuffleWriteMetrics {
     fn new() -> Self {
         Self {
             write_time: SQLMetric::time_nanos(),
+            input_rows: SQLMetric::counter(),
+            output_rows: SQLMetric::counter(),
         }
     }
 }
@@ -112,6 +120,169 @@ impl ShuffleWriterExec {
     /// Get the Stage ID for this query stage
     pub fn stage_id(&self) -> usize {
         self.stage_id
+    }
+
+    pub async fn execute_shuffle_write(
+        &self,
+        input_partition: usize,
+    ) -> Result<Vec<ShuffleWritePartition>> {
+        let now = Instant::now();
+
+        let mut stream = self.plan.execute(input_partition).await?;
+
+        let mut path = PathBuf::from(&self.work_dir);
+        path.push(&self.job_id);
+        path.push(&format!("{}", self.stage_id));
+
+        match &self.shuffle_output_partitioning {
+            None => {
+                path.push(&format!("{}", input_partition));
+                std::fs::create_dir_all(&path)?;
+                path.push("data.arrow");
+                let path = path.to_str().unwrap();
+                info!("Writing results to {}", path);
+
+                // stream results to disk
+                let stats = utils::write_stream_to_disk(
+                    &mut stream,
+                    path,
+                    self.metrics.write_time.clone(),
+                )
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
+
+                info!(
+                    "Executed partition {} in {} seconds. Statistics: {}",
+                    input_partition,
+                    now.elapsed().as_secs(),
+                    stats
+                );
+
+                Ok(vec![ShuffleWritePartition {
+                    partition_id: input_partition as u64,
+                    path: path.to_owned(),
+                    num_batches: stats.num_batches.unwrap_or(0),
+                    num_rows: stats.num_rows.unwrap_or(0),
+                    num_bytes: stats.num_bytes.unwrap_or(0),
+                }])
+            }
+
+            Some(Partitioning::Hash(exprs, n)) => {
+                let num_output_partitions = *n;
+
+                // we won't necessary produce output for every possible partition, so we
+                // create writers on demand
+                let mut writers: Vec<Option<ShuffleWriter>> = vec![];
+                for _ in 0..num_output_partitions {
+                    writers.push(None);
+                }
+
+                let hashes_buf = &mut vec![];
+                let random_state = ahash::RandomState::with_seeds(0, 0, 0, 0);
+
+                while let Some(result) = stream.next().await {
+                    let input_batch = result?;
+
+                    self.metrics.input_rows.add(input_batch.num_rows());
+
+                    let arrays = exprs
+                        .iter()
+                        .map(|expr| {
+                            Ok(expr
+                                .evaluate(&input_batch)?
+                                .into_array(input_batch.num_rows()))
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    hashes_buf.clear();
+                    hashes_buf.resize(arrays[0].len(), 0);
+                    // Hash arrays and compute buckets based on number of partitions
+                    let hashes = create_hashes(&arrays, &random_state, hashes_buf)?;
+                    let mut indices = vec![vec![]; num_output_partitions];
+                    for (index, hash) in hashes.iter().enumerate() {
+                        indices[(*hash % num_output_partitions as u64) as usize]
+                            .push(index as u64)
+                    }
+                    for (output_partition, partition_indices) in
+                        indices.into_iter().enumerate()
+                    {
+                        let indices = partition_indices.into();
+
+                        // Produce batches based on indices
+                        let columns = input_batch
+                            .columns()
+                            .iter()
+                            .map(|c| {
+                                take(c.as_ref(), &indices, None).map_err(|e| {
+                                    DataFusionError::Execution(e.to_string())
+                                })
+                            })
+                            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+
+                        let output_batch =
+                            RecordBatch::try_new(input_batch.schema(), columns)?;
+
+                        // write non-empty batch out
+                        //if output_batch.num_rows() > 0 {
+                        let start = Instant::now();
+                        match &mut writers[output_partition] {
+                            Some(w) => {
+                                w.write(&output_batch)?;
+                            }
+                            None => {
+                                let mut path = path.clone();
+                                path.push(&format!("{}", output_partition));
+                                std::fs::create_dir_all(&path)?;
+
+                                path.push(format!("data-{}.arrow", input_partition));
+                                let path = path.to_str().unwrap();
+                                info!("Writing results to {}", path);
+
+                                let mut writer =
+                                    ShuffleWriter::new(path, stream.schema().as_ref())?;
+
+                                writer.write(&output_batch)?;
+                                writers[output_partition] = Some(writer);
+                            }
+                        }
+                        self.metrics.output_rows.add(output_batch.num_rows());
+                        self.metrics.write_time.add_elapsed(start);
+                        //}
+                    }
+                }
+
+                let mut part_locs = vec![];
+
+                for (i, w) in writers.iter_mut().enumerate() {
+                    match w {
+                        Some(w) => {
+                            w.finish()?;
+                            info!(
+                                "Finished writing shuffle partition {} at {}. Batches: {}. Rows: {}. Bytes: {}.",
+                                i,
+                                w.path(),
+                                w.num_batches,
+                                w.num_rows,
+                                w.num_bytes
+                            );
+
+                            part_locs.push(ShuffleWritePartition {
+                                partition_id: i as u64,
+                                path: w.path().to_owned(),
+                                num_batches: w.num_batches,
+                                num_rows: w.num_rows,
+                                num_bytes: w.num_bytes,
+                            });
+                        }
+                        None => {}
+                    }
+                }
+                Ok(part_locs)
+            }
+
+            _ => Err(DataFusionError::Execution(
+                "Invalid shuffle partitioning scheme".to_owned(),
+            )),
+        }
     }
 }
 
@@ -152,193 +323,58 @@ impl ExecutionPlan for ShuffleWriterExec {
 
     async fn execute(
         &self,
-        partition: usize,
+        input_partition: usize,
     ) -> Result<Pin<Box<dyn RecordBatchStream + Send + Sync>>> {
-        let now = Instant::now();
+        let part_loc = self.execute_shuffle_write(input_partition).await?;
 
-        let mut stream = self.plan.execute(partition).await?;
+        // build metadata result batch
+        let num_writers = part_loc.len();
+        let mut partition_builder = UInt32Builder::new(num_writers);
+        let mut path_builder = StringBuilder::new(num_writers);
+        let mut num_rows_builder = UInt64Builder::new(num_writers);
+        let mut num_batches_builder = UInt64Builder::new(num_writers);
+        let mut num_bytes_builder = UInt64Builder::new(num_writers);
 
-        let mut path = PathBuf::from(&self.work_dir);
-        path.push(&self.job_id);
-        path.push(&format!("{}", self.stage_id));
+        for loc in &part_loc {
+            path_builder.append_value(loc.path.clone())?;
+            partition_builder.append_value(loc.partition_id as u32)?;
+            num_rows_builder.append_value(loc.num_rows)?;
+            num_batches_builder.append_value(loc.num_batches)?;
+            num_bytes_builder.append_value(loc.num_bytes)?;
+        }
 
-        match &self.shuffle_output_partitioning {
-            None => {
-                path.push(&format!("{}", partition));
-                std::fs::create_dir_all(&path)?;
-                path.push("data.arrow");
-                let path = path.to_str().unwrap();
-                info!("Writing results to {}", path);
+        // build arrays
+        let partition_num: ArrayRef = Arc::new(partition_builder.finish());
+        let path: ArrayRef = Arc::new(path_builder.finish());
+        let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
+            Box::new(num_rows_builder),
+            Box::new(num_batches_builder),
+            Box::new(num_bytes_builder),
+        ];
+        let mut stats_builder = StructBuilder::new(
+            PartitionStats::default().arrow_struct_fields(),
+            field_builders,
+        );
+        for _ in 0..num_writers {
+            stats_builder.append(true)?;
+        }
+        let stats = Arc::new(stats_builder.finish());
 
-                // stream results to disk
-                let stats = utils::write_stream_to_disk(
-                    &mut stream,
-                    path,
-                    self.metrics.write_time.clone(),
-                )
-                .await
-                .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
-
-                info!(
-                    "Executed partition {} in {} seconds. Statistics: {}",
-                    partition,
-                    now.elapsed().as_secs(),
-                    stats
-                );
-
-                let schema = result_schema();
-
-                // build result set with summary of the partition execution status
-                let mut part_builder = UInt32Builder::new(1);
-                part_builder.append_value(partition as u32)?;
-                let part: ArrayRef = Arc::new(part_builder.finish());
-
-                let mut path_builder = StringBuilder::new(1);
-                path_builder.append_value(&path)?;
-                let path: ArrayRef = Arc::new(path_builder.finish());
-
-                let stats: ArrayRef = stats
-                    .to_arrow_arrayref()
-                    .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
-                let batch = RecordBatch::try_new(schema.clone(), vec![part, path, stats])
-                    .map_err(DataFusionError::ArrowError)?;
-
-                Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
-            }
-
-            Some(Partitioning::Hash(exprs, n)) => {
-                let num_output_partitions = *n;
-
-                // we won't necessary produce output for every possible partition, so we
-                // create writers on demand
-                let mut writers: Vec<Option<ShuffleWriter>> = vec![];
-                for _ in 0..num_output_partitions {
-                    writers.push(None);
-                }
-
-                let hashes_buf = &mut vec![];
-                let random_state = ahash::RandomState::with_seeds(0, 0, 0, 0);
-                while let Some(result) = stream.next().await {
-                    let input_batch = result?;
-                    let arrays = exprs
-                        .iter()
-                        .map(|expr| {
-                            Ok(expr
-                                .evaluate(&input_batch)?
-                                .into_array(input_batch.num_rows()))
-                        })
-                        .collect::<Result<Vec<_>>>()?;
-                    hashes_buf.clear();
-                    hashes_buf.resize(arrays[0].len(), 0);
-                    // Hash arrays and compute buckets based on number of partitions
-                    let hashes = create_hashes(&arrays, &random_state, hashes_buf)?;
-                    let mut indices = vec![vec![]; num_output_partitions];
-                    for (index, hash) in hashes.iter().enumerate() {
-                        indices[(*hash % num_output_partitions as u64) as usize]
-                            .push(index as u64)
-                    }
-                    for (output_partition, partition_indices) in
-                        indices.into_iter().enumerate()
-                    {
-                        let indices = partition_indices.into();
-                        // Produce batches based on indices
-                        let columns = input_batch
-                            .columns()
-                            .iter()
-                            .map(|c| {
-                                take(c.as_ref(), &indices, None).map_err(|e| {
-                                    DataFusionError::Execution(e.to_string())
-                                })
-                            })
-                            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
-
-                        let output_batch =
-                            RecordBatch::try_new(input_batch.schema(), columns)?;
-
-                        // write batch out
-                        let start = Instant::now();
-                        match &mut writers[output_partition] {
-                            Some(w) => {
-                                w.write(&output_batch)?;
-                            }
-                            None => {
-                                let mut path = path.clone();
-                                path.push(&format!("{}", output_partition));
-                                std::fs::create_dir_all(&path)?;
-
-                                path.push("data.arrow");
-                                let path = path.to_str().unwrap();
-                                info!("Writing results to {}", path);
-
-                                let mut writer =
-                                    ShuffleWriter::new(path, stream.schema().as_ref())?;
-
-                                writer.write(&output_batch)?;
-                                writers[output_partition] = Some(writer);
-                            }
-                        }
-                        self.metrics.write_time.add_elapsed(start);
-                    }
-                }
-
-                // build metadata result batch
-                let num_writers = writers.iter().filter(|w| w.is_some()).count();
-                let mut partition_builder = UInt32Builder::new(num_writers);
-                let mut path_builder = StringBuilder::new(num_writers);
-                let mut num_rows_builder = UInt64Builder::new(num_writers);
-                let mut num_batches_builder = UInt64Builder::new(num_writers);
-                let mut num_bytes_builder = UInt64Builder::new(num_writers);
-
-                for (i, w) in writers.iter_mut().enumerate() {
-                    match w {
-                        Some(w) => {
-                            w.finish()?;
-                            path_builder.append_value(w.path())?;
-                            partition_builder.append_value(i as u32)?;
-                            num_rows_builder.append_value(w.num_rows)?;
-                            num_batches_builder.append_value(w.num_batches)?;
-                            num_bytes_builder.append_value(w.num_bytes)?;
-                        }
-                        None => {}
-                    }
-                }
-
-                // build arrays
-                let partition_num: ArrayRef = Arc::new(partition_builder.finish());
-                let path: ArrayRef = Arc::new(path_builder.finish());
-                let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
-                    Box::new(num_rows_builder),
-                    Box::new(num_batches_builder),
-                    Box::new(num_bytes_builder),
-                ];
-                let mut stats_builder = StructBuilder::new(
-                    PartitionStats::default().arrow_struct_fields(),
-                    field_builders,
-                );
-                for _ in 0..num_writers {
-                    stats_builder.append(true)?;
-                }
-                let stats = Arc::new(stats_builder.finish());
-
-                // build result batch containing metadata
-                let schema = result_schema();
-                let batch = RecordBatch::try_new(
-                    schema.clone(),
-                    vec![partition_num, path, stats],
-                )
+        // build result batch containing metadata
+        let schema = result_schema();
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![partition_num, path, stats])
                 .map_err(DataFusionError::ArrowError)?;
 
-                Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
-            }
+        debug!("RESULTS METADATA:\n{:?}", batch);
 
-            _ => Err(DataFusionError::Execution(
-                "Invalid shuffle partitioning scheme".to_owned(),
-            )),
-        }
+        Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
     }
 
     fn metrics(&self) -> HashMap<String, SQLMetric> {
         let mut metrics = HashMap::new();
+        metrics.insert("inputRows".to_owned(), (*self.metrics.input_rows).clone());
+        metrics.insert("outputRows".to_owned(), (*self.metrics.output_rows).clone());
         metrics.insert("writeTime".to_owned(), (*self.metrics.write_time).clone());
         metrics
     }
@@ -454,13 +490,13 @@ mod tests {
 
         let file0 = path.value(0);
         assert!(
-            file0.ends_with("/jobOne/1/0/data.arrow")
-                || file0.ends_with("\\jobOne\\1\\0\\data.arrow")
+            file0.ends_with("/jobOne/1/0/data-0.arrow")
+                || file0.ends_with("\\jobOne\\1\\0\\data-0.arrow")
         );
         let file1 = path.value(1);
         assert!(
-            file1.ends_with("/jobOne/1/1/data.arrow")
-                || file1.ends_with("\\jobOne\\1\\1\\data.arrow")
+            file1.ends_with("/jobOne/1/1/data-0.arrow")
+                || file1.ends_with("\\jobOne\\1\\1\\data-0.arrow")
         );
 
         let stats = batch.columns()[2]

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -297,10 +297,11 @@ impl ExecutionPlan for ShuffleWriterExec {
     }
 
     fn output_partitioning(&self) -> Partitioning {
-        match &self.shuffle_output_partitioning {
-            Some(p) => p.clone(),
-            _ => Partitioning::UnknownPartitioning(1),
-        }
+        // This operator needs to be executed once for each *input* partition and there
+        // isn't really a mechanism yet in DataFusion to support this use case so we report
+        // the input partitioning as the output partitioning here. The executor reports
+        // output partition meta data back to the scheduler.
+        self.plan.output_partitioning()
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -122,6 +122,11 @@ impl ShuffleWriterExec {
         self.stage_id
     }
 
+    /// Get the true output partitioning
+    pub fn shuffle_output_partitioning(&self) -> Option<&Partitioning> {
+        self.shuffle_output_partitioning.as_ref()
+    }
+
     pub async fn execute_shuffle_write(
         &self,
         input_partition: usize,

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -102,6 +102,7 @@ impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
                     )
                 })?
                 .into(),
+            path: self.path,
         })
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -96,9 +96,9 @@ impl From<protobuf::ExecutorMetadata> for ExecutorMeta {
 /// Summary of executed partition
 #[derive(Debug, Copy, Clone)]
 pub struct PartitionStats {
-    num_rows: Option<u64>,
-    num_batches: Option<u64>,
-    num_bytes: Option<u64>,
+    pub(crate) num_rows: Option<u64>,
+    pub(crate) num_batches: Option<u64>,
+    pub(crate) num_bytes: Option<u64>,
 }
 
 impl Default for PartitionStats {

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -62,6 +62,7 @@ pub struct PartitionLocation {
     pub partition_id: PartitionId,
     pub executor_meta: ExecutorMeta,
     pub partition_stats: PartitionStats,
+    pub path: String,
 }
 
 /// Meta-data for an executor, used when fetching shuffle partitions from other executors

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -70,6 +70,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
             partition_stats: Some(self.partition_stats.into()),
+            path: self.path.to_string(),
         })
     }
 }

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -70,7 +70,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
             partition_stats: Some(self.partition_stats.into()),
-            path: self.path.to_string(),
+            path: self.path,
         })
     }
 }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -27,16 +27,13 @@ use prost::Message;
 use tokio::sync::OwnedMutexGuard;
 
 use ballista_core::serde::protobuf::{
-    job_status, task_status, CompletedJob, CompletedTask, ExecutorHeartbeat,
+    self, job_status, task_status, CompletedJob, CompletedTask, ExecutorHeartbeat,
     ExecutorMetadata, FailedJob, FailedTask, JobStatus, PhysicalPlanNode, RunningJob,
     RunningTask, TaskStatus,
 };
 use ballista_core::serde::scheduler::PartitionStats;
 use ballista_core::{error::BallistaError, serde::scheduler::ExecutorMeta};
-use ballista_core::{
-    error::Result, execution_plans::UnresolvedShuffleExec,
-    serde::protobuf::PartitionLocation,
-};
+use ballista_core::{error::Result, execution_plans::UnresolvedShuffleExec};
 
 use super::planner::remove_unresolved_shuffles;
 
@@ -298,8 +295,11 @@ impl SchedulerState {
                 // Let's try to resolve any unresolved shuffles we find
                 let unresolved_shuffles = find_unresolved_shuffles(&plan)?;
                 let mut partition_locations: HashMap<
-                    usize,
-                    Vec<Vec<ballista_core::serde::scheduler::PartitionLocation>>,
+                    usize, // stage id
+                    HashMap<
+                        usize,                                                   // shuffle input partition id
+                        Vec<ballista_core::serde::scheduler::PartitionLocation>, // shuffle output partitions
+                    >,
                 > = HashMap::new();
                 for unresolved_shuffle in unresolved_shuffles {
                     for partition_id in 0..unresolved_shuffle.partition_count {
@@ -317,34 +317,49 @@ impl SchedulerState {
                         if task_is_dead {
                             continue 'tasks;
                         } else if let Some(task_status::Status::Completed(
-                            CompletedTask { executor_id, .. },
+                            CompletedTask {
+                                executor_id,
+                                partitions,
+                            },
                         )) = &referenced_task.status
                         {
-                            //TODO: this logic is incorrect and is ignoring the shuffle write
-                            // meta-data in the CompletedTask
-                            // see https://github.com/apache/arrow-datafusion/issues/707
-
-                            let empty = vec![];
                             let locations = partition_locations
                                 .entry(unresolved_shuffle.stage_id)
-                                .or_insert(empty);
+                                .or_insert_with(HashMap::new);
                             let executor_meta = executors
                                 .iter()
                                 .find(|exec| exec.id == *executor_id)
                                 .unwrap()
                                 .clone();
-                            locations.push(vec![
-                                ballista_core::serde::scheduler::PartitionLocation {
-                                    partition_id:
-                                        ballista_core::serde::scheduler::PartitionId {
-                                            job_id: partition.job_id.clone(),
-                                            stage_id: unresolved_shuffle.stage_id,
-                                            partition_id,
-                                        },
-                                    executor_meta,
-                                    partition_stats: PartitionStats::default(),
-                                },
-                            ]);
+
+                            let temp =
+                                locations.entry(partition_id).or_insert_with(Vec::new);
+                            for p in partitions {
+                                let executor_meta = executor_meta.clone();
+                                let partition_location =
+                                    ballista_core::serde::scheduler::PartitionLocation {
+                                        partition_id:
+                                            ballista_core::serde::scheduler::PartitionId {
+                                                job_id: partition.job_id.clone(),
+                                                stage_id: unresolved_shuffle.stage_id,
+                                                partition_id,
+                                            },
+                                        executor_meta,
+                                        partition_stats: PartitionStats::new(
+                                            Some(p.num_rows),
+                                            Some(p.num_batches),
+                                            Some(p.num_bytes),
+                                        ),
+                                        path: p.path.clone(),
+                                    };
+                                info!(
+                                    "Scheduler storing stage {} partition {} path: {}",
+                                    unresolved_shuffle.stage_id,
+                                    partition_id,
+                                    partition_location.path
+                                );
+                                temp.push(partition_location);
+                            }
                         } else {
                             continue 'tasks;
                         }
@@ -458,29 +473,37 @@ impl SchedulerState {
             .map(|status| match &status.status {
                 Some(task_status::Status::Completed(CompletedTask {
                     executor_id,
-                    ..
-                })) => Ok((status, executor_id)),
+                    partitions,
+                })) => Ok((status, executor_id, partitions)),
                 _ => Err(BallistaError::General("Task not completed".to_string())),
             })
             .collect::<Result<Vec<_>>>()
             .ok()
             .map(|info| {
-                let partition_location = info
-                    .into_iter()
-                    .map(|(status, execution_id)| {
-                        //TODO: this logic is incorrect and is ignoring the shuffle write
-                        // meta-data in the CompletedTask
-                        // see https://github.com/apache/arrow-datafusion/issues/707
-
-                        PartitionLocation {
-                            partition_id: status.partition_id.to_owned(),
-                            executor_meta: executors
-                                .get(execution_id)
-                                .map(|e| e.clone().into()),
-                            partition_stats: None,
-                        }
-                    })
-                    .collect();
+                let mut partition_location = vec![];
+                for (status, executor_id, partitions) in info {
+                    let input_partition_id = status.partition_id.as_ref().unwrap(); //TODO unwrap
+                    let executor_meta =
+                        executors.get(executor_id).map(|e| e.clone().into());
+                    for shuffle_write_partition in partitions {
+                        let shuffle_input_partition_id = Some(protobuf::PartitionId {
+                            job_id: input_partition_id.job_id.clone(),
+                            stage_id: input_partition_id.stage_id,
+                            partition_id: input_partition_id.partition_id,
+                        });
+                        partition_location.push(protobuf::PartitionLocation {
+                            partition_id: shuffle_input_partition_id.clone(),
+                            executor_meta: executor_meta.clone(),
+                            partition_stats: Some(protobuf::PartitionStats {
+                                num_batches: shuffle_write_partition.num_batches as i64,
+                                num_rows: shuffle_write_partition.num_rows as i64,
+                                num_bytes: shuffle_write_partition.num_bytes as i64,
+                                column_stats: vec![],
+                            }),
+                            path: shuffle_write_partition.path.clone(),
+                        });
+                    }
+                }
                 job_status::Status::Completed(CompletedJob { partition_location })
             });
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #737.

```
Query 12 iteration 0 took 29591.0 ms
+------------+-----------------+----------------+
| l_shipmode | high_line_count | low_line_count |
+------------+-----------------+----------------+
| MAIL       | 623092          | 934696         |
| SHIP       | 622964          | 934514         |
+------------+-----------------+----------------+
Query 12 avg time: 29591.04 ms
```

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This fixes a bug introduced in #712 and also gets us closer to truly supporting shuffle.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Executors now collect meta-data from `ShuffleWriterExec` about the output partitions and return this information to the scheduler
- Comments are added where the current design is broken, with links to the relevant GitHub issue
- Added `inputRows` and `outputRows` metrics to `ShuffleWriterExec`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

