### PR TITLE
Avoid stack overflow by reducing stack usage of `BinaryExpr::evaluate` in debug builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,8 +105,6 @@ jobs:
         run: |
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
-          # run tests on all workspace members with default feature list + avro
-          RUST_MIN_STACK=10485760 cargo test --features=avro
           # test datafusion examples
           cd datafusion-examples
           cargo test --no-default-features

--- a/datafusion/src/physical_plan/expressions/binary.rs
+++ b/datafusion/src/physical_plan/expressions/binary.rs
@@ -1431,14 +1431,13 @@ mod tests {
         let schema = batch.schema();
 
         // build a left deep tree ((((a + a) + a) + a ....
-        let tree_depth: i32 = 10;
+        let tree_depth: i32 = 100;
         let expr = (0..tree_depth)
             .into_iter()
             .map(|_| col("a", schema.as_ref()).unwrap())
             .reduce(|l, r| binary_simple(l, Operator::Plus, r))
             .unwrap();
 
-        println!("Evaluating expr {:?}", expr);
         let result = expr
             .evaluate(&batch)
             .expect("evaluation")


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/419

 # Rationale for this change
Prior to this PR, trying to evaluate `BinaryExprs` more than a few level deep (e.g. something like `a + a + a + a + a + a + a + a ...`) would result in a stack overflow

For example the test included  fails like this with `tree_depth` of 10 (in debug builds)

```
thread 'physical_plan::expressions::binary::tests::relatively_deeply_nested' has overflowed its stack
fatal runtime error: stack overflow
error: test failed, to rerun pass '-p datafusion --lib'

Caused by:
  process didn't exit successfully: `/Users/alamb/Software/arrow-datafusion/target/debug/deps/datafusion-68280be86fef135e deeply` (signal: 6, SIGABRT: process abort signal)
```

# What changes are included in this PR?
1. Break the `BinaryExpr::evaluate` into a few smaller functions
2. Remove special case workaround added for #910 

# Are there any user-facing changes?
Not really other than avoiding stack overflows while evaluating queries in debug builds

# Technical Backstory

I believe the issue is that in debug builds, each local variable gets its own (unique space in the stack). Due to the size of `BinaryExpr::evaluate` (largely hidden by macros) this results in a ludicrous amount of stack required for each call to `BinaryExpr::evaluate`. Since `BinaryExpr::evaluate` is implemented recursively this means even a few nesting levels exhausts a 2MB stack. 

You can see evidence of  looking at the disassembly. Here is how I did it on a mac:

```shell
otool -vt target/debug/deps/datafusion-68280be86fef135e > /tmp/df.asm
```

And the associated assembly shows the stack size to be 0x55a10 (350736 bytes)
```asm
__ZN118_$LT$datafusion..physical_plan..expressions..binary..BinaryExpr$u20$as$u20$datafusion..physical_plan..PhysicalExpr$GT$8evaluate17h2877dfaf102fa64eE:
0000000100d316d0	pushq	%rbp
0000000100d316d1	movq	%rsp, %rbp
0000000100d316d4	movl	$0x55a10, %eax                  ## the subq instruction below uses this value
0000000100d316d9	callq	0x1025dc540                     ## to effectively add 350736 (350K!) to the stack pointer
0000000100d316de	subq	%rax, %rsp
0000000100d316e1	movq	%rdx, -0x4a998(%rbp)
0000000100d316e8	movq	%rsi, -0x4a990(%rbp)
0000000100d316ef	movq	%rdi, %rax
...
```

In case you were curious, the same function in a  release build only uses 0x398 (920 bytes) of stack space.

```asm
__ZN118_$LT$datafusion..physical_plan..expressions..binary..BinaryExpr$u20$as$u20$datafusion..physical_plan..PhysicalExpr$GT$8evaluate17h51f0595db0e2c70cE:
00000001009468a0        pushq   %rbp
00000001009468a1        movq    %rsp, %rbp
00000001009468a4        pushq   %r15
00000001009468a6        pushq   %r14
00000001009468a8        pushq   %r13
00000001009468aa        pushq   %r12
00000001009468ac        pushq   %rbx
00000001009468ad        subq    $0x398, %rsp                    ## imm = 0x398
```


For those of you visually minded, here is an illustration:

```text
┌ ─ ─ ─ ─ ─ ─ ─ ─ ─
                   │
│     Function                      Base Pointer
     Parameters    │     ┌──────       (%ebp)
│                        │
┌──────────────────┤     │
│  Return Address  │     │
├──────────────────┤     │
│Saved Base Pointer│◀────┘
├──────────────────┘
    Local Var 1    │
├ ─ ─ ─ ─ ─ ─ ─ ─ ─
    Local Var 2    │             I theorize that in a debug build, a
├ ─ ─ ─ ─ ─ ─ ─ ─ ─           distinct space is reserved for each local
        ...        │                  variable of the function.
├ ─ ─ ─ ─ ─ ─ ─ ─ ─
    Local Var N    │            Thus a large number of local variables
├ ─ ─ ─ ─ ─ ─ ─ ─ ─            will result in a large stack frame (and
                   │              thus a large amount of stack space
│     Function                         consumed for each call)
     Parameters    │
│
┌──────────────────┤
│  Return Address  │◀────┐
└──────────────────┘     │
                         │
                         │
                         │         Stack Pointer
                         └──────       (%esp)
```


The "Fix" if you will is to break BinaryExpr into smaller functions that each require less stack space

The stack frame size after this PR is 0x770 = 1904 bytes


```asm
__ZN118_$LT$datafusion..physical_plan..expressions..binary..BinaryExpr$u20$as$u20$datafusion..physical_plan..PhysicalExpr$GT$8evaluate17h2877dfaf102fa64eE:
0000000100d31a50        pushq   %rbp
0000000100d31a51        movq    %rsp, %rbp
0000000100d31a54        subq    $0x770, %rsp                    ## imm = 0x770
0000000100d31a5b        movq    %rdx, -0x6a8(%rbp)
0000000100d31a62        movq    %rsi, -0x6a0(%rbp)
```

Note that even though some of the new functions require non trivial stack size (listed below), a major difference is they are not called recursively and thus there is only ever one frame of them on the stack:

```
evaluate_array_scalar:       0x1DE80 (122496 bytes)
evaluate_scalar_array:       0x162A0 (90784 bytes)
evaluate_with_resolved_args: 0x1F970 (129392 bytes)
```