### PR TITLE
add community communication docs

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -112,8 +112,10 @@ new specifications as you see fit.
 
 Here is the list current active specifications:
 
-- [Output field name semantic](docs/specification/output-field-name-semantic.md)
-- [Invariants](docs/specification/invariants.md)
+- [Output field name semantic](https://arrow.apache.org/datafusion/specification/output-field-name-semantic.html)
+- [Invariants](https://arrow.apache.org/datafusion/specification/invariants.html)
+
+All specifications are stored in the `docs/source/specification` folder.
 
 ## How to format `.md` document
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,14 @@ inside a Python virtualenv.
 ```bash
 make html
 ```
+
+## Release
+
+The documentation is served through the
+[arrow-site](https://github.com/apache/arrow-site/) repo. To release a new
+version of the docs, follow these steps:
+
+- Run `make html` inside `docs` folder to generate the docs website inside the `build/html` folder.
+- Clone the arrow-site repo and checkout to the `asf-site` branch
+- Copy build artifacts into `arrow-site` repo's `datafusion` folder: `'cp' -rT ./build/html/ ../arrow-site/datafusion/`
+- Commit changes in `arrow-site` and send a PR.

--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -1,0 +1,66 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Communication
+
+We welcome participation from everyone and encourage you to join us, ask
+questions, and get involved.
+
+All participation in the Apache Arrow DataFusion project is governed by the
+Apache Software Foundation's [code of
+conduct](https://www.apache.org/foundation/policies/conduct.html).
+
+## Questions?
+
+### Mailing list
+
+We use arrow.apache.org's `dev@` mailing list for project management, release
+coorindation and design discussions
+([subscribe](mailto:dev-subscribe@arrow.apache.org),
+[unsubscribe](mailto:dev-unsubscribe@arrow.apache.org),
+[archives](https://lists.apache.org/list.html?dev@arrow.apache.org)).
+
+When emailing the dev list, please make sure to prefix the subject line with a
+`[DataFusion]` tag, e.g. `"[DataFusion] New API for remote data sources"`, so
+that the appropriate people in the Apache Arrow community notice the message.
+
+### Slack and Discord
+
+We use the official [ASF](https://s.apache.org/slack-invite) Slack workspace
+for informal discussions and coordination. This is a great place to meet other
+contributors and get guidance on where to contribute. Join us in the
+`#arrow-rust` channel.
+
+We also have a backup Arrow Rust Discord
+server ([invite link](https://discord.gg/Qw5gKqHxUM)) in case you are not able
+to join the Slack workspace. If you need an invite to the Slack workspace, you
+can also ask for one in our Discord server.
+
+## Contributing
+
+Our source code is hosted on
+[GitHub](https://github.com/apache/arrow-datafusion). For developers new to
+the project, we have curated a
+[good-first-issue](https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+list to help you get started.
+
+We use GitHub issues for maintaining a queue of development work and as the
+public record. We often use Google docs, Github issues and pull requests for
+quick and small design discussions. For major design change proposals, please
+make sure to send them to the dev list for more visibility.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,3 +63,13 @@ Table of content
 
    Datafusion <https://github.com/apache/arrow-datafusion/blob/master/README.md>
    Ballista <https://github.com/apache/arrow-datafusion/tree/master/ballista/README.md>
+
+.. _toc.community:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Community
+
+   community/communication
+   Issue tracker <https://github.com/apache/arrow-datafusion/issues>
+   Code of conduct <https://github.com/apache/arrow-datafusion/blob/master/CODE_OF_CONDUCT.md>


### PR DESCRIPTION
# Rationale for this change

Make it easier for new contributors to engage with the community.

# What changes are included in this PR?

Added dev list, slack workspace and discord server to our docs.

![df-doc-community](https://user-images.githubusercontent.com/670302/134119339-85407f75-ffdc-47c8-adc7-ab1862c2f010.png)


# Are there any user-facing changes?

no