### PR TITLE
update release automation scripts

### DIFF
--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -46,27 +46,26 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_TOP_DIR="$(cd "${SOURCE_DIR}/../../" && pwd)"
 
 if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <tag> <rc>"
+    echo "Usage: $0 <version> <rc>"
     echo "ex. $0 4.1.0 2"
   exit
 fi
 
-tag=$1
+version=$1
 rc=$2
+tag="${version}-rc${rc}"
 
+echo "Attempting to create ${tarball} from tag ${tag}"
 release_hash=$(cd "${SOURCE_TOP_DIR}" && git rev-list --max-count=1 ${tag})
 
-release=apache-arrow-datafusion-${tag}
+release=apache-arrow-datafusion-${version}
 distdir=${SOURCE_TOP_DIR}/dev/dist/${release}-rc${rc}
 tarname=${release}.tar.gz
 tarball=${distdir}/${tarname}
 url="https://dist.apache.org/repos/dist/dev/arrow/${release}-rc${rc}"
 
-echo "Attempting to create ${tarball} from tag ${tag}"
-
-
 if [ -z "$release_hash" ]; then
-    echo "Cannot continue: unknown git tag: $tag"
+    echo "Cannot continue: unknown git tag: ${tag}"
 fi
 
 echo "Draft email for dev@arrow.apache.org mailing list"
@@ -74,11 +73,11 @@ echo ""
 echo "---------------------------------------------------------"
 cat <<MAIL
 To: dev@arrow.apache.org
-Subject: [VOTE][RUST][Datafusion] Release Apache Arrow Datafusion ${tag} RC${rc}
+Subject: [VOTE][RUST][Datafusion] Release Apache Arrow Datafusion ${version} RC${rc}
 Hi,
 
 I would like to propose a release of Apache Arrow Datafusion Implementation,
-version ${tag}.
+version ${version}.
 
 This release candidate is based on commit: ${release_hash} [1]
 The proposed release tarball and signatures are hosted at [2].
@@ -99,7 +98,7 @@ echo "---------------------------------------------------------"
 
 
 # create <tarball> containing the files in git at $release_hash
-# the files in the tarball are prefixed with {tag} (e.g. 4.0.1)
+# the files in the tarball are prefixed with {version} (e.g. 4.0.1)
 mkdir -p ${distdir}
 (cd "${SOURCE_TOP_DIR}" && git archive ${release_hash} --prefix ${release}/ | gzip > ${tarball})
 
@@ -117,5 +116,5 @@ gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
 echo "Uploading to apache dist/dev to ${url}"
 svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow ${SOURCE_TOP_DIR}/dev/dist
 svn add ${distdir}
-svn ci -m "Apache Arrow Datafusion ${tag} ${rc}" ${distdir}
+svn ci -m "Apache Arrow Datafusion ${version} ${rc}" ${distdir}
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -125,6 +125,10 @@ test_source_distribution() {
 
   cargo build
   cargo test --all
+
+  pushd datafusion
+    cargo publish --dry-run
+  popd
 }
 
 TEST_SUCCESS=no


### PR DESCRIPTION
# Which issue does this PR close?
related to #771 

# Rationale for this change

The current create-tarball script uses the version tag to extract the release commit. This could be error prone because it requires force git tag update on every subsequent release candidate update.

# What changes are included in this PR?

* Work with rc tag instead of final version during release preparation process so we don't need to do force git tag update on rc version bump.
* Check for cargo publish in release verification automation process

# Are there any user-facing changes?
no

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
