### PR TITLE
Qualified field resolution too strict

### DIFF
--- a/datafusion/src/logical_plan/dfschema.rs
+++ b/datafusion/src/logical_plan/dfschema.rs
@@ -160,10 +160,7 @@ impl DFSchema {
                 // field to lookup is qualified.
                 // current field is qualified and not shared between relations, compare both
                 // qualifer and name.
-                (Some(q), Some(field_q)) => {
-                    field.name() == name
-                        && (q == field_q || field_q.ends_with(&format!(".{}", q)))
-                }
+                (Some(q), Some(field_q)) => q == field_q && field.name() == name,
                 // field to lookup is qualified but current field is unqualified.
                 (Some(_), None) => false,
                 // field to lookup is unqualified, no need to compare qualifier

--- a/datafusion/src/logical_plan/dfschema.rs
+++ b/datafusion/src/logical_plan/dfschema.rs
@@ -160,7 +160,13 @@ impl DFSchema {
                 // field to lookup is qualified.
                 // current field is qualified and not shared between relations, compare both
                 // qualifer and name.
-                (Some(q), Some(field_q)) => q == field_q && field.name() == name,
+                (Some(q), Some(field_q)) => {
+                    if field_q.contains('.') {
+                        field_q.ends_with(q) && field.name() == name
+                    } else {
+                        q == field_q && field.name() == name
+                    }
+                }
                 // field to lookup is qualified but current field is unqualified.
                 (Some(_), None) => false,
                 // field to lookup is unqualified, no need to compare qualifier
@@ -289,7 +295,10 @@ impl DFSchema {
     fn get_field_names(&self) -> String {
         self.fields
             .iter()
-            .map(|f| format!("'{}'", f.name()))
+            .map(|f| match f.qualifier() {
+                Some(qualifier) => format!("'{}.{}'", qualifier, f.name()),
+                None => format!("'{}'", f.name()),
+            })
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -619,7 +628,7 @@ mod tests {
     #[test]
     fn helpful_error_messages() -> Result<()> {
         let schema = DFSchema::try_from_qualified_schema("t1", &test_schema_1())?;
-        let expected_help = "Valid fields are \'c0\', \'c1\'.";
+        let expected_help = "Valid fields are \'t1.c0\', \'t1.c1\'.";
         assert!(schema
             .field_with_qualified_name("x", "y")
             .unwrap_err()

--- a/datafusion/src/logical_plan/dfschema.rs
+++ b/datafusion/src/logical_plan/dfschema.rs
@@ -162,9 +162,7 @@ impl DFSchema {
                 // qualifer and name.
                 (Some(q), Some(field_q)) => {
                     field.name() == name
-                        && (q == field_q
-                            || (field_q.contains('.')
-                                && field_q.ends_with(&format!(".{}", q))))
+                        && (q == field_q || field_q.ends_with(&format!(".{}", q)))
                 }
                 // field to lookup is qualified but current field is unqualified.
                 (Some(_), None) => false,

--- a/datafusion/src/logical_plan/dfschema.rs
+++ b/datafusion/src/logical_plan/dfschema.rs
@@ -161,11 +161,10 @@ impl DFSchema {
                 // current field is qualified and not shared between relations, compare both
                 // qualifer and name.
                 (Some(q), Some(field_q)) => {
-                    if field_q.contains('.') {
-                        field_q.ends_with(q) && field.name() == name
-                    } else {
-                        q == field_q && field.name() == name
-                    }
+                    field.name() == name
+                        && (q == field_q
+                            || (field_q.contains('.')
+                                && field_q.ends_with(&format!(".{}", q))))
                 }
                 // field to lookup is qualified but current field is unqualified.
                 (Some(_), None) => false,

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -942,9 +942,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .find(|field| match field.qualifier() {
                             Some(field_q) => {
                                 field.name() == &col.name
-                                    && q != field_q
-                                    && (field_q.contains('.')
-                                        && field_q.ends_with(&format!(".{}", q)))
+                                    && field_q.ends_with(&format!(".{}", q))
                             }
                             _ => false,
                         }) {

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -926,14 +926,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Generate a relational expression from a SQL expression
     pub fn sql_to_rex(&self, sql: &SQLExpr, schema: &DFSchema) -> Result<Expr> {
         let mut expr = self.sql_expr_to_logical_expr(sql, schema)?;
-        self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
         expr = self.rewrite_partial_qualifier(expr, schema);
+        self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
         Ok(expr)
     }
 
     /// Rewrite aliases which are not-complete (e.g. ones that only include only table qualifier in a schema.table qualified relation)
     fn rewrite_partial_qualifier(&self, expr: Expr, schema: &DFSchema) -> Expr {
-        match expr.clone() {
+        match expr {
             Expr::Column(col) => match &col.relation {
                 Some(q) => {
                     match schema
@@ -950,10 +950,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             relation: df_field.qualifier().cloned(),
                             name: df_field.name().clone(),
                         }),
-                        None => expr,
+                        None => Expr::Column(col),
                     }
                 }
-                None => expr,
+                None => Expr::Column(col),
             },
             _ => expr,
         }

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -925,9 +925,39 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     /// Generate a relational expression from a SQL expression
     pub fn sql_to_rex(&self, sql: &SQLExpr, schema: &DFSchema) -> Result<Expr> {
-        let expr = self.sql_expr_to_logical_expr(sql, schema)?;
+        let mut expr = self.sql_expr_to_logical_expr(sql, schema)?;
         self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
+        expr = self.rewrite_partial_qualifier(expr, schema);
         Ok(expr)
+    }
+
+    /// Rewrite aliases which are not-complete (e.g. ones that only include only table qualifier in a schema.table qualified relation)
+    fn rewrite_partial_qualifier(&self, expr: Expr, schema: &DFSchema) -> Expr {
+        match expr.clone() {
+            Expr::Column(col) => match &col.relation {
+                Some(q) => {
+                    match schema
+                        .fields()
+                        .iter()
+                        .find(|field| match field.qualifier() {
+                            Some(field_q) if field_q.contains('.') => {
+                                field_q != q
+                                    && field_q.ends_with(q)
+                                    && field.name() == &col.name
+                            }
+                            _ => false,
+                        }) {
+                        Some(df_field) => Expr::Column(Column {
+                            relation: df_field.qualifier().cloned(),
+                            name: df_field.name().clone(),
+                        }),
+                        None => expr,
+                    }
+                }
+                None => expr,
+            },
+            _ => expr,
+        }
     }
 
     fn sql_fn_arg_to_logical_expr(
@@ -3387,5 +3417,13 @@ mod tests {
         fn get_aggregate_meta(&self, _name: &str) -> Option<Arc<AggregateUDF>> {
             unimplemented!()
         }
+    }
+
+    #[test]
+    fn select_partially_qualified_column() {
+        let sql = r#"SELECT person.first_name FROM public.person"#;
+        let expected = "Projection: #public.person.first_name\
+            \n  TableScan: public.person projection=None";
+        quick_test(sql, expected);
     }
 }

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -940,10 +940,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .fields()
                         .iter()
                         .find(|field| match field.qualifier() {
-                            Some(field_q) if field_q.contains('.') => {
-                                field_q != q
-                                    && field_q.ends_with(q)
-                                    && field.name() == &col.name
+                            Some(field_q) => {
+                                field.name() == &col.name
+                                    && q != field_q
+                                    && (field_q.contains('.')
+                                        && field_q.ends_with(&format!(".{}", q)))
                             }
                             _ => false,
                         }) {

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -4058,3 +4058,18 @@ fn normalize_vec_for_explain(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
         })
         .collect::<Vec<_>>()
 }
+
+#[tokio::test]
+async fn test_partial_qualified_name() -> Result<()> {
+    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let sql = "SELECT t1.t1_id, t1_name FROM public.t1";
+    let expected = vec![
+        vec!["11", "a"],
+        vec!["22", "b"],
+        vec!["33", "c"],
+        vec!["44", "d"],
+    ];
+    let actual = execute(&mut ctx, sql).await;
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #809.

 # Rationale for this change

Due to the way the field qualification works a query this does not work as technically the field is qualified but the matching only works on complete matches between the field qualifier `person` and the schema qualifier `public.person`.

```sql
SELECT person.first_name FROM public.person
```

# What changes are included in this PR?

This PR adds:
- ability to partially match qualified fields against the schema.
- a rewrite step in the logical planner to rewrite the partial match to a fully resolved qualifier so it can be used downstream.

# Are there any user-facing changes?

No, just more standard Postgres SQL will work.