### PR TITLE
Change datatype of tpch keys from Int32 to UInt64 to support sf=1000

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -490,7 +490,7 @@ fn get_schema(table: &str) -> Schema {
 
     match table {
         "part" => Schema::new(vec![
-            Field::new("p_partkey", DataType::Int32, false),
+            Field::new("p_partkey", DataType::UInt64, false),
             Field::new("p_name", DataType::Utf8, false),
             Field::new("p_mfgr", DataType::Utf8, false),
             Field::new("p_brand", DataType::Utf8, false),
@@ -502,28 +502,28 @@ fn get_schema(table: &str) -> Schema {
         ]),
 
         "supplier" => Schema::new(vec![
-            Field::new("s_suppkey", DataType::Int32, false),
+            Field::new("s_suppkey", DataType::UInt64, false),
             Field::new("s_name", DataType::Utf8, false),
             Field::new("s_address", DataType::Utf8, false),
-            Field::new("s_nationkey", DataType::Int32, false),
+            Field::new("s_nationkey", DataType::UInt64, false),
             Field::new("s_phone", DataType::Utf8, false),
             Field::new("s_acctbal", DataType::Float64, false),
             Field::new("s_comment", DataType::Utf8, false),
         ]),
 
         "partsupp" => Schema::new(vec![
-            Field::new("ps_partkey", DataType::Int32, false),
-            Field::new("ps_suppkey", DataType::Int32, false),
+            Field::new("ps_partkey", DataType::UInt64, false),
+            Field::new("ps_suppkey", DataType::UInt64, false),
             Field::new("ps_availqty", DataType::Int32, false),
             Field::new("ps_supplycost", DataType::Float64, false),
             Field::new("ps_comment", DataType::Utf8, false),
         ]),
 
         "customer" => Schema::new(vec![
-            Field::new("c_custkey", DataType::Int32, false),
+            Field::new("c_custkey", DataType::UInt64, false),
             Field::new("c_name", DataType::Utf8, false),
             Field::new("c_address", DataType::Utf8, false),
-            Field::new("c_nationkey", DataType::Int32, false),
+            Field::new("c_nationkey", DataType::UInt64, false),
             Field::new("c_phone", DataType::Utf8, false),
             Field::new("c_acctbal", DataType::Float64, false),
             Field::new("c_mktsegment", DataType::Utf8, false),
@@ -531,21 +531,21 @@ fn get_schema(table: &str) -> Schema {
         ]),
 
         "orders" => Schema::new(vec![
-            Field::new("o_orderkey", DataType::Int32, false),
-            Field::new("o_custkey", DataType::Int32, false),
+            Field::new("o_orderkey", DataType::UInt64, false),
+            Field::new("o_custkey", DataType::UInt64, false),
             Field::new("o_orderstatus", DataType::Utf8, false),
             Field::new("o_totalprice", DataType::Float64, false),
             Field::new("o_orderdate", DataType::Date32, false),
             Field::new("o_orderpriority", DataType::Utf8, false),
             Field::new("o_clerk", DataType::Utf8, false),
-            Field::new("o_shippriority", DataType::Int32, false),
+            Field::new("o_shippriority", DataType::UInt64, false),
             Field::new("o_comment", DataType::Utf8, false),
         ]),
 
         "lineitem" => Schema::new(vec![
-            Field::new("l_orderkey", DataType::Int32, false),
-            Field::new("l_partkey", DataType::Int32, false),
-            Field::new("l_suppkey", DataType::Int32, false),
+            Field::new("l_orderkey", DataType::UInt64, false),
+            Field::new("l_partkey", DataType::UInt64, false),
+            Field::new("l_suppkey", DataType::UInt64, false),
             Field::new("l_linenumber", DataType::Int32, false),
             Field::new("l_quantity", DataType::Float64, false),
             Field::new("l_extendedprice", DataType::Float64, false),
@@ -562,14 +562,14 @@ fn get_schema(table: &str) -> Schema {
         ]),
 
         "nation" => Schema::new(vec![
-            Field::new("n_nationkey", DataType::Int32, false),
+            Field::new("n_nationkey", DataType::UInt64, false),
             Field::new("n_name", DataType::Utf8, false),
-            Field::new("n_regionkey", DataType::Int32, false),
+            Field::new("n_regionkey", DataType::UInt64, false),
             Field::new("n_comment", DataType::Utf8, false),
         ]),
 
         "region" => Schema::new(vec![
-            Field::new("r_regionkey", DataType::Int32, false),
+            Field::new("r_regionkey", DataType::UInt64, false),
             Field::new("r_name", DataType::Utf8, false),
             Field::new("r_comment", DataType::Utf8, false),
         ]),

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -538,7 +538,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("o_orderdate", DataType::Date32, false),
             Field::new("o_orderpriority", DataType::Utf8, false),
             Field::new("o_clerk", DataType::Utf8, false),
-            Field::new("o_shippriority", DataType::UInt64, false),
+            Field::new("o_shippriority", DataType::Int32, false),
             Field::new("o_comment", DataType::Utf8, false),
         ]),
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #834.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is required to support testing at SF=1000 and above.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changes data type of keys from Int32 to UInt64.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
