### PR TITLE
Box ScalarValue:Lists, reduce size by half size

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -537,7 +537,7 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::scalar_value::Value
             }
             protobuf::scalar_value::Value::ListValue(v) => v.try_into()?,
             protobuf::scalar_value::Value::NullListValue(v) => {
-                ScalarValue::List(None, v.try_into()?)
+                ScalarValue::List(None, Box::new(v.try_into()?))
             }
             protobuf::scalar_value::Value::NullValue(null_enum) => {
                 PrimitiveScalarType::from_i32(*null_enum)
@@ -581,8 +581,8 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::ScalarListValue {
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 datafusion::scalar::ScalarValue::List(
-                    Some(typechecked_values),
-                    leaf_scalar_type.into(),
+                    Some(Box::new(typechecked_values)),
+                    Box::new(leaf_scalar_type.into()),
                 )
             }
             Datatype::List(list_type) => {
@@ -626,9 +626,9 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::ScalarListValue {
                 datafusion::scalar::ScalarValue::List(
                     match typechecked_values.len() {
                         0 => None,
-                        _ => Some(typechecked_values),
+                        _ => Some(Box::new(typechecked_values)),
                     },
-                    list_type.try_into()?,
+                    Box::new(list_type.try_into()?),
                 )
             }
         };
@@ -766,14 +766,16 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::ScalarValue {
                     .map(|val| val.try_into())
                     .collect::<Result<Vec<_>, _>>()?;
                 let scalar_type: DataType = pb_scalar_type.try_into()?;
-                ScalarValue::List(Some(typechecked_values), scalar_type)
+                let scalar_type = Box::new(scalar_type);
+                ScalarValue::List(Some(Box::new(typechecked_values)), scalar_type)
             }
             protobuf::scalar_value::Value::NullListValue(v) => {
                 let pb_datatype = v
                     .datatype
                     .as_ref()
                     .ok_or_else(|| proto_error("Protobuf deserialization error: NullListValue message missing required field 'datatyp'"))?;
-                ScalarValue::List(None, pb_datatype.try_into()?)
+                let pb_datatype = Box::new(pb_datatype.try_into()?);
+                ScalarValue::List(None, pb_datatype)
             }
             protobuf::scalar_value::Value::NullValue(v) => {
                 let null_type_enum = protobuf::PrimitiveScalarType::from_i32(*v)

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -126,49 +126,57 @@ mod roundtrip_tests {
         let should_fail_on_seralize: Vec<ScalarValue> = vec![
             //Should fail due to inconsistent types
             ScalarValue::List(
-                Some(vec![
+                Some(Box::new(vec![
                     ScalarValue::Int16(None),
                     ScalarValue::Float32(Some(32.0)),
-                ]),
-                DataType::List(new_box_field("item", DataType::Int16, true)),
+                ])),
+                Box::new(DataType::List(new_box_field("item", DataType::Int16, true))),
             ),
             ScalarValue::List(
-                Some(vec![
+                Some(Box::new(vec![
                     ScalarValue::Float32(None),
                     ScalarValue::Float32(Some(32.0)),
-                ]),
-                DataType::List(new_box_field("item", DataType::Int16, true)),
+                ])),
+                Box::new(DataType::List(new_box_field("item", DataType::Int16, true))),
             ),
             ScalarValue::List(
-                Some(vec![
+                Some(Box::new(vec![
                     ScalarValue::List(
                         None,
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
+                        Box::new(DataType::List(new_box_field(
+                            "level2",
+                            DataType::Float32,
+                            true,
+                        ))),
                     ),
                     ScalarValue::List(
-                        Some(vec![
+                        Some(Box::new(vec![
                             ScalarValue::Float32(Some(-213.1)),
                             ScalarValue::Float32(None),
                             ScalarValue::Float32(Some(5.5)),
                             ScalarValue::Float32(Some(2.0)),
                             ScalarValue::Float32(Some(1.0)),
-                        ]),
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
+                        ])),
+                        Box::new(DataType::List(new_box_field(
+                            "level2",
+                            DataType::Float32,
+                            true,
+                        ))),
                     ),
                     ScalarValue::List(
                         None,
-                        DataType::List(new_box_field(
+                        Box::new(DataType::List(new_box_field(
                             "lists are typed inconsistently",
                             DataType::Int16,
                             true,
-                        )),
+                        ))),
                     ),
-                ]),
-                DataType::List(new_box_field(
+                ])),
+                Box::new(DataType::List(new_box_field(
                     "level1",
                     DataType::List(new_box_field("level2", DataType::Float32, true)),
                     true,
-                )),
+                ))),
             ),
         ];
 
@@ -200,7 +208,7 @@ mod roundtrip_tests {
             ScalarValue::UInt64(None),
             ScalarValue::Utf8(None),
             ScalarValue::LargeUtf8(None),
-            ScalarValue::List(None, DataType::Boolean),
+            ScalarValue::List(None, Box::new(DataType::Boolean)),
             ScalarValue::Date32(None),
             ScalarValue::TimestampMicrosecond(None),
             ScalarValue::TimestampNanosecond(None),
@@ -248,37 +256,49 @@ mod roundtrip_tests {
             ScalarValue::TimestampMicrosecond(Some(i64::MAX)),
             ScalarValue::TimestampMicrosecond(None),
             ScalarValue::List(
-                Some(vec![
+                Some(Box::new(vec![
                     ScalarValue::Float32(Some(-213.1)),
                     ScalarValue::Float32(None),
                     ScalarValue::Float32(Some(5.5)),
                     ScalarValue::Float32(Some(2.0)),
                     ScalarValue::Float32(Some(1.0)),
-                ]),
-                DataType::List(new_box_field("level1", DataType::Float32, true)),
+                ])),
+                Box::new(DataType::List(new_box_field(
+                    "level1",
+                    DataType::Float32,
+                    true,
+                ))),
             ),
             ScalarValue::List(
-                Some(vec![
+                Some(Box::new(vec![
                     ScalarValue::List(
                         None,
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
+                        Box::new(DataType::List(new_box_field(
+                            "level2",
+                            DataType::Float32,
+                            true,
+                        ))),
                     ),
                     ScalarValue::List(
-                        Some(vec![
+                        Some(Box::new(vec![
                             ScalarValue::Float32(Some(-213.1)),
                             ScalarValue::Float32(None),
                             ScalarValue::Float32(Some(5.5)),
                             ScalarValue::Float32(Some(2.0)),
                             ScalarValue::Float32(Some(1.0)),
-                        ]),
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
+                        ])),
+                        Box::new(DataType::List(new_box_field(
+                            "level2",
+                            DataType::Float32,
+                            true,
+                        ))),
                     ),
-                ]),
-                DataType::List(new_box_field(
+                ])),
+                Box::new(DataType::List(new_box_field(
                     "level1",
                     DataType::List(new_box_field("level2", DataType::Float32, true)),
                     true,
-                )),
+                ))),
             ),
         ];
 

--- a/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/datafusion/src/physical_plan/distinct_expressions.rs
@@ -178,7 +178,9 @@ impl Accumulator for DistinctCountAccumulator {
             .state_data_types
             .iter()
             .map(|state_data_type| {
-                ScalarValue::List(Some(Vec::new()), state_data_type.clone())
+                let values = Box::new(Vec::new());
+                let data_type = Box::new(state_data_type.clone());
+                ScalarValue::List(Some(values), data_type)
             })
             .collect::<Vec<_>>();
 
@@ -254,8 +256,8 @@ mod tests {
     macro_rules! state_to_vec {
         ($LIST:expr, $DATA_TYPE:ident, $PRIM_TY:ty) => {{
             match $LIST {
-                ScalarValue::List(_, data_type) => match data_type {
-                    DataType::$DATA_TYPE => (),
+                ScalarValue::List(_, data_type) => match data_type.as_ref() {
+                    &DataType::$DATA_TYPE => (),
                     _ => panic!("Unexpected DataType for list"),
                 },
                 _ => panic!("Expected a ScalarValue::List"),


### PR DESCRIPTION
# Which issue does this PR close?

 Re https://github.com/apache/arrow-datafusion/pull/786


# Changes:
1. Reduce size of ScalarValue from 64 bytes to 32 bytes by boxing `ScalarValue:List`s internal parts


 # Rationale for this change
1. A smaller `ScalarValue` means switching to use it in hash aggregations and hash joins will not be as expensive memory wise (where one is instantiated for each distinct grouping value)

# What changes are included in this PR?
1. Reduce size of ScalarValue from 64 bytes to 32 bytes by boxing `ScalarValue:List`s internal parts

# Are there any user-facing changes?
No
