### PR TITLE
docs: include edit on github link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,6 +86,17 @@ autosummary_generate = True
 #
 html_theme = 'pydata_sphinx_theme'
 
+html_theme_options = {
+    "use_edit_page_button": True,
+}
+
+html_context = {
+    "github_user": "apache",
+    "github_repo": "arrow-datafusion",
+    "github_version": "master",
+    "doc_path": "docs/source",
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
# Rationale for this change

Make it easier for people to contribute to our docs.

# What changes are included in this PR?

Enable edit on github feature.

See edit link on the right panel:

![df-doc-edit](https://user-images.githubusercontent.com/670302/133962241-7715cce4-2271-45a9-b343-5606704ae2a1.png)


# Are there any user-facing changes?

no
