### PR TITLE
update `python` crate to support latest pyo3 syntax and gil sematics

### DIFF
--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 /// Expression representing a column on the existing plan.
 #[pyfunction]
-#[text_signature = "(name)"]
+#[pyo3(text_signature = "(name)")]
 fn col(name: &str) -> expression::Expression {
     expression::Expression {
         expr: logical_plan::col(name),
@@ -34,7 +34,7 @@ fn col(name: &str) -> expression::Expression {
 
 /// Expression representing a constant value
 #[pyfunction]
-#[text_signature = "(value)"]
+#[pyo3(text_signature = "(value)")]
 fn lit(value: i32) -> expression::Expression {
     expression::Expression {
         expr: logical_plan::lit(value),

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 /// Expression representing a column on the existing plan.
 #[pyfunction]
-#[pyo3(text_signature = "(name)")]
+#[text_signature = "(name)"]
 fn col(name: &str) -> expression::Expression {
     expression::Expression {
         expr: logical_plan::col(name),
@@ -34,7 +34,7 @@ fn col(name: &str) -> expression::Expression {
 
 /// Expression representing a constant value
 #[pyfunction]
-#[pyo3(text_signature = "(value)")]
+#[text_signature = "(value)"]
 fn lit(value: i32) -> expression::Expression {
     expression::Expression {
         expr: logical_plan::lit(value),


### PR DESCRIPTION
# Which issue does this PR close?

update `python` crate to support latest pyo3 syntax and gil sematics.

must be merged after #740 

update usage of [`acquire_gil`](https://docs.rs/pyo3/0.14.1/pyo3/struct.Python.html#method.acquire_gil) to [`with_gil`](https://docs.rs/pyo3/0.14.1/pyo3/struct.Python.html#method.with_gil) because:

> Most users should not need to use this API directly, and should prefer one of two options:
>
> 1. When implementing #[pymethods] or #[pyfunction] add a function argument py: Python to receive access to the GIL context in which the function is running.
> 2. Use Python::with_gil to run a closure with the GIL, acquiring only if needed.

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
