### PR TITLE
build python wheels for release rc tags

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -15,11 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Build
+name: Python Release Build
 on:
   push:
     tags:
-      - v*
+      - '*-rc*'
+
+defaults:
+  run:
+    working-directory: ./python
 
 jobs:
   build-python-mac-win:
@@ -28,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6"]
         os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,18 +48,18 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin
+          pip install maturin==0.11.2
 
       - name: Build Python package
-        run: cd python && maturin build --release --no-sdist --strip --interpreter python${{matrix.python_version}}
+        run: maturin build --release --no-sdist --strip
 
-      - name: List wheels
+      - name: List Windows wheels
         if: matrix.os == 'windows-latest'
-        run: dir python/target\wheels\
+        run: dir target\wheels\
 
-      - name: List wheels
+      - name: List Mac wheels
         if: matrix.os != 'windows-latest'
-        run: find ./python/target/wheels/
+        run: find target/wheels/
 
       - name: Archive wheels
         uses: actions/upload-artifact@v2
@@ -69,21 +73,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels
-        run: docker run --rm -v $(pwd):/io konstin2/maturin build --release --manylinux
+        run: |
+          docker run --rm -v $(pwd):/io \
+            konstin2/maturin:v0.11.2 \
+            build --release --manylinux 2010
       - name: Archive wheels
         uses: actions/upload-artifact@v2
         with:
           name: dist
           path: python/target/wheels/*
 
-  release:
-    name: Publish in PyPI
-    needs: [build-manylinux, build-python-mac-win]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+  # NOTE: PyPI publish needs to be done manually for now after release passed the vote
+  # release:
+  #   name: Publish in PyPI
+  #   needs: [build-manylinux, build-python-mac-win]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #     - name: Publish to PyPI
+  #       uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.pypi_password }}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2018"
 libc = "0.2"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 rand = "0.7"
-pyo3 = { version = "0.14.1", features = ["extension-module"] }
+pyo3 = { version = "0.14.1", features = ["extension-module", "abi3", "abi3-py36"] }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4d61196dee8526998aee7e7bb10ea88422e5f9e1" }
 
 [lib]


### PR DESCRIPTION
# Which issue does this PR close?

close https://github.com/apache/arrow-datafusion/issues/921

 # Rationale for this change

Update python release build to get ready for 0.3.0 release.

# What changes are included in this PR?

* Build abi3 python wheels for datafusion binding (single wheel file per platform targeting python >= 3.6)
* Update pipeline trigger to watch release rc tag push

https://github.com/houqp/arrow-datafusion/actions/runs/1156782355 contains an example of the abi3 wheel build.

The new python release workflow will work like this:

* push 5.1.0-rc0 tag
* wait for wheel build job to complete
* download wheels to local machine (through create-tarbarll.sh)
* sign datafusion source and binaries wheels (through create-tarball.sh)
* publish signed artifacts to svn (through create-tarball.sh)
* create voting thread in dev list for voting

# Are there any user-facing changes?

no
