### PR TITLE
WIP Optimize hash_aggregate when there are no null group keys

### DIFF
--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -365,10 +365,16 @@ fn group_aggregate_batch(
             // actually the same key value as the group in
             // existing_idx  (aka group_values @ row)
             let group_state = &group_states[*group_idx];
-            group_values
-                .iter()
-                .zip(group_state.group_by_values.iter())
-                .all(|(array, scalar)| scalar.eq_array(array, row))
+                group_values
+                    .iter()
+                    .zip(group_state.group_by_values.iter())
+                    .all(|(array, scalar)| {
+                        if array.null_count() > 0 {
+                            scalar.eq_array(array, row)
+                        } else {
+                            scalar.eq_array_no_nulls(array, row)
+                        }
+                    })
         });
 
         match entry {

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -435,6 +435,16 @@ macro_rules! eq_array_primitive {
     }};
 }
 
+macro_rules! eq_array_no_nulls_primitive {
+    ($array:expr, $index:expr, $ARRAYTYPE:ident, $VALUE:expr) => {{
+        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
+        match $VALUE {
+            Some(val) => &array.value($index) == val,
+            None => false,
+        }
+    }};
+}
+
 impl ScalarValue {
     /// Getter for the `DataType` of the value
     pub fn get_datatype(&self) -> DataType {
@@ -1094,6 +1104,78 @@ impl ScalarValue {
             }
         }
     }
+
+
+    /// an unsafe version of `eq_array` optimised for the situation
+    /// where we know in advance that the array has no nulls
+    #[inline]
+    pub fn eq_array_no_nulls(&self, array: &ArrayRef, index:usize) -> bool {
+        if let DataType::Dictionary(key_type, _) = array.data_type() {
+            return self.eq_array_dictionary(array, index, key_type);
+        }
+
+        match self {
+            ScalarValue::Boolean(val) => {
+                eq_array_no_nulls_primitive!(array, index, BooleanArray, val)
+            }
+            ScalarValue::Float32(val) => {
+                eq_array_no_nulls_primitive!(array, index, Float32Array, val)
+            }
+            ScalarValue::Float64(val) => {
+                eq_array_no_nulls_primitive!(array, index, Float64Array, val)
+            }
+            ScalarValue::Int8(val) => eq_array_no_nulls_primitive!(array, index, Int8Array, val),
+            ScalarValue::Int16(val) => eq_array_no_nulls_primitive!(array, index, Int16Array, val),
+            ScalarValue::Int32(val) => eq_array_no_nulls_primitive!(array, index, Int32Array, val),
+            ScalarValue::Int64(val) => eq_array_no_nulls_primitive!(array, index, Int64Array, val),
+            ScalarValue::UInt8(val) => eq_array_no_nulls_primitive!(array, index, UInt8Array, val),
+            ScalarValue::UInt16(val) => {
+                eq_array_no_nulls_primitive!(array, index, UInt16Array, val)
+            }
+            ScalarValue::UInt32(val) => {
+                eq_array_no_nulls_primitive!(array, index, UInt32Array, val)
+            }
+            ScalarValue::UInt64(val) => {
+                eq_array_no_nulls_primitive!(array, index, UInt64Array, val)
+            }
+            ScalarValue::Utf8(val) => eq_array_no_nulls_primitive!(array, index, StringArray, val),
+            ScalarValue::LargeUtf8(val) => {
+                eq_array_no_nulls_primitive!(array, index, LargeStringArray, val)
+            }
+            ScalarValue::Binary(val) => {
+                eq_array_no_nulls_primitive!(array, index, BinaryArray, val)
+            }
+            ScalarValue::LargeBinary(val) => {
+                eq_array_no_nulls_primitive!(array, index, LargeBinaryArray, val)
+            }
+            ScalarValue::List(_, _) => unimplemented!(),
+            ScalarValue::Date32(val) => {
+                eq_array_no_nulls_primitive!(array, index, Date32Array, val)
+            }
+            ScalarValue::Date64(val) => {
+                eq_array_no_nulls_primitive!(array, index, Date64Array, val)
+            }
+            ScalarValue::TimestampSecond(val) => {
+                eq_array_no_nulls_primitive!(array, index, TimestampSecondArray, val)
+            }
+            ScalarValue::TimestampMillisecond(val) => {
+                eq_array_no_nulls_primitive!(array, index, TimestampMillisecondArray, val)
+            }
+            ScalarValue::TimestampMicrosecond(val) => {
+                eq_array_no_nulls_primitive!(array, index, TimestampMicrosecondArray, val)
+            }
+            ScalarValue::TimestampNanosecond(val) => {
+                eq_array_no_nulls_primitive!(array, index, TimestampNanosecondArray, val)
+            }
+            ScalarValue::IntervalYearMonth(val) => {
+                eq_array_no_nulls_primitive!(array, index, IntervalYearMonthArray, val)
+            }
+            ScalarValue::IntervalDayTime(val) => {
+                eq_array_no_nulls_primitive!(array, index, IntervalDayTimeArray, val)
+            }
+        }
+    }
+
 
     /// Compares a dictionary array with indexes of type `key_type`
     /// with the array @ index for equality with self


### PR DESCRIPTION
ref #850 

WIP - for purposes of discussion and feedback.

@alamb I have done the simplest possible thing to get the branching code path that avoids the `is_valid` check. However, I'd appreciate some input on how best to proceed:

- I'd like to figure out how best to refactor this code to reduce duplication. I'm not sure that the duplication is that bad in the first place. If we were to improve it, is this best done via an additional macro, or perhaps by changing the API of `eq_array` to take an additional parameter that signals whether the array has no-nulls.
- How do I test `eq_array_no_nulls`? Should I look to follow the test for `eq_array`?

Thanks much in advance for the guidance and input.