### PR TITLE
Update to sqlparser v 0.10.0

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -37,7 +37,7 @@ hashbrown = "0.11"
 log = "0.4"
 prost = "0.8"
 serde = {version = "1", features = ["derive"]}
-sqlparser = "0.9.0"
+sqlparser = "0.10.0"
 tokio = "1.0"
 tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -51,7 +51,7 @@ ahash = "0.7"
 hashbrown = { version = "0.11", features = ["raw"] }
 arrow = { version = "^5.2", features = ["prettyprint"] }
 parquet = { version = "^5.2", features = ["arrow"] }
-sqlparser = "0.10.0"
+sqlparser = "0.10"
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -51,7 +51,7 @@ ahash = "0.7"
 hashbrown = { version = "0.11", features = ["raw"] }
 arrow = { version = "^5.2", features = ["prettyprint"] }
 parquet = { version = "^5.2", features = ["arrow"] }
-sqlparser = "0.9.0"
+sqlparser = "0.10.0"
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -587,7 +587,7 @@ impl Expr {
     /// Calculate the modulus of two expressions.
     /// Return `self % other`
     pub fn modulus(self, other: Expr) -> Expr {
-        binary_expr(self, Operator::Modulus, other)
+        binary_expr(self, Operator::Modulo, other)
     }
 
     /// Return `self LIKE other`

--- a/datafusion/src/logical_plan/operators.rs
+++ b/datafusion/src/logical_plan/operators.rs
@@ -43,7 +43,7 @@ pub enum Operator {
     /// Division operator, like `/`
     Divide,
     /// Remainder operator, like `%`
-    Modulus,
+    Modulo,
     /// Logical AND, like `&&`
     And,
     /// Logical OR, like `||`
@@ -67,7 +67,7 @@ impl fmt::Display for Operator {
             Operator::Minus => "-",
             Operator::Multiply => "*",
             Operator::Divide => "/",
-            Operator::Modulus => "%",
+            Operator::Modulo => "%",
             Operator::And => "AND",
             Operator::Or => "OR",
             Operator::Like => "LIKE",

--- a/datafusion/src/physical_plan/expressions/binary.rs
+++ b/datafusion/src/physical_plan/expressions/binary.rs
@@ -365,7 +365,7 @@ fn common_binary_type(
         // because coercion favours higher information types
         Operator::Plus
         | Operator::Minus
-        | Operator::Modulus
+        | Operator::Modulo
         | Operator::Divide
         | Operator::Multiply => numerical_coercion(lhs_type, rhs_type),
     };
@@ -412,7 +412,7 @@ pub fn binary_operator_data_type(
         | Operator::Minus
         | Operator::Divide
         | Operator::Multiply
-        | Operator::Modulus => Ok(common_type),
+        | Operator::Modulo => Ok(common_type),
     }
 }
 
@@ -472,7 +472,7 @@ impl PhysicalExpr for BinaryExpr {
                     Operator::Divide => {
                         binary_primitive_array_op_scalar!(array, scalar.clone(), divide)
                     }
-                    Operator::Modulus => {
+                    Operator::Modulo => {
                         binary_primitive_array_op_scalar!(array, scalar.clone(), modulus)
                     }
                     // if scalar operation is not supported - fallback to array implementation
@@ -524,7 +524,7 @@ impl PhysicalExpr for BinaryExpr {
             Operator::Minus => binary_primitive_array_op!(left, right, subtract),
             Operator::Multiply => binary_primitive_array_op!(left, right, multiply),
             Operator::Divide => binary_primitive_array_op!(left, right, divide),
-            Operator::Modulus => binary_primitive_array_op!(left, right, modulus),
+            Operator::Modulo => binary_primitive_array_op!(left, right, modulus),
             Operator::And => {
                 if left_data_type == DataType::Boolean {
                     boolean_op!(left, right, and_kleene)
@@ -1008,7 +1008,7 @@ mod tests {
         apply_arithmetic::<Int32Type>(
             schema,
             vec![a, b],
-            Operator::Modulus,
+            Operator::Modulo,
             Int32Array::from(vec![0, 0, 2, 8, 0]),
         )?;
 

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1274,6 +1274,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 })
             }
 
+            SQLExpr::Trim { expr, trim_where } => {
+                let fun = match trim_where {
+                    Some((trim_where, _expr)) => {
+                        return Err(DataFusionError::Plan(format!(
+                            "TRIM {} is not yet supported ",
+                            trim_where
+                        )))
+                    }
+                    None => functions::BuiltinScalarFunction::Trim,
+                };
+
+                let arg = self.sql_expr_to_logical_expr(expr, schema)?;
+                Ok(Expr::ScalarFunction {
+                    fun,
+                    args: vec![arg],
+                })
+            }
+
             SQLExpr::Function(function) => {
                 let name = if function.name.0.len() > 1 {
                     // DF doesn't handle compound identifiers

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1256,7 +1256,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     BinaryOperator::Minus => Ok(Operator::Minus),
                     BinaryOperator::Multiply => Ok(Operator::Multiply),
                     BinaryOperator::Divide => Ok(Operator::Divide),
-                    BinaryOperator::Modulus => Ok(Operator::Modulus),
+                    BinaryOperator::Modulo => Ok(Operator::Modulo),
                     BinaryOperator::And => Ok(Operator::And),
                     BinaryOperator::Or => Ok(Operator::Or),
                     BinaryOperator::Like => Ok(Operator::Like),


### PR DESCRIPTION
# Which issue does this PR close?
related to https://github.com/apache/arrow-datafusion/issues/795


 # Rationale for this change
 Get SQL support for regular expression matching added by @b41sh in https://github.com/ballista-compute/sqlparser-rs/pull/328, thus unblocking https://github.com/apache/arrow-datafusion/pull/870.


# What changes are included in this PR?
1. Update dependency to sqlparser v 0.10.0
2. Update datafusion code for new version
3. Rename `Operator::Modulus` to `Operator::Modulo` to match change in SQL in https://github.com/sqlparser-rs/sqlparser-rs/pull/335


# Are there any user-facing changes?
`Operator::Modulus` --> `Operator::Modulo`
