### PR TITLE
Update plan_query_stages doc

### DIFF
--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -57,8 +57,6 @@ impl DistributedPlanner {
     /// Returns a vector of ExecutionPlans, where the root node is a [ShuffleWriterExec].
     /// Plans that depend on the input of other plans will have leaf nodes of type [UnresolvedShuffleExec].
     /// A [ShuffleWriterExec] is created whenever the partitioning changes.
-    ///
-    /// Returns an empty vector if the execution_plan doesn't need to be sliced into several stages.
     pub fn plan_query_stages(
         &mut self,
         job_id: &str,


### PR DESCRIPTION
 # Rationale for this change
I don't think the result of `DistributedPlanner.plan_query_stages()` can be an empty vector: if the plan does not need to be sliced it is still wrapped into a `ShuffleWriterExec` and returned as such.

# What changes are included in this PR?
Doc update

# Are there any user-facing changes?
No
