### PR TITLE
Add support for PostgreSQL regex match

### DIFF
--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -28,7 +28,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-arrow-flight = { version = "^5.2" }
+arrow-flight = { version = "^5.3" }
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client" }
 prost = "0.8"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -42,7 +42,7 @@ tokio = "1.0"
 tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow-flight = { version = "^5.2"  }
+arrow-flight = { version = "^5.3"  }
 
 datafusion = { path = "../../../datafusion", version = "5.1.0" }
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -29,8 +29,8 @@ edition = "2018"
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-arrow = { version = "^5.2"  }
-arrow-flight = { version = "^5.2"  }
+arrow = { version = "^5.3"  }
+arrow-flight = { version = "^5.3"  }
 anyhow = "1"
 async-trait = "0.1.36"
 ballista-core = { path = "../core", version = "0.6.0" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -31,5 +31,5 @@ clap = "2.33"
 rustyline = "8.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 datafusion = { path = "../datafusion", version = "5.1.0" }
-arrow = { version = "^5.2"  }
+arrow = { version = "^5.3"  }
 ballista = { path = "../ballista/rust/client", version = "0.6.0" }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -29,7 +29,7 @@ publish = false
 
 
 [dev-dependencies]
-arrow-flight = { version = "^5.2" }
+arrow-flight = { version = "^5.3" }
 datafusion = { path = "../datafusion" }
 prost = "0.8"
 tonic = "0.5"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -49,8 +49,8 @@ force_hash_collisions = []
 [dependencies]
 ahash = "0.7"
 hashbrown = { version = "0.11", features = ["raw"] }
-arrow = { version = "^5.2", features = ["prettyprint"] }
-parquet = { version = "^5.2", features = ["arrow"] }
+arrow = { version = "^5.3", features = ["prettyprint"] }
+parquet = { version = "^5.3", features = ["arrow"] }
 sqlparser = "0.10"
 paste = "^1.0"
 num_cpus = "1.13.0"

--- a/datafusion/src/logical_plan/operators.rs
+++ b/datafusion/src/logical_plan/operators.rs
@@ -52,6 +52,14 @@ pub enum Operator {
     Like,
     /// Does not match a wildcard pattern
     NotLike,
+    /// Case sensitive regex match
+    RegexMatch,
+    /// Case insensitive regex match
+    RegexIMatch,
+    /// Case sensitive regex not match
+    RegexNotMatch,
+    /// Case insensitive regex not match
+    RegexNotIMatch,
 }
 
 impl fmt::Display for Operator {
@@ -72,6 +80,10 @@ impl fmt::Display for Operator {
             Operator::Or => "OR",
             Operator::Like => "LIKE",
             Operator::NotLike => "NOT LIKE",
+            Operator::RegexMatch => "~",
+            Operator::RegexIMatch => "~*",
+            Operator::RegexNotMatch => "!~",
+            Operator::RegexNotIMatch => "!~*",
         };
         write!(f, "{}", display)
     }

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1261,6 +1261,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     BinaryOperator::Or => Ok(Operator::Or),
                     BinaryOperator::Like => Ok(Operator::Like),
                     BinaryOperator::NotLike => Ok(Operator::NotLike),
+                    BinaryOperator::PGRegexMatch => Ok(Operator::RegexMatch),
+                    BinaryOperator::PGRegexIMatch => Ok(Operator::RegexIMatch),
+                    BinaryOperator::PGRegexNotMatch => Ok(Operator::RegexNotMatch),
+                    BinaryOperator::PGRegexNotIMatch => Ok(Operator::RegexNotIMatch),
                     _ => Err(DataFusionError::NotImplemented(format!(
                         "Unsupported SQL binary operator {:?}",
                         op


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #795

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Implement PostgreSQL pattern matching operator


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. modify sqlparser to support PostgreSQL regex match syntax [sqlparser-rs#328](https://github.com/ballista-compute/sqlparser-rs/pull/328)
2. use arrow-rs kernel `regexp_match` function to do regular expression

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

support pattern matching using POSIX regular expressions

```
> CREATE EXTERNAL TABLE X STORED AS PARQUET LOCATION './benchmarks/parquet/nation/';

0 rows in set. Query took 0.005 seconds.
> select n_name from X where n_name ~ '^[A-D]';
+-----------+
| n_name    |
+-----------+
| ARGENTINA |
| BRAZIL    |
| CANADA    |
| CHINA     |
+-----------+
4 rows in set. Query took 0.010 seconds.
> select n_name from X where n_name ~* '^[a-d]';
+-----------+
| n_name    |
+-----------+
| ARGENTINA |
| BRAZIL    |
| CANADA    |
| CHINA     |
+-----------+
4 rows in set. Query took 0.008 seconds.
> select n_name from X where n_name !~ '^[C-R]';
+----------------+
| n_name         |
+----------------+
| ARGENTINA      |
| BRAZIL         |
| SAUDI ARABIA   |
| VIETNAM        |
| UNITED KINGDOM |
| UNITED STATES  |
+----------------+
6 rows in set. Query took 0.009 seconds.
> select n_name from X where n_name !~* '^[c-r]';
+----------------+
| n_name         |
+----------------+
| ARGENTINA      |
| BRAZIL         |
| SAUDI ARABIA   |
| VIETNAM        |
| UNITED KINGDOM |
| UNITED STATES  |
+----------------+
6 rows in set. Query took 0.009 seconds.
```

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
