### PR TITLE
Better join order resolution logic

### DIFF
--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -290,39 +290,28 @@ impl LogicalPlanBuilder {
                     let l = l.into();
                     let r = r.into();
 
-                    let lr = l.relation.clone();
-                    let rr = r.relation.clone();
-
-                    match (lr, rr) {
+                    match (&l.relation, &r.relation) {
                         (Some(lr), Some(rr)) => {
-                            let l_is_left = self
-                                .plan
-                                .schema()
-                                .field_with_qualified_name(&lr, &l.name);
+                            let l_is_left =
+                                self.plan.schema().field_with_qualified_name(lr, &l.name);
                             let l_is_right =
-                                right.schema().field_with_qualified_name(&lr, &l.name);
-                            let r_is_left = self
-                                .plan
-                                .schema()
-                                .field_with_qualified_name(&rr, &r.name);
+                                right.schema().field_with_qualified_name(lr, &l.name);
+                            let r_is_left =
+                                self.plan.schema().field_with_qualified_name(rr, &r.name);
                             let r_is_right =
-                                right.schema().field_with_qualified_name(&rr, &r.name);
+                                right.schema().field_with_qualified_name(rr, &r.name);
 
                             match (l_is_left, l_is_right, r_is_left, r_is_right) {
                                 (_, Ok(_), Ok(_), _) => (Ok(r), Ok(l)),
                                 (Ok(_), _, _, Ok(_)) => (Ok(l), Ok(r)),
-                                (_, _, _, _) => {
-                                    (l.normalize(&self.plan), r.normalize(right))
-                                }
+                                _ => (l.normalize(&self.plan), r.normalize(right)),
                             }
                         }
                         (Some(lr), None) => {
-                            let l_is_left = self
-                                .plan
-                                .schema()
-                                .field_with_qualified_name(&lr, &l.name);
+                            let l_is_left =
+                                self.plan.schema().field_with_qualified_name(lr, &l.name);
                             let l_is_right =
-                                right.schema().field_with_qualified_name(&lr, &l.name);
+                                right.schema().field_with_qualified_name(lr, &l.name);
 
                             match (l_is_left, l_is_right) {
                                 (Ok(_), _) => (Ok(l), r.normalize(right)),
@@ -331,12 +320,10 @@ impl LogicalPlanBuilder {
                             }
                         }
                         (None, Some(rr)) => {
-                            let r_is_left = self
-                                .plan
-                                .schema()
-                                .field_with_qualified_name(&rr, &r.name);
+                            let r_is_left =
+                                self.plan.schema().field_with_qualified_name(rr, &r.name);
                             let r_is_right =
-                                right.schema().field_with_qualified_name(&rr, &r.name);
+                                right.schema().field_with_qualified_name(rr, &r.name);
 
                             match (r_is_left, r_is_right) {
                                 (Ok(_), _) => (Ok(r), l.normalize(right)),

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1730,6 +1730,17 @@ async fn equijoin() -> Result<()> {
         let actual = execute(&mut ctx, sql).await;
         assert_eq!(expected, actual);
     }
+
+    let mut ctx = create_join_context_qualified()?;
+    let equivalent_sql = [
+        "SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t1.a = t2.a ORDER BY t1.a",
+        "SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t2.a = t1.a ORDER BY t1.a",
+    ];
+    let expected = vec![vec!["1", "100"], vec!["2", "200"], vec!["4", "400"]];
+    for sql in equivalent_sql.iter() {
+        let actual = execute(&mut ctx, sql).await;
+        assert_eq!(expected, actual);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Reopens #777.

 # Rationale for this change

The previous resolution strategy ignored the qualifications on the columns if they were present so it required unique column names for resolution. This one is smarter and allows out-of-order qualified fields in the join condition.

# What changes are included in this PR?

This change makes better use of the information provided to the join logical plan builder to better resolve column relations. More work could be done to deal with other 'error' conditions (like referring to the same 'left' relation twice) but I wanted to get feedback first.

There are still outstanding issues unrelated that i am working through.

# Are there any user-facing changes?

More queries will behave like the SQL standard.