### PR TITLE
Make Metrics::labels() public

### DIFF
--- a/datafusion/src/physical_plan/metrics/mod.rs
+++ b/datafusion/src/physical_plan/metrics/mod.rs
@@ -141,7 +141,7 @@ impl Metric {
     }
 
     /// What labels are present for this metric?
-    fn labels(&self) -> &[Label] {
+    pub fn labels(&self) -> &[Label] {
         &self.labels
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Forgotten part of https://github.com/apache/arrow-datafusion/pull/908

 # Rationale for this change
This was meant to be public so that consumers of this API can use labels

# What changes are included in this PR?
Make `Metrics::label()` is public

# Are there any user-facing changes?
`Metrics::labels()` is public
