### PR TITLE
Ignore metadata on schema merge

### DIFF
--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -136,7 +136,6 @@ pub trait TableDescriptorBuilder {
                     let FileAndSchema {file, schema} = Self::file_meta(file_path)?;
                     if schemas.is_empty() {
                         schemas.push(schema);
-                        
                     } else if schema.fields() != schemas[0].fields() {
                         // we currently get the schema information from the first file rather than do
                         // schema merging and this is a limitation.

--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -163,9 +163,8 @@ pub trait TableDescriptorBuilder {
                 ext, path
             )));
         }
-        let merged_schemas = Schema::try_merge(schemas).unwrap();
-        println!("{:?}", &merged_schemas);
-        let result_schema = provided_schema.unwrap_or_else(|| merged_schemas);
+
+        let result_schema = provided_schema.unwrap_or_else(|| schemas.pop().unwrap());
 
         Ok(TableDescriptor {
             path: path.to_string(),

--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -136,7 +136,8 @@ pub trait TableDescriptorBuilder {
                     let FileAndSchema {file, schema} = Self::file_meta(file_path)?;
                     if schemas.is_empty() {
                         schemas.push(schema);
-                    } else if schema != schemas[0] {
+                        
+                    } else if schema.fields() != schemas[0].fields() {
                         // we currently get the schema information from the first file rather than do
                         // schema merging and this is a limitation.
                         // See https://issues.apache.org/jira/browse/ARROW-11017
@@ -163,8 +164,9 @@ pub trait TableDescriptorBuilder {
                 ext, path
             )));
         }
-
-        let result_schema = provided_schema.unwrap_or_else(|| schemas.pop().unwrap());
+        let merged_schemas = Schema::try_merge(schemas).unwrap();
+        println!("{:?}", &merged_schemas);
+        let result_schema = provided_schema.unwrap_or_else(|| merged_schemas);
 
         Ok(TableDescriptor {
             path: path.to_string(),

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -3753,6 +3753,67 @@ mod tests {
         assert_eq!(Weak::strong_count(&catalog_weak), 0);
     }
 
+    #[tokio::test]
+    async fn schema_merge_ignores_metadata() {
+        // Create two parquet files in same table with same schema but different metadata
+        let tmp_dir = TempDir::new().unwrap();
+        let table_dir = tmp_dir.path().join("parquet_test");
+        let table_path = Path::new(&table_dir);
+
+        let mut non_empty_metadata: HashMap<String, String> = HashMap::new();
+        non_empty_metadata.insert("testing".to_string(), "metadata".to_string());
+
+        let fields = vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("name", DataType::Utf8, true),
+        ];
+        let schemas = vec![
+            Arc::new(Schema::new_with_metadata(
+                fields.clone(),
+                non_empty_metadata.clone(),
+            )),
+            Arc::new(Schema::new(fields.clone())),
+        ];
+
+        match fs::create_dir(table_path) {
+            Ok(()) => {
+                for i in 0..2 {
+                    let filename = format!("part-{}.parquet", i);
+                    let path = table_path.join(&filename);
+                    let file = fs::File::create(path).unwrap();
+                    let mut writer = ArrowWriter::try_new(
+                        file.try_clone().unwrap(),
+                        schemas[i].clone(),
+                        None,
+                    )
+                    .unwrap();
+
+                    // create mock record batch
+                    let ids = Arc::new(Int32Array::from(vec![i as i32]));
+                    let names = Arc::new(StringArray::from(vec!["test"]));
+                    let rec_batch =
+                        RecordBatch::try_new(schemas[i].clone(), vec![ids, names])
+                            .unwrap();
+
+                    writer.write(&rec_batch).unwrap();
+                    writer.close().unwrap();
+                }
+            }
+            _ => {}
+        }
+
+        // Read the parquet files into a dataframe to confirm results
+        let mut ctx = ExecutionContext::new();
+        let df = ctx
+            .read_parquet(table_dir.to_str().unwrap().to_string())
+            .unwrap();
+        let result = df.collect().await.unwrap();
+
+        // I expected this to be true if files are read sequentially
+        // assert_eq!(result[0].schema().metadata(), &non_empty_metadata);
+        assert_eq!(result[0].schema().metadata(), result[1].schema().metadata());
+    }
+
     struct MyPhysicalPlanner {}
 
     impl PhysicalPlanner for MyPhysicalPlanner {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #936

 # Rationale for this change

Make schema checking less strict by only comparing the fields of the schema and not the additional metadata.