### PR TITLE
Update docs to use vendored version of arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Run a SQL query against data stored in a CSV:
 
 ```rust
 use datafusion::prelude::*;
-use arrow::util::pretty::print_batches;
-use arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty::print_batches;
+use datafusion::arrow::record_batch::RecordBatch;
 
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {
@@ -92,8 +92,8 @@ Use the DataFrame API to process data stored in a CSV:
 
 ```rust
 use datafusion::prelude::*;
-use arrow::util::pretty::print_batches;
-use arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty::print_batches;
+use datafusion::arrow::record_batch::RecordBatch;
 
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -39,7 +39,7 @@
 //! ```rust
 //! # use datafusion::prelude::*;
 //! # use datafusion::error::Result;
-//! # use arrow::record_batch::RecordBatch;
+//! # use datafusion::arrow::record_batch::RecordBatch;
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
@@ -77,7 +77,7 @@
 //! ```
 //! # use datafusion::prelude::*;
 //! # use datafusion::error::Result;
-//! # use arrow::record_batch::RecordBatch;
+//! # use datafusion::arrow::record_batch::RecordBatch;
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/769

 # Rationale for this change
@yuribudilov pointed out the challenge that the most recently released version of datafusion (4.0.0) doesn't work with the most recently released version of arrow (5.0.0).


# What changes are included in this PR?
update the examples to use `datafusion::arrow` rather than `arrow`

Note this won't help users until we actually release a new version of Datafusion to crates.io


# Are there any user-facing changes?
Example might be clearer