### PR TITLE
prepare code base for 5.1.0 release

### DIFF
--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-examples"
 description = "Ballista usage examples"
-version = "0.5.0"
+version = "0.6.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -19,21 +19,21 @@
 name = "ballista"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "0.5.0"
+version = "0.6.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2018"
 
 [dependencies]
-ballista-core = { path = "../core", version = "0.5.0" }
-ballista-executor = { path = "../executor", version = "0.5.0", optional = true }
-ballista-scheduler = { path = "../scheduler", version = "0.5.0", optional = true }
+ballista-core = { path = "../core", version = "0.6.0" }
+ballista-executor = { path = "../executor", version = "0.6.0", optional = true }
+ballista-scheduler = { path = "../scheduler", version = "0.6.0", optional = true }
 futures = "0.3"
 log = "0.4"
 tokio = "1.0"
 
-datafusion = { path = "../../../datafusion", version = "5.0.0" }
+datafusion = { path = "../../../datafusion", version = "5.1.0" }
 
 [features]
 default = []

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-core"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "0.5.0"
+version = "0.6.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -44,7 +44,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 arrow-flight = { version = "5.0"  }
 
-datafusion = { path = "../../../datafusion", version = "5.0.0" }
+datafusion = { path = "../../../datafusion", version = "5.1.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-executor"
 description = "Ballista Distributed Compute - Executor"
 license = "Apache-2.0"
-version = "0.5.0"
+version = "0.6.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -33,9 +33,9 @@ arrow = { version = "5.0"  }
 arrow-flight = { version = "5.0"  }
 anyhow = "1"
 async-trait = "0.1.36"
-ballista-core = { path = "../core", version = "0.5.0" }
+ballista-core = { path = "../core", version = "0.6.0" }
 configure_me = "0.4.0"
-datafusion = { path = "../../../datafusion", version = "5.0.0" }
+datafusion = { path = "../../../datafusion", version = "5.1.0" }
 env_logger = "0.8"
 futures = "0.3"
 log = "0.4"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-scheduler"
 description = "Ballista Distributed Compute - Scheduler"
 license = "Apache-2.0"
-version = "0.5.0"
+version = "0.6.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -32,10 +32,10 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-ballista-core = { path = "../core", version = "0.5.0" }
+ballista-core = { path = "../core", version = "0.6.0" }
 clap = "2"
 configure_me = "0.4.0"
-datafusion = { path = "../../../datafusion", version = "5.0.0" }
+datafusion = { path = "../../../datafusion", version = "5.1.0" }
 env_logger = "0.8"
 etcd-client = { version = "0.6", optional = true }
 futures = "0.3"
@@ -55,7 +55,7 @@ tower = { version = "0.4" }
 warp = "0.3"
 
 [dev-dependencies]
-ballista-core = { path = "../core", version = "0.5.0" }
+ballista-core = { path = "../core", version = "0.6.0" }
 uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -30,5 +30,5 @@ repository = "https://github.com/apache/arrow-datafusion"
 clap = "2.33"
 rustyline = "8.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
-datafusion = { path = "../datafusion" }
+datafusion = { path = "../datafusion", version = "5.1.0" }
 arrow = { version = "5.0"  }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion"
 description = "DataFusion is an in-memory query engine that uses Apache Arrow as the memory model"
-version = "5.0.0"
+version = "5.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "../README.md"

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script that updates verions for datafusion crates, locally
+#
+# dependencies:
+# pip install tomlkit
+
+import os
+import argparse
+from pathlib import Path
+import tomlkit
+
+
+def update_datafusion_version(cargo_toml: str, new_version: str):
+    print(f'updating {cargo_toml}')
+    with open(cargo_toml) as f:
+        data = f.read()
+
+    doc = tomlkit.parse(data)
+    doc.get('package')['version'] = new_version
+
+    with open(cargo_toml, 'w') as f:
+        f.write(tomlkit.dumps(doc))
+
+
+def update_downstream_versions(cargo_toml: str, new_version: str):
+    with open(cargo_toml) as f:
+        data = f.read()
+
+    doc = tomlkit.parse(data)
+
+    df_dep = doc.get('dependencies', {}).get('datafusion')
+    # skip crates that pin datafusion using git hash
+    if df_dep is not None and df_dep.get('version') is not None:
+        print(f'updating datafusion dependency in {cargo_toml}')
+        df_dep['version'] = new_version
+
+    df_dep = doc.get('dev-dependencies', {}).get('datafusion')
+    if df_dep is not None and df_dep.get('version') is not None:
+        print(f'updating datafusion dev-dependency in {cargo_toml}')
+        df_dep['version'] = new_version
+
+    with open(cargo_toml, 'w') as f:
+        f.write(tomlkit.dumps(doc))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Update datafusion crate version and corresponding version pins '
+            'in downstream crates.'
+        ))
+    parser.add_argument('new_version', type=str, help='new datafusion version')
+    args = parser.parse_args()
+
+    new_version = args.new_version
+    repo_root = Path(__file__).parent.parent.absolute()
+
+    print(f'Updating datafusion versions in {repo_root} to {new_version}')
+
+    update_datafusion_version("datafusion/Cargo.toml", new_version)
+    for cargo_toml in repo_root.rglob('Cargo.toml'):
+        update_downstream_versions(cargo_toml, new_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Rationale for this change

5.0.0 is now out, update version to get ready for 5.1.0.

# What changes are included in this PR?

Bump datafusion and ballista versions everywhere for the next one. Datafusion codebase already contained new feature, so we will need to bump the minor version.

Also added automation to help bump datafusion version where. The ballista version bump automation has been updated to only bump ballista related versions.

All cargo changes are created with the following two commands:

```
./dev/update_datafusion_versions.py 5.1.0
./dev/update_ballista_versions.py 0.6.0
```

# Are there any user-facing changes?

no
