### PR TITLE
Add tests for hash collisions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -312,6 +312,54 @@ jobs:
           # Ignore MIRI errors until we can get a clean run
           cargo miri test || true
 
+
+  # Check answers are correct when hash values collide
+  hash-collisions:
+    name: Test Hash Collisions on AMD64 Rust ${{ matrix.rust }}
+    needs: [linux-build-lib]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [stable]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
+      - name: Run tests
+        run: |
+          export ARROW_TEST_DATA=$(pwd)/testing/data
+          export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
+          cd datafusion
+          # Force all hash values to collide
+          cargo test --features=force_hash_collisions
+        env:
+          CARGO_HOME: "/github/home/.cargo"
+          CARGO_TARGET_DIR: "/github/home/target"
+
 # Coverage job was failing. https://github.com/apache/arrow-datafusion/issues/590 tracks re-instating it
 
   # coverage:

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -42,6 +42,9 @@ simd = ["arrow/simd"]
 crypto_expressions = ["md-5", "sha2"]
 regex_expressions = ["regex", "lazy_static"]
 unicode_expressions = ["unicode-segmentation"]
+# Used for testing ONLY: causes all values to hash to the same value (test for collisions)
+force_hash_collisions = []
+
 
 [dependencies]
 ahash = "0.7"

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -1372,6 +1372,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+    #[cfg(not(feature = "force_hash_collisions"))]
     async fn join_full_multi_batch() {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
@@ -1637,6 +1639,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+    #[cfg(not(feature = "force_hash_collisions"))]
     async fn join_right_one() -> Result<()> {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
@@ -1673,6 +1677,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+    #[cfg(not(feature = "force_hash_collisions"))]
     async fn partitioned_join_right_one() -> Result<()> {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
@@ -1710,6 +1716,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+    #[cfg(not(feature = "force_hash_collisions"))]
     async fn join_full_one() -> Result<()> {
         let left = build_table(
             ("a1", &vec![1, 2, 3]),

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -678,6 +678,8 @@ mod tests {
     }
 
     #[test]
+    // Tests actual values of hashes, which are different if forcing collisions
+    #[cfg(not(feature = "force_hash_collisions"))]
     fn create_hashes_for_dict_arrays() {
         let strings = vec![Some("foo"), None, Some("bar"), Some("foo"), None];
 
@@ -714,12 +716,14 @@ mod tests {
         assert_eq!(strings[0], strings[3]);
         assert_eq!(dict_hashes[0], dict_hashes[3]);
 
-        // different strings should matp to different hash values
+        // different strings should map to different hash values
         assert_ne!(strings[0], strings[2]);
         assert_ne!(dict_hashes[0], dict_hashes[2]);
     }
 
     #[test]
+    // Tests actual values of hashes, which are different if forcing collisions
+    #[cfg(not(feature = "force_hash_collisions"))]
     fn create_multi_column_hash_for_dict_arrays() {
         let strings1 = vec![Some("foo"), None, Some("bar")];
         let strings2 = vec![Some("blarg"), Some("blah"), None];

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -298,11 +298,28 @@ fn create_hashes_dictionary<K: ArrowDictionaryKeyType>(
     Ok(())
 }
 
+/// Test version of `create_hashes` that produces the same value for
+/// all hashes (to test collisions)
+///
+/// See comments on `hashes_buffer` for more details
+#[cfg(feature = "force_hash_collisions")]
+pub fn create_hashes<'a>(
+    _arrays: &[ArrayRef],
+    _random_state: &RandomState,
+    hashes_buffer: &'a mut Vec<u64>,
+) -> Result<&'a mut Vec<u64>> {
+    for hash in hashes_buffer.iter_mut() {
+        *hash = 0
+    }
+    return Ok(hashes_buffer);
+}
+
 /// Creates hash values for every row, based on the values in the
 /// columns.
 ///
 /// The number of rows to hash is determined by `hashes_buffer.len()`.
 /// `hashes_buffer` should be pre-sized appropriately
+#[cfg(not(feature = "force_hash_collisions"))]
 pub fn create_hashes<'a>(
     arrays: &[ArrayRef],
     random_state: &RandomState,

--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -732,6 +732,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // skip this test when hash function is different because the hard
+    // coded expected output is a function of the hash values
+    #[cfg(not(feature = "force_hash_collisions"))]
     async fn repartition_with_dropping_output_stream() {
         #[derive(Debug)]
         struct Case<'a> {

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -1797,6 +1797,8 @@ async fn equijoin_left_and_condition_from_right() -> Result<()> {
 }
 
 #[tokio::test]
+// Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+#[cfg(not(feature = "force_hash_collisions"))]
 async fn equijoin_right_and_condition_from_left() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
@@ -1850,6 +1852,8 @@ async fn left_join() -> Result<()> {
 }
 
 #[tokio::test]
+// Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+#[cfg(not(feature = "force_hash_collisions"))]
 async fn right_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
@@ -1870,6 +1874,8 @@ async fn right_join() -> Result<()> {
 }
 
 #[tokio::test]
+// Disable until https://github.com/apache/arrow-datafusion/issues/843 fixed
+#[cfg(not(feature = "force_hash_collisions"))]
 async fn full_join() -> Result<()> {
     let mut ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/841

 # Rationale for this change
1. The hash implementation in `ahash::RandomState` is *very good*, and thus it is very hard to cause hash collisions in tests
2. Since it is hard to cause hash collisions, it means we do not have test coverage of this case. This is a problem because checking for hash collisions is often required in the performance critical section of code and thus prone to being optimized out

# What changes are included in this PR?
1. Add a (off by default) feature flag that forces hash collisions
2. Add a CI test that runs queries using those flags
3. Updates tests to pass, and filed tickets for those that did not (TODO)

# Are there any user-facing changes?
No
