### PR TITLE
JOIN conditions are order dependent

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -272,8 +272,7 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                     JoinConstraint::On => builder.join(
                         &convert_box_required!(join.right)?,
                         join_type.into(),
-                        left_keys,
-                        right_keys,
+                        (left_keys, right_keys),
                     )?,
                     JoinConstraint::Using => builder.join_using(
                         &convert_box_required!(join.right)?,

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -701,7 +701,7 @@ mod roundtrip_tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             Some(vec![0, 3, 4]),
         )
-        .and_then(|plan| plan.join(&scan_plan, JoinType::Inner, vec!["id"], vec!["id"]))
+        .and_then(|plan| plan.join(&scan_plan, JoinType::Inner, (vec!["id"], vec!["id"])))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
 

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -117,8 +117,7 @@ impl DataFrame for DataFrameImpl {
             .join(
                 &right.to_logical_plan(),
                 join_type,
-                left_cols.to_vec(),
-                right_cols.to_vec(),
+                (left_cols.to_vec(), right_cols.to_vec()),
             )?
             .build()?;
         Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -273,19 +273,19 @@ impl LogicalPlanBuilder {
         &self,
         right: &LogicalPlan,
         join_type: JoinType,
-        left_keys: Vec<impl Into<Column>>,
-        right_keys: Vec<impl Into<Column>>,
+        join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
     ) -> Result<Self> {
-        if left_keys.len() != right_keys.len() {
+        if join_keys.0.len() != join_keys.1.len() {
             return Err(DataFusionError::Plan(
                 "left_keys and right_keys were not the same length".to_string(),
             ));
         }
 
         let (left_keys, right_keys): (Vec<Result<Column>>, Vec<Result<Column>>) =
-            left_keys
+            join_keys
+                .0
                 .into_iter()
-                .zip(right_keys.into_iter())
+                .zip(join_keys.1.into_iter())
                 .map(|(l, r)| {
                     let mut swap = false;
                     let l = l.into();

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -973,8 +973,7 @@ mod tests {
             .join(
                 &right,
                 JoinType::Inner,
-                vec![Column::from_name("a")],
-                vec![Column::from_name("a")],
+                (vec![Column::from_name("a")], vec![Column::from_name("a")]),
             )?
             .filter(col("a").lt_eq(lit(1i64)))?
             .build()?;
@@ -1058,8 +1057,7 @@ mod tests {
             .join(
                 &right,
                 JoinType::Inner,
-                vec![Column::from_name("a")],
-                vec![Column::from_name("a")],
+                (vec![Column::from_name("a")], vec![Column::from_name("a")]),
             )?
             // "b" and "c" are not shared by either side: they are only available together after the join
             .filter(col("c").lt_eq(col("b")))?
@@ -1099,8 +1097,7 @@ mod tests {
             .join(
                 &right,
                 JoinType::Inner,
-                vec![Column::from_name("a")],
-                vec![Column::from_name("a")],
+                (vec![Column::from_name("a")], vec![Column::from_name("a")]),
             )?
             .filter(col("b").lt_eq(lit(1i64)))?
             .build()?;

--- a/datafusion/src/optimizer/projection_push_down.rs
+++ b/datafusion/src/optimizer/projection_push_down.rs
@@ -555,7 +555,7 @@ mod tests {
             LogicalPlanBuilder::scan_empty(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
-            .join(&table2_scan, JoinType::Left, vec!["a"], vec!["c1"])?
+            .join(&table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]))?
             .project(vec![col("a"), col("b"), col("c1")])?
             .build()?;
 
@@ -594,7 +594,7 @@ mod tests {
             LogicalPlanBuilder::scan_empty(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
-            .join(&table2_scan, JoinType::Left, vec!["a"], vec!["c1"])?
+            .join(&table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]))?
             // projecting joined column `a` should push the right side column `c1` projection as
             // well into test2 table even though `c1` is not referenced in projection.
             .project(vec![col("a"), col("b")])?

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -375,8 +375,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let (left_keys, right_keys): (Vec<Column>, Vec<Column>) =
                     keys.into_iter().unzip();
                 // return the logical plan representing the join
-                let join = LogicalPlanBuilder::from(left)
-                    .join(right, join_type, left_keys, right_keys)?;
+                let join = LogicalPlanBuilder::from(left).join(
+                    right,
+                    join_type,
+                    (left_keys, right_keys),
+                )?;
 
                 if filter.is_empty() {
                     join.build()
@@ -548,7 +551,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             join_keys.iter().map(|(_, r)| r.clone()).collect();
                         let builder = LogicalPlanBuilder::from(left);
                         left = builder
-                            .join(right, JoinType::Inner, left_keys, right_keys)?
+                            .join(right, JoinType::Inner, (left_keys, right_keys))?
                             .build()?;
                     }
 

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1717,15 +1717,19 @@ fn create_case_context() -> Result<ExecutionContext> {
 #[tokio::test]
 async fn equijoin() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql =
-        "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
+    ];
     let expected = vec![
         vec!["11", "a", "z"],
         vec!["22", "b", "y"],
         vec!["44", "d", "x"],
     ];
-    assert_eq!(expected, actual);
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
     Ok(())
 }
 
@@ -1754,39 +1758,50 @@ async fn equijoin_and_unsupported_condition() -> Result<()> {
 #[tokio::test]
 async fn left_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql = "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
+    ];
     let expected = vec![
         vec!["11", "a", "z"],
         vec!["22", "b", "y"],
         vec!["33", "c", "NULL"],
         vec!["44", "d", "x"],
     ];
-    assert_eq!(expected, actual);
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql =
-        "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t2_id = t1_id ORDER BY t1_id"
+    ];
     let expected = vec![
         vec!["NULL", "NULL", "w"],
         vec!["11", "a", "z"],
         vec!["22", "b", "y"],
         vec!["44", "d", "x"],
     ];
-    assert_eq!(expected, actual);
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
     Ok(())
 }
 
 #[tokio::test]
 async fn full_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql = "SELECT t1_id, t1_name, t2_name FROM t1 FULL JOIN t2 ON t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1 FULL JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1 FULL JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
+    ];
     let expected = vec![
         vec!["NULL", "NULL", "w"],
         vec!["11", "a", "z"],
@@ -1794,11 +1809,19 @@ async fn full_join() -> Result<()> {
         vec!["33", "c", "NULL"],
         vec!["44", "d", "x"],
     ];
-    assert_eq!(expected, actual);
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
 
-    let sql = "SELECT t1_id, t1_name, t2_name FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
-    assert_eq!(expected, actual);
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1 FULL OUTER JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
+    ];
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
 
     Ok(())
 }
@@ -1821,15 +1844,19 @@ async fn left_join_using() -> Result<()> {
 #[tokio::test]
 async fn equijoin_implicit_syntax() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql =
-        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t1_id = t2_id ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
+    let sqls = &[
+        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t1_id = t2_id ORDER BY t1_id",
+        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id",
+    ];
     let expected = vec![
         vec!["11", "a", "z"],
         vec!["22", "b", "y"],
         vec!["44", "d", "x"],
     ];
-    assert_eq!(expected, actual);
+    for sql in sqls {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
     Ok(())
 }
 
@@ -1842,21 +1869,6 @@ async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
         AND t1_id = t2_id \
         AND t2_id < 99 \
         ORDER BY t1_id";
-    let actual = execute(&mut ctx, sql).await;
-    let expected = vec![
-        vec!["11", "a", "z"],
-        vec!["22", "b", "y"],
-        vec!["44", "d", "x"],
-    ];
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[tokio::test]
-async fn equijoin_implicit_syntax_reversed() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
-    let sql =
-        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![
         vec!["11", "a", "z"],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #777.

 # Rationale for this change
Currently the Logical Plan builder assumes that the join conditions fields are provided in the same order as the tables are specified. This is different behavior to how Postgres works which does not care about the order of the tables listed in the condition. This PR aims to rectify this discrepancy.

# What changes are included in this PR?
This change allows the conditions to be reversed and will fail as previously if neither relation contains the column. A lot of the tests in `sql.rs` have been updated to test both conditions.

# Are there any user-facing changes?
This does not change public APIs, and should not be noticeable by any current users.