### PR TITLE
Fix: Update clippy lints for Rust 1.54

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -133,7 +133,7 @@ impl BallistaContext {
         let mut ctx = create_datafusion_context(
             &guard.scheduler_host,
             guard.scheduler_port,
-            &guard.config(),
+            guard.config(),
         );
         let df = ctx.read_parquet(path.to_str().unwrap())?;
         Ok(df)
@@ -155,7 +155,7 @@ impl BallistaContext {
         let mut ctx = create_datafusion_context(
             &guard.scheduler_host,
             guard.scheduler_port,
-            &guard.config(),
+            guard.config(),
         );
         let df = ctx.read_csv(path.to_str().unwrap(), options)?;
         Ok(df)

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -105,7 +105,7 @@ mod roundtrip_tests {
                     Arc::new(EmptyExec::new(false, schema_left.clone())),
                     Arc::new(EmptyExec::new(false, schema_right.clone())),
                     on.clone(),
-                    &join_type,
+                    join_type,
                     *partition_mode,
                 )?))?;
             }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -316,7 +316,7 @@ impl SchedulerState {
                             ))
                             .unwrap();
                         let task_is_dead = self
-                            .reschedule_dead_task(&referenced_task, &executors)
+                            .reschedule_dead_task(referenced_task, &executors)
                             .await?;
                         if task_is_dead {
                             continue 'tasks;


### PR DESCRIPTION
# Rationale:

It's that time again! [Rust released 1.54 today](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1540-2021-07-29) which causes some additional clippy errors:

If you run clippy on master after running `rustup update` you get erros such as the following

```
error: this expression borrows a reference (`&datafusion::logical_plan::JoinType`) that is immediately dereferenced by the compiler
   --> ballista/rust/core/src/serde/physical_plan/mod.rs:108:21
    |
108 |                     &join_type,
    |                     ^^^^^^^^^^ help: change this to: `join_type`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: aborting due to previous error

error: this expression borrows a reference (`&ballista_core::config::BallistaConfig`) that is immediately dereferenced by the compiler
   --> ballista/rust/client/src/context.rs:136:13
    |
136 |             &guard.config(),
    |             ^^^^^^^^^^^^^^^ help: change this to: `guard.config()`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

...

```

# Changes:

1. Fix clippy errors by doing its suggestions
