### PR TITLE
Remove GetFileMetadata

### DIFF
--- a/ballista/docs/architecture.md
+++ b/ballista/docs/architecture.md
@@ -50,7 +50,6 @@ The scheduler process implements a gRPC interface (defined in
 | -------------------- | -------------------------------------------------------------------- |
 | ExecuteQuery         | Submit a logical query plan or SQL query for execution               |
 | GetExecutorsMetadata | Retrieves a list of executors that have registered with a scheduler  |
-| GetFileMetadata      | Retrieve metadata about files available in the cluster file system   |
 | GetJobStatus         | Get the status of a submitted query                                  |
 | RegisterExecutor     | Executors call this method to register themselves with the scheduler |
 

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -913,25 +913,9 @@ message GetJobStatusResult {
   JobStatus status = 1;
 }
 
-message GetFileMetadataParams {
-  string path = 1;
-  FileType file_type = 2;
-}
-
-message GetFileMetadataResult {
-  Schema schema = 1;
-  repeated FilePartitionMetadata partitions = 2;
-}
-
-message FilePartitionMetadata {
-  repeated string filename = 1;
-}
-
 service SchedulerGrpc {
   // Executors must poll the scheduler for heartbeat and to receive tasks
   rpc PollWork (PollWorkParams) returns (PollWorkResult) {}
-
-  rpc GetFileMetadata (GetFileMetadataParams) returns (GetFileMetadataResult) {}
 
   rpc ExecuteQuery (ExecuteQueryParams) returns (ExecuteQueryResult) {}
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #963 .

 # Rationale for this change

Ballista doesn't own a cluster file system, and the RPC `GetFileMetadata` is not used

# What changes are included in this PR?

Remove `GetFileMetadata` RPC and related types.

# Are there any user-facing changes?
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
