### PR TITLE
Support date datatypes in max/min

### DIFF
--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -188,6 +188,11 @@ static TIMESTAMPS: &[DataType] = &[
     DataType::Timestamp(TimeUnit::Nanosecond, None),
 ];
 
+static DATES: &[DataType] = &[
+    DataType::Date32,
+    DataType::Date64,
+];
+
 /// the signatures supported by the function `fun`.
 pub fn signature(fun: &AggregateFunction) -> Signature {
     // note: the physical expression must accept the type returned by this function or the execution panics.
@@ -198,6 +203,7 @@ pub fn signature(fun: &AggregateFunction) -> Signature {
                 .iter()
                 .chain(NUMERICS.iter())
                 .chain(TIMESTAMPS.iter())
+                .chain(DATES.iter())
                 .cloned()
                 .collect::<Vec<_>>();
             Signature::Uniform(1, valid)

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -188,10 +188,7 @@ static TIMESTAMPS: &[DataType] = &[
     DataType::Timestamp(TimeUnit::Nanosecond, None),
 ];
 
-static DATES: &[DataType] = &[
-    DataType::Date32,
-    DataType::Date64,
-];
+static DATES: &[DataType] = &[DataType::Date32, DataType::Date64];
 
 /// the signatures supported by the function `fun`.
 pub fn signature(fun: &AggregateFunction) -> Signature {

--- a/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/datafusion/src/physical_plan/expressions/min_max.rs
@@ -28,7 +28,7 @@ use arrow::compute;
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow::{
     array::{
-        ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+        ArrayRef, Date32Array, Date64Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
         Int8Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
         UInt16Array, UInt32Array, UInt64Array, UInt8Array,
@@ -158,6 +158,18 @@ macro_rules! min_max_batch {
                 TimestampNanosecond,
                 $OP
             ),
+            DataType::Date32 => typed_min_max_batch!(
+                $VALUES,
+                Date32Array,
+                Date32,
+                $OP
+            ),
+            DataType::Date64 => typed_min_max_batch!(
+                $VALUES,
+                Date64Array,
+                Date64,
+                $OP
+            ),
             other => {
                 // This should have been handled before
                 return Err(DataFusionError::Internal(format!(
@@ -279,6 +291,18 @@ macro_rules! min_max {
                 ScalarValue::TimestampNanosecond(rhs),
             ) => {
                 typed_min_max!(lhs, rhs, TimestampNanosecond, $OP)
+            }
+            (
+                ScalarValue::Date32(lhs),
+                ScalarValue::Date32(rhs),
+            ) => {
+                typed_min_max!(lhs, rhs, Date32, $OP)
+            }
+             (
+                ScalarValue::Date64(lhs),
+                ScalarValue::Date64(rhs),
+            ) => {
+                typed_min_max!(lhs, rhs, Date64, $OP)
             }
             e => {
                 return Err(DataFusionError::Internal(format!(
@@ -666,6 +690,58 @@ mod tests {
             Min,
             ScalarValue::from(1_f64),
             DataType::Float64
+        )
+    }
+
+    #[test]
+    fn min_date32() -> Result<()> {
+        let a: ArrayRef =
+            Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
+        generic_test_op!(
+            a,
+            DataType::Date32,
+            Min,
+            ScalarValue::Date32(Some(1)),
+            DataType::Date32
+        )
+    }
+
+    #[test]
+    fn min_date64() -> Result<()> {
+        let a: ArrayRef =
+            Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
+        generic_test_op!(
+            a,
+            DataType::Date64,
+            Min,
+            ScalarValue::Date64(Some(1)),
+            DataType::Date64
+        )
+    }
+
+    #[test]
+    fn max_date32() -> Result<()> {
+        let a: ArrayRef =
+            Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
+        generic_test_op!(
+            a,
+            DataType::Date32,
+            Max,
+            ScalarValue::Date32(Some(5)),
+            DataType::Date32
+        )
+    }
+
+    #[test]
+    fn max_date64() -> Result<()> {
+        let a: ArrayRef =
+            Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
+        generic_test_op!(
+            a,
+            DataType::Date64,
+            Max,
+            ScalarValue::Date64(Some(5)),
+            DataType::Date64
         )
     }
 }

--- a/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/datafusion/src/physical_plan/expressions/min_max.rs
@@ -28,10 +28,10 @@ use arrow::compute;
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow::{
     array::{
-        ArrayRef, Date32Array, Date64Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
-        Int8Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
-        UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+        ArrayRef, Date32Array, Date64Array, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeStringArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
     },
     datatypes::Field,
 };
@@ -158,18 +158,8 @@ macro_rules! min_max_batch {
                 TimestampNanosecond,
                 $OP
             ),
-            DataType::Date32 => typed_min_max_batch!(
-                $VALUES,
-                Date32Array,
-                Date32,
-                $OP
-            ),
-            DataType::Date64 => typed_min_max_batch!(
-                $VALUES,
-                Date64Array,
-                Date64,
-                $OP
-            ),
+            DataType::Date32 => typed_min_max_batch!($VALUES, Date32Array, Date32, $OP),
+            DataType::Date64 => typed_min_max_batch!($VALUES, Date64Array, Date64, $OP),
             other => {
                 // This should have been handled before
                 return Err(DataFusionError::Internal(format!(
@@ -695,8 +685,7 @@ mod tests {
 
     #[test]
     fn min_date32() -> Result<()> {
-        let a: ArrayRef =
-            Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
+        let a: ArrayRef = Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
         generic_test_op!(
             a,
             DataType::Date32,
@@ -708,8 +697,7 @@ mod tests {
 
     #[test]
     fn min_date64() -> Result<()> {
-        let a: ArrayRef =
-            Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
+        let a: ArrayRef = Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
         generic_test_op!(
             a,
             DataType::Date64,
@@ -721,8 +709,7 @@ mod tests {
 
     #[test]
     fn max_date32() -> Result<()> {
-        let a: ArrayRef =
-            Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
+        let a: ArrayRef = Arc::new(Date32Array::from(vec![1, 2, 3, 4, 5]));
         generic_test_op!(
             a,
             DataType::Date32,
@@ -734,8 +721,7 @@ mod tests {
 
     #[test]
     fn max_date64() -> Result<()> {
-        let a: ArrayRef =
-            Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
+        let a: ArrayRef = Arc::new(Date64Array::from(vec![1, 2, 3, 4, 5]));
         generic_test_op!(
             a,
             DataType::Date64,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently only datafusion only supports string, numeric and timestamp types for min max aggregation. This is to add date types to make it more complete.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
