### PR TITLE
Derive PartialOrd for Expr

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -217,7 +217,7 @@ impl fmt::Display for Column {
 ///   assert_eq!(op, Operator::Eq);
 /// }
 /// ```
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, PartialOrd)]
 pub enum Expr {
     /// An expression with a specific name.
     Alias(Box<Expr>, String),
@@ -2069,5 +2069,19 @@ mod tests {
         test_unary_scalar_expr!(Translate, translate);
         test_unary_scalar_expr!(Trim, trim);
         test_unary_scalar_expr!(Upper, upper);
+    }
+
+    #[test]
+    fn test_partial_ord() {
+        // Test validates that partial ord is defined for Expr, not
+        // intended to exhaustively test all possibilities
+        let exp1 = col("a") + lit(1);
+        let exp2 = col("a") + lit(2);
+        let exp3 = !(col("a") + lit(2));
+
+        assert!(exp1 < exp2);
+        assert!(exp2 > exp1);
+        assert!(exp2 < exp3);
+        assert!(exp3 > exp2);
     }
 }

--- a/datafusion/src/logical_plan/operators.rs
+++ b/datafusion/src/logical_plan/operators.rs
@@ -20,7 +20,7 @@ use std::{fmt, ops};
 use super::{binary_expr, Expr};
 
 /// Operators applied to expressions
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
 pub enum Operator {
     /// Expressions are equal
     Eq,

--- a/datafusion/src/logical_plan/window_frames.rs
+++ b/datafusion/src/logical_plan/window_frames.rs
@@ -34,7 +34,7 @@ use std::fmt;
 /// The ending frame boundary can be omitted (if the BETWEEN and AND keywords that surround the
 /// starting frame boundary are also omitted), in which case the ending frame boundary defaults to
 /// CURRENT ROW.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub struct WindowFrame {
     /// A frame type - either ROWS, RANGE or GROUPS
     pub units: WindowFrameUnits,
@@ -211,7 +211,7 @@ impl WindowFrameBound {
 
 /// There are three frame types: ROWS, GROUPS, and RANGE. The frame type determines how the
 /// starting and ending boundaries of the frame are measured.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub enum WindowFrameUnits {
     /// The ROWS frame type means that the starting and ending boundaries for the frame are
     /// determined by counting individual rows relative to the current row.

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -47,7 +47,7 @@ pub type StateTypeFunction =
     Arc<dyn Fn(&DataType) -> Result<Arc<Vec<DataType>>> + Send + Sync>;
 
 /// Enum of all built-in scalar functions
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum AggregateFunction {
     /// count
     Count,

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -57,7 +57,7 @@ use std::convert::From;
 use std::{any::Any, fmt, str::FromStr, sync::Arc};
 
 /// A function's signature, which defines the function's supported argument types.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum Signature {
     /// arbitrary number of arguments of an common type out of a list of valid types
     // A function such as `concat` is `Variadic(vec![DataType::Utf8, DataType::LargeUtf8])`
@@ -94,7 +94,7 @@ pub type ReturnTypeFunction =
     Arc<dyn Fn(&[DataType]) -> Result<Arc<DataType>> + Send + Sync>;
 
 /// Enum of all built-in scalar functions
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum BuiltinScalarFunction {
     // math functions
     /// abs

--- a/datafusion/src/physical_plan/udaf.rs
+++ b/datafusion/src/physical_plan/udaf.rs
@@ -71,6 +71,17 @@ impl PartialEq for AggregateUDF {
     }
 }
 
+impl PartialOrd for AggregateUDF {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let c = self.name.partial_cmp(&other.name);
+        if matches!(c, Some(std::cmp::Ordering::Equal)) {
+            self.signature.partial_cmp(&other.signature)
+        } else {
+            c
+        }
+    }
+}
+
 impl AggregateUDF {
     /// Create a new AggregateUDF
     pub fn new(

--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -69,6 +69,17 @@ impl PartialEq for ScalarUDF {
     }
 }
 
+impl PartialOrd for ScalarUDF {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let c = self.name.partial_cmp(&other.name);
+        if matches!(c, Some(std::cmp::Ordering::Equal)) {
+            self.signature.partial_cmp(&other.signature)
+        } else {
+            c
+        }
+    }
+}
+
 impl ScalarUDF {
     /// Create a new ScalarUDF
     pub fn new(

--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::{fmt, str::FromStr};
 
 /// WindowFunction
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum WindowFunction {
     /// window function that leverages an aggregate function
     AggregateFunction(AggregateFunction),
@@ -90,7 +90,7 @@ impl fmt::Display for WindowFunction {
 }
 
 /// An aggregate function that is part of a built-in window function
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum BuiltInWindowFunction {
     /// number of the current row within its partition, counting from 1
     RowNumber,


### PR DESCRIPTION
# Which issue does this PR close?

Resolves https://github.com/apache/arrow-datafusion/issues/1014

 # Rationale for this change
We would like to order `Expr`s in a consistent way in our tests. See details on https://github.com/influxdata/influxdb_iox/pull/2564 in https://github.com/influxdata/influxdb_iox/pull/2564#discussion_r710817261

This also is a necessary (but not sufficient) step towards being able to use `Expr`s in sets and maps (still need to implement `Ord` and `Hash`) which might have helped @waynexia in https://github.com/apache/arrow-datafusion/pull/792 with CSE and would help with other algebriac transformations in the future.


# What changes are included in this PR?
```rust
impl PartialOrd` for `Expr`
```

# Are there any user-facing changes?
Can now compare Exprs

