### PR TITLE
Show optimized physical and logical plans in EXPLAIN

### DIFF
--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -399,7 +399,7 @@ impl LogicalPlanBuilder {
     /// Create an expression to represent the explanation of the plan
     pub fn explain(&self, verbose: bool) -> Result<Self> {
         let stringified_plans = vec![StringifiedPlan::new(
-            PlanType::LogicalPlan,
+            PlanType::InitialLogicalPlan,
             format!("{:#?}", self.plan.clone()),
         )];
 
@@ -740,14 +740,24 @@ mod tests {
     #[test]
     fn stringified_plan() {
         let stringified_plan =
-            StringifiedPlan::new(PlanType::LogicalPlan, "...the plan...");
+            StringifiedPlan::new(PlanType::InitialLogicalPlan, "...the plan...");
+        assert!(stringified_plan.should_display(true));
+        assert!(!stringified_plan.should_display(false)); // not in non verbose mode
+
+        let stringified_plan =
+            StringifiedPlan::new(PlanType::FinalLogicalPlan, "...the plan...");
         assert!(stringified_plan.should_display(true));
         assert!(stringified_plan.should_display(false)); // display in non verbose mode too
 
         let stringified_plan =
-            StringifiedPlan::new(PlanType::PhysicalPlan, "...the plan...");
+            StringifiedPlan::new(PlanType::InitialPhysicalPlan, "...the plan...");
         assert!(stringified_plan.should_display(true));
-        assert!(!stringified_plan.should_display(false));
+        assert!(!stringified_plan.should_display(false)); // not in non verbose mode
+
+        let stringified_plan =
+            StringifiedPlan::new(PlanType::FinalPhysicalPlan, "...the plan...");
+        assert!(stringified_plan.should_display(true));
+        assert!(stringified_plan.should_display(false)); // display in non verbose mode
 
         let stringified_plan = StringifiedPlan::new(
             PlanType::OptimizedLogicalPlan {

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -542,7 +542,7 @@ mod tests {
             &optimizer,
             true,
             &empty_plan,
-            &[StringifiedPlan::new(PlanType::LogicalPlan, "...")],
+            &[StringifiedPlan::new(PlanType::InitialLogicalPlan, "...")],
             schema.as_ref(),
             &ExecutionProps::new(),
         )?;
@@ -556,7 +556,7 @@ mod tests {
                 assert!(*verbose);
 
                 let expected_stringified_plans = vec![
-                    StringifiedPlan::new(PlanType::LogicalPlan, "..."),
+                    StringifiedPlan::new(PlanType::InitialLogicalPlan, "..."),
                     StringifiedPlan::new(
                         PlanType::OptimizedLogicalPlan {
                             optimizer_name: "test_optimizer".into(),

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -234,8 +234,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.sql_statement_to_plan(statement)?;
 
         let stringified_plans = vec![StringifiedPlan::new(
-            PlanType::LogicalPlan,
-            format!("{:#?}", plan),
+            PlanType::InitialLogicalPlan,
+            plan.display_indent().to_string(),
         )];
 
         let schema = LogicalPlan::explain_schema();

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1976,10 +1976,17 @@ async fn csv_explain() {
     let expected = vec![
         vec![
             "logical_plan",
-            "Projection: #aggregate_test_100.c1\n  Filter: #aggregate_test_100.c2 Gt Int64(10)\n    TableScan: aggregate_test_100 projection=Some([0, 1])"
+            "Projection: #aggregate_test_100.c1\
+             \n  Filter: #aggregate_test_100.c2 Gt Int64(10)\
+             \n    TableScan: aggregate_test_100 projection=Some([0, 1])"
         ],
         vec!["physical_plan",
-             "ProjectionExec: expr=[c1@0 as c1]\n  CoalesceBatchesExec: target_batch_size=4096\n    FilterExec: CAST(c2@1 AS Int64) > 10\n      RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES)\n        CsvExec: source=Path(ARROW_TEST_DATA/csv/aggregate_test_100.csv: [ARROW_TEST_DATA/csv/aggregate_test_100.csv]), has_header=true\n"
+             "ProjectionExec: expr=[c1@0 as c1]\
+              \n  CoalesceBatchesExec: target_batch_size=4096\
+              \n    FilterExec: CAST(c2@1 AS Int64) > 10\
+              \n      RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES)\
+              \n        CsvExec: source=Path(ARROW_TEST_DATA/csv/aggregate_test_100.csv: [ARROW_TEST_DATA/csv/aggregate_test_100.csv]), has_header=true\
+              \n"
     ]];
     assert_eq!(expected, actual);
 
@@ -3940,12 +3947,12 @@ fn normalize_for_explain(s: &str) -> String {
 }
 
 /// Applies normalize_for_explain to every line
-fn normalize_vec_for_explain(v: Vec<Vec<String>>) -> Vec<Vec<String>>
-{
-    v
-        .into_iter()
+fn normalize_vec_for_explain(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    v.into_iter()
         .map(|l| {
-            l.into_iter().map(|s|normalize_for_explain(&s)).collect::<Vec<_>>()
+            l.into_iter()
+                .map(|s| normalize_for_explain(&s))
+                .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>()
 }

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -163,9 +163,9 @@ async fn topk_plan() -> Result<()> {
     let mut ctx = setup_table(make_topk_context()).await?;
 
     let expected = vec![
-        "| logical_plan after topk                 | TopK: k=3                                                                            |",
-        "|                                         |   Projection: #sales.customer_id, #sales.revenue                                     |",
-        "|                                         |     TableScan: sales projection=Some([0, 1])                                         |",
+        "| logical_plan after topk                 | TopK: k=3                                                                                |",
+        "|                                         |   Projection: #sales.customer_id, #sales.revenue                                         |",
+        "|                                         |     TableScan: sales projection=Some([0, 1])                                             |",
     ].join("\n");
 
     let explain_query = format!("EXPLAIN VERBOSE {}", QUERY);


### PR DESCRIPTION
# Which issue does this PR close?

 Closes https://github.com/apache/arrow-datafusion/issues/221

 # Rationale for this change
"The EXPLAIN command is useful to show the plan of the query engine. However, the current output shows the un-optimized logical plan, which is not very useful as it maps almost 1:1 to the query."

Most users issue an `EXPLAIN` command to see what the query engine is actually going to run.

# What changes are included in this PR?
Change EXPLAIN to show the optimized logical plan (after all logical optimizer passes) and optimized physical plan (after all physical optimizer passes).

Working with sql.rs reminded me of my goal for cleaning up sql tests, and so I filed https://github.com/apache/arrow-datafusion/issues/743


# Are there any user-facing changes?
Explain plan output is different

For example, before this PR

```
> EXPLAIN SELECT c2 from foo;
+--------------+----------------------------------+
| plan_type    | plan                             |
+--------------+----------------------------------+
| logical_plan | Projection: #foo.c2              |
|              |   TableScan: foo projection=None |
+--------------+----------------------------------+
1 row in set. Query took 0.002 seconds.
```

and after this PR (note the inclusion of the projection pushdown and physical plan)
```
> EXPLAIN SELECT c2 from foo;
+---------------+--------------------------------------------------------------------------+
| plan_type     | plan                                                                     |
+---------------+--------------------------------------------------------------------------+
| logical_plan  | Projection: #foo.c2                                                      |
|               |   TableScan: foo projection=Some([1])                                    |
| physical_plan | ProjectionExec: expr=[c2@0 as c2]                                        |
|               |   RepartitionExec: partitioning=RoundRobinBatch(16)                      |
|               |     CsvExec: source=Path(/tmp/foo.csv: [/tmp/foo.csv]), has_header=false |
+---------------+--------------------------------------------------------------------------+
```