### PR TITLE
Add support for EXPLAIN ANALYZE

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -249,6 +249,7 @@ message LogicalPlanNode {
     RepartitionNode repartition = 9;
     EmptyRelationNode empty_relation = 10;
     CreateExternalTableNode create_external_table = 11;
+    AnalyzeNode analyze = 14;
     ExplainNode explain = 12;
     WindowNode window = 13;
   }
@@ -321,6 +322,11 @@ enum FileType{
   NdJson = 0;
   Parquet = 1;
   CSV = 2;
+}
+
+message AnalyzeNode {
+  LogicalPlanNode input = 1;
+  bool verbose = 2;
 }
 
 message ExplainNode{

--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -231,10 +231,17 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                     has_header: create_extern_table.has_header,
                 })
             }
+            LogicalPlanType::Analyze(analyze) => {
+                let input: LogicalPlan = convert_box_required!(analyze.input)?;
+                LogicalPlanBuilder::from(input)
+                    .explain(analyze.verbose, true)?
+                    .build()
+                    .map_err(|e| e.into())
+            }
             LogicalPlanType::Explain(explain) => {
                 let input: LogicalPlan = convert_box_required!(explain.input)?;
                 LogicalPlanBuilder::from(input)
-                    .explain(explain.verbose)?
+                    .explain(explain.verbose, false)?
                     .build()
                     .map_err(|e| e.into())
             }

--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -931,6 +931,17 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                     )),
                 })
             }
+            LogicalPlan::Analyze { verbose, input, .. } => {
+                let input: protobuf::LogicalPlanNode = input.as_ref().try_into()?;
+                Ok(protobuf::LogicalPlanNode {
+                    logical_plan_type: Some(LogicalPlanType::Analyze(Box::new(
+                        protobuf::AnalyzeNode {
+                            input: Some(Box::new(input)),
+                            verbose: *verbose,
+                        },
+                    ))),
+                })
+            }
             LogicalPlan::Explain { verbose, plan, .. } => {
                 let input: protobuf::LogicalPlanNode = plan.as_ref().try_into()?;
                 Ok(protobuf::LogicalPlanNode {

--- a/datafusion/src/dataframe.rs
+++ b/datafusion/src/dataframe.rs
@@ -289,6 +289,8 @@ pub trait DataFrame: Send + Sync {
 
     /// Return a DataFrame with the explanation of its plan so far.
     ///
+    /// if `analyze` is specified, runs the plan and reports metrics
+    ///
     /// ```
     /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
@@ -296,11 +298,11 @@ pub trait DataFrame: Send + Sync {
     /// # async fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
-    /// let batches = df.limit(100)?.explain(false)?.collect().await?;
+    /// let batches = df.limit(100)?.explain(false, false)?.collect().await?;
     /// # Ok(())
     /// # }
     /// ```
-    fn explain(&self, verbose: bool) -> Result<Arc<dyn DataFrame>>;
+    fn explain(&self, verbose: bool, analyze: bool) -> Result<Arc<dyn DataFrame>>;
 
     /// Return a `FunctionRegistry` used to plan udf's calls
     ///

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -986,7 +986,7 @@ mod tests {
 
         let plan = LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
             .unwrap()
-            .explain(true)
+            .explain(true, false)
             .unwrap()
             .build()
             .unwrap();

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -183,9 +183,9 @@ impl DataFrame for DataFrameImpl {
         self.plan.schema()
     }
 
-    fn explain(&self, verbose: bool) -> Result<Arc<dyn DataFrame>> {
+    fn explain(&self, verbose: bool, analyze: bool) -> Result<Arc<dyn DataFrame>> {
         let plan = LogicalPlanBuilder::from(self.to_logical_plan())
-            .explain(verbose)?
+            .explain(verbose, analyze)?
             .build()?;
         Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))
     }
@@ -318,7 +318,7 @@ mod tests {
         let df = df
             .select_columns(&["c1", "c2", "c11"])?
             .limit(10)?
-            .explain(false)?;
+            .explain(false, false)?;
         let plan = df.to_logical_plan();
 
         // build query using SQL

--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -455,18 +455,32 @@ impl LogicalPlanBuilder {
     }
 
     /// Create an expression to represent the explanation of the plan
-    pub fn explain(&self, verbose: bool) -> Result<Self> {
-        let stringified_plans =
-            vec![self.plan.to_stringified(PlanType::InitialLogicalPlan)];
-
+    ///
+    /// if `analyze` is true, runs the actual plan and produces
+    /// information about metrics during run.
+    ///
+    /// if `verbose` is true, prints out additional details.
+    pub fn explain(&self, verbose: bool, analyze: bool) -> Result<Self> {
         let schema = LogicalPlan::explain_schema();
+        let schema = schema.to_dfschema_ref()?;
 
-        Ok(Self::from(LogicalPlan::Explain {
-            verbose,
-            plan: Arc::new(self.plan.clone()),
-            stringified_plans,
-            schema: schema.to_dfschema_ref()?,
-        }))
+        if analyze {
+            Ok(Self::from(LogicalPlan::Analyze {
+                verbose,
+                input: Arc::new(self.plan.clone()),
+                schema,
+            }))
+        } else {
+            let stringified_plans =
+                vec![self.plan.to_stringified(PlanType::InitialLogicalPlan)];
+
+            Ok(Self::from(LogicalPlan::Explain {
+                verbose,
+                plan: Arc::new(self.plan.clone()),
+                stringified_plans,
+                schema,
+            }))
+        }
     }
 
     /// Build the plan

--- a/datafusion/src/optimizer/constant_folding.rs
+++ b/datafusion/src/optimizer/constant_folding.rs
@@ -80,6 +80,7 @@ impl OptimizerRule for ConstantFolding {
             | LogicalPlan::Extension { .. }
             | LogicalPlan::Sort { .. }
             | LogicalPlan::Explain { .. }
+            | LogicalPlan::Analyze { .. }
             | LogicalPlan::Limit { .. }
             | LogicalPlan::Union { .. }
             | LogicalPlan::Join { .. }

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -284,6 +284,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             // push the optimization to the plan of this explain
             push_down(&state, plan)
         }
+        LogicalPlan::Analyze { .. } => push_down(&state, plan),
         LogicalPlan::Filter { input, predicate } => {
             let mut predicates = vec![];
             split_members(predicate, &mut predicates);

--- a/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -80,6 +80,11 @@ fn get_num_rows(logical_plan: &LogicalPlan) -> Option<usize> {
             // we cannot predict how rows will be repartitioned
             None
         }
+        LogicalPlan::Analyze { .. } => {
+            // Analyze  produces one row, verbose produces more
+            // but it should never be used as an input to a Join anyways
+            None
+        }
         // the following operators are special cases and not querying data
         LogicalPlan::CreateExternalTable { .. } => None,
         LogicalPlan::Explain { .. } => None,
@@ -201,6 +206,7 @@ impl OptimizerRule for HashBuildProbeOrder {
             | LogicalPlan::Sort { .. }
             | LogicalPlan::CreateExternalTable { .. }
             | LogicalPlan::Explain { .. }
+            | LogicalPlan::Analyze { .. }
             | LogicalPlan::Union { .. }
             | LogicalPlan::Extension { .. } => {
                 let expr = plan.expressions();

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -198,7 +198,8 @@ pub fn from_plan(
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
-        | LogicalPlan::Explain { .. } => Ok(plan.clone()),
+        | LogicalPlan::Explain { .. }
+        | LogicalPlan::Analyze { .. } => Ok(plan.clone()),
     }
 }
 

--- a/datafusion/src/physical_plan/analyze.rs
+++ b/datafusion/src/physical_plan/analyze.rs
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the ANALYZE operator
+
+use std::sync::Arc;
+use std::{any::Any, time::Instant};
+
+use crate::{
+    error::{DataFusionError, Result},
+    physical_plan::{display::DisplayableExecutionPlan, Partitioning},
+    physical_plan::{DisplayFormatType, ExecutionPlan},
+};
+use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
+use futures::StreamExt;
+
+use super::{stream::RecordBatchReceiverStream, Distribution, SendableRecordBatchStream};
+use async_trait::async_trait;
+
+/// `EXPLAIN ANALYZE` execution plan operator. This operator runs its input,
+/// discards the results, and then prints out an annotated plan with metrics
+#[derive(Debug, Clone)]
+pub struct AnalyzeExec {
+    /// control how much extra to print
+    verbose: bool,
+    /// The input plan (the plan being analyzed)
+    input: Arc<dyn ExecutionPlan>,
+    /// The output schema for RecordBatches of this exec node
+    schema: SchemaRef,
+}
+
+impl AnalyzeExec {
+    /// Create a new AnalyzeExec
+    pub fn new(verbose: bool, input: Arc<dyn ExecutionPlan>, schema: SchemaRef) -> Self {
+        AnalyzeExec {
+            verbose,
+            input,
+            schema,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for AnalyzeExec {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    /// Specifies we want the input as a single stream
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::SinglePartition
+    }
+
+    /// Get the output partitioning of this plan
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn with_new_children(
+        &self,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() == 1 {
+            Ok(Arc::new(Self::new(
+                self.verbose,
+                children.pop().unwrap(),
+                self.schema.clone(),
+            )))
+        } else {
+            Err(DataFusionError::Internal(format!(
+                "Invalid child count for AnalyzeExec. Expected 1 got {}",
+                children.len()
+            )))
+        }
+    }
+
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        if 0 != partition {
+            return Err(DataFusionError::Internal(format!(
+                "AnalyzeExec invalid partition. Expected 0, got {}",
+                partition
+            )));
+        }
+
+        // should be ensured by `SinglePartition`  above
+        let input_partitions = self.input.output_partitioning().partition_count();
+        if input_partitions != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "AnalyzeExec invalid number of input partitions. Expected 1, got {}",
+                input_partitions
+            )));
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel(input_partitions);
+
+        let captured_input = self.input.clone();
+        let mut input_stream = captured_input.execute(0).await?;
+        let captured_schema = self.schema.clone();
+        let verbose = self.verbose;
+
+        // Task reads batches the input and when complete produce a
+        // RecordBatch with a report that is written to `tx` when done
+        tokio::task::spawn(async move {
+            let start = Instant::now();
+            let mut total_rows = 0;
+
+            // Note the code below ignores errors sending on tx. An
+            // error sending means the plan is being torn down and
+            // nothing is left that will handle the error (aka no one
+            // will hear us scream)
+            while let Some(b) = input_stream.next().await {
+                match b {
+                    Ok(batch) => {
+                        total_rows += batch.num_rows();
+                    }
+                    b @ Err(_) => {
+                        // try and pass on errors from input
+                        if tx.send(b).await.is_err() {
+                            // receiver hung up, stop executing (no
+                            // one will look at any further results we
+                            // send)
+                            return;
+                        }
+                    }
+                }
+            }
+            let end = Instant::now();
+
+            let mut type_builder = StringBuilder::new(1);
+            let mut plan_builder = StringBuilder::new(1);
+
+            // TODO use some sort of enum rather than strings?
+            type_builder.append_value("Plan with Metrics").unwrap();
+
+            let annotated_plan =
+                DisplayableExecutionPlan::with_metrics(captured_input.as_ref())
+                    .indent()
+                    .to_string();
+            plan_builder.append_value(annotated_plan).unwrap();
+
+            // Verbose output
+            // TODO make this more sophisticated
+            if verbose {
+                type_builder.append_value("Output Rows").unwrap();
+                plan_builder.append_value(total_rows.to_string()).unwrap();
+
+                type_builder.append_value("Duration").unwrap();
+                plan_builder
+                    .append_value(format!("{:?}", end - start))
+                    .unwrap();
+            }
+
+            let maybe_batch = RecordBatch::try_new(
+                captured_schema,
+                vec![
+                    Arc::new(type_builder.finish()),
+                    Arc::new(plan_builder.finish()),
+                ],
+            );
+            // again ignore error
+            tx.send(maybe_batch).await.ok();
+        });
+
+        Ok(RecordBatchReceiverStream::create(&self.schema, rx))
+    }
+
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(f, "AnalyzeExec verbose={}", self.verbose)
+            }
+        }
+    }
+}

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -639,6 +639,7 @@ pub trait Accumulator: Send + Sync + Debug {
 }
 
 pub mod aggregates;
+pub mod analyze;
 pub mod array_expressions;
 pub mod coalesce_batches;
 pub mod coalesce_partitions;
@@ -671,6 +672,7 @@ pub mod repartition;
 pub mod sort;
 pub mod sort_preserving_merge;
 pub mod source;
+pub mod stream;
 pub mod string_expressions;
 pub mod type_coercion;
 pub mod udaf;

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -17,6 +17,7 @@
 
 //! Physical query planner
 
+use super::analyze::AnalyzeExec;
 use super::{
     aggregates, cross_join::CrossJoinExec, empty::EmptyExec, expressions::binary,
     functions, hash_join::PartitionMode, udaf, union::UnionExec, windows,
@@ -741,6 +742,15 @@ impl DefaultPhysicalPlanner {
             LogicalPlan::Explain { .. } => Err(DataFusionError::Internal(
                 "Unsupported logical plan: Explain must be root of the plan".to_string(),
             )),
+            LogicalPlan::Analyze {
+                verbose,
+                input,
+                schema,
+            } => {
+                let input = self.create_initial_plan(input, ctx_state)?;
+                let schema = SchemaRef::new(schema.as_ref().to_owned().into());
+                Ok(Arc::new(AnalyzeExec::new(*verbose, input, schema)))
+            }
             LogicalPlan::Extension { node } => {
                 let physical_inputs = node
                     .inputs()
@@ -1651,7 +1661,7 @@ mod tests {
         let logical_plan =
             LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
                 .unwrap()
-                .explain(true)
+                .explain(true, false)
                 .unwrap()
                 .build()
                 .unwrap();

--- a/datafusion/src/physical_plan/stream.rs
+++ b/datafusion/src/physical_plan/stream.rs
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Stream wrappers for physical operators
+
+use arrow::{
+    datatypes::SchemaRef, error::Result as ArrowResult, record_batch::RecordBatch,
+};
+use futures::{Stream, StreamExt};
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::{RecordBatchStream, SendableRecordBatchStream};
+
+/// Adapter for a tokio [`ReceiverStream`] that implements the
+/// [`SendableRecordBatchStream`]
+/// interface
+pub struct RecordBatchReceiverStream {
+    schema: SchemaRef,
+    inner: ReceiverStream<ArrowResult<RecordBatch>>,
+}
+
+impl RecordBatchReceiverStream {
+    /// Construct a new [`RecordBatchReceiverStream`] which will send
+    /// batches of the specfied schema from `inner`
+    pub fn create(
+        schema: &SchemaRef,
+        rx: tokio::sync::mpsc::Receiver<ArrowResult<RecordBatch>>,
+    ) -> SendableRecordBatchStream {
+        let schema = schema.clone();
+        let inner = ReceiverStream::new(rx);
+        Box::pin(Self { schema, inner })
+    }
+}
+
+impl Stream for RecordBatchReceiverStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl RecordBatchStream for RecordBatchReceiverStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2152,8 +2152,7 @@ async fn csv_explain_analyze() {
 
     // Only test basic plumbing and try to avoid having to change too
     // many things
-    let needle =
-        "RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES), metrics=[";
+    let needle = "RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES), metrics=[";
     assert!(
         formatted.contains(needle),
         "did not find '{}' in\n{}",

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2141,6 +2141,55 @@ async fn csv_explain() {
 }
 
 #[tokio::test]
+async fn csv_explain_analyze() {
+    // This test uses the execute function to run an actual plan under EXPLAIN ANALYZE
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv_by_sql(&mut ctx).await;
+    let sql = "EXPLAIN ANALYZE SELECT count(*), c1 FROM aggregate_test_100 group by c1";
+    let actual = execute_to_batches(&mut ctx, sql).await;
+    let formatted = arrow::util::pretty::pretty_format_batches(&actual).unwrap();
+    let formatted = normalize_for_explain(&formatted);
+
+    // Only test basic plumbing and try to avoid having to change too
+    // many things
+    let needle =
+        "RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES), metrics=[";
+    assert!(
+        formatted.contains(needle),
+        "did not find '{}' in\n{}",
+        needle,
+        formatted
+    );
+    let verbose_needle = "Output Rows       | 5";
+    assert!(
+        !formatted.contains(verbose_needle),
+        "found unexpected '{}' in\n{}",
+        verbose_needle,
+        formatted
+    );
+}
+
+#[tokio::test]
+async fn csv_explain_analyze_verbose() {
+    // This test uses the execute function to run an actual plan under EXPLAIN VERBOSE ANALYZE
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv_by_sql(&mut ctx).await;
+    let sql =
+        "EXPLAIN ANALYZE VERBOSE SELECT count(*), c1 FROM aggregate_test_100 group by c1";
+    let actual = execute_to_batches(&mut ctx, sql).await;
+    let formatted = arrow::util::pretty::pretty_format_batches(&actual).unwrap();
+    let formatted = normalize_for_explain(&formatted);
+
+    let verbose_needle = "Output Rows       | 5";
+    assert!(
+        formatted.contains(verbose_needle),
+        "did not find '{}' in\n{}",
+        verbose_needle,
+        formatted
+    );
+}
+
+#[tokio::test]
 async fn csv_explain_plans() {
     // This test verify the look of each plan in its full cycle plan creation
 


### PR DESCRIPTION
# Which issue does this PR close?
Resolves https://github.com/apache/arrow-datafusion/issues/779

 # Rationale for this change
`EXPLAIN PLAN` is great to understand what DataFusion plans to do, but it is hard today using the SQL or dataframe interface to understand in more depth what *actually happened* during execution.

My real usecase is being able to see how many rows flowed through each operator as well as the  "time spent" and "rows produced" by each operator, and this PR is a step in that direction.

# What changes are included in this PR?
1. Add basic plan nodes for `EXPLAIN ANALYZE` and EXPLAIN ANALYZE VERBOSE` (example below) sql
2. Refactor special case `ParquetStrream` into `RecordBatchReceiverStream` for reuse


# Are there any user-facing changes?
Yes, `EXPLAIN ANALYZE` now does something different than `EXPLAIN`

## Example of use
```shell
echo "1,A" > /tmp/foo.csv
echo "1,B" >> /tmp/foo.csv
echo "2,A" >> /tmp/foo.csv
```

Run CLI
```shell
cargo run --bin datafusion-cli
```

```sql
CREATE EXTERNAL TABLE foo(x INT, b VARCHAR) STORED AS CSV LOCATION '/tmp/foo.csv';
```

## Example `EXPLAIN ANALYZE` output

```sql
> EXPLAIN ANALYZE SELECT SUM(x) FROM foo GROUP BY b;
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                      |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | CoalescePartitionsExec, metrics=[]                                                                                                                        |
|                   |   ProjectionExec: expr=[SUM(foo.x)@1 as SUM(x)], metrics=[]                                                                                               |
|                   |     HashAggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[SUM(x)], metrics=[outputRows=2]                                                       |
|                   |       CoalesceBatchesExec: target_batch_size=4096, metrics=[]                                                                                             |
|                   |         RepartitionExec: partitioning=Hash([Column { name: "b", index: 0 }], 16), metrics=[sendTime=839560, fetchTime=122528525, repartitionTime=5327877] |
|                   |           HashAggregateExec: mode=Partial, gby=[b@1 as b], aggr=[SUM(x)], metrics=[outputRows=2]                                                          |
|                   |             RepartitionExec: partitioning=RoundRobinBatch(16), metrics=[fetchTime=5660489, repartitionTime=0, sendTime=8012]                              |
|                   |               CsvExec: source=Path(/tmp/foo.csv: [/tmp/foo.csv]), has_header=false, metrics=[]                                                            |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set. Query took 0.012 seconds.
```

## Example `EXPLAIN ANALYZE VERBOSE` output

```sql
> EXPLAIN ANALYZE VERBOSE SELECT SUM(x) FROM foo GROUP BY b;
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                      |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | CoalescePartitionsExec, metrics=[]                                                                                                                        |
|                   |   ProjectionExec: expr=[SUM(foo.x)@1 as SUM(x)], metrics=[]                                                                                               |
|                   |     HashAggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[SUM(x)], metrics=[outputRows=2]                                                       |
|                   |       CoalesceBatchesExec: target_batch_size=4096, metrics=[]                                                                                             |
|                   |         RepartitionExec: partitioning=Hash([Column { name: "b", index: 0 }], 16), metrics=[repartitionTime=6584110, fetchTime=132927514, sendTime=904001] |
|                   |           HashAggregateExec: mode=Partial, gby=[b@1 as b], aggr=[SUM(x)], metrics=[outputRows=2]                                                          |
|                   |             RepartitionExec: partitioning=RoundRobinBatch(16), metrics=[repartitionTime=0, sendTime=8246, fetchTime=6239096]                              |
|                   |               CsvExec: source=Path(/tmp/foo.csv: [/tmp/foo.csv]), has_header=false, metrics=[]                                                            |
| Output Rows       | 2                                                                                                                                                         |
| Duration          | 10.283764ms                                                                                                                                               |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set. Query took 0.014 seconds.
```

# Future work:
Note this PR is designed just to hook up / plumb the existing code and metrics we have into SQL (basically what got added in https://github.com/apache/arrow-datafusion/pull/662). I plan a sequence of follow on PRs to both improve the metrics infrastructure https://github.com/apache/arrow-datafusion/issues/679 and add/fix the metrics that are actually reported so they are consistent. The specific metrics that are displayed are verbose and somewhat ad hoc at the moment.


