### PR TITLE
update automation for arrow version bump

### DIFF
--- a/dev/update_arrow_deps.py
+++ b/dev/update_arrow_deps.py
@@ -22,9 +22,19 @@
 # installation:
 # pip install tomlkit requests
 #
-# usage:
-# python update_arrow_deps.py
+# pin all arrow crates deps to a specific version:
+#
+# python update_arrow_deps.py version '^5.2'
+#
+# update all arrow git deps to latest commit:
+#
+# python update_arrow_deps.py commit
+#
+# help:
+#
+# python update_arrow_deps.py --help
 
+import argparse
 from pathlib import Path
 
 # use tomlkit as it preserves comments and other formatting
@@ -45,7 +55,7 @@ def get_arrow_sha():
 #   'rev': 'c3fe3bab9905739fdda75301dab07a18c91731bd'
 # }
 # to point at a new SHA
-def update_dependencies(dependencies, new_sha):
+def update_commit_dependencies(dependencies, new_sha):
     if dependencies is None:
         return
     for dep_name in dependencies:
@@ -55,29 +65,61 @@ def update_dependencies(dependencies, new_sha):
                 dep['rev'] = new_sha
 
 
-def update_cargo_toml(cargo_toml, new_sha):
+def update_commit_cargo_toml(cargo_toml, new_sha):
     print('updating {}'.format(cargo_toml.absolute()))
     with open(cargo_toml) as f:
         data = f.read()
 
     doc = tomlkit.parse(data)
 
-    update_dependencies(doc.get('dependencies'), new_sha)
-    update_dependencies(doc.get('dev-dependencies'), new_sha)
+    update_commit_dependencies(doc.get('dependencies'), new_sha)
+    update_commit_dependencies(doc.get('dev-dependencies'), new_sha)
 
     with open(cargo_toml, 'w') as f:
         f.write(tomlkit.dumps(doc))
 
 
-# Begin main script
+def update_version_cargo_toml(cargo_toml, new_version):
+    print('updating {}'.format(cargo_toml.absolute()))
+    with open(cargo_toml) as f:
+        data = f.read()
 
-repo_root = Path(__file__).parent.parent.absolute()
+    doc = tomlkit.parse(data)
+
+    for section in ("dependencies", "dev-dependencies"):
+        for (dep_name, constraint) in doc.get(section, {}).items():
+            if dep_name in ("arrow", "parquet", "arrow-flight") and constraint.get("version") is not None:
+                doc[section][dep_name]["version"] = new_version
+
+    with open(cargo_toml, 'w') as f:
+        f.write(tomlkit.dumps(doc))
 
 
-new_sha = get_arrow_sha()
+def main():
+    parser = argparse.ArgumentParser(description='Update arrow dep versions.')
+    sub_parsers = parser.add_subparsers(help='sub-command help')
 
-print('Updating files in {} to use sha {}'.format(repo_root, new_sha))
+    parser_version = sub_parsers.add_parser('version', help='update arrow version')
+    parser_version.add_argument('new_version', type=str, help='new arrow version')
+    parser_version.set_defaults(which='version')
+
+    parser_commit = sub_parsers.add_parser('commit', help='update arrow commit')
+    parser_commit.set_defaults(which='commit')
+
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent.absolute()
+
+    if args.which == "version":
+        for cargo_toml in repo_root.rglob('Cargo.toml'):
+            update_version_cargo_toml(cargo_toml, args.new_version)
+    elif args.which == "commit":
+        new_sha = get_arrow_sha()
+        print('Updating files in {} to use sha {}'.format(repo_root, new_sha))
+        for cargo_toml in repo_root.rglob('Cargo.toml'):
+            update_commit_cargo_toml(cargo_toml, new_sha)
 
 
-for cargo_toml in repo_root.rglob('Cargo.toml'):
-    update_cargo_toml(cargo_toml, new_sha)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Which issue does this PR close?

Related to #863.

# Rationale for this change

Make it easier to update arrow versions across crates.

# What changes are included in this PR?

update_arrow_deps.py updated to support batch update for both git version dependency pins and crates version pins.

# Are there any user-facing changes?

no
