### PR TITLE
Add metrics for Limit and Projection, and CoalesceBatches

### DIFF
--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2361,13 +2361,15 @@ async fn explain_analyze_baseline_metrics() {
                FROM aggregate_test_100 \
                WHERE c13 != 'C2GT5KVyOPZpgKVl110TyZO0NcJ434' \
                GROUP BY c1 \
-               ORDER BY c1)";
+               ORDER BY c1) \
+               LIMIT 1";
     println!("running query: {}", sql);
     let plan = ctx.create_logical_plan(sql).unwrap();
     let plan = ctx.optimize(&plan).unwrap();
     let physical_plan = ctx.create_physical_plan(&plan).unwrap();
     let results = collect(physical_plan.clone()).await.unwrap();
     let formatted = arrow::util::pretty::pretty_format_batches(&results).unwrap();
+    println!("Query Output:\n\n{}", formatted);
     let formatted = normalize_for_explain(&formatted);
 
     assert_metrics!(
@@ -2395,14 +2397,33 @@ async fn explain_analyze_baseline_metrics() {
         "FilterExec: c13@1 != C2GT5KVyOPZpgKVl110TyZO0NcJ434",
         "metrics=[output_rows=99, elapsed_compute="
     );
+    assert_metrics!(
+        &formatted,
+        "GlobalLimitExec: limit=1, ",
+        "metrics=[output_rows=1, elapsed_compute="
+    );
+    assert_metrics!(
+        &formatted,
+        "ProjectionExec: expr=[COUNT(UInt8(1))",
+        "metrics=[output_rows=1, elapsed_compute="
+    );
+    assert_metrics!(
+        &formatted,
+        "CoalesceBatchesExec: target_batch_size=4096",
+        "metrics=[output_rows=5, elapsed_compute"
+    );
 
     fn expected_to_have_metrics(plan: &dyn ExecutionPlan) -> bool {
-        use datafusion::physical_plan::{
-            hash_aggregate::HashAggregateExec, sort::SortExec,
-        };
+        use datafusion::physical_plan;
 
-        plan.as_any().downcast_ref::<SortExec>().is_some()
-            || plan.as_any().downcast_ref::<HashAggregateExec>().is_some()
+        plan.as_any().downcast_ref::<physical_plan::sort::SortExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::hash_aggregate::HashAggregateExec>().is_some()
+            // CoalescePartitionsExec doesn't do any work so is not included
+            || plan.as_any().downcast_ref::<physical_plan::hash_aggregate::HashAggregateExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::filter::FilterExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::projection::ProjectionExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::coalesce_batches::CoalesceBatchesExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::limit::GlobalLimitExec>().is_some()
     }
 
     // Validate that the recorded elapsed compute time was more than

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2419,7 +2419,6 @@ async fn explain_analyze_baseline_metrics() {
         plan.as_any().downcast_ref::<physical_plan::sort::SortExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::hash_aggregate::HashAggregateExec>().is_some()
             // CoalescePartitionsExec doesn't do any work so is not included
-            || plan.as_any().downcast_ref::<physical_plan::hash_aggregate::HashAggregateExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::filter::FilterExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::projection::ProjectionExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::coalesce_batches::CoalesceBatchesExec>().is_some()


### PR DESCRIPTION
# Which issue does this PR close?

Next part https://github.com/apache/arrow-datafusion/issues/866 (following the same model as https://github.com/apache/arrow-datafusion/pull/960).


 # Rationale for this change
We want basic understanding of where a plan's time is spent and in what operators. See https://github.com/apache/arrow-datafusion/issues/866 for more details

# What changes are included in this PR?
1. Instrument `ProjectionExec`, `GlobalLimitExec`, `LocalLimitExec` and `CoalesceBatchesExec` using the API from https://github.com/apache/arrow-datafusion/pull/909
2. Tests for same


# Are there any user-facing changes?
More fields in `EXPLAIN ANALYZE` are now filled out

Example of how explain analyze is looking (dense but packed with good info)

```sql
running query: EXPLAIN ANALYZE select count(*) from (SELECT count(*), c1 FROM aggregate_test_100 WHERE c13 != 'C2GT5KVyOPZpgKVl110TyZO0NcJ434' GROUP BY c1 ORDER BY c1) LIMIT 1
Query Output:

+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                                                                                                |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | GlobalLimitExec: limit=1, metrics=[output_rows=1, elapsed_compute=182ns]                                                                                                                                                            |
|                   |   ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))], metrics=[output_rows=1, elapsed_compute=7.556µs]                                                                                                                     |
|                   |     HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))], metrics=[output_rows=1, elapsed_compute=48.283µs]                                                                                                                |
|                   |       CoalescePartitionsExec, metrics=[output_rows=3, elapsed_compute=NOT RECORDED]                                                                                                                                                 |
|                   |         HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))], metrics=[output_rows=3, elapsed_compute=101.291µs]                                                                                                         |
|                   |           RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[fetch_time{inputPartition=0}=10.721068ms, send_time{inputPartition=0}=3.93µs, repart_time{inputPartition=0}=NOT RECORDED]                                      |
|                   |             SortExec: [c1@0 ASC], metrics=[output_rows=5, elapsed_compute=184.753µs]                                                                                                                                                |
|                   |               CoalescePartitionsExec, metrics=[output_rows=5, elapsed_compute=NOT RECORDED]                                                                                                                                         |
|                   |                 HashAggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[COUNT(UInt8(1))], metrics=[output_rows=5, elapsed_compute=299.555µs]                                                                              |
|                   |                   CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=5, elapsed_compute=73.812µs]                                                                                                                    |
|                   |                     RepartitionExec: partitioning=Hash([Column { name: "c1", index: 0 }], 3), metrics=[send_time{inputPartition=0}=NOT RECORDED, fetch_time{inputPartition=0}=28.696948ms, repart_time{inputPartition=0}=201.886µs] |
|                   |                       HashAggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[COUNT(UInt8(1))], metrics=[output_rows=5, elapsed_compute=560.718µs]                                                                                 |
|                   |                         CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=99, elapsed_compute=306.864µs]                                                                                                            |
|                   |                           FilterExec: c13@1 != C2GT5KVyOPZpgKVl110TyZO0NcJ434, metrics=[output_rows=99, elapsed_compute=264.367µs]                                                                                                  |
|                   |                             RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[repart_time{inputPartition=0}=NOT RECORDED, send_time{inputPartition=0}=5.482µs, fetch_time{inputPartition=0}=6.933244ms]                    |
|                   |                               CsvExec: source=Path(/Users/alamb/Software/arrow/testing/data/csv/aggregate_test_100.csv: [/Users/alamb/Software/arrow/testing/data/csv/aggregate_test_100.csv]), has_header=true, metrics=[]         |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


```
