### PR TITLE
 Update sqlparser-rs to 0.11

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -37,7 +37,7 @@ hashbrown = "0.11"
 log = "0.4"
 prost = "0.8"
 serde = {version = "1", features = ["derive"]}
-sqlparser = "0.10.0"
+sqlparser = "0.11.0"
 tokio = "1.0"
 tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -52,7 +52,7 @@ ahash = "0.7"
 hashbrown = { version = "0.11", features = ["raw"] }
 arrow = { version = "^5.3", features = ["prettyprint"] }
 parquet = { version = "^5.3", features = ["arrow"] }
-sqlparser = "0.10"
+sqlparser = "0.11"
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/datafusion/src/sql/parser.rs
+++ b/datafusion/src/sql/parser.rs
@@ -362,9 +362,10 @@ mod tests {
     fn create_external_table() -> Result<(), ParserError> {
         // positive case
         let sql = "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv'";
+        let display = None;
         let expected = Statement::CreateExternalTable(CreateExternalTable {
             name: "t".into(),
-            columns: vec![make_column_def("c1", DataType::Int)],
+            columns: vec![make_column_def("c1", DataType::Int(display))],
             file_type: FileType::CSV,
             has_header: false,
             location: "foo.csv".into(),

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -102,6 +102,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 verbose,
                 statement,
                 analyze,
+                describe_alias: _,
             } => self.explain_statement_to_plan(*verbose, *analyze, statement),
             Statement::Query(query) => self.query_to_plan(query),
             Statement::ShowVariable { variable } => self.show_variable_to_plan(variable),
@@ -275,9 +276,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Maps the SQL type to the corresponding Arrow `DataType`
     fn make_data_type(&self, sql_type: &SQLDataType) -> Result<DataType> {
         match sql_type {
-            SQLDataType::BigInt => Ok(DataType::Int64),
-            SQLDataType::Int => Ok(DataType::Int32),
-            SQLDataType::SmallInt => Ok(DataType::Int16),
+            SQLDataType::BigInt(_display) => Ok(DataType::Int64),
+            SQLDataType::Int(_display) => Ok(DataType::Int32),
+            SQLDataType::SmallInt(_display) => Ok(DataType::Int16),
             SQLDataType::Char(_) | SQLDataType::Varchar(_) | SQLDataType::Text => {
                 Ok(DataType::Utf8)
             }
@@ -1829,9 +1830,9 @@ fn extract_possible_join_keys(
 pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
     match sql {
         SQLDataType::Boolean => Ok(DataType::Boolean),
-        SQLDataType::SmallInt => Ok(DataType::Int16),
-        SQLDataType::Int => Ok(DataType::Int32),
-        SQLDataType::BigInt => Ok(DataType::Int64),
+        SQLDataType::SmallInt(_display) => Ok(DataType::Int16),
+        SQLDataType::Int(_display) => Ok(DataType::Int32),
+        SQLDataType::BigInt(_display) => Ok(DataType::Int64),
         SQLDataType::Float(_) | SQLDataType::Real => Ok(DataType::Float64),
         SQLDataType::Double => Ok(DataType::Float64),
         SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/1051

 # Rationale for this change
Make https://github.com/sqlparser-rs/sqlparser-rs/pull/356 from @Igosuki available in DataFusion in support of https://github.com/apache/arrow-datafusion/pull/1006

# What changes are included in this PR?
1. Update dependencies to sqlparser-rs 0.11
2. Update code to handle changes in API


# Are there any user-facing changes?
Yes, new dependent versions are needed
