### PR TITLE
Include planning time in datafusion-cli printing

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -238,8 +238,9 @@ async fn exec_and_print(
     print_options: PrintOptions,
     sql: String,
 ) -> Result<()> {
-    let df = ctx.sql(&sql)?;
     let now = Instant::now();
+
+    let df = ctx.sql(&sql)?;
     let results = df.collect().await?;
 
     print_options.print_batches(&results, now)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #859

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Planning / retrieving statistics / etc can take a considerable time. This makes the cost more visible.

Before:

```
> CREATE EXTERNAL TABLE parts STORED AS PARQUET LOCATION './lineitem/';
0 rows in set. Query took 0.000 seconds.
```

After:

```
> CREATE EXTERNAL TABLE parts STORED AS PARQUET LOCATION './lineitem/';
0 rows in set. Query took 1.999 seconds.
```



# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Just moving the retrieval of start time before the `sql` call.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
