### PR TITLE
[Python] - Support show function for DataFrame api of python library

### DIFF
--- a/python/src/dataframe.rs
+++ b/python/src/dataframe.rs
@@ -146,9 +146,7 @@ impl DataFrame {
         let ctx = _ExecutionContext::from(self.ctx_state.clone());
         let plan = ctx
             .optimize(&self.limit(num)?.plan)
-            .map_err(|e| -> errors::DataFusionError { e.into() })?;
-        let plan = ctx
-            .create_physical_plan(&plan)
+            .and_then(|plan| ctx.create_physical_plan(&plan))
             .map_err(|e| -> errors::DataFusionError { e.into() })?;
 
         let rt = Runtime::new().unwrap();

--- a/python/src/dataframe.rs
+++ b/python/src/dataframe.rs
@@ -28,6 +28,7 @@ use datafusion::{execution::context::ExecutionContextState, logical_plan};
 
 use crate::{errors, to_py};
 use crate::{errors::DataFusionError, expression};
+use datafusion::arrow::util::pretty;
 
 /// A DataFrame is a representation of a logical plan and an API to compose statements.
 /// Use it to build a plan and `.collect()` to execute the plan and collect the result.
@@ -138,6 +139,30 @@ impl DataFrame {
         })?;
         to_py::to_py(&batches)
     }
+
+    /// Print the result, 20 lines by default
+    #[args(num = "20")]
+    fn show(&self, py: Python, num: usize) -> PyResult<()> {
+        let ctx = _ExecutionContext::from(self.ctx_state.clone());
+        let plan = ctx
+            .optimize(&self.limit(num)?.plan)
+            .map_err(|e| -> errors::DataFusionError { e.into() })?;
+        let plan = ctx
+            .create_physical_plan(&plan)
+            .map_err(|e| -> errors::DataFusionError { e.into() })?;
+
+        let rt = Runtime::new().unwrap();
+        let batches = py.allow_threads(|| {
+            rt.block_on(async {
+                collect(plan)
+                    .await
+                    .map_err(|e| -> errors::DataFusionError { e.into() })
+            })
+        })?;
+
+        Ok(pretty::print_batches(&batches).unwrap())
+    }
+
 
     /// Returns the join of two DataFrames `on`.
     fn join(&self, right: &DataFrame, on: Vec<&str>, how: &str) -> PyResult<Self> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #941

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `show` function for DataFrame api of python library

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Users can directly print the query results by calling the show function.

```python
import pyarrow as pa
from datafusion import ExecutionContext

ctx = ExecutionContext()

batch = pa.RecordBatch.from_arrays(
    [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
    names=["a", "b"],
)

df = ctx.create_dataframe([[batch]])
df.show(10)

```

Result

```
+---+---+
| a | b |
+---+---+
| 1 | 4 |
| 2 | 5 |
| 3 | 6 |
+---+---+
```