### PR TITLE
update docker-compose.yaml on ballista version bump

### DIFF
--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     image: quay.io/coreos/etcd:v3.4.9
     command: "etcd -advertise-client-urls http://etcd:2379 -listen-client-urls http://0.0.0.0:2379"
   ballista-scheduler:
-    image: ballista:0.5.0-SNAPSHOT
+    image: ballista:0.6.0
     command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
     environment:
       - RUST_LOG=ballista=debug
@@ -29,7 +29,7 @@ services:
     depends_on:
       - etcd
   ballista-executor:
-    image: ballista:0.5.0-SNAPSHOT
+    image: ballista:0.6.0
     command: "/executor --bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
     scale: 2
     environment:
@@ -39,7 +39,7 @@ services:
     depends_on:
       - ballista-scheduler
   ballista-client:
-    image: ballista:0.5.0-SNAPSHOT
+    image: ballista:0.6.0
     command: "/bin/sh" # do nothing
     environment:
       - RUST_LOG=info

--- a/dev/update_ballista_versions.py
+++ b/dev/update_ballista_versions.py
@@ -23,6 +23,7 @@
 # pip install tomlkit
 
 import os
+import re
 import argparse
 from pathlib import Path
 import tomlkit
@@ -76,6 +77,16 @@ def main():
 
     for cargo_toml in ballista_crates:
         update_cargo_toml(cargo_toml, new_version)
+
+    docker_compose_path = os.path.join(repo_root, "benchmarks/docker-compose.yaml")
+    print(f'Updating ballista versions in {docker_compose_path}')
+    with open(docker_compose_path, "r+") as fd:
+        data = fd.read()
+        pattern = re.compile(r'(^\s+image:\sballista:)\d+\.\d+\.\d+(-SNAPSHOT)?', re.MULTILINE)
+        data = pattern.sub(r"\g<1>"+new_version, data)
+        fd.truncate(0)
+        fd.seek(0)
+        fd.write(data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Rationale for this change

Local integration test uses the version from pinned in docker-compose.yaml, which is not in sync with the version used in `build-ballista-docker.sh`.

# What changes are included in this PR?

Fix ballista version bump automation to also take care of docker-compose.yaml
Update version in docker-compose.yaml

# Are there any user-facing changes?

no