### PR TITLE
feat: add lit_timestamp_nanosecond

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1360,9 +1360,6 @@ pub fn in_list(expr: Expr, list: Vec<Expr>, negated: bool) -> Expr {
 pub trait Literal {
     /// convert the value to a Literal expression
     fn lit(&self) -> Expr;
-
-    // /// convert the number to literal expression of timestamp in nanosecond
-    // fn lit_timestamp_nanosecond(&self) -> Expr;
 }
 
 /// Trait for converting a type to a literal timestamp

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1385,37 +1385,6 @@ impl Literal for ScalarValue {
     }
 }
 
-impl TimestampLiteral for ScalarValue {
-    fn lit_timestamp_nano(&self) -> Expr {
-        match self {
-            ScalarValue::Int64(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some(*val)))
-            }
-            ScalarValue::Int32(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            ScalarValue::Int16(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            ScalarValue::Int8(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            ScalarValue::UInt8(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            ScalarValue::UInt16(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            ScalarValue::UInt32(Some(val)) => {
-                Expr::Literal(ScalarValue::TimestampNanosecond(Some((*val).into())))
-            }
-            _ => {
-                panic!("cannot convert {} to timestamp nanosecond", self)
-            }
-        }
-    }
-}
-
 macro_rules! make_literal {
     ($TYPE:ty, $SCALAR:ident, $DOC: expr) => {
         #[doc = $DOC]

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -39,13 +39,14 @@ pub use expr::{
     abs, acos, and, array, ascii, asin, atan, avg, binary_expr, bit_length, btrim, case,
     ceil, character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws,
     cos, count, count_distinct, create_udaf, create_udf, date_part, date_trunc, exp,
-    exprlist_to_fields, floor, in_list, initcap, left, length, lit, ln, log10, log2,
-    lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols, now, octet_length,
-    or, random, regexp_match, regexp_replace, repeat, replace, replace_col, reverse,
-    right, round, rpad, rtrim, sha224, sha256, sha384, sha512, signum, sin, split_part,
-    sqrt, starts_with, strpos, substr, sum, tan, to_hex, translate, trim, trunc,
-    unnormalize_col, unnormalize_cols, upper, when, Column, Expr, ExprRewriter,
-    ExpressionVisitor, Literal, Recursion, RewriteRecursion,
+    exprlist_to_fields, floor, in_list, initcap, left, length, lit,
+    lit_timestamp_nanosecond, ln, log10, log2, lower, lpad, ltrim, max, md5, min,
+    normalize_col, normalize_cols, now, octet_length, or, random, regexp_match,
+    regexp_replace, repeat, replace, replace_col, reverse, right, round, rpad, rtrim,
+    sha224, sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos,
+    substr, sum, tan, to_hex, translate, trim, trunc, unnormalize_col, unnormalize_cols,
+    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
+    RewriteRecursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -39,14 +39,13 @@ pub use expr::{
     abs, acos, and, array, ascii, asin, atan, avg, binary_expr, bit_length, btrim, case,
     ceil, character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws,
     cos, count, count_distinct, create_udaf, create_udf, date_part, date_trunc, exp,
-    exprlist_to_fields, floor, in_list, initcap, left, length, lit,
-    lit_timestamp_nanosecond, ln, log10, log2, lower, lpad, ltrim, max, md5, min,
-    normalize_col, normalize_cols, now, octet_length, or, random, regexp_match,
-    regexp_replace, repeat, replace, replace_col, reverse, right, round, rpad, rtrim,
-    sha224, sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos,
-    substr, sum, tan, to_hex, translate, trim, trunc, unnormalize_col, unnormalize_cols,
-    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
-    RewriteRecursion,
+    exprlist_to_fields, floor, in_list, initcap, left, length, lit, lit_timestamp_nano,
+    ln, log10, log2, lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols,
+    now, octet_length, or, random, regexp_match, regexp_replace, repeat, replace,
+    replace_col, reverse, right, round, rpad, rtrim, sha224, sha256, sha384, sha512,
+    signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
+    translate, trim, trunc, unnormalize_col, unnormalize_cols, upper, when, Column, Expr,
+    ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
Add function `lit_timestamp_nanosecond` to create a literal timestamp expression for a number. See tests for examples