### PR TITLE
Update dependencies: prost to 0.8 and tonic to 0.5

### DIFF
--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -31,8 +31,8 @@ publish = false
 arrow-flight = { version = "5.0" }
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client" }
-prost = "0.7"
-tonic = "0.4"
+prost = "0.8"
+tonic = "0.5"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,11 +35,11 @@ async-trait = "0.1.36"
 futures = "0.3"
 hashbrown = "0.11"
 log = "0.4"
-prost = "0.7"
+prost = "0.8"
 serde = {version = "1", features = ["derive"]}
 sqlparser = "0.9.0"
 tokio = "1.0"
-tonic = "0.4"
+tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 
 arrow-flight = { version = "5.0"  }
@@ -50,4 +50,4 @@ datafusion = { path = "../../../datafusion" }
 tempfile = "3"
 
 [build-dependencies]
-tonic-build = { version = "0.4" }
+tonic-build = { version = "0.5" }

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,7 +40,7 @@ snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = "0.4"
+tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 
 arrow = { version = "5.0"  }

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -218,8 +218,8 @@ where
         let batch_flight_data: Vec<_> = batch
             .map(|b| create_flight_iter(&b, &options).collect())
             .map_err(|e| from_arrow_err(&e))?;
-        for batch in &batch_flight_data {
-            send_response(&tx, batch.clone()).await?;
+        for batch in batch_flight_data.into_iter() {
+            send_response(&tx, batch).await?;
         }
     }
     info!("FetchPartition streamed {} rows", row_count);

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -43,13 +43,13 @@ http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
 parse_arg = "0.1.3"
-prost = "0.7"
+prost = "0.8"
 rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
-tonic = "0.4"
+tonic = "0.5"
 tower = { version = "0.4" }
 warp = "0.3"
 
@@ -61,7 +61,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]
 configure_me_codegen = "0.4.0"
-tonic-build = { version = "0.4" }
+tonic-build = { version = "0.5" }
 
 [package.metadata.configure_me.bin]
 scheduler = "scheduler_config_spec.toml"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -31,8 +31,8 @@ publish = false
 [dev-dependencies]
 arrow-flight = { version = "5.0" }
 datafusion = { path = "../datafusion" }
-prost = "0.7"
-tonic = "0.4"
+prost = "0.8"
+tonic = "0.5"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 num_cpus = "1.13.0"


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/817

 # Rationale for this change
Examples are failing as they use an incompatible version of tonic/prost that came in with arrow 5.1.0 (https://github.com/apache/arrow-rs/pull/560)  which leads to failures on CI PRs such as https://github.com/apache/arrow-datafusion/pull/808/checks?check_run_id=3223418729

# What changes are included in this PR?
Update dependencies: prost to 0.8 and tonic to 0.5

# Are there any user-facing changes?
New version of dependent libraries

