### PR TITLE
add ExecutionConfig.with_optimizer_rules

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -809,6 +809,15 @@ impl ExecutionConfig {
         self
     }
 
+    /// Replace the optimizer rules
+    pub fn with_optimizer_rules(
+        mut self,
+        optimizers: Vec<Arc<dyn OptimizerRule + Send + Sync>>,
+    ) -> Self {
+        self.optimizers = optimizers;
+        self
+    }
+
     /// Replace the physical optimizer rules
     pub fn with_physical_optimizer_rules(
         mut self,


### PR DESCRIPTION
 # Rationale for this change

Currently there is no way to override/remove the 'default' set of physical optimizer rules. This (small) PR exposes the ability to override them similar to how the `with_physical_optimizer_rules` does.

# Are there any user-facing changes?

This is just and extension of the existing API and has no user-facing impact.