### PR TITLE
Remove unnecessary projection in logical plan optimization phase

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1185,7 +1185,6 @@ mod tests {
             _ => panic!("expect optimized_plan to be projection"),
         }
 
-        // let expected = format!("TableScan: {} projection=Some([1])", UNNAMED_TABLE);
         let expected = format!(
             "Projection: #{}.b\
         \n  TableScan: {} projection=Some([1])",

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1098,22 +1098,18 @@ mod tests {
 
         let optimized_plan = ctx.optimize(&logical_plan)?;
         match &optimized_plan {
-            LogicalPlan::Projection { input, .. } => match &**input {
-                LogicalPlan::TableScan {
-                    source,
-                    projected_schema,
-                    ..
-                } => {
-                    assert_eq!(source.schema().fields().len(), 3);
-                    assert_eq!(projected_schema.fields().len(), 1);
-                }
-                _ => panic!("input to projection should be TableScan"),
-            },
-            _ => panic!("expect optimized_plan to be projection"),
+            LogicalPlan::TableScan {
+                source,
+                projected_schema,
+                ..
+            } => {
+                assert_eq!(source.schema().fields().len(), 3);
+                assert_eq!(projected_schema.fields().len(), 1);
+            }
+            _ => panic!("input to projection should be TableScan"),
         }
 
-        let expected = "Projection: #test.c2\
-        \n  TableScan: test projection=Some([1])";
+        let expected = "TableScan: test projection=Some([1])";
         assert_eq!(format!("{:?}", optimized_plan), expected);
 
         let physical_plan = ctx.create_physical_plan(&optimized_plan)?;
@@ -1171,25 +1167,18 @@ mod tests {
         let ctx = ExecutionContext::new();
         let optimized_plan = ctx.optimize(&plan)?;
         match &optimized_plan {
-            LogicalPlan::Projection { input, .. } => match &**input {
-                LogicalPlan::TableScan {
-                    source,
-                    projected_schema,
-                    ..
-                } => {
-                    assert_eq!(source.schema().fields().len(), 3);
-                    assert_eq!(projected_schema.fields().len(), 1);
-                }
-                _ => panic!("input to projection should be InMemoryScan"),
-            },
-            _ => panic!("expect optimized_plan to be projection"),
+            LogicalPlan::TableScan {
+                source,
+                projected_schema,
+                ..
+            } => {
+                assert_eq!(source.schema().fields().len(), 3);
+                assert_eq!(projected_schema.fields().len(), 1);
+            }
+            _ => panic!("input to projection should be InMemoryScan"),
         }
 
-        let expected = format!(
-            "Projection: #{}.b\
-        \n  TableScan: {} projection=Some([1])",
-            UNNAMED_TABLE, UNNAMED_TABLE
-        );
+        let expected = format!("TableScan: {} projection=Some([1])", UNNAMED_TABLE);
         assert_eq!(format!("{:?}", optimized_plan), expected);
 
         let physical_plan = ctx.create_physical_plan(&optimized_plan)?;

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1098,18 +1098,22 @@ mod tests {
 
         let optimized_plan = ctx.optimize(&logical_plan)?;
         match &optimized_plan {
-            LogicalPlan::TableScan {
-                source,
-                projected_schema,
-                ..
-            } => {
-                assert_eq!(source.schema().fields().len(), 3);
-                assert_eq!(projected_schema.fields().len(), 1);
-            }
-            _ => panic!("input to projection should be TableScan"),
+            LogicalPlan::Projection { input, .. } => match &**input {
+                LogicalPlan::TableScan {
+                    source,
+                    projected_schema,
+                    ..
+                } => {
+                    assert_eq!(source.schema().fields().len(), 3);
+                    assert_eq!(projected_schema.fields().len(), 1);
+                }
+                _ => panic!("input to projection should be TableScan"),
+            },
+            _ => panic!("expect optimized_plan to be projection"),
         }
 
-        let expected = "TableScan: test projection=Some([1])";
+        let expected = "Projection: #test.c2\
+        \n  TableScan: test projection=Some([1])";
         assert_eq!(format!("{:?}", optimized_plan), expected);
 
         let physical_plan = ctx.create_physical_plan(&optimized_plan)?;
@@ -1167,18 +1171,26 @@ mod tests {
         let ctx = ExecutionContext::new();
         let optimized_plan = ctx.optimize(&plan)?;
         match &optimized_plan {
-            LogicalPlan::TableScan {
-                source,
-                projected_schema,
-                ..
-            } => {
-                assert_eq!(source.schema().fields().len(), 3);
-                assert_eq!(projected_schema.fields().len(), 1);
-            }
-            _ => panic!("input to projection should be InMemoryScan"),
+            LogicalPlan::Projection { input, .. } => match &**input {
+                LogicalPlan::TableScan {
+                    source,
+                    projected_schema,
+                    ..
+                } => {
+                    assert_eq!(source.schema().fields().len(), 3);
+                    assert_eq!(projected_schema.fields().len(), 1);
+                }
+                _ => panic!("input to projection should be InMemoryScan"),
+            },
+            _ => panic!("expect optimized_plan to be projection"),
         }
 
-        let expected = format!("TableScan: {} projection=Some([1])", UNNAMED_TABLE);
+        // let expected = format!("TableScan: {} projection=Some([1])", UNNAMED_TABLE);
+        let expected = format!(
+            "Projection: #{}.b\
+        \n  TableScan: {} projection=Some([1])",
+            UNNAMED_TABLE, UNNAMED_TABLE
+        );
         assert_eq!(format!("{:?}", optimized_plan), expected);
 
         let physical_plan = ctx.create_physical_plan(&optimized_plan)?;

--- a/datafusion/src/optimizer/projection_push_down.rs
+++ b/datafusion/src/optimizer/projection_push_down.rs
@@ -56,7 +56,13 @@ impl OptimizerRule for ProjectionPushDown {
             .collect::<HashSet<Column>>();
         let optimized =
             optimize_plan(self, plan, &required_columns, false, execution_props)?;
-        println!("after optimize: {:?}", optimized);
+        println!("after optimize:\n{:?}", optimized);
+
+        // let eliminated =
+        //     eliminate_projection(&optimized, plan.expressions(), &required_columns)?;
+        // println!("after eliminated:\n{:?}", eliminated);
+        // Ok(eliminated)
+
         Ok(optimized)
     }
 
@@ -132,6 +138,178 @@ fn get_projected_schema(
     Ok((projection, projected_fields.to_dfschema_ref()?))
 }
 
+// check and remove redundent projection.
+fn eliminate_projection(
+    plan: &LogicalPlan,
+    new_expr: Vec<Expr>,
+    // new_fields: Vec<DFField>,
+    required_columns: &HashSet<Column>,
+) -> Result<LogicalPlan> {
+    let is_all_column_expr = new_expr.iter().all(|expr| matches!(expr, Expr::Column(_)));
+    println!("all column: {}", is_all_column_expr);
+
+    println!("enter plan: {:?}", plan);
+
+    // if &new_required_columns_optimized == required_columns
+    //     && is_all_column_expr
+    //     && !matches!(new_input, LogicalPlan::TableScan { .. })
+    // {
+    //     return Ok(plan);
+    // }
+
+    match plan {
+        LogicalPlan::Projection {
+            input,
+            expr,
+            schema,
+        } => {
+            let new_required_columns = input
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.qualified_column())
+                .collect::<HashSet<Column>>();
+
+            // println!("new fields: {:?}", new_fields);
+
+            // if &new_required_columns != required_columns {
+            // if schema.fields() == input.schema().fields() {
+            if required_columns == &new_required_columns {
+                return Ok(eliminate_projection(input, new_expr, required_columns)?);
+            } else {
+                let expr = expr.clone();
+                let new_input =
+                    eliminate_projection(input, expr.clone(), required_columns)?;
+                return Ok(LogicalPlan::Projection {
+                    input: Arc::new(new_input),
+                    expr,
+                    schema: schema.clone(),
+                });
+            }
+
+            // Ok((
+            //     true,
+            //     LogicalPlan::Projection {
+            //         input: input.clone(),
+            //         expr: new_expr,
+            //         schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+            //     },
+            // ))
+        }
+        LogicalPlan::Window {
+            input,
+            window_expr,
+            schema,
+        } =>
+        //
+        // {
+        //     Ok(LogicalPlan::Window {
+        //         input: input.clone(),
+        //         window_expr: window_expr.clone(),
+        //         schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        //     })
+        // }
+        {
+            // eliminate_projection(input, new_expr, new_fields, required_columns)
+            eliminate_projection(plan, new_expr, required_columns)
+        }
+        LogicalPlan::Aggregate {
+            input,
+            group_expr,
+            aggr_expr,
+            schema,
+        } => todo!(),
+        // Ok(LogicalPlan::Aggregate {
+        //     input: input.clone(),
+        //     group_expr: group_expr.clone(),
+        //     aggr_expr: aggr_expr.clone(),
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        // }),
+        LogicalPlan::Join {
+            left,
+            right,
+            on,
+            join_type,
+            join_constraint,
+            schema,
+        } => todo!(),
+        // Ok(LogicalPlan::Join {
+        //     left: left.clone(),
+        //     right: right.clone(),
+        //     on: on.clone(),
+        //     join_type: join_type.clone(),
+        //     join_constraint: join_constraint.clone(),
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        // }),
+        LogicalPlan::CrossJoin {
+            left,
+            right,
+            schema,
+        } => todo!(),
+        // Ok(LogicalPlan::CrossJoin {
+        //     left: left.clone(),
+        //     right: right.clone(),
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        // }),
+        LogicalPlan::Union {
+            inputs,
+            schema,
+            alias,
+        } => todo!(),
+        //  Ok(LogicalPlan::Union {
+        //     inputs: inputs.clone(),
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        //     alias: alias.clone(),
+        // }),
+        LogicalPlan::TableScan { .. } => Ok(plan.to_owned()),
+        LogicalPlan::EmptyRelation {
+            produce_one_row,
+            schema,
+        } => todo!(),
+        // Ok(LogicalPlan::EmptyRelation {
+        //     produce_one_row: *produce_one_row,
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        // }),
+        LogicalPlan::Explain {
+            verbose,
+            plan,
+            stringified_plans,
+            schema,
+        } => todo!(),
+        // Ok(LogicalPlan::Explain {
+        //     verbose: *verbose,
+        //     plan: plan.clone(),
+        //     stringified_plans: stringified_plans.clone(),
+        //     schema: DFSchemaRef::new(DFSchema::new(new_fields)?),
+        // }),
+        LogicalPlan::Filter { .. }
+        | LogicalPlan::Extension { .. }
+        | LogicalPlan::Sort { .. }
+        | LogicalPlan::Repartition { .. }
+        | LogicalPlan::Limit { .. }
+        | LogicalPlan::CreateExternalTable { .. } =>
+        // Ok((
+        //     true,
+        //     utils::from_plan(plan, &plan.expressions(), &plan.inputs())?,
+        // )),
+        {
+            let expr = plan.expressions();
+            let inputs = plan.inputs();
+            let new_inputs = inputs
+                .iter()
+                .map(|input_plan| {
+                    eliminate_projection(input_plan, new_expr.clone(), required_columns)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // eliminate_projection(plan, new_expr, new_fields, required_columns)
+
+            utils::from_plan(plan, &expr, &new_inputs)
+        }
+    }
+
+    // todo!()
+}
+
 /// Recursively transverses the logical plan removing expressions and that are not needed.
 fn optimize_plan(
     optimizer: &ProjectionPushDown,
@@ -194,11 +372,12 @@ fn optimize_plan(
                 expr.iter().all(|expr| matches!(expr, Expr::Column(_)));
             println!("d: {}", is_all_column_expr);
 
-            if new_fields.is_empty()
-                || (new_required_columns_optimized.is_subset(required_columns)
-                    && is_all_column_expr)
-            {
+            if new_fields.is_empty() {
                 // no need for an expression at all
+                Ok(new_input)
+            } else if &new_required_columns_optimized == required_columns
+                && has_projection
+            {
                 Ok(new_input)
             } else {
                 Ok(LogicalPlan::Projection {
@@ -528,8 +707,48 @@ mod tests {
             .project(vec![col("a"), col("b"), col("c")])?
             .project(vec![col("a"), col("c"), col("b")])?
             .build()?;
+        let expected = "Projection: #test.a, #test.c, #test.b\
+        \n  TableScan: test projection=Some([0, 1, 2])";
 
-        assert_optimized_plan_eq(&plan, "TableScan: test projection=Some([0, 1, 2])");
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn reorder_projection() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .project(vec![col("c"), col("b"), col("a")])?
+            .build()?;
+        let expected = "Projection: #test.c, #test.b, #test.a\
+        \n  TableScan: test projection=Some([0, 1, 2])";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn noncontiguous_redundunt_projection() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .project(vec![col("c"), col("b"), col("a")])?
+            .filter(col("c").gt(lit(1)))?
+            .project(vec![col("c"), col("a"), col("b")])?
+            .filter(col("b").gt(lit(1)))?
+            .filter(col("a").gt(lit(1)))?
+            .project(vec![col("a"), col("c"), col("b")])?
+            .build()?;
+        let expected = "Projection: #test.a, #test.c, #test.b\
+        \n  Filter: #test.a Gt Int32(1)\
+        \n    Filter: #test.b Gt Int32(1)\
+        \n      Filter: #test.c Gt Int32(1)\
+        \n        TableScan: test projection=Some([0, 1, 2])";
+
+        assert_optimized_plan_eq(&plan, expected);
 
         Ok(())
     }
@@ -682,7 +901,8 @@ mod tests {
 
         assert_fields_eq(&plan, vec!["a", "b"]);
 
-        let expected = "TableScan: test projection=Some([0, 1])";
+        let expected = "Projection: #test.a, #test.b\
+        \n  TableScan: test projection=Some([0, 1])";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -732,7 +952,8 @@ mod tests {
         assert_fields_eq(&plan, vec!["c", "a"]);
 
         let expected = "Limit: 5\
-        \n  TableScan: test projection=Some([0, 2])";
+        \n  Projection: #test.c, #test.a\
+        \n    TableScan: test projection=Some([0, 2])";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -780,7 +1001,8 @@ mod tests {
         let expected = "\
         Aggregate: groupBy=[[#test.c]], aggr=[[MAX(#test.a)]]\
         \n  Filter: #test.c Gt Int32(1)\
-        \n    TableScan: test projection=Some([0, 2])";
+        \n    Projection: #test.c, #test.a\
+        \n      TableScan: test projection=Some([0, 2])";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -847,9 +1069,10 @@ mod tests {
 
         assert_fields_eq(&plan, vec!["c", "a", "MAX(test.b)"]);
 
-        let expected = "Filter: #test.c Gt Int32(1)\
-        \n  Aggregate: groupBy=[[#test.a, #test.c]], aggr=[[MAX(#test.b)]]\
-        \n    TableScan: test projection=Some([0, 1, 2])";
+        let expected = "Projection: #test.c, #test.a, #MAX(test.b)\
+        \n  Filter: #test.c Gt Int32(1)\
+        \n    Aggregate: groupBy=[[#test.a, #test.c]], aggr=[[MAX(#test.b)]]\
+        \n      TableScan: test projection=Some([0, 1, 2])";
 
         assert_optimized_plan_eq(&plan, expected);
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #277 .

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds an optimization rule to remove unnecessary projection plans.

We'll consider a projection as "unnecessary" if it only reorders columns (requires the same columns against its sub-plan) and is not the first projection.

For the case where the sub-plan of a projection is a table scan, projection will be pushed down into the table scan plan as a `Vec<usize>` array. From the [documentation](https://github.com/apache/arrow-datafusion/blob/afe29bd3c6322db88936d5936db58ad1fb5c9ae2/datafusion/src/optimizer/projection_push_down.rs#L82-L83), this array should be ordered. So I keep the projection in this situation (test case `reorder_projection()`).
