### PR TITLE
show prettier diff in CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -63,8 +63,9 @@ jobs:
         run: |
           # if you encounter error, try rerun the command below with --write instead of --check
           # and commit the changes
-          npx prettier@2.3.2 --check \
+          npx prettier@2.3.2 --write \
             {ballista,datafusion,datafusion-examples,docs,python}/**/*.md \
             README.md \
             DEVELOPERS.md \
             ballista/**/*.{ts,tsx}
+          git diff --exit-code


### PR DESCRIPTION

 # Rationale for this change

It's hard to tell what's offending prettier from CI output. Showing the expected change from prettier should help make it easier for contributor to fix CI issues.

# What changes are included in this PR?

Invoke prettier with `--write`, then use `git diff --exit-code` to show diff and fail CI if there is any change produced.

# Are there any user-facing changes?

no
