### PR TITLE
Rename NthValue::{first_value,last_value,nth_value} to satisfy clippy in Rust 1.55

### DIFF
--- a/datafusion/src/physical_plan/expressions/nth_value.rs
+++ b/datafusion/src/physical_plan/expressions/nth_value.rs
@@ -50,7 +50,7 @@ pub struct NthValue {
 
 impl NthValue {
     /// Create a new FIRST_VALUE window aggregate function
-    pub fn first_value(
+    pub fn first(
         name: impl Into<String>,
         expr: Arc<dyn PhysicalExpr>,
         data_type: DataType,
@@ -64,7 +64,7 @@ impl NthValue {
     }
 
     /// Create a new LAST_VALUE window aggregate function
-    pub fn last_value(
+    pub fn last(
         name: impl Into<String>,
         expr: Arc<dyn PhysicalExpr>,
         data_type: DataType,
@@ -78,7 +78,7 @@ impl NthValue {
     }
 
     /// Create a new NTH_VALUE window aggregate function
-    pub fn nth_value(
+    pub fn nth(
         name: impl Into<String>,
         expr: Arc<dyn PhysicalExpr>,
         data_type: DataType,
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn first_value() -> Result<()> {
-        let first_value = NthValue::first_value(
+        let first_value = NthValue::first(
             "first_value".to_owned(),
             Arc::new(Column::new("arr", 0)),
             DataType::Int32,
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn last_value() -> Result<()> {
-        let last_value = NthValue::last_value(
+        let last_value = NthValue::last(
             "last_value".to_owned(),
             Arc::new(Column::new("arr", 0)),
             DataType::Int32,
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn nth_value_1() -> Result<()> {
-        let nth_value = NthValue::nth_value(
+        let nth_value = NthValue::nth(
             "nth_value".to_owned(),
             Arc::new(Column::new("arr", 0)),
             DataType::Int32,
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn nth_value_2() -> Result<()> {
-        let nth_value = NthValue::nth_value(
+        let nth_value = NthValue::nth(
             "nth_value".to_owned(),
             Arc::new(Column::new("arr", 0)),
             DataType::Int32,

--- a/datafusion/src/physical_plan/windows/mod.rs
+++ b/datafusion/src/physical_plan/windows/mod.rs
@@ -129,19 +129,19 @@ fn create_built_in_window_expr(
                 .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
             let n: u32 = n as u32;
             let data_type = args[0].data_type(input_schema)?;
-            Arc::new(NthValue::nth_value(name, arg, data_type, n)?)
+            Arc::new(NthValue::nth(name, arg, data_type, n)?)
         }
         BuiltInWindowFunction::FirstValue => {
             let arg =
                 coerce(args, input_schema, &signature_for_built_in(fun))?[0].clone();
             let data_type = args[0].data_type(input_schema)?;
-            Arc::new(NthValue::first_value(name, arg, data_type))
+            Arc::new(NthValue::first(name, arg, data_type))
         }
         BuiltInWindowFunction::LastValue => {
             let arg =
                 coerce(args, input_schema, &signature_for_built_in(fun))?[0].clone();
             let data_type = args[0].data_type(input_schema)?;
-            Arc::new(NthValue::last_value(name, arg, data_type))
+            Arc::new(NthValue::last(name, arg, data_type))
         }
         _ => {
             return Err(DataFusionError::NotImplemented(format!(


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/985

 # Rationale for this change
CI should be clean


# What changes are included in this PR?
I tried to port the changes from  @Igosuki in #910  to minimize merge conflicts

# Are there any user-facing changes?
function names change in `NthValue`
