### PR TITLE
Produce correct answers for Group BY NULL (Option 1)

### DIFF
--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -395,7 +395,10 @@ fn group_aggregate_batch(
                 // We can safely unwrap here as we checked we can create an accumulator before
                 let accumulator_set = create_accumulators(aggr_expr).unwrap();
                 batch_keys.push(key.clone());
-                let _ = create_group_by_values(&group_values, row, &mut group_by_values);
+                // Note it would be nice to make this a real error (rather than panic)
+                // but it is better than silently ignoring the issue and getting wrong results
+                create_group_by_values(&group_values, row, &mut group_by_values)
+                    .expect("can not create group by value");
                 (
                     key.clone(),
                     (group_by_values.clone(), accumulator_set, vec![row as u32]),
@@ -508,7 +511,9 @@ fn dictionary_create_key_for_col<K: ArrowDictionaryKeyType>(
 }
 
 /// Appends a sequence of [u8] bytes for the value in `col[row]` to
-/// `vec` to be used as a key into the hash map
+/// `vec` to be used as a key into the hash map.
+///
+/// NOTE: This functon does not check col.is_valid(). Caller must do so
 fn create_key_for_col(col: &ArrayRef, row: usize, vec: &mut Vec<u8>) -> Result<()> {
     match col.data_type() {
         DataType::Boolean => {
@@ -640,6 +645,50 @@ fn create_key_for_col(col: &ArrayRef, row: usize, vec: &mut Vec<u8>) -> Result<(
 }
 
 /// Create a key `Vec<u8>` that is used as key for the hashmap
+///
+/// This looks like
+/// [null_byte][col_value_bytes][null_byte][col_value_bytes]
+///
+/// Note that relatively uncommon patterns (e.g. not 0x00) are chosen
+/// for the null_byte to make debugging easier. The actual values are
+/// arbitrary.
+///
+/// For a NULL value in a column, the key looks like
+/// [0xFE]
+///
+/// For a Non-NULL value in a column, this looks like:
+/// [0xFF][byte representation of column value]
+///
+/// Example of a key with no NULL values:
+/// ```text
+///                        0xFF byte at the start of each column
+///                           signifies the value is non-null
+///                                          │
+///
+///                      ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┴ ─ ─ ─ ─ ─ ─ ─ ┐
+///
+///                      │        string len                 │  0x1234
+/// {                    ▼       (as usize le)      "foo"    ▼(as u16 le)
+///   k1: "foo"        ╔ ═┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──╦ ═┌──┬──┐
+///   k2: 0x1234u16     FF║03│00│00│00│00│00│00│00│"f│"o│"o│FF║34│12│
+/// }                  ╚ ═└──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──╩ ═└──┴──┘
+///                     0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
+/// ```
+///
+///  Example of a key with NULL values:
+///
+///```text
+///                         0xFE byte at the start of k1 column
+///                     ┌ ─     signifies the value is NULL
+///
+///                     └ ┐
+///                              0x1234
+/// {                     ▼    (as u16 le)
+///   k1: NULL          ╔ ═╔ ═┌──┬──┐
+///   k2: 0x1234u16      FE║FF║12│34│
+/// }                   ╚ ═╚ ═└──┴──┘
+///                       0  1  2  3
+///```
 pub(crate) fn create_key(
     group_by_keys: &[ArrayRef],
     row: usize,
@@ -647,7 +696,12 @@ pub(crate) fn create_key(
 ) -> Result<()> {
     vec.clear();
     for col in group_by_keys {
-        create_key_for_col(col, row, vec)?
+        if !col.is_valid(row) {
+            vec.push(0xFE);
+        } else {
+            vec.push(0xFF);
+            create_key_for_col(col, row, vec)?
+        }
     }
     Ok(())
 }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -513,7 +513,7 @@ fn dictionary_create_key_for_col<K: ArrowDictionaryKeyType>(
 /// Appends a sequence of [u8] bytes for the value in `col[row]` to
 /// `vec` to be used as a key into the hash map.
 ///
-/// NOTE: This functon does not check col.is_valid(). Caller must do so
+/// NOTE: This function does not check col.is_valid(). Caller must do so
 fn create_key_for_col(col: &ArrayRef, row: usize, vec: &mut Vec<u8>) -> Result<()> {
     match col.data_type() {
         DataType::Boolean => {

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3015,6 +3015,109 @@ async fn query_count_distinct() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_group_on_null() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Int32, true)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![
+            Some(0),
+            Some(3),
+            None,
+            Some(1),
+            Some(3),
+        ]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let mut ctx = ExecutionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT COUNT(*), c1 FROM test GROUP BY c1";
+
+    let actual = execute_to_batches(&mut ctx, sql).await;
+
+    // Note that the results also
+    // include a row for NULL (c1=NULL, count = 1)
+    let expected = vec![
+        "+-----------------+----+",
+        "| COUNT(UInt8(1)) | c1 |",
+        "+-----------------+----+",
+        "| 1               |    |",
+        "| 1               | 0  |",
+        "| 1               | 1  |",
+        "| 2               | 3  |",
+        "+-----------------+----+",
+    ];
+    assert_batches_sorted_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_group_on_null_multi_col() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("c1", DataType::Int32, true),
+        Field::new("c2", DataType::Utf8, true),
+    ]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![
+                Some(0),
+                Some(0),
+                Some(3),
+                None,
+                None,
+                Some(3),
+                Some(0),
+                None,
+                Some(3),
+            ])),
+            Arc::new(StringArray::from(vec![
+                None,
+                None,
+                Some("foo"),
+                None,
+                Some("bar"),
+                Some("foo"),
+                None,
+                Some("bar"),
+                Some("foo"),
+            ])),
+        ],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let mut ctx = ExecutionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT COUNT(*), c1, c2 FROM test GROUP BY c1, c2";
+
+    let actual = execute_to_batches(&mut ctx, sql).await;
+
+    // Note that the results also include values for null
+    // include a row for NULL (c1=NULL, count = 1)
+    let expected = vec![
+        "+-----------------+----+-----+",
+        "| COUNT(UInt8(1)) | c1 | c2  |",
+        "+-----------------+----+-----+",
+        "| 1               |    |     |",
+        "| 2               |    | bar |",
+        "| 3               | 0  |     |",
+        "| 3               | 3  | foo |",
+        "+-----------------+----+-----+",
+    ];
+    assert_batches_sorted_eq!(expected, &actual);
+
+    // Also run query with group columns reversed (results shoudl be the same)
+    let sql = "SELECT COUNT(*), c1, c2 FROM test GROUP BY c2, c1";
+    let actual = execute_to_batches(&mut ctx, sql).await;
+    assert_batches_sorted_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_on_string_dictionary() -> Result<()> {
     // Test to ensure DataFusion can operate on dictionary types
     // Use StringDictionary (32 bit indexes = keys)
@@ -3065,6 +3168,13 @@ async fn query_on_string_dictionary() -> Result<()> {
     let sql = "SELECT COUNT(d1) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["2"]];
+    assert_eq!(expected, actual);
+
+    // grouping
+    let sql = "SELECT d1, COUNT(*) FROM test group by d1";
+    let mut actual = execute(&mut ctx, sql).await;
+    actual.sort();
+    let expected = vec![vec!["NULL", "1"], vec!["one", "1"], vec!["three", "1"]];
     assert_eq!(expected, actual);
 
     Ok(())


### PR DESCRIPTION
# Which issue does this PR close?
This PR closes https://github.com/apache/arrow-datafusion/issues/781 and https://github.com/apache/arrow-datafusion/issues/782;

Built on https://github.com/apache/arrow-datafusion/pull/786 so review that first.

 # Rationale for this change
1. Grouping on columns that contain NULLs today produces incorrect results
2. This is what I think is the minimum change required to produce correct results

This is a version of the "Alternative" approach described in https://github.com/apache/arrow-datafusion/issues/790 which I think is the minimum change to GroupByHash to produce the correct answers when grouping on columns that contain nulls. Thanks to @jhorstmann and @Dandandan  for the ideas leading to this PR

It will likely reduce the speed of grouping as well as require more memory than the current implementation (though it does get correct answers!)

I created this PR  it available for comparison and as a fallback in case I run into trouble or run out of time time trying to implement https://github.com/apache/arrow-datafusion/issues/790, which I expect will take longer to code and review.

# What changes are included in this PR?
1. https://github.com/apache/arrow-datafusion/pull/786
2. Include a "null byte" for each column when creating the key to the hash table
3. Fix some bugs related to NULL handling in `ScalarValue`
4. Tests

On master keys are created like this:
```
                            string len                   0x1234
{                          (as usize le)      "foo"    (as u16 le)
  k1: "foo"         ┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┐
  k2: 0x1234u16     │03│00│00│00│00│00│00│00│"f│"o│"o│34│12│
}                   └──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┘
                    0  1  2  3  4  5  6  7  8  9  10 11 12
```

After this PR, the keys are created as follows (note the two extra bytes, one for each grouping column)

Example of a key without any nulls:

```
                       0xFF byte at the start of each column
                          signifies the value is non-null
                                         │

                     ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┴ ─ ─ ─ ─ ─ ─ ─ ┐

                     │        string len                 │  0x1234
{                    ▼       (as usize le)      "foo"    ▼(as u16 le)
  k1: "foo"        ╔ ═┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──╦ ═┌──┬──┐
  k2: 0x1234u16     FF║03│00│00│00│00│00│00│00│"f│"o│"o│FF║34│12│
}                  ╚ ═└──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──╩ ═└──┴──┘
                    0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
```

Example of a key with NULL values:
```
                        0xFE byte at the start of k1 column
                    ┌ ─     signifies the value is NULL

                    └ ┐
                             0x1234
{                     ▼    (as u16 le)
  k1: NULL          ╔ ═╔ ═┌──┬──┐
  k2: 0x1234u16      FE║FF║12│34│
}                   ╚ ═╚ ═└──┴──┘
                      0  1  2  3
```


# Are there any user-facing changes?
Correct answers! 

# Benchmark results

The benchmarks show a slight slowdown, which is not unexpected given there is now more work being done

```
group                                                gby_null_alternative                   master
-----                                                --------------------                   ------
aggregate_query_group_by                             1.16      3.6±0.14ms        ? ?/sec    1.00      3.1±0.10ms        ? ?/sec
aggregate_query_group_by_u64 15 12                   1.06      3.7±0.09ms        ? ?/sec    1.00      3.5±0.04ms        ? ?/sec
aggregate_query_group_by_with_filter                 1.06      2.5±0.05ms        ? ?/sec    1.00      2.3±0.04ms        ? ?/sec
aggregate_query_group_by_with_filter_u64 15 12       1.02      2.4±0.10ms        ? ?/sec    1.00      2.4±0.04ms        ? ?/sec
aggregate_query_no_group_by 15 12                    1.00  1152.2±30.38µs        ? ?/sec    1.00  1155.2±28.60µs        ? ?/sec
aggregate_query_no_group_by_count_distinct_narrow    1.14      6.1±0.14ms        ? ?/sec    1.00      5.4±0.05ms        ? ?/sec
aggregate_query_no_group_by_count_distinct_wide      1.18      8.8±0.30ms        ? ?/sec    1.00      7.4±0.10ms        ? ?/sec
aggregate_query_no_group_by_min_max_f64              1.06  1225.6±27.57µs        ? ?/sec    1.00  1160.5±29.22µs        ? ?/sec
```