### PR TITLE
dependencies: update etcd-client to 0.7

### DIFF
--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -37,7 +37,7 @@ clap = "2"
 configure_me = "0.4.0"
 datafusion = { path = "../../../datafusion", version = "5.1.0" }
 env_logger = "0.8"
-etcd-client = { version = "0.6", optional = true }
+etcd-client = { version = "0.7", optional = true }
 futures = "0.3"
 http = "0.2"
 http-body = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #990 

 # Rationale for this change
Repository is using two different prost versions through transitive dependencies

# What changes are included in this PR?
etcd-client is updated to 0.7 which brings prost to 0.8 

# Are there any user-facing changes?
 
None, besides being able to build this on nightly again
