### PR TITLE
Fix metric name typo

### DIFF
--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -142,7 +142,7 @@ impl HashJoinMetrics {
         let input_rows = MetricBuilder::new(metrics).counter("input_rows", partition);
 
         let output_batches =
-            MetricBuilder::new(metrics).counter("output_rows", partition);
+            MetricBuilder::new(metrics).counter("output_batches", partition);
 
         let output_rows = MetricBuilder::new(metrics).output_rows(partition);
 


### PR DESCRIPTION
# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/940

 # Rationale for this change

As metrics are now typed, and grouping is done by partition, the types of all counters with the same name must match otherwise a `panic!` results

# What changes are included in this PR?
Fix a typo in the name of a HashJoin metrics.

Note as part of #866 I plan to revisit the metrics for HashJoin and will add a proper test at that time.

# Are there any user-facing changes?
fixed metric name