### PR TITLE
Add some additional asserts in `utils::from_plan`

### DIFF
--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -206,10 +206,28 @@ pub fn from_plan(
                 input: Arc::new(inputs[0].clone()),
             })
         }
+        LogicalPlan::Explain { .. } => {
+            // Explain shoudl be handled specially in the optimizers;
+            // If this assert fails it means some optimizer pass is
+            // trying to optimize Explain directly
+            assert!(
+                expr.is_empty(),
+                "Explain can not be created from utils::from_expr"
+            );
+            assert!(
+                inputs.is_empty(),
+                "Explain can not be created from utils::from_expr"
+            );
+            Ok(plan.clone())
+        }
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }
-        | LogicalPlan::CreateExternalTable { .. }
-        | LogicalPlan::Explain { .. } => Ok(plan.clone()),
+        | LogicalPlan::CreateExternalTable { .. } => {
+            // All of these plan types have no inputs / exprs so should not be called
+            assert!(expr.is_empty(), "{:?} should have no exprs", plan);
+            assert!(inputs.is_empty(), "{:?}  should have no inputs", plan);
+            Ok(plan.clone())
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Re: https://github.com/apache/arrow-datafusion/issues/917

 # Rationale for this change
https://github.com/apache/arrow-datafusion/issues/917 was due to mishandling a newly added `LogicalPlan` node in `utils::from_plan`

# What changes are included in this PR?
1. Make it harder to introduce such bugs in the future by adding asserts

# Are there any user-facing changes?
no