### PR TITLE
Improve SQLMetric APIs, port existing metrics

### DIFF
--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -110,24 +110,25 @@ mod tests {
 
     use super::*;
     use crate::datasource::datasource::Statistics;
-    use crate::physical_plan::parquet::{
-        ParquetExec, ParquetExecMetrics, ParquetPartition,
-    };
+    use crate::physical_plan::metrics::ExecutionPlanMetricsSet;
+    use crate::physical_plan::parquet::{ParquetExec, ParquetPartition};
     use crate::physical_plan::projection::ProjectionExec;
 
     #[test]
     fn added_repartition_to_single_partition() -> Result<()> {
         let schema = Arc::new(Schema::empty());
+        let metrics = ExecutionPlanMetricsSet::new();
         let parquet_project = ProjectionExec::try_new(
             vec![],
             Arc::new(ParquetExec::new(
                 vec![ParquetPartition::new(
                     vec!["x".to_string()],
                     Statistics::default(),
+                    metrics.clone(),
                 )],
                 schema,
                 None,
-                ParquetExecMetrics::new(),
+                metrics,
                 None,
                 2048,
                 None,
@@ -154,6 +155,7 @@ mod tests {
     #[test]
     fn repartition_deepest_node() -> Result<()> {
         let schema = Arc::new(Schema::empty());
+        let metrics = ExecutionPlanMetricsSet::new();
         let parquet_project = ProjectionExec::try_new(
             vec![],
             Arc::new(ProjectionExec::try_new(
@@ -162,10 +164,11 @@ mod tests {
                     vec![ParquetPartition::new(
                         vec!["x".to_string()],
                         Statistics::default(),
+                        metrics.clone(),
                     )],
                     schema,
                     None,
-                    ParquetExecMetrics::new(),
+                    metrics,
                     None,
                     2048,
                     None,

--- a/datafusion/src/physical_plan/analyze.rs
+++ b/datafusion/src/physical_plan/analyze.rs
@@ -164,6 +164,14 @@ impl ExecutionPlan for AnalyzeExec {
             // Verbose output
             // TODO make this more sophisticated
             if verbose {
+                type_builder.append_value("Plan with Full Metrics").unwrap();
+
+                let annotated_plan =
+                    DisplayableExecutionPlan::with_full_metrics(captured_input.as_ref())
+                        .indent()
+                        .to_string();
+                plan_builder.append_value(annotated_plan).unwrap();
+
                 type_builder.append_value("Output Rows").unwrap();
                 plan_builder.append_value(total_rows.to_string()).unwrap();
 

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -35,7 +35,6 @@ use std::{time::Instant, vec};
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt, TryStreamExt};
-use hashbrown::HashMap;
 use tokio::sync::Mutex;
 
 use arrow::array::Array;
@@ -51,11 +50,14 @@ use arrow::array::{
 
 use hashbrown::raw::RawTable;
 
-use super::expressions::Column;
 use super::hash_utils::create_hashes;
 use super::{
     coalesce_partitions::CoalescePartitionsExec,
     hash_utils::{build_join_schema, check_join_is_valid, JoinOn},
+};
+use super::{
+    expressions::Column,
+    metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet},
 };
 use crate::error::{DataFusionError, Result};
 use crate::logical_plan::JoinType;
@@ -65,7 +67,7 @@ use super::{
     SendableRecordBatchStream,
 };
 use crate::physical_plan::coalesce_batches::concat_batches;
-use crate::physical_plan::{PhysicalExpr, SQLMetric};
+use crate::physical_plan::PhysicalExpr;
 use log::debug;
 use std::fmt;
 
@@ -111,33 +113,45 @@ pub struct HashJoinExec {
     random_state: RandomState,
     /// Partitioning mode to use
     mode: PartitionMode,
-    /// Metrics
-    metrics: Arc<HashJoinMetrics>,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
 }
 
 /// Metrics for HashJoinExec
 #[derive(Debug)]
 struct HashJoinMetrics {
     /// Total time for joining probe-side batches to the build-side batches
-    join_time: Arc<SQLMetric>,
+    join_time: metrics::Time,
     /// Number of batches consumed by this operator
-    input_batches: Arc<SQLMetric>,
+    input_batches: metrics::Count,
     /// Number of rows consumed by this operator
-    input_rows: Arc<SQLMetric>,
+    input_rows: metrics::Count,
     /// Number of batches produced by this operator
-    output_batches: Arc<SQLMetric>,
+    output_batches: metrics::Count,
     /// Number of rows produced by this operator
-    output_rows: Arc<SQLMetric>,
+    output_rows: metrics::Count,
 }
 
 impl HashJoinMetrics {
-    fn new() -> Self {
+    pub fn new(partition: usize, metrics: &ExecutionPlanMetricsSet) -> Self {
+        let join_time = MetricBuilder::new(metrics).subset_time("join_time", partition);
+
+        let input_batches =
+            MetricBuilder::new(metrics).counter("input_batches", partition);
+
+        let input_rows = MetricBuilder::new(metrics).counter("input_rows", partition);
+
+        let output_batches =
+            MetricBuilder::new(metrics).counter("output_rows", partition);
+
+        let output_rows = MetricBuilder::new(metrics).output_rows(partition);
+
         Self {
-            join_time: SQLMetric::time_nanos(),
-            input_batches: SQLMetric::counter(),
-            input_rows: SQLMetric::counter(),
-            output_batches: SQLMetric::counter(),
-            output_rows: SQLMetric::counter(),
+            join_time,
+            input_batches,
+            input_rows,
+            output_batches,
+            output_rows,
         }
     }
 }
@@ -187,7 +201,7 @@ impl HashJoinExec {
             build_side: Arc::new(Mutex::new(None)),
             random_state,
             mode: partition_mode,
-            metrics: Arc::new(HashJoinMetrics::new()),
+            metrics: ExecutionPlanMetricsSet::new(),
         })
     }
 
@@ -425,7 +439,7 @@ impl ExecutionPlan for HashJoinExec {
             column_indices,
             self.random_state.clone(),
             visited_left_side,
-            self.metrics.clone(),
+            HashJoinMetrics::new(partition, &self.metrics),
         )))
     }
 
@@ -445,20 +459,8 @@ impl ExecutionPlan for HashJoinExec {
         }
     }
 
-    fn metrics(&self) -> HashMap<String, SQLMetric> {
-        let mut metrics = HashMap::new();
-        metrics.insert("joinTime".to_owned(), (*self.metrics.join_time).clone());
-        metrics.insert(
-            "inputBatches".to_owned(),
-            (*self.metrics.input_batches).clone(),
-        );
-        metrics.insert("inputRows".to_owned(), (*self.metrics.input_rows).clone());
-        metrics.insert(
-            "outputBatches".to_owned(),
-            (*self.metrics.output_batches).clone(),
-        );
-        metrics.insert("outputRows".to_owned(), (*self.metrics.output_rows).clone());
-        metrics
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
     }
 }
 
@@ -522,7 +524,7 @@ struct HashJoinStream {
     /// There is nothing to process anymore and left side is processed in case of left join
     is_exhausted: bool,
     /// Metrics
-    metrics: Arc<HashJoinMetrics>,
+    join_metrics: HashJoinMetrics,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -537,7 +539,7 @@ impl HashJoinStream {
         column_indices: Vec<ColumnIndex>,
         random_state: RandomState,
         visited_left_side: Vec<bool>,
-        metrics: Arc<HashJoinMetrics>,
+        join_metrics: HashJoinMetrics,
     ) -> Self {
         HashJoinStream {
             schema,
@@ -550,7 +552,7 @@ impl HashJoinStream {
             random_state,
             visited_left_side,
             is_exhausted: false,
-            metrics,
+            join_metrics,
         }
     }
 }
@@ -876,7 +878,7 @@ impl Stream for HashJoinStream {
             .poll_next_unpin(cx)
             .map(|maybe_batch| match maybe_batch {
                 Some(Ok(batch)) => {
-                    let start = Instant::now();
+                    let timer = self.join_metrics.join_time.timer();
                     let result = build_batch(
                         &batch,
                         &self.left_data,
@@ -887,14 +889,12 @@ impl Stream for HashJoinStream {
                         &self.column_indices,
                         &self.random_state,
                     );
-                    self.metrics.input_batches.add(1);
-                    self.metrics.input_rows.add(batch.num_rows());
+                    self.join_metrics.input_batches.add(1);
+                    self.join_metrics.input_rows.add(batch.num_rows());
                     if let Ok((ref batch, ref left_side)) = result {
-                        self.metrics
-                            .join_time
-                            .add(start.elapsed().as_millis() as usize);
-                        self.metrics.output_batches.add(1);
-                        self.metrics.output_rows.add(batch.num_rows());
+                        timer.done();
+                        self.join_metrics.output_batches.add(1);
+                        self.join_metrics.output_rows.add(batch.num_rows());
 
                         match self.join_type {
                             JoinType::Left
@@ -911,7 +911,7 @@ impl Stream for HashJoinStream {
                     Some(result.map(|x| x.0))
                 }
                 other => {
-                    let start = Instant::now();
+                    let timer = self.join_metrics.join_time.timer();
                     // For the left join, produce rows for unmatched rows
                     match self.join_type {
                         JoinType::Left
@@ -928,16 +928,14 @@ impl Stream for HashJoinStream {
                                 self.join_type != JoinType::Semi,
                             );
                             if let Ok(ref batch) = result {
-                                self.metrics.input_batches.add(1);
-                                self.metrics.input_rows.add(batch.num_rows());
+                                self.join_metrics.input_batches.add(1);
+                                self.join_metrics.input_rows.add(batch.num_rows());
                                 if let Ok(ref batch) = result {
-                                    self.metrics
-                                        .join_time
-                                        .add(start.elapsed().as_millis() as usize);
-                                    self.metrics.output_batches.add(1);
-                                    self.metrics.output_rows.add(batch.num_rows());
+                                    self.join_metrics.output_batches.add(1);
+                                    self.join_metrics.output_rows.add(batch.num_rows());
                                 }
                             }
+                            timer.done();
                             self.is_exhausted = true;
                             return Some(result);
                         }

--- a/datafusion/src/physical_plan/metrics/builder.rs
+++ b/datafusion/src/physical_plan/metrics/builder.rs
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Builder for creating arbitrary metrics
+
+use std::{borrow::Cow, sync::Arc};
+
+use super::{Count, ExecutionPlanMetricsSet, Label, Metric, MetricValue, Time};
+
+/// Structure for constructing metrics, counters, timers, etc.
+///
+/// Note the use of `Cow<..>` is to avoid allocations in the common
+/// case of constant strings
+///
+/// ```rust
+///  use datafusion::physical_plan::metrics::*;
+///
+///  let metrics = ExecutionPlanMetricsSet::new();
+///  let partition = 1;
+///
+///  // Create the standard output_rows metric
+///  let output_rows = MetricBuilder::new(&metrics).output_rows(partition);
+///
+///  // Create a operator specific counter with some labels
+///  let num_bytes = MetricBuilder::new(&metrics)
+///    .with_new_label("filename", "my_awesome_file.parquet")
+///    .counter("num_bytes", partition);
+///
+/// ```
+pub struct MetricBuilder<'a> {
+    /// Location that the metric created by this builder will be added do
+    metrics: &'a ExecutionPlanMetricsSet,
+
+    /// optional partition number
+    partition: Option<usize>,
+
+    /// arbitrary name=value pairs identifiying this metric
+    labels: Vec<Label>,
+}
+
+impl<'a> MetricBuilder<'a> {
+    /// Create a new `MetricBuilder` that will register the result of `build()` with the `metrics`
+    pub fn new(metrics: &'a ExecutionPlanMetricsSet) -> Self {
+        Self {
+            metrics,
+            partition: None,
+            labels: vec![],
+        }
+    }
+
+    /// Add a label to the metric being constructed
+    pub fn with_label(mut self, label: Label) -> Self {
+        self.labels.push(label);
+        self
+    }
+
+    /// Add a label to the metric being constructed
+    pub fn with_new_label(
+        self,
+        name: impl Into<Cow<'static, str>>,
+        value: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.with_label(Label::new(name.into(), value.into()))
+    }
+
+    /// Set the partition of the metric being constructed
+    pub fn with_partition(mut self, partition: usize) -> Self {
+        self.partition = Some(partition);
+        self
+    }
+
+    /// Consume self and create a metric of the specified value
+    /// registered with the MetricsSet
+    pub fn build(self, value: MetricValue) {
+        let Self {
+            labels,
+            partition,
+            metrics,
+        } = self;
+        let metric = Arc::new(Metric::new_with_labels(value, partition, labels));
+        metrics.register(metric);
+    }
+
+    /// Consume self and create a new counter for recording output rows
+    pub fn output_rows(self, partition: usize) -> Count {
+        let count = Count::new();
+        self.with_partition(partition)
+            .build(MetricValue::OutputRows(count.clone()));
+        count
+    }
+
+    /// Consumes self and creates a new [`Count`] for recording some
+    /// arbitrary metric of an operator.
+    pub fn counter(
+        self,
+        counter_name: impl Into<Cow<'static, str>>,
+        partition: usize,
+    ) -> Count {
+        self.with_partition(partition).global_counter(counter_name)
+    }
+
+    /// Consumes self and creates a new [`Count`] for recording a
+    /// metric of an overall operator (not per partition)
+    pub fn global_counter(self, counter_name: impl Into<Cow<'static, str>>) -> Count {
+        let count = Count::new();
+        self.build(MetricValue::Count {
+            name: counter_name.into(),
+            count: count.clone(),
+        });
+        count
+    }
+
+    /// Consume self and create a new Timer for recording the overall cpu time
+    /// spent by an operator
+    pub fn cpu_time(self, partition: usize) -> Time {
+        let time = Time::new();
+        self.with_partition(partition)
+            .build(MetricValue::CPUTime(time.clone()));
+        time
+    }
+
+    /// Consumes self and creates a new Timer for recording some
+    /// subset of of an operators execution time.
+    pub fn subset_time(
+        self,
+        subset_name: impl Into<Cow<'static, str>>,
+        partition: usize,
+    ) -> Time {
+        let time = Time::new();
+        self.with_partition(partition).build(MetricValue::Time {
+            name: subset_name.into(),
+            time: time.clone(),
+        });
+        time
+    }
+}

--- a/datafusion/src/physical_plan/metrics/mod.rs
+++ b/datafusion/src/physical_plan/metrics/mod.rs
@@ -1,0 +1,528 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Metrics for recording information about execution
+
+mod builder;
+mod value;
+
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+    sync::{Arc, Mutex},
+};
+
+use hashbrown::HashMap;
+
+// public exports
+pub use builder::MetricBuilder;
+pub use value::{Count, MetricValue, ScopedTimerGuard, Time};
+
+/// Something that tracks a value of interest (metric) of a DataFusion
+/// [`ExecutionPlan`] execution.
+///
+/// Typically [`Metric`]s are not created directly, but instead
+/// are created using [`MetricBuilder`] or methods on
+/// [`ExecutionPlanMetricsSet`].
+///
+/// ```
+///  use datafusion::physical_plan::metrics::*;
+///
+///  let metrics = ExecutionPlanMetricsSet::new();
+///  assert!(metrics.clone_inner().output_rows().is_none());
+///
+///  // Create a counter to increment using the MetricBuilder
+///  let partition = 1;
+///  let output_rows = MetricBuilder::new(&metrics)
+///      .output_rows(partition);
+///
+///  // Counter can be incremented
+///  output_rows.add(13);
+///
+///  // The value can be retrieved directly:
+///  assert_eq!(output_rows.value(), 13);
+///
+///  // As well as from the metrics set
+///  assert_eq!(metrics.clone_inner().output_rows(), Some(13));
+/// ```
+
+#[derive(Debug)]
+pub struct Metric {
+    /// The value the metric
+    value: MetricValue,
+
+    /// arbitrary name=value pairs identifiying this metric
+    labels: Vec<Label>,
+
+    /// To which partition of an operators output did this metric
+    /// apply? If None means all partitions.
+    partition: Option<usize>,
+}
+
+impl Display for Metric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value.name())?;
+
+        let mut iter = self
+            .partition
+            .iter()
+            .map(|partition| Label::new("partition", partition.to_string()))
+            .chain(self.labels().iter().cloned())
+            .peekable();
+
+        // print out the labels specially
+        if iter.peek().is_some() {
+            write!(f, "{{")?;
+
+            let mut is_first = true;
+            for i in iter {
+                if !is_first {
+                    write!(f, ", ")?;
+                } else {
+                    is_first = false;
+                }
+
+                write!(f, "{}", i)?;
+            }
+
+            write!(f, "}}")?;
+        }
+
+        // and now the value
+        write!(f, "={}", self.value)
+    }
+}
+
+impl Metric {
+    /// Create a new [`Metric`]. Consider using [`MetricBuilder`]
+    /// rather than this function directly.
+    pub fn new(value: MetricValue, partition: Option<usize>) -> Self {
+        Self {
+            value,
+            labels: vec![],
+            partition,
+        }
+    }
+
+    /// Create a new [`Metric`]. Consider using [`MetricBuilder`]
+    /// rather than this function directly.
+    pub fn new_with_labels(
+        value: MetricValue,
+        partition: Option<usize>,
+        labels: Vec<Label>,
+    ) -> Self {
+        Self {
+            value,
+            labels,
+            partition,
+        }
+    }
+
+    /// Add a new label to this metric
+    pub fn with(mut self, label: Label) -> Self {
+        self.labels.push(label);
+        self
+    }
+
+    /// What labels are present for this metric?
+    fn labels(&self) -> &[Label] {
+        &self.labels
+    }
+
+    /// return a reference to the value of this metric
+    pub fn value(&self) -> &MetricValue {
+        &self.value
+    }
+
+    /// return a mutable reference to the value of this metric
+    pub fn value_mut(&mut self) -> &mut MetricValue {
+        &mut self.value
+    }
+
+    /// return a reference to the partition
+    pub fn partition(&self) -> &Option<usize> {
+        &self.partition
+    }
+}
+
+/// A snapshot of the metrics for a particular operator (`dyn
+/// ExecutionPlan`).
+#[derive(Default, Debug, Clone)]
+pub struct MetricsSet {
+    metrics: Vec<Arc<Metric>>,
+}
+
+impl MetricsSet {
+    /// Create a new container of metrics
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Add the specified metric
+    pub fn push(&mut self, metric: Arc<Metric>) {
+        self.metrics.push(metric)
+    }
+
+    /// Returns an interator across all metrics
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<Metric>> {
+        self.metrics.iter()
+    }
+
+    /// convenience: return the number of rows produced, aggregated
+    /// across partitions or None if no metric is present
+    pub fn output_rows(&self) -> Option<usize> {
+        self.sum(|metric| matches!(metric.value(), MetricValue::OutputRows(_)))
+            .map(|v| v.as_usize())
+    }
+
+    /// convenience: return the amount of CPU time spent, aggregated
+    /// across partitions or None if no metric is present
+    pub fn cpu_time(&self) -> Option<usize> {
+        self.sum(|metric| matches!(metric.value(), MetricValue::CPUTime(_)))
+            .map(|v| v.as_usize())
+    }
+
+    /// Sums the values for metrics for which `f(metric)` returns
+    /// true, and returns the value. Returns None if no metrics match
+    /// the predicate.
+    pub fn sum<F>(&self, mut f: F) -> Option<MetricValue>
+    where
+        F: FnMut(&Metric) -> bool,
+    {
+        let mut iter = self
+            .metrics
+            .iter()
+            .filter(|metric| f(metric.as_ref()))
+            .peekable();
+
+        let mut accum = match iter.peek() {
+            None => {
+                return None;
+            }
+            Some(metric) => metric.value().new_empty(),
+        };
+
+        iter.for_each(|metric| accum.add(metric.value()));
+
+        Some(accum)
+    }
+
+    /// Returns returns a new derived `MetricsSet` where all metrics
+    /// that had the same name and partition=`Some(..)` have been
+    /// aggregated together. The resulting `MetricsSet` has all
+    /// metrics with `Partition=None`
+    pub fn aggregate_by_partition(&self) -> Self {
+        let mut map = HashMap::new();
+
+        // There are all sorts of ways to make this more efficient
+        for metric in &self.metrics {
+            let key = (metric.value.name(), metric.labels.clone());
+            map.entry(key)
+                .and_modify(|accum: &mut Metric| {
+                    accum.value_mut().add(metric.value());
+                })
+                .or_insert_with(|| {
+                    // accumulate with no partition
+                    let partition = None;
+                    let mut accum = Metric::new_with_labels(
+                        metric.value().new_empty(),
+                        partition,
+                        metric.labels().to_vec(),
+                    );
+                    accum.value_mut().add(metric.value());
+                    accum
+                });
+        }
+
+        let new_metrics = map
+            .into_iter()
+            .map(|(_k, v)| Arc::new(v))
+            .collect::<Vec<_>>();
+
+        Self {
+            metrics: new_metrics,
+        }
+    }
+}
+
+impl Display for MetricsSet {
+    /// format the MetricsSet as a single string
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut is_first = true;
+        for i in self.metrics.iter() {
+            if !is_first {
+                write!(f, ", ")?;
+            } else {
+                is_first = false;
+            }
+
+            write!(f, "{}", i)?;
+        }
+        Ok(())
+    }
+}
+
+/// A set of [`Metric`] for an individual "operator" (e.g. `&dyn
+/// ExecutionPlan`).
+///
+/// This structure is intended as a convenience for [`ExecutionPlan`]
+/// implementations so they can generate different streams for multiple
+/// partitions but easily report them together.
+///
+/// Each `clone()` of this structure will add metrics to the same
+/// underlying metrics set
+#[derive(Default, Debug, Clone)]
+pub struct ExecutionPlanMetricsSet {
+    inner: Arc<Mutex<MetricsSet>>,
+}
+
+impl ExecutionPlanMetricsSet {
+    /// Create a new empty shared metrics set
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(MetricsSet::new())),
+        }
+    }
+
+    /// Add the specified metric to the underlying metric set
+    pub fn register(&self, metric: Arc<Metric>) {
+        self.inner.lock().expect("not poisoned").push(metric)
+    }
+
+    /// Return a clone of the inner MetricsSet
+    pub fn clone_inner(&self) -> MetricsSet {
+        let guard = self.inner.lock().expect("not poisoned");
+        (*guard).clone()
+    }
+}
+
+/// name=value pairs identifiying a metric. This concept is called various things
+/// in various different systems:
+///
+/// "labels" in
+/// [prometheus](https://prometheus.io/docs/concepts/data_model/) and
+/// "tags" in
+/// [InfluxDB](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/)
+/// , "attributes" in [open
+/// telemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md],
+/// etc.
+///
+/// As the name and value are expected to mostly be constant strings,
+/// use a `Cow` to avoid copying / allocations in this common case.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Label {
+    name: Cow<'static, str>,
+    value: Cow<'static, str>,
+}
+
+impl Label {
+    /// Create a new Label
+    pub fn new(
+        name: impl Into<Cow<'static, str>>,
+        value: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        let name = name.into();
+        let value = value.into();
+        Self { name, value }
+    }
+}
+
+impl Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}={}", self.name, self.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_display_no_labels_no_partition() {
+        let count = Count::new();
+        count.add(33);
+        let value = MetricValue::OutputRows(count);
+        let partition = None;
+        let metric = Metric::new(value, partition);
+
+        assert_eq!("output_rows=33", metric.to_string())
+    }
+
+    #[test]
+    fn test_display_no_labels_with_partition() {
+        let count = Count::new();
+        count.add(44);
+        let value = MetricValue::OutputRows(count);
+        let partition = Some(1);
+        let metric = Metric::new(value, partition);
+
+        assert_eq!("output_rows{partition=1}=44", metric.to_string())
+    }
+
+    #[test]
+    fn test_display_labels_no_partition() {
+        let count = Count::new();
+        count.add(55);
+        let value = MetricValue::OutputRows(count);
+        let partition = None;
+        let label = Label::new("foo", "bar");
+        let metric = Metric::new_with_labels(value, partition, vec![label]);
+
+        assert_eq!("output_rows{foo=bar}=55", metric.to_string())
+    }
+
+    #[test]
+    fn test_display_labels_and_partition() {
+        let count = Count::new();
+        count.add(66);
+        let value = MetricValue::OutputRows(count);
+        let partition = Some(2);
+        let label = Label::new("foo", "bar");
+        let metric = Metric::new_with_labels(value, partition, vec![label]);
+
+        assert_eq!("output_rows{partition=2, foo=bar}=66", metric.to_string())
+    }
+
+    #[test]
+    fn test_output_rows() {
+        let metrics = ExecutionPlanMetricsSet::new();
+        assert!(metrics.clone_inner().output_rows().is_none());
+
+        let partition = 1;
+        let output_rows = MetricBuilder::new(&metrics).output_rows(partition);
+        output_rows.add(13);
+
+        let output_rows = MetricBuilder::new(&metrics).output_rows(partition + 1);
+        output_rows.add(7);
+        assert_eq!(metrics.clone_inner().output_rows().unwrap(), 20);
+    }
+
+    #[test]
+    fn test_cpu_time() {
+        let metrics = ExecutionPlanMetricsSet::new();
+        assert!(metrics.clone_inner().cpu_time().is_none());
+
+        let partition = 1;
+        let cpu_time = MetricBuilder::new(&metrics).cpu_time(partition);
+        cpu_time.add_duration(Duration::from_nanos(1234));
+
+        let cpu_time = MetricBuilder::new(&metrics).cpu_time(partition + 1);
+        cpu_time.add_duration(Duration::from_nanos(6));
+        assert_eq!(metrics.clone_inner().cpu_time().unwrap(), 1240);
+    }
+
+    #[test]
+    fn test_sum() {
+        let metrics = ExecutionPlanMetricsSet::new();
+
+        let count1 = MetricBuilder::new(&metrics)
+            .with_new_label("foo", "bar")
+            .counter("my_counter", 1);
+        count1.add(1);
+
+        let count2 = MetricBuilder::new(&metrics).counter("my_counter", 2);
+        count2.add(2);
+
+        let metrics = metrics.clone_inner();
+        assert!(metrics.sum(|_| false).is_none());
+
+        let expected_count = Count::new();
+        expected_count.add(3);
+        let expected_sum = MetricValue::Count {
+            name: "my_counter".into(),
+            count: expected_count,
+        };
+
+        assert_eq!(metrics.sum(|_| true), Some(expected_sum));
+    }
+
+    #[test]
+    #[should_panic(expected = "Mismatched metric types. Can not aggregate Count")]
+    fn test_bad_sum() {
+        // can not add different kinds of metrics
+        let metrics = ExecutionPlanMetricsSet::new();
+
+        let count = MetricBuilder::new(&metrics).counter("my_metric", 1);
+        count.add(1);
+
+        let time = MetricBuilder::new(&metrics).subset_time("my_metric", 1);
+        time.add_duration(Duration::from_nanos(10));
+
+        // expect that this will error out
+        metrics.clone_inner().sum(|_| true);
+    }
+
+    #[test]
+    fn test_aggregate_partition() {
+        let metrics = ExecutionPlanMetricsSet::new();
+
+        // Note cpu_time1 has labels so it is not aggregated with 2 and 3
+        let cpu_time1 = MetricBuilder::new(&metrics)
+            .with_new_label("foo", "bar")
+            .cpu_time(1);
+        cpu_time1.add_duration(Duration::from_nanos(12));
+
+        let cpu_time2 = MetricBuilder::new(&metrics).cpu_time(2);
+        cpu_time2.add_duration(Duration::from_nanos(34));
+
+        let cpu_time3 = MetricBuilder::new(&metrics).cpu_time(4);
+        cpu_time3.add_duration(Duration::from_nanos(56));
+
+        let output_rows = MetricBuilder::new(&metrics).output_rows(1); // output rows
+        output_rows.add(56);
+
+        let aggregated = metrics.clone_inner().aggregate_by_partition();
+
+        // cpu time should be aggregated:
+        let cpu_times = aggregated
+            .iter()
+            .filter(|metric| {
+                matches!(metric.value(), MetricValue::CPUTime(_))
+                    && metric.labels().is_empty()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cpu_times.len(), 1);
+        assert_eq!(cpu_times[0].value().as_usize(), 34 + 56);
+        assert!(cpu_times[0].partition().is_none());
+
+        // output rows should
+        let output_rows = aggregated
+            .iter()
+            .filter(|metric| matches!(metric.value(), MetricValue::OutputRows(_)))
+            .collect::<Vec<_>>();
+        assert_eq!(output_rows.len(), 1);
+        assert_eq!(output_rows[0].value().as_usize(), 56);
+        assert!(output_rows[0].partition.is_none())
+    }
+
+    #[test]
+    #[should_panic(expected = "Mismatched metric types. Can not aggregate Count")]
+    fn test_aggregate_partition_bad_sum() {
+        let metrics = ExecutionPlanMetricsSet::new();
+
+        let count = MetricBuilder::new(&metrics).counter("my_metric", 1);
+        count.add(1);
+
+        let time = MetricBuilder::new(&metrics).subset_time("my_metric", 1);
+        time.add_duration(Duration::from_nanos(10));
+
+        // can't aggregate time and count -- expect a panic
+        metrics.clone_inner().aggregate_by_partition();
+    }
+}

--- a/datafusion/src/physical_plan/metrics/value.rs
+++ b/datafusion/src/physical_plan/metrics/value.rs
@@ -1,0 +1,261 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Value representation of metrics
+
+use std::{
+    borrow::{Borrow, Cow},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+/// A counter to record things such as number of input or output rows
+///
+/// Note `clone`ing counters update the same underlying metrics
+#[derive(Debug, Clone)]
+pub struct Count {
+    /// value of the metric counter
+    value: std::sync::Arc<AtomicUsize>,
+}
+
+impl PartialEq for Count {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().eq(&other.value())
+    }
+}
+
+impl Count {
+    /// create a new counter
+    pub fn new() -> Self {
+        Self {
+            value: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Add `n` to the metric's value
+    pub fn add(&self, n: usize) {
+        // relaxed ordering for operations on `value` poses no issues
+        // we're purely using atomic ops with no associated memory ops
+        self.value.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Get the current value
+    pub fn value(&self) -> usize {
+        self.value.load(Ordering::Relaxed)
+    }
+}
+
+/// Measure a potentially non contiguous duration of time
+#[derive(Debug, Clone)]
+pub struct Time {
+    /// elapsed time, in nanoseconds
+    nanos: Arc<AtomicUsize>,
+}
+
+impl PartialEq for Time {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().eq(&other.value())
+    }
+}
+
+impl Time {
+    /// Create a new [`Time`] wrapper suitable for recording elapsed
+    /// times for operations.
+    pub fn new() -> Self {
+        Self {
+            nanos: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Add elapsed nanoseconds since `start`to self
+    pub fn add_elapsed(&self, start: Instant) {
+        self.add_duration(start.elapsed());
+    }
+
+    /// Add duration of time to self
+    pub fn add_duration(&self, duration: Duration) {
+        let more_nanos = duration.as_nanos() as usize;
+        self.nanos.fetch_add(more_nanos, Ordering::Relaxed);
+    }
+
+    /// Add the number of nanoseconds of other `Time` to self
+    pub fn add(&self, other: &Time) {
+        self.nanos.fetch_add(other.value(), Ordering::Relaxed);
+    }
+
+    /// return a scoped guard that adds the amount of time elapsed
+    /// between its creation and its drop or call to `stop` to the
+    /// underlying metric.
+    pub fn timer(&self) -> ScopedTimerGuard<'_> {
+        ScopedTimerGuard {
+            inner: self,
+            start: Some(Instant::now()),
+        }
+    }
+
+    /// Get the number of nanoseconds record by this Time metric
+    pub fn value(&self) -> usize {
+        self.nanos.load(Ordering::Relaxed)
+    }
+}
+
+/// RAAI structure that adds all time between its construction and
+/// destruction to the CPU time or the first call to `stop` whichever
+/// comes first
+pub struct ScopedTimerGuard<'a> {
+    inner: &'a Time,
+    start: Option<Instant>,
+}
+
+impl<'a> ScopedTimerGuard<'a> {
+    /// Stop the timer timing and record the time taken
+    pub fn stop(&mut self) {
+        if let Some(start) = self.start.take() {
+            self.inner.add_elapsed(start)
+        }
+    }
+
+    /// Stop the timer, record the time taken and consume self
+    pub fn done(mut self) {
+        self.stop()
+    }
+}
+
+impl<'a> Drop for ScopedTimerGuard<'a> {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+/// Possible values for a metric.
+///
+/// Among other differences, the metric types have different ways to
+/// logically interpret their underlying values and some metrics are
+/// so common they are given special treatment.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricValue {
+    /// Number of output rows produced: "output_rows" metric
+    OutputRows(Count),
+    /// CPU time: the "cpu_time" metric
+    CPUTime(Time),
+    /// Operator defined count.
+    Count {
+        /// The provided name of this metric
+        name: Cow<'static, str>,
+        /// The value of the metric
+        count: Count,
+    },
+    /// Operator defined time
+    Time {
+        /// The provided name of this metric
+        name: Cow<'static, str>,
+        /// The value of the metric
+        time: Time,
+    },
+    // TODO timestamp, etc
+    // https://github.com/apache/arrow-datafusion/issues/866
+}
+
+impl MetricValue {
+    /// Return the name of this SQL metric
+    pub fn name(&self) -> &str {
+        match self {
+            Self::OutputRows(_) => "output_rows",
+            Self::CPUTime(_) => "cpu_time",
+            Self::Count { name, .. } => name.borrow(),
+            Self::Time { name, .. } => name.borrow(),
+        }
+    }
+
+    /// Return the value of the metric as a usize value
+    pub fn as_usize(&self) -> usize {
+        match self {
+            Self::OutputRows(count) => count.value(),
+            Self::CPUTime(time) => time.value(),
+            Self::Count { count, .. } => count.value(),
+            Self::Time { time, .. } => time.value(),
+        }
+    }
+
+    /// create a new MetricValue with the same type as `self` suitable
+    /// for accumulating
+    pub fn new_empty(&self) -> Self {
+        match self {
+            Self::OutputRows(_) => Self::OutputRows(Count::new()),
+            Self::CPUTime(_) => Self::CPUTime(Time::new()),
+            Self::Count { name, .. } => Self::Count {
+                name: name.clone(),
+                count: Count::new(),
+            },
+            Self::Time { name, .. } => Self::Time {
+                name: name.clone(),
+                time: Time::new(),
+            },
+        }
+    }
+
+    /// Add the value of other to `self`. panic's if the type is mismatched or
+    /// aggregating does not make sense for this value
+    ///
+    /// Note this is purposely marked `mut` (even though atomics are
+    /// used) so Rust's type system can be used to ensure the
+    /// appropriate API access. `MetricValues` should be modified
+    /// using the original [`Count`] or [`Time`] they were created
+    /// from.
+    pub fn add(&mut self, other: &Self) {
+        match (self, other) {
+            (Self::OutputRows(count), Self::OutputRows(other_count))
+            | (
+                Self::Count { count, .. },
+                Self::Count {
+                    count: other_count, ..
+                },
+            ) => count.add(other_count.value()),
+            (Self::CPUTime(time), Self::CPUTime(other_time))
+            | (
+                Self::Time { time, .. },
+                Self::Time {
+                    time: other_time, ..
+                },
+            ) => time.add(other_time),
+            m @ (_, _) => {
+                panic!(
+                    "Mismatched metric types. Can not aggregate {:?} with value {:?}",
+                    m.0, m.1
+                )
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for MetricValue {
+    /// Prints the value of this metric
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutputRows(count) | Self::Count { count, .. } => {
+                write!(f, "{}", count.value())
+            }
+            Self::CPUTime(time) | Self::Time { time, .. } => {
+                let duration = std::time::Duration::from_nanos(time.value() as u64);
+                write!(f, "{:?}", duration)
+            }
+        }
+    }
+}

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2172,6 +2172,8 @@ async fn csv_explain_analyze() {
     let formatted = arrow::util::pretty::pretty_format_batches(&actual).unwrap();
     let formatted = normalize_for_explain(&formatted);
 
+    println!("ANALYZE EXPLAIN:\n{}", formatted);
+
     // Only test basic plumbing and try to avoid having to change too
     // many things
     let needle = "RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES), metrics=[";
@@ -2181,7 +2183,7 @@ async fn csv_explain_analyze() {
         needle,
         formatted
     );
-    let verbose_needle = "Output Rows       | 5";
+    let verbose_needle = "Output Rows";
     assert!(
         !formatted.contains(verbose_needle),
         "found unexpected '{}' in\n{}",
@@ -2201,7 +2203,7 @@ async fn csv_explain_analyze_verbose() {
     let formatted = arrow::util::pretty::pretty_format_batches(&actual).unwrap();
     let formatted = normalize_for_explain(&formatted);
 
-    let verbose_needle = "Output Rows       | 5";
+    let verbose_needle = "Output Rows";
     assert!(
         formatted.contains(verbose_needle),
         "did not find '{}' in\n{}",


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/679. See https://github.com/apache/arrow-datafusion/pull/901 for an earlier version with feedback from @tustvold  and @andygrove 

 # Rationale for this change
See the description on https://github.com/apache/arrow-datafusion/issues/679#issue-937015511 for the full rationale, but the TLDR version is:
1. Better align the metric data model with industry best practice to ease integration in other metric systems (e.g. prometheus, influxdb, etc)
2. Ability to get per-partition metrics
3. Ability to get current metric values *during* execution without allocation


# What changes are included in this PR?
1. Update the `SQLMetric` API to be in its own module, have labels, know about partitions, and allow for real time inspection
2. Rename `SQLMetric` --> `Metric` 
2. Update uses of metrics in DataFusion and Ballista to the new API 
2. Functionality to aggregate (sum) metrics via predicate and via partition (as requested by @Dandandan  in https://github.com/apache/arrow-datafusion/issues/679#issuecomment-874341354 and @andygrove  in https://github.com/apache/arrow-datafusion/issues/679#issuecomment-874187741)
3. Rename metric names to snake case (`output_rows`) rather than camel 🐫  case  (`outputRows`) to conform to Rust expectations (see note from @andygrove  on the reason the names were camelCase to begin with: https://github.com/apache/arrow-datafusion/pull/901#issuecomment-901362155)


# Are there any user-facing changes?
YES! 

The `SQLMetric` / `Metric` API is now totally different so any code that creates / uses `SQLMetrics` would have to be updated. The updates are fairly mechanical as you can see in this PR)

# Notes
In keeping with Rust's tradition of static typing, I also changed to using more strongly typed versions of the metric values to avoid mistakes such as adding a "time" to a counter value, as well as allowing other counter specific operations.

Also, as the metrics aren't specific to SQL (they apply to any ExecutionPlan, even if that plan was created via the DataFrame API or the LogicalPlanBuilder) I renamed `SQLMetric` --> `Metric`

# Not included in this PR:
1. Ensure that all operators have reasonable metrics: (I plan this in a follow on PR for #866, using this API)
2. Support for a global "operator id" as described by @andygrove in https://github.com/apache/arrow-datafusion/issues/679#issuecomment-874187741
