### PR TITLE
automate ballista version update in user doc

### DIFF
--- a/dev/update_ballista_versions.py
+++ b/dev/update_ballista_versions.py
@@ -55,6 +55,17 @@ def update_cargo_toml(cargo_toml: str, new_version: str):
         f.write(tomlkit.dumps(doc))
 
 
+def update_docker_compose(docker_compose_path: str, new_version: str):
+    print(f'Updating ballista versions in {docker_compose_path}')
+    with open(docker_compose_path, "r+") as fd:
+        data = fd.read()
+        pattern = re.compile(r'(^\s+image:\sballista:)\d+\.\d+\.\d+(-SNAPSHOT)?', re.MULTILINE)
+        data = pattern.sub(r"\g<1>"+new_version, data)
+        fd.truncate(0)
+        fd.seek(0)
+        fd.write(data)
+
+
 def main():
     parser = argparse.ArgumentParser(description='Update ballista crate versions.')
     parser.add_argument('new_version', type=str, help='new ballista version')
@@ -78,15 +89,9 @@ def main():
     for cargo_toml in ballista_crates:
         update_cargo_toml(cargo_toml, new_version)
 
-    docker_compose_path = os.path.join(repo_root, "benchmarks/docker-compose.yaml")
-    print(f'Updating ballista versions in {docker_compose_path}')
-    with open(docker_compose_path, "r+") as fd:
-        data = fd.read()
-        pattern = re.compile(r'(^\s+image:\sballista:)\d+\.\d+\.\d+(-SNAPSHOT)?', re.MULTILINE)
-        data = pattern.sub(r"\g<1>"+new_version, data)
-        fd.truncate(0)
-        fd.seek(0)
-        fd.write(data)
+    for path in ("benchmarks/docker-compose.yaml", "docs/user-guide/src/distributed/docker-compose.md"):
+        path = os.path.join(repo_root, path)
+        update_docker_compose(path, new_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Rationale for this change

Follow up for https://github.com/apache/arrow-datafusion/pull/919

# What changes are included in this PR?

Update ballista version bump script to also update ballista version in user doc.

I left out the update for the base docker file because the base file will be removed when https://github.com/apache/arrow-datafusion/pull/688 is merged.

# Are there any user-facing changes?

no