### PR TITLE
Default to zstd in convert tool

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -152,7 +152,7 @@ struct ConvertOpt {
     file_format: String,
 
     /// Compression to use when writing Parquet files
-    #[structopt(short = "c", long = "compression", default_value = "snappy")]
+    #[structopt(short = "c", long = "compression", default_value = "zstd")]
     compression: String,
 
     /// Number of partitions to produce


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #848

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
zstd saves about 20-25% of data compared to snappy compression, and is used more and more as the goto compression method.
Performance-wise, I am getting comparable performance on the Parquet data on a laptop SSD / 8-core CPU.


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change the default

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
