### PR TITLE
Remove unused `use` statements from examples

### DIFF
--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -23,8 +23,6 @@ Run a SQL query against data stored in a CSV:
 
 ```rust
 use datafusion::prelude::*;
-use arrow::util::pretty::print_batches;
-use arrow::record_batch::RecordBatch;
 
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {
@@ -45,8 +43,6 @@ Use the DataFrame API to process data stored in a CSV:
 
 ```rust
 use datafusion::prelude::*;
-use arrow::util::pretty::print_batches;
-use arrow::record_batch::RecordBatch;
 
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {


### PR DESCRIPTION
Noticed this while checking out our public webpage: https://arrow.apache.org/datafusion/ (props to @houqp  and @Jimexist !)

I don't think these `use` statements are needed anymore