### PR TITLE
manage python binding metadata with pyproject.toml

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -18,6 +18,8 @@
 name: Python Release Build
 on:
   push:
+    tags:
+      - "*-rc*"
 
 defaults:
   run:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -18,15 +18,30 @@
 name: Python Release Build
 on:
   push:
-    tags:
-      - "*-rc*"
 
 defaults:
   run:
     working-directory: ./python
 
 jobs:
+  generate-license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Generate license file
+        run: python ../dev/create_license.py
+      - uses: actions/upload-artifact@v2
+        with:
+          name: python-wheel-license
+          path: python/LICENSE.txt
+
   build-python-mac-win:
+    needs: [generate-license]
     name: Mac/Win
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,6 +65,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install maturin==0.11.2
 
+      - run: rm LICENSE.txt
+      - name: Download LICENSE.txt
+        uses: actions/download-artifact@v2
+        with:
+          name: python-wheel-license
+          path: python
+
       - name: Build Python package
         run: maturin build --release --no-sdist --strip
 
@@ -68,13 +90,22 @@ jobs:
           path: python/target/wheels/*
 
   build-manylinux:
+    needs: [generate-license]
     name: Manylinux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: rm LICENSE.txt
+      - name: Download LICENSE.txt
+        uses: actions/download-artifact@v2
+        with:
+          name: python-wheel-license
+          path: python
+      - run: cat LICENSE.txt
       - name: Build wheels
         run: |
-          docker run --rm -v $(pwd):/io \
+          docker run --rm -v $(pwd)/..:/io \
+            --workdir /io/python \
             konstin2/maturin:v0.11.2 \
             build --release --manylinux 2010
       - name: Archive wheels

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,23 +36,3 @@ datafusion = { path = "../datafusion", version = "5.1.0" }
 [lib]
 name = "datafusion"
 crate-type = ["cdylib"]
-
-[package.metadata.maturin]
-requires-dist = ["pyarrow>=1"]
-
-classifier = [
-    "Development Status :: 2 - Pre-Alpha",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python",
-    "Programming Language :: Rust",
-]

--- a/python/LICENSE.txt
+++ b/python/LICENSE.txt
@@ -1,38 +1,4 @@
-#!/usr/bin/python
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
-import json
-import subprocess
-
-subprocess.check_output(["cargo", "install", "cargo-license"])
-data = subprocess.check_output(
-    [
-        "cargo",
-        "license",
-        "--avoid-build-deps",
-        "--avoid-dev-deps",
-        "--do-not-bundle",
-        "--json",
-    ]
-)
-data = json.loads(data)
-
-result = """
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -234,17 +200,3 @@ result = """
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-"""
-result += "\n------------------\n\n"
-result += "This software is built and contains the following software:\n\n"
-result += "(automatically generated via [cargo-license](https://crates.io/crates/cargo-license))\n\n"
-for item in data:
-    license = item["license"]
-    name = item["name"]
-    version = item["version"]
-    repository = item["repository"]
-    result += "------------------\n\n"
-    result += f"### {name} {version}\n* source: [{repository}]({repository})\n* license: {license}\n\n"
-
-with open("LICENSE.txt", "w") as f:
-    f.write(result)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,3 +18,34 @@
 [build-system]
 requires = ["maturin>=0.11,<0.12"]
 build-backend = "maturin"
+
+[project]
+name = "datafusion"
+description = "Build and run queries against data"
+readme = "README.md"
+license = {file = "LICENSE.txt"}
+requires-python = ">=3.6"
+keywords = ["datafusion", "dataframe", "rust", "query-engine"]
+classifier = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python",
+    "Programming Language :: Rust",
+]
+dependencies = [
+    "pyarrow>=1",
+]
+
+[project.urls]
+documentation = "https://arrow.apache.org/datafusion/python"
+repository = "https://github.com/apache/arrow-datafusion"


### PR DESCRIPTION
# Rationale for this change

pyproject.toml is a more idiomatic and easier to update compared to cargo.toml. also set package name to `datafusion` in pyproject.toml so we maturin names the final wheel as datafusion.tar.gz instead of datafusion-python.tar.gz
