### PR TITLE
EXPLAIN ANALYZE should run all Optimizer passes

### DIFF
--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -195,11 +195,21 @@ pub fn from_plan(
             schema: schema.clone(),
             alias: alias.clone(),
         }),
+        LogicalPlan::Analyze {
+            verbose, schema, ..
+        } => {
+            assert!(expr.is_empty());
+            assert_eq!(inputs.len(), 1);
+            Ok(LogicalPlan::Analyze {
+                verbose: *verbose,
+                schema: schema.clone(),
+                input: Arc::new(inputs[0].clone()),
+            })
+        }
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
-        | LogicalPlan::Explain { .. }
-        | LogicalPlan::Analyze { .. } => Ok(plan.clone()),
+        | LogicalPlan::Explain { .. } => Ok(plan.clone()),
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?
Fixes https://github.com/apache/arrow-datafusion/issues/917 found by @Dandandan 


# Rationale for this change
1. `EXPLAIN ANALYZE` should run the same plan as normal execution

# What changes are included in this PR?
1. Fix bug
2. Add test
3. Add `assert_contains!` macro in sql.rs (from IOx) to make the testing less repetitious


# Are there any user-facing changes?
Bug is fixed