### PR TITLE
Add baseline execution stats to `WindowAggExec` and `UnionExec`, and fixup `CoalescePartitionsExec`

### DIFF
--- a/datafusion/src/physical_plan/coalesce_partitions.rs
+++ b/datafusion/src/physical_plan/coalesce_partitions.rs
@@ -97,8 +97,6 @@ impl ExecutionPlan for CoalescePartitionsExec {
     }
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
-        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
-
         // CoalescePartitionsExec produces a single partition
         if 0 != partition {
             return Err(DataFusionError::Internal(format!(
@@ -113,10 +111,16 @@ impl ExecutionPlan for CoalescePartitionsExec {
                 "CoalescePartitionsExec requires at least one input partition".to_owned(),
             )),
             1 => {
-                // bypass any threading if there is a single partition
+                // bypass any threading / metrics if there is a single partition
                 self.input.execute(0).await
             }
             _ => {
+                let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+                // record the (very) minimal work done so that
+                // elapsed_compute is not reported as 0
+                let elapsed_compute = baseline_metrics.elapsed_compute().clone();
+                let _timer = elapsed_compute.timer();
+
                 // use a stream that allows each sender to put in at
                 // least one result in an attempt to maximize
                 // parallelism.

--- a/datafusion/src/physical_plan/union.rs
+++ b/datafusion/src/physical_plan/union.rs
@@ -23,13 +23,18 @@
 
 use std::{any::Any, sync::Arc};
 
-use arrow::datatypes::SchemaRef;
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use futures::StreamExt;
 
 use super::{
-    ColumnStatistics, DisplayFormatType, ExecutionPlan, Partitioning,
+    metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    ColumnStatistics, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
-use crate::{error::Result, physical_plan::expressions};
+use crate::{
+    error::Result,
+    physical_plan::{expressions, metrics::BaselineMetrics},
+};
 use async_trait::async_trait;
 
 /// UNION ALL execution plan
@@ -37,12 +42,17 @@ use async_trait::async_trait;
 pub struct UnionExec {
     /// Input execution plan
     inputs: Vec<Arc<dyn ExecutionPlan>>,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl UnionExec {
     /// Create a new UnionExec
     pub fn new(inputs: Vec<Arc<dyn ExecutionPlan>>) -> Self {
-        UnionExec { inputs }
+        UnionExec {
+            inputs,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
     }
 }
 
@@ -82,11 +92,18 @@ impl ExecutionPlan for UnionExec {
     }
 
     async fn execute(&self, mut partition: usize) -> Result<SendableRecordBatchStream> {
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        // record the tiny amount of work done in this function so
+        // elapsed_compute is reported as non zero
+        let timer = baseline_metrics.elapsed_compute().timer();
+
         // find partition to execute
         for input in self.inputs.iter() {
             // Calculate whether partition belongs to the current partition
             if partition < input.output_partitioning().partition_count() {
-                return input.execute(partition).await;
+                let stream = input.execute(partition).await?;
+                drop(timer);
+                return Ok(Box::pin(ObservedStream::new(stream, baseline_metrics)));
             } else {
                 partition -= input.output_partitioning().partition_count();
             }
@@ -110,12 +127,50 @@ impl ExecutionPlan for UnionExec {
         }
     }
 
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
     fn statistics(&self) -> Statistics {
         self.inputs
             .iter()
             .map(|ep| ep.statistics())
             .reduce(stats_union)
             .unwrap_or_default()
+    }
+}
+
+/// Stream wrapper that records `BaselineMetrics` for a particular
+/// partition
+struct ObservedStream {
+    inner: SendableRecordBatchStream,
+    baseline_metrics: BaselineMetrics,
+}
+
+impl ObservedStream {
+    fn new(inner: SendableRecordBatchStream, baseline_metrics: BaselineMetrics) -> Self {
+        Self {
+            inner,
+            baseline_metrics,
+        }
+    }
+}
+
+impl RecordBatchStream for ObservedStream {
+    fn schema(&self) -> arrow::datatypes::SchemaRef {
+        self.inner.schema()
+    }
+}
+
+impl futures::Stream for ObservedStream {
+    type Item = arrow::error::Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let poll = self.inner.poll_next_unpin(cx);
+        self.baseline_metrics.record_poll(poll)
     }
 }
 

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2302,9 +2302,9 @@ async fn csv_explain_analyze() {
     let formatted = normalize_for_explain(&formatted);
 
     // Only test basic plumbing and try to avoid having to change too
-    // many things
-    let needle =
-        "CoalescePartitionsExec, metrics=[output_rows=5, elapsed_compute=NOT RECORDED";
+    // many things. explain_analyze_baseline_metrics covers the values
+    // in greater depth
+    let needle = "CoalescePartitionsExec, metrics=[output_rows=5, elapsed_compute=";
     assert_contains!(&formatted, needle);
 
     let verbose_needle = "Output Rows";

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2362,7 +2362,7 @@ async fn explain_analyze_baseline_metrics() {
                SELECT 1 as cnt \
                  UNION ALL \
                SELECT lead(c1, 1) OVER () as cnt FROM (select 1 as c1) \
-               LIMIT 2";
+               LIMIT 3";
     println!("running query: {}", sql);
     let plan = ctx.create_logical_plan(sql).unwrap();
     let plan = ctx.optimize(&plan).unwrap();
@@ -2372,11 +2372,6 @@ async fn explain_analyze_baseline_metrics() {
     println!("Query Output:\n\n{}", formatted);
     let formatted = normalize_for_explain(&formatted);
 
-    assert_metrics!(
-        &formatted,
-        "CoalescePartitionsExec",
-        "metrics=[output_rows=5, elapsed_compute=NOT RECORDED"
-    );
     assert_metrics!(
         &formatted,
         "HashAggregateExec: mode=Partial, gby=[]",
@@ -2389,7 +2384,7 @@ async fn explain_analyze_baseline_metrics() {
     );
     assert_metrics!(
         &formatted,
-        "SortExec: [c1@0 ASC]",
+        "SortExec: [c1@1 ASC]",
         "metrics=[output_rows=5, elapsed_compute="
     );
     assert_metrics!(
@@ -2399,8 +2394,13 @@ async fn explain_analyze_baseline_metrics() {
     );
     assert_metrics!(
         &formatted,
-        "GlobalLimitExec: limit=1, ",
+        "GlobalLimitExec: limit=3, ",
         "metrics=[output_rows=1, elapsed_compute="
+    );
+    assert_metrics!(
+        &formatted,
+        "LocalLimitExec: limit=3",
+        "metrics=[output_rows=3, elapsed_compute="
     );
     assert_metrics!(
         &formatted,
@@ -2412,8 +2412,21 @@ async fn explain_analyze_baseline_metrics() {
         "CoalesceBatchesExec: target_batch_size=4096",
         "metrics=[output_rows=5, elapsed_compute"
     );
-
-    assert!(false, "TODO: Test for cpaslce partitoon, union and window agg exec");
+    assert_metrics!(
+        &formatted,
+        "CoalescePartitionsExec",
+        "metrics=[output_rows=5, elapsed_compute="
+    );
+    assert_metrics!(
+        &formatted,
+        "UnionExec",
+        "metrics=[output_rows=3, elapsed_compute="
+    );
+    assert_metrics!(
+        &formatted,
+        "WindowAggExec",
+        "metrics=[output_rows=1, elapsed_compute="
+    );
 
     fn expected_to_have_metrics(plan: &dyn ExecutionPlan) -> bool {
         use datafusion::physical_plan;
@@ -2422,12 +2435,13 @@ async fn explain_analyze_baseline_metrics() {
             || plan.as_any().downcast_ref::<physical_plan::hash_aggregate::HashAggregateExec>().is_some()
             // CoalescePartitionsExec doesn't do any work so is not included
             || plan.as_any().downcast_ref::<physical_plan::filter::FilterExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::limit::GlobalLimitExec>().is_some()
+            || plan.as_any().downcast_ref::<physical_plan::limit::LocalLimitExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::projection::ProjectionExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::coalesce_batches::CoalesceBatchesExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::coalesce_partitions::CoalescePartitionsExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::union::UnionExec>().is_some()
             || plan.as_any().downcast_ref::<physical_plan::windows::WindowAggExec>().is_some()
-            || plan.as_any().downcast_ref::<physical_plan::limit::GlobalLimitExec>().is_some()
     }
 
     // Validate that the recorded elapsed compute time was more than


### PR DESCRIPTION
# Which issue does this PR close?

Finally 🎉  closes https://github.com/apache/arrow-datafusion/issues/866 (following the same model as https://github.com/apache/arrow-datafusion/pull/1004). 

There are still some operators like Parquet, CSV, Avro, and Json sources that are not instrumented, but I don't have time to devote to intrumenting them now, https://github.com/apache/arrow-datafusion/issues/1019 tracks that work


 # Rationale for this change
We want basic understanding of where a plan's time is spent and in what operators. See https://github.com/apache/arrow-datafusion/issues/866 for more details

# What changes are included in this PR?
1. Instrument `WindowAggExec` and `UnionExec`,  using the API from https://github.com/apache/arrow-datafusion/pull/909
2. Tweak instrumentation for `CoalescePartitionsExec` so it reports `elapsed_compute`
3. Tests for same

# Are there any user-facing changes?
More fields in `EXPLAIN ANALYZE` are now filled out

Example of how explain analyze is looking (dense but packed with good info). I find it quite cool that DataFusion can even plan and execute such queries.

```sql
running query: EXPLAIN ANALYZE SELECT count(*) as cnt FROM (SELECT count(*), c1 FROM aggregate_test_100 WHERE c13 != 'C2GT5KVyOPZpgKVl110TyZO0NcJ434' GROUP BY c1 ORDER BY c1 ) UNION ALL SELECT 1 as cnt UNION ALL SELECT lead(c1, 1) OVER () as cnt FROM (select 1 as c1) LIMIT 2
Query Output:

+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                                                                                                            |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | GlobalLimitExec: limit=2, metrics=[output_rows=2, elapsed_compute=3.023µs]                                                                                                                                                                      |
|                   |   CoalescePartitionsExec, metrics=[output_rows=3, elapsed_compute=50.216µs]                                                                                                                                                                     |
|                   |     LocalLimitExec: limit=2, metrics=[output_rows=3, elapsed_compute=699ns]                                                                                                                                                                     |
|                   |       UnionExec, metrics=[output_rows=3, elapsed_compute=198.269µs]                                                                                                                                                                             |
|                   |         RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[repart_time{inputPartition=0}=NOT RECORDED, fetch_time{inputPartition=0}=11.908387ms, send_time{inputPartition=0}=3.816µs]                                                   |
|                   |           GlobalLimitExec: limit=2, metrics=[output_rows=1, elapsed_compute=157ns]                                                                                                                                                              |
|                   |             ProjectionExec: expr=[COUNT(UInt8(1))@0 as cnt], metrics=[output_rows=1, elapsed_compute=4.125µs]                                                                                                                                   |
|                   |               HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))], metrics=[output_rows=1, elapsed_compute=66.501µs]                                                                                                                  |
|                   |                 CoalescePartitionsExec, metrics=[output_rows=3, elapsed_compute=11.969µs]                                                                                                                                                       |
|                   |                   HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))], metrics=[output_rows=3, elapsed_compute=89.888µs]                                                                                                            |
|                   |                     RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[fetch_time{inputPartition=0}=11.049667ms, send_time{inputPartition=0}=3.965µs, repart_time{inputPartition=0}=NOT RECORDED]                                       |
|                   |                       SortExec: [c1@1 ASC], metrics=[output_rows=5, elapsed_compute=196.635µs]                                                                                                                                                  |
|                   |                         CoalescePartitionsExec, metrics=[output_rows=5, elapsed_compute=11.127µs]                                                                                                                                               |
|                   |                           ProjectionExec: expr=[COUNT(UInt8(1))@1 as COUNT(UInt8(1)), c1@0 as c1], metrics=[output_rows=5, elapsed_compute=17.878µs]                                                                                            |
|                   |                             HashAggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[COUNT(UInt8(1))], metrics=[output_rows=5, elapsed_compute=308.373µs]                                                                              |
|                   |                               CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=5, elapsed_compute=77.054µs]                                                                                                                    |
|                   |                                 RepartitionExec: partitioning=Hash([Column { name: "c1", index: 0 }], 3), metrics=[send_time{inputPartition=0}=NOT RECORDED, repart_time{inputPartition=0}=200.022µs, fetch_time{inputPartition=0}=28.377811ms] |
|                   |                                   HashAggregateExec: mode=Partial, gby=[c1@0 as c1], aggr=[COUNT(UInt8(1))], metrics=[output_rows=5, elapsed_compute=585.625µs]                                                                                 |
|                   |                                     CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=99, elapsed_compute=268.21µs]                                                                                                             |
|                   |                                       FilterExec: c13@1 != C2GT5KVyOPZpgKVl110TyZO0NcJ434, metrics=[output_rows=99, elapsed_compute=228.181µs]                                                                                                  |
|                   |                                         RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[repart_time{inputPartition=0}=NOT RECORDED, fetch_time{inputPartition=0}=6.765885ms, send_time{inputPartition=0}=3.554µs]                    |
|                   |                                           CsvExec: source=Path(/Users/alamb/Software/arrow/testing/data/csv/aggregate_test_100.csv: [/Users/alamb/Software/arrow/testing/data/csv/aggregate_test_100.csv]), has_header=true, metrics=[]         |
|                   |         RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[fetch_time{inputPartition=0}=131.806µs, send_time{inputPartition=0}=11.372µs, repart_time{inputPartition=0}=NOT RECORDED]                                                    |
|                   |           GlobalLimitExec: limit=2, metrics=[output_rows=1, elapsed_compute=211ns]                                                                                                                                                              |
|                   |             ProjectionExec: expr=[1 as cnt], metrics=[output_rows=1, elapsed_compute=60.248µs]                                                                                                                                                  |
|                   |               EmptyExec: produce_one_row=true, metrics=[]                                                                                                                                                                                       |
|                   |         RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[repart_time{inputPartition=0}=NOT RECORDED, fetch_time{inputPartition=0}=10.627386ms, send_time{inputPartition=0}=2.322µs]                                                   |
|                   |           GlobalLimitExec: limit=2, metrics=[output_rows=1, elapsed_compute=287ns]                                                                                                                                                              |
|                   |             CoalescePartitionsExec, metrics=[output_rows=1, elapsed_compute=11.487µs]                                                                                                                                                           |
|                   |               ProjectionExec: expr=[LEAD(c1,Int64(1))@0 as cnt], metrics=[output_rows=1, elapsed_compute=5.57µs]                                                                                                                                |
|                   |                 RepartitionExec: partitioning=RoundRobinBatch(3), metrics=[repart_time{inputPartition=0}=NOT RECORDED, send_time{inputPartition=0}=4.463µs, fetch_time{inputPartition=0}=618.203µs]                                             |
|                   |                   WindowAggExec: wdw=[LEAD(c1,Int64(1)): Ok(Field { name: "LEAD(c1,Int64(1))", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None })], metrics=[output_rows=1, elapsed_compute=140.931µs]     |
|                   |                     ProjectionExec: expr=[1 as c1], metrics=[output_rows=1, elapsed_compute=9.968µs]                                                                                                                                            |
|                   |                       EmptyExec: produce_one_row=true, metrics=[]                                                                                                                                                                               |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
