### PR TITLE
WIP: Extended Tokomak optimizer

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -58,7 +58,6 @@ num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
 egg="0.6.0"
-nom="7.0"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -57,6 +57,8 @@ paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
+egg="0.6.0"
+nom="7.0"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }

--- a/datafusion/src/logical_plan/window_frames.rs
+++ b/datafusion/src/logical_plan/window_frames.rs
@@ -34,7 +34,7 @@ use std::fmt;
 /// The ending frame boundary can be omitted (if the BETWEEN and AND keywords that surround the
 /// starting frame boundary are also omitted), in which case the ending frame boundary defaults to
 /// CURRENT ROW.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowFrame {
     /// A frame type - either ROWS, RANGE or GROUPS
     pub units: WindowFrameUnits,
@@ -126,7 +126,7 @@ impl Default for WindowFrame {
 /// 5. UNBOUNDED FOLLOWING
 ///
 /// in this implementation we'll only allow <expr> to be u64 (i.e. no dynamic boundary)
-#[derive(Debug, Clone, Copy, Eq)]
+#[derive(Debug, Clone, Copy, Eq, Hash)]
 pub enum WindowFrameBound {
     /// 1. UNBOUNDED PRECEDING
     /// The frame boundary is the first row in the partition.
@@ -211,7 +211,7 @@ impl WindowFrameBound {
 
 /// There are three frame types: ROWS, GROUPS, and RANGE. The frame type determines how the
 /// starting and ending boundaries of the frame are measured.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowFrameUnits {
     /// The ROWS frame type means that the starting and ending boundaries for the frame are
     /// determined by counting individual rows relative to the current row.

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -26,4 +26,5 @@ pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
 pub mod simplify_expressions;
+pub mod tokomak;
 pub mod utils;

--- a/datafusion/src/optimizer/tokomak/datatype.rs
+++ b/datafusion/src/optimizer/tokomak/datatype.rs
@@ -1,7 +1,7 @@
 use crate::error::DataFusionError;
 use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
 use egg::*;
-use std::convert::{TryFrom};
+use std::convert::TryFrom;
 use std::fmt::Display;
 use std::str::FromStr;
 

--- a/datafusion/src/optimizer/tokomak/datatype.rs
+++ b/datafusion/src/optimizer/tokomak/datatype.rs
@@ -1,0 +1,166 @@
+use crate::error::DataFusionError;
+use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
+use egg::*;
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Display;
+use std::str::FromStr;
+
+define_language! {
+    #[derive(Copy)]
+    pub enum TokomakDataType {
+        "date32" = Date32,
+        "date64" = Date64,
+        "bool" = Boolean,
+        "int8" = Int8,
+        "int16" =Int16,
+        "int32" =Int32,
+        "int64" =Int64,
+        "uint8" =UInt8,
+        "uint16" =UInt16,
+        "uint32" =UInt32,
+        "uint64" =UInt64,
+        "float16" =Float16,
+        "float32" =Float32,
+        "float64" =Float64,
+        "utf8"=Utf8,
+        "largeutf8"=LargeUtf8,
+        "time(s)"=TimestampSecond,
+        "time(ms)"=TimestampMillisecond,
+        "time(us)"=TimestampMicrosecond,
+        "time(ns)"=TimestampNanosecond,
+        "interval(yearmonth)"=IntervalYearMonth,
+        "interval(daytime)"=IntervalDayTime,
+    }
+}
+
+impl Display for TokomakDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self))
+    }
+}
+
+impl Into<DataType> for &TokomakDataType {
+    fn into(self) -> DataType {
+        let v = *self;
+        v.into()
+    }
+}
+
+impl Into<DataType> for TokomakDataType {
+    fn into(self) -> DataType {
+        match self {
+            TokomakDataType::Date32 => DataType::Date32,
+            TokomakDataType::Date64 => DataType::Date64,
+            TokomakDataType::Boolean => DataType::Boolean,
+            TokomakDataType::Int8 => DataType::Int8,
+            TokomakDataType::Int16 => DataType::Int16,
+            TokomakDataType::Int32 => DataType::Int32,
+            TokomakDataType::Int64 => DataType::Int64,
+            TokomakDataType::UInt8 => DataType::UInt8,
+            TokomakDataType::UInt16 => DataType::UInt16,
+            TokomakDataType::UInt32 => DataType::UInt32,
+            TokomakDataType::UInt64 => DataType::UInt64,
+            TokomakDataType::Float16 => DataType::Float16,
+            TokomakDataType::Float32 => DataType::Float32,
+            TokomakDataType::Float64 => DataType::Float64,
+            TokomakDataType::Utf8 => DataType::Utf8,
+            TokomakDataType::LargeUtf8 => DataType::LargeUtf8,
+            TokomakDataType::TimestampSecond => {
+                DataType::Timestamp(TimeUnit::Second, None)
+            }
+            TokomakDataType::TimestampMillisecond => {
+                DataType::Timestamp(TimeUnit::Millisecond, None)
+            }
+            TokomakDataType::TimestampMicrosecond => {
+                DataType::Timestamp(TimeUnit::Microsecond, None)
+            }
+            TokomakDataType::TimestampNanosecond => {
+                DataType::Timestamp(TimeUnit::Nanosecond, None)
+            }
+            TokomakDataType::IntervalYearMonth => {
+                DataType::Interval(IntervalUnit::YearMonth)
+            }
+            TokomakDataType::IntervalDayTime => DataType::Interval(IntervalUnit::DayTime),
+        }
+    }
+}
+
+impl TryFrom<DataType> for TokomakDataType {
+    type Error = DataFusionError;
+    fn try_from(val: DataType) -> Result<Self, Self::Error> {
+        Ok(match val {
+            DataType::Date32 => TokomakDataType::Date32,
+            DataType::Date64 => TokomakDataType::Date64,
+            DataType::Boolean => TokomakDataType::Boolean,
+            DataType::Int8 => TokomakDataType::Int8,
+            DataType::Int16 => TokomakDataType::Int16,
+            DataType::Int32 => TokomakDataType::Int32,
+            DataType::Int64 => TokomakDataType::Int64,
+            DataType::UInt8 => TokomakDataType::UInt8,
+            DataType::UInt16 => TokomakDataType::UInt16,
+            DataType::UInt32 => TokomakDataType::UInt32,
+            DataType::UInt64 => TokomakDataType::UInt64,
+            DataType::Float16 => TokomakDataType::Float16,
+            DataType::Float32 => TokomakDataType::Float32,
+            DataType::Float64 => TokomakDataType::Float64,
+            DataType::Utf8 => TokomakDataType::Utf8,
+            DataType::LargeUtf8 => TokomakDataType::LargeUtf8,
+            DataType::Timestamp(TimeUnit::Second, None) => {
+                TokomakDataType::TimestampSecond
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, None) => {
+                TokomakDataType::TimestampMillisecond
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, None) => {
+                TokomakDataType::TimestampMicrosecond
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond, None) => {
+                TokomakDataType::TimestampNanosecond
+            }
+            DataType::Interval(IntervalUnit::YearMonth) => {
+                TokomakDataType::IntervalYearMonth
+            }
+            DataType::Interval(IntervalUnit::DayTime) => TokomakDataType::IntervalDayTime,
+            _ => {
+                return Err(DataFusionError::Internal(format!(
+                    "The data type {} is invalid as a tokomak datatype",
+                    val
+                )))
+            }
+        })
+    }
+}
+
+impl FromStr for TokomakDataType {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "date32" => Ok(TokomakDataType::Date32),
+            "date64" => Ok(TokomakDataType::Date64),
+            "bool" => Ok(TokomakDataType::Boolean),
+            "int8" => Ok(TokomakDataType::Int8),
+            "int16" => Ok(TokomakDataType::Int16),
+            "int32" => Ok(TokomakDataType::Int32),
+            "int64" => Ok(TokomakDataType::Int64),
+            "uint8" => Ok(TokomakDataType::UInt8),
+            "uint16" => Ok(TokomakDataType::UInt16),
+            "uint32" => Ok(TokomakDataType::UInt32),
+            "uint64" => Ok(TokomakDataType::UInt64),
+            "float16" => Ok(TokomakDataType::Float16),
+            "float32" => Ok(TokomakDataType::Float32),
+            "float64" => Ok(TokomakDataType::Float64),
+            "utf8" => Ok(TokomakDataType::Utf8),
+            "largeutf8" => Ok(TokomakDataType::LargeUtf8),
+            "time(s)" => Ok(TokomakDataType::TimestampSecond),
+            "time(ms)" => Ok(TokomakDataType::TimestampMillisecond),
+            "time(us)" => Ok(TokomakDataType::TimestampMicrosecond),
+            "time(ns)" => Ok(TokomakDataType::TimestampNanosecond),
+            "interval(yearmonth)" => Ok(TokomakDataType::IntervalYearMonth),
+            "interval(daytime)" => Ok(TokomakDataType::IntervalDayTime),
+            _ => Err(DataFusionError::Internal(
+                "Parsing string as TokomakDataType failed".to_string(),
+            )),
+        }
+    }
+}

--- a/datafusion/src/optimizer/tokomak/datatype.rs
+++ b/datafusion/src/optimizer/tokomak/datatype.rs
@@ -1,7 +1,7 @@
 use crate::error::DataFusionError;
 use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
 use egg::*;
-use std::convert::{TryFrom, TryInto};
+use std::convert::{TryFrom};
 use std::fmt::Display;
 use std::str::FromStr;
 

--- a/datafusion/src/optimizer/tokomak/expr.rs
+++ b/datafusion/src/optimizer/tokomak/expr.rs
@@ -1,0 +1,113 @@
+use crate::{error::DataFusionError, logical_plan::window_frames::WindowFrame, optimizer::tokomak::{SortSpec, UDFName}, physical_plan::{
+        aggregates::AggregateFunction, functions::BuiltinScalarFunction,
+        window_functions::WindowFunction,
+    }, scalar::ScalarValue};
+use egg::{rewrite as rw, *};
+use ordered_float::OrderedFloat;
+
+use super::datatype::TokomakDataType;
+use super::scalar::TokomakScalar;
+use std::str::FromStr;
+use std::convert::{TryFrom, TryInto};
+define_language! {
+pub enum TokomakExpr {
+    "+" = Plus([Id; 2]),
+    "-" = Minus([Id; 2]),
+    "*" = Multiply([Id; 2]),
+    "/" = Divide([Id; 2]),
+    "%" = Modulus([Id; 2]),
+    "not" = Not(Id),
+    "or" = Or([Id; 2]),
+    "and" = And([Id; 2]),
+    "=" = Eq([Id; 2]),
+    "<>" = NotEq([Id; 2]),
+    "<" = Lt([Id; 2]),
+    "<=" = LtEq([Id; 2]),
+    ">" = Gt([Id; 2]),
+    ">=" = GtEq([Id; 2]),
+    "regex_match"=RegexMatch([Id;2]),
+    "regex_imatch"=RegexIMatch([Id;2]),
+    "regex_not_match"=RegexNotMatch([Id;2]),
+    "regex_not_imatch"=RegexNotIMatch([Id;2]),
+
+
+    "is_not_null" = IsNotNull(Id),
+    "is_null" = IsNull(Id),
+    "negative" = Negative(Id),
+    "between" = Between([Id; 3]),
+    "between_inverted" = BetweenInverted([Id; 3]),
+    "like" = Like([Id; 2]),
+    "not_like" = NotLike([Id; 2]),
+    "in_list" = InList([Id; 2]),
+    "not_in_list" = NotInList([Id; 2]),
+    "list" = List(Vec<Id>),
+
+    //ScalarValue types
+
+    Scalar(TokomakScalar),
+    Type(TokomakDataType),
+    ScalarBuiltin(BuiltinScalarFunction),
+    AggregateBuiltin(AggregateFunction),
+    WindowBuiltin(WindowFunction),
+    //THe fist expression for all of the function call types must be the corresponding function type
+    //For UDFs this is a string, which is looked up in the ExecutionProps
+    //The last expression must be a List and is the arguments for the function.
+    "call" = ScalarBuiltinCall([Id; 2]),
+    "call_udf"=ScalarUDFCall([Id; 2]),
+    "call_agg" = AggregateBuiltinCall([Id; 2]),
+    "call_agg_distinct"=AggregateBuiltinDistinctCall([Id;2]),
+    "call_udaf" = AggregateUDFCall([Id; 2]),
+    //For window fuctions index 1 is the window partition
+    //index 2 is the window order
+    "call_win" = WindowBuiltinCallUnframed([Id;4 ]),
+    //For a framed window function index 3 is the frame parameters
+    "call_win_framed" = WindowBuiltinCallFramed([Id;5 ]),
+    //Last Id of the Sort node MUST be a SortSpec
+    "sort" = Sort([Id;2]),
+    SortSpec(SortSpec),
+    ScalarUDF(UDFName),
+    AggregateUDF(UDFName),
+    Column(Symbol),
+    WindowFrame(WindowFrame),
+
+    // cast id as expr. Type is encoded as symbol
+    "cast" = Cast([Id; 2]),
+    "try_cast" = TryCast([Id;2]),
+}
+}
+
+
+impl TokomakExpr{
+   pub(crate) fn can_convert_to_scalar_value(&self)->bool{
+        matches!(self, TokomakExpr::Scalar(_))
+    }
+}
+
+impl TryInto<ScalarValue> for &TokomakExpr{
+    type Error = DataFusionError;
+
+    fn try_into(self) -> Result<ScalarValue, Self::Error> {
+        match self{
+            TokomakExpr::Scalar(s)=>Ok(s.clone().into()),
+            e => Err(DataFusionError::Internal(format!("Could not convert {:?} to scalar", e)))
+        }
+    }
+
+}
+
+
+
+impl From<ScalarValue> for TokomakExpr{
+    fn from(v: ScalarValue) -> Self {
+        TokomakExpr::Scalar(v.into())
+    }
+}
+impl FromStr for WindowFrame {
+    type Err = DataFusionError;
+    #[allow(unused_variables)]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Err(DataFusionError::NotImplemented(
+            "WindowFrame's aren't parsed yet".to_string(),
+        ))
+    }
+}

--- a/datafusion/src/optimizer/tokomak/expr.rs
+++ b/datafusion/src/optimizer/tokomak/expr.rs
@@ -1,13 +1,19 @@
-use crate::{error::DataFusionError, logical_plan::window_frames::WindowFrame, optimizer::tokomak::{ScalarUDFName, SortSpec, UDAFName, UDFName}, physical_plan::{
+use crate::{
+    error::DataFusionError,
+    logical_plan::window_frames::WindowFrame,
+    optimizer::tokomak::{ScalarUDFName, SortSpec, UDAFName, UDFName},
+    physical_plan::{
         aggregates::AggregateFunction, functions::BuiltinScalarFunction,
         window_functions::WindowFunction,
-    }, scalar::ScalarValue};
-use egg:: *;
+    },
+    scalar::ScalarValue,
+};
+use egg::*;
 
 use super::datatype::TokomakDataType;
 use super::scalar::TokomakScalar;
+use std::convert::TryInto;
 use std::str::FromStr;
-use std::convert::{ TryInto};
 define_language! {
 pub enum TokomakExpr {
     "+" = Plus([Id; 2]),
@@ -76,28 +82,27 @@ pub enum TokomakExpr {
 }
 }
 
-
-impl TokomakExpr{
-   pub(crate) fn can_convert_to_scalar_value(&self)->bool{
+impl TokomakExpr {
+    pub(crate) fn can_convert_to_scalar_value(&self) -> bool {
         matches!(self, TokomakExpr::Scalar(_))
     }
 }
 
-impl TryInto<ScalarValue> for &TokomakExpr{
+impl TryInto<ScalarValue> for &TokomakExpr {
     type Error = DataFusionError;
 
     fn try_into(self) -> Result<ScalarValue, Self::Error> {
-        match self{
-            TokomakExpr::Scalar(s)=>Ok(s.clone().into()),
-            e => Err(DataFusionError::Internal(format!("Could not convert {:?} to scalar", e)))
+        match self {
+            TokomakExpr::Scalar(s) => Ok(s.clone().into()),
+            e => Err(DataFusionError::Internal(format!(
+                "Could not convert {:?} to scalar",
+                e
+            ))),
         }
     }
-
 }
 
-
-
-impl From<ScalarValue> for TokomakExpr{
+impl From<ScalarValue> for TokomakExpr {
     fn from(v: ScalarValue) -> Self {
         TokomakExpr::Scalar(v.into())
     }

--- a/datafusion/src/optimizer/tokomak/expr.rs
+++ b/datafusion/src/optimizer/tokomak/expr.rs
@@ -1,14 +1,13 @@
-use crate::{error::DataFusionError, logical_plan::window_frames::WindowFrame, optimizer::tokomak::{SortSpec, UDFName}, physical_plan::{
+use crate::{error::DataFusionError, logical_plan::window_frames::WindowFrame, optimizer::tokomak::{ScalarUDFName, SortSpec, UDAFName, UDFName}, physical_plan::{
         aggregates::AggregateFunction, functions::BuiltinScalarFunction,
         window_functions::WindowFunction,
     }, scalar::ScalarValue};
-use egg::{rewrite as rw, *};
-use ordered_float::OrderedFloat;
+use egg:: *;
 
 use super::datatype::TokomakDataType;
 use super::scalar::TokomakScalar;
 use std::str::FromStr;
-use std::convert::{TryFrom, TryInto};
+use std::convert::{ TryInto};
 define_language! {
 pub enum TokomakExpr {
     "+" = Plus([Id; 2]),
@@ -44,11 +43,12 @@ pub enum TokomakExpr {
 
     //ScalarValue types
 
-    Scalar(TokomakScalar),
     Type(TokomakDataType),
     ScalarBuiltin(BuiltinScalarFunction),
     AggregateBuiltin(AggregateFunction),
     WindowBuiltin(WindowFunction),
+    Scalar(TokomakScalar),
+
     //THe fist expression for all of the function call types must be the corresponding function type
     //For UDFs this is a string, which is looked up in the ExecutionProps
     //The last expression must be a List and is the arguments for the function.
@@ -65,8 +65,8 @@ pub enum TokomakExpr {
     //Last Id of the Sort node MUST be a SortSpec
     "sort" = Sort([Id;2]),
     SortSpec(SortSpec),
-    ScalarUDF(UDFName),
-    AggregateUDF(UDFName),
+    ScalarUDF(ScalarUDFName),
+    AggregateUDF(UDAFName),
     Column(Symbol),
     WindowFrame(WindowFrame),
 

--- a/datafusion/src/optimizer/tokomak/mod.rs
+++ b/datafusion/src/optimizer/tokomak/mod.rs
@@ -3,19 +3,15 @@
 //!
 //! This saves time in planning and executing the query.
 
-use arrow::datatypes::{DataType};
-use std::convert::{TryInto};
+use arrow::datatypes::DataType;
+use std::convert::TryInto;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::str::FromStr;
 
-
-
 use crate::physical_plan::udaf::AggregateUDF;
 use crate::physical_plan::udf::ScalarUDF;
-use crate::{
-    logical_plan::LogicalPlan, optimizer::optimizer::OptimizerRule,
-};
+use crate::{logical_plan::LogicalPlan, optimizer::optimizer::OptimizerRule};
 use log::debug;
 
 use crate::error::{DataFusionError, Result as DFResult};
@@ -607,8 +603,9 @@ impl<'a> ExprConverter<'a> {
                 let args_id = self.add_list(args)?;
                 self.udf_registry.add_sudf(fun.clone());
                 let fun_name: Symbol = fun.name.clone().into();
-                let fun_name_id =
-                    self.rec_expr.add(TokomakExpr::ScalarUDF(ScalarUDFName(fun_name)));
+                let fun_name_id = self
+                    .rec_expr
+                    .add(TokomakExpr::ScalarUDF(ScalarUDFName(fun_name)));
                 self.rec_expr
                     .add(TokomakExpr::ScalarUDFCall([fun_name_id, args_id]))
             }
@@ -728,7 +725,11 @@ impl FromStr for UDFName {
         //    println!("{} - {}", pos, c);
         //}
         //println!("The first char was of the string '{}' was '{}'",s, first_char);
-        if first_char == '?' || first_char.is_numeric() || first_char=='"' || first_char == '\'' {
+        if first_char == '?'
+            || first_char.is_numeric()
+            || first_char == '"'
+            || first_char == '\''
+        {
             //println!("Could not parse {} as udf name ", s);
             return Err(DataFusionError::Internal(
                 "Found ? or number as first char".to_string(),
@@ -740,28 +741,29 @@ impl FromStr for UDFName {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 
 pub struct ScalarUDFName(pub Symbol);
-impl FromStr for ScalarUDFName{
-    type Err=();
+impl FromStr for ScalarUDFName {
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 7{
+        if s.len() < 7 {
             return Err(());
         }
-        match &s[0..4]{
+        match &s[0..4] {
             "udf[" => {
-                if &s[s.len()-1..s.len()]=="]"{
-                    Ok( ScalarUDFName(Symbol::from_str(&s[4..(s.len()-1)]).unwrap()))
-                }else{
+                if &s[s.len() - 1..s.len()] == "]" {
+                    Ok(ScalarUDFName(
+                        Symbol::from_str(&s[4..(s.len() - 1)]).unwrap(),
+                    ))
+                } else {
                     Err(())
                 }
-                
             }
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }
 
-impl Display for ScalarUDFName{
+impl Display for ScalarUDFName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "udf[{}]", self.0)
     }
@@ -770,34 +772,31 @@ impl Display for ScalarUDFName{
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 
 pub struct UDAFName(pub Symbol);
-impl FromStr for UDAFName{
-    type Err=();
+impl FromStr for UDAFName {
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 8{
+        if s.len() < 8 {
             return Err(());
         }
-        match &s[0..5]{
+        match &s[0..5] {
             "udaf[" => {
-                if &s[s.len()-1..s.len()]=="]"{
-                    Ok( UDAFName(Symbol::from_str(&s[5..(s.len()-1)]).unwrap()))
-                }else{
+                if &s[s.len() - 1..s.len()] == "]" {
+                    Ok(UDAFName(Symbol::from_str(&s[5..(s.len() - 1)]).unwrap()))
+                } else {
                     Err(())
                 }
-                
             }
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }
 
-impl Display for UDAFName{
+impl Display for UDAFName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "udaf[{}]", self.0)
     }
 }
-
-
 
 impl OptimizerRule for Tokomak {
     fn optimize(

--- a/datafusion/src/optimizer/tokomak/mod.rs
+++ b/datafusion/src/optimizer/tokomak/mod.rs
@@ -1,0 +1,787 @@
+#![allow(missing_docs)]
+
+//!
+//! This saves time in planning and executing the query.
+
+use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Display;
+use std::hash::Hash;
+use std::str::FromStr;
+
+use crate::physical_plan::aggregates::AggregateFunction;
+use crate::physical_plan::functions::BuiltinScalarFunction;
+use crate::physical_plan::udaf::AggregateUDF;
+use crate::physical_plan::udf::ScalarUDF;
+use crate::{
+    logical_plan::LogicalPlan, optimizer::optimizer::OptimizerRule, scalar::ScalarValue,
+};
+use log::debug;
+
+use crate::error::{DataFusionError, Result as DFResult};
+use crate::execution::context::ExecutionProps;
+use crate::logical_plan::{Column, Expr};
+use crate::{logical_plan::Operator, optimizer::utils};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use egg::{rewrite as rw, *};
+use ordered_float::OrderedFloat;
+pub mod datatype;
+pub mod expr;
+pub mod rules;
+pub mod scalar;
+use datatype::TokomakDataType;
+use expr::TokomakExpr;
+
+use std::rc::Rc;
+
+pub trait UDFRegistry {
+    fn add_sudf(&mut self, udf: Arc<ScalarUDF>);
+    fn add_uadf(&mut self, udf: Arc<AggregateUDF>);
+}
+
+impl UDFRegistry for HashMap<String, UDF> {
+    fn add_sudf(&mut self, udf: Arc<ScalarUDF>) {
+        if !self.contains_key(&udf.name) {
+            self.insert(udf.name.to_owned(), UDF::Scalar(udf));
+        }
+    }
+
+    fn add_uadf(&mut self, udf: Arc<AggregateUDF>) {
+        if !self.contains_key(&udf.name) {
+            self.insert(udf.name.to_owned(), UDF::Aggregate(udf));
+        }
+    }
+}
+pub trait UDFAwareRuleGenerator {
+    fn generate_rules(
+        &self,
+        udf_registry: Rc<HashMap<String, UDF>>,
+    ) -> Vec<Rewrite<TokomakExpr, ()>>;
+}
+impl<F: Fn(Rc<HashMap<String, UDF>>) -> Vec<Rewrite<TokomakExpr, ()>>>
+    UDFAwareRuleGenerator for F
+{
+    fn generate_rules(
+        &self,
+        udf_registry: Rc<HashMap<String, UDF>>,
+    ) -> Vec<Rewrite<TokomakExpr, ()>> {
+        self(udf_registry)
+    }
+}
+
+pub struct Tokomak {
+    rules: Vec<Rewrite<TokomakExpr, ()>>,
+    udf_aware_rules: Vec<Box<dyn UDFAwareRuleGenerator>>,
+}
+impl Tokomak {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {
+            rules: Vec::new(),
+            udf_aware_rules: Vec::new(),
+        }
+    }
+    pub fn with_rules(custom_rules: &[Rewrite<TokomakExpr, ()>]) -> Self {
+        let mut new = Self::new();
+        new.add_rules(custom_rules);
+        new
+    }
+    pub fn add_rules(&mut self, rules: &[Rewrite<TokomakExpr, ()>]) {
+        self.rules.extend_from_slice(rules);
+    }
+    pub fn add_rule(&mut self, rule: Rewrite<TokomakExpr, ()>) {
+        self.rules.push(rule);
+    }
+    pub fn add_udf_aware_rules(&mut self, generator: Box<dyn UDFAwareRuleGenerator>) {
+        self.udf_aware_rules.push(generator);
+    }
+}
+
+fn convert_to_tokomak_expr(
+    expr: Expr,
+    udf_reg: &mut HashMap<String, UDF>,
+) -> DFResult<RecExpr<TokomakExpr>> {
+    let mut rec_expr = RecExpr::default();
+    let mut converter = ExprConverter::new(&mut rec_expr, udf_reg);
+    converter.to_tokomak_expr(expr)?;
+    Ok(rec_expr)
+}
+
+fn to_expr(
+    rec_expr: &RecExpr<TokomakExpr>,
+    udf_reg: &HashMap<String, UDF>,
+) -> DFResult<Expr> {
+    let converter = TokomakExprConverter::new(udf_reg, rec_expr);
+    let start = rec_expr.as_ref().len() - 1;
+    converter.convert_to_expr(start.into())
+}
+struct TokomakExprConverter<'a> {
+    udf_reg: &'a HashMap<String, UDF>,
+    rec_expr: &'a RecExpr<TokomakExpr>,
+    refs: &'a [TokomakExpr],
+}
+
+impl<'a> TokomakExprConverter<'a> {
+    fn new(
+        udf_reg: &'a HashMap<String, UDF>,
+        rec_expr: &'a RecExpr<TokomakExpr>,
+    ) -> Self {
+        Self {
+            udf_reg,
+            rec_expr,
+            refs: rec_expr.as_ref(),
+        }
+    }
+    fn get_ref(&self, id: Id) -> &TokomakExpr {
+        let idx: usize = id.into();
+        &self.refs[idx]
+    }
+
+    fn to_list(&self, id: Id) -> DFResult<Vec<Expr>> {
+        let idx: usize = id.into();
+        let list_expr = &self.rec_expr.as_ref()[idx];
+        match list_expr {
+            TokomakExpr::List(ids) => ids
+                .iter()
+                .map(|i| self.convert_to_expr(*i))
+                .collect::<DFResult<Vec<_>>>(),
+            e => Err(DataFusionError::Internal(format!(
+                "Expected Tokomak list found: {:?}",
+                e
+            ))),
+        }
+    }
+    fn to_binary_op(&self, &[l, r]: &[Id; 2], op: Operator) -> DFResult<Expr> {
+        let l = self.convert_to_expr(l)?;
+        let r = self.convert_to_expr(r)?;
+        Ok(Expr::BinaryExpr {
+            left: Box::new(l),
+            op,
+            right: Box::new(r),
+        })
+    }
+    fn convert_to_expr(&self, id: Id) -> DFResult<Expr> {
+        let expr = match self.get_ref(id) {
+            TokomakExpr::Plus(ids) => self.to_binary_op(ids, Operator::Plus)?,
+            TokomakExpr::Minus(ids) => self.to_binary_op(ids, Operator::Minus)?,
+            TokomakExpr::Divide(ids) =>self.to_binary_op(ids, Operator::Divide)?,
+            TokomakExpr::Modulus(ids) => self.to_binary_op(ids, Operator::Modulo)?,
+            TokomakExpr::Multiply(ids) => self.to_binary_op(ids, Operator::Multiply)?,
+            TokomakExpr::Or(ids) => self.to_binary_op(ids, Operator::Or)?,
+            TokomakExpr::And(ids) => self.to_binary_op(ids, Operator::And)?,
+            TokomakExpr::Eq(ids) => self.to_binary_op(ids, Operator::Eq)?,
+            TokomakExpr::NotEq(ids) => self.to_binary_op(ids, Operator::NotEq)?,
+            TokomakExpr::Lt(ids) => self.to_binary_op(ids, Operator::Lt)?,
+            TokomakExpr::LtEq(ids) =>self.to_binary_op(ids, Operator::LtEq)?,
+            TokomakExpr::Gt(ids) => self.to_binary_op(ids, Operator::Gt)?,
+            TokomakExpr::GtEq(ids) => self.to_binary_op(ids, Operator::GtEq)?,
+            TokomakExpr::Like(ids) => self.to_binary_op(ids, Operator::Like)?,
+            TokomakExpr::NotLike(ids) => self.to_binary_op(ids, Operator::NotLike)?,
+            TokomakExpr::RegexMatch(ids) => self.to_binary_op(ids, Operator::RegexMatch)?,
+            TokomakExpr::RegexIMatch(ids) => self.to_binary_op(ids, Operator::RegexIMatch)?,
+            TokomakExpr::RegexNotMatch(ids) => self.to_binary_op(ids, Operator::RegexNotMatch)?,
+            TokomakExpr::RegexNotIMatch(ids) => self.to_binary_op(ids, Operator::RegexNotIMatch)?,
+            TokomakExpr::Not(id) => {
+                let l = self.convert_to_expr(*id)?;
+                Expr::Not(Box::new(l))
+            }
+            TokomakExpr::IsNotNull(id) => {
+                let l = self.convert_to_expr(*id)?;
+                Expr::IsNotNull(Box::new(l))
+            }
+            TokomakExpr::IsNull(id) => {
+                let l = self.convert_to_expr(*id)?;
+                Expr::IsNull(Box::new(l))
+            }
+            TokomakExpr::Negative(id) => {
+                let l = self.convert_to_expr(*id)?;
+                Expr::Negative(Box::new(l))
+            }
+            TokomakExpr::Between([expr, low, high]) => {
+                let left = self.convert_to_expr(*expr)?;
+                let low_expr = self.convert_to_expr(*low)?;
+                let high_expr = self.convert_to_expr(*high)?;
+                Expr::Between {
+                    expr: Box::new(left),
+                    negated: false,
+                    low: Box::new(low_expr),
+                    high: Box::new(high_expr),
+                }
+            }
+            TokomakExpr::BetweenInverted([expr, low, high]) => {
+                let left = self.convert_to_expr(*expr)?;
+                let low_expr = self.convert_to_expr(*low)?;
+                let high_expr = self.convert_to_expr(*high)?;
+                Expr::Between {
+                    expr: Box::new(left),
+                    negated: false,
+                    low: Box::new(low_expr),
+                    high: Box::new(high_expr),
+                }
+            }
+            //TODO: Fix column handling
+            TokomakExpr::Column(col) => Expr::Column(Column{name: col.to_string(), relation:None}),
+            TokomakExpr::Cast([e, ty]) => {
+                let l = self.convert_to_expr(*e)?;
+                let dt = match self.get_ref(*ty) {
+                    TokomakExpr::Type(s) => s,
+                    e => return Err(DataFusionError::Internal(format!("Cast expected a type expression in the second position, found: {:?}",e))),
+                };
+                let dt: DataType = dt.into();
+                Expr::Cast { expr: Box::new(l), data_type: dt}
+            }
+            TokomakExpr::Type(_) => {
+                panic!("Type should only be part of expression")
+            }
+            TokomakExpr::InList([val, list])=>{
+                let l = self.convert_to_expr(*val)?;
+                let list = self.get_ref(*list);
+                let list = match list{
+                    TokomakExpr::List(ref l) => l.iter().map(|i| self.convert_to_expr(*i )).collect::<DFResult<Vec<Expr>>>()?,
+                    e => return Err(DataFusionError::Internal(format!("InList expected a list in the second position found {:?}", e))),
+                };
+                Expr::InList{
+                  list,
+                  expr: Box::new(l),
+                  negated: false,
+                }
+            }
+            TokomakExpr::NotInList([val, list])=>{
+                let l = self.convert_to_expr(*val)?;
+                let list = self.get_ref(*list);
+                let list = match list{
+                    TokomakExpr::List(ref l) => l.iter().map(|i| self.convert_to_expr(*i )).collect::<DFResult<Vec<Expr>>>()?,
+                    e=> return Err(DataFusionError::Internal(format!("NotInList expected a list in the second position found {:?}", e))),
+                };
+                Expr::InList{
+                  list,
+                  expr: Box::new(l),
+                  negated: true,
+                }
+            }
+            TokomakExpr::List(_) => return Err(DataFusionError::Internal("TokomakExpr::List should only ever be a child expr and should be handled by the parent expression".to_string())),
+            TokomakExpr::Scalar(s) => Expr::Literal(s.clone().into()),
+            TokomakExpr::ScalarBuiltin(_) => panic!("ScalarBuiltin should only be part of an expression"),
+            TokomakExpr::ScalarBuiltinCall([fun, args]) => {
+                let fun = match self.get_ref(*fun){
+                    TokomakExpr::ScalarBuiltin(f)=>f,
+                    f => return Err(DataFusionError::Internal(format!("Expected a builtin scalar function function in the first position, found {:?}", f))),
+                };
+                let arg_ids = match self.get_ref(*args){
+                    TokomakExpr::List(args)=> args,
+                    e => panic!("Expected a list of function arguments for a ScalarBuiltinCall, found: {:?}", e),
+                };
+                let args = arg_ids.iter().map(|expr| self.convert_to_expr(*expr)).collect::<DFResult<Vec<_>>>()?;
+                Expr::ScalarFunction{
+                    fun:fun.clone(),
+                    args,
+                }
+            },
+            TokomakExpr::TryCast([e, ty]) => {
+                let l = self.convert_to_expr(*e)?;
+                let dt = match self.get_ref(*ty) {
+                    TokomakExpr::Type(s) => s,
+                    e => return Err(DataFusionError::Internal(format!("Cast expected a type expression in the second position, found: {:?}",e))),
+                };
+                let dt: DataType = dt.into();
+                Expr::TryCast { expr: Box::new(l), data_type: dt}
+            },
+            TokomakExpr::AggregateBuiltin(_) => todo!(),
+            TokomakExpr::ScalarUDFCall([name, args]) => {
+                let args = self.get_ref(*args);
+                let args = match args{
+                    TokomakExpr::List(ref l) => l.iter().map(|i| self.convert_to_expr(*i )).collect::<DFResult<Vec<Expr>>>()?,
+                    e => return Err(DataFusionError::Internal(format!("ScalarUDFCall expected a type expression in the second position, found: {:?}",e))),
+                };
+                let name = self.get_ref(*name);
+                let name = match name{
+                    TokomakExpr::ScalarUDF(sym)=> sym.0.to_string(),
+                    e => panic!("Found a non ScalarUDF node in the first position of ScalarUdf: {:#?}",e),
+                };
+                let fun = match self.udf_reg.get(&name){
+                    Some(s) => s,
+                    None => return Err(DataFusionError::Internal(format!("Did not find the scalar UDF {} in the registry", name))),
+                };
+                let fun = match fun{
+                    UDF::Scalar(s) => s.clone(),
+                    UDF::Aggregate(_) => return Err(DataFusionError::Internal(format!("Did not find scalar UDF named {}. Found an aggregate UDF instead.", name))),
+                };
+                Expr::ScalarUDF{
+                    fun,
+                    args
+                }
+            },
+            TokomakExpr::AggregateBuiltinCall([fun, args]) =>{
+                let fun = match self.get_ref(*fun){
+                    TokomakExpr::AggregateBuiltin(f)=>f.clone(),
+                    e => return Err(DataFusionError::Internal(format!("Expected a built in AggregateFunction, found {:?}", e))),
+                };
+                let args = self.to_list(*args).map_err(|e| DataFusionError::Internal(format!("AggregateBuiltinCall could not convert args expr to list of expressions: {}", e)))?;
+                Expr::AggregateFunction{
+                    fun,
+                    args,
+                    distinct: false
+                }
+            },
+            TokomakExpr::AggregateBuiltinDistinctCall([fun,args]) => {
+                let fun = match self.get_ref(*fun){
+                    TokomakExpr::AggregateBuiltin(f)=>f.clone(),
+                    e => return Err(DataFusionError::Internal(format!("Expected a built in AggregateFunction, found {:?}", e))),
+                };
+                let args = self.to_list(*args).map_err(|e| DataFusionError::Internal(format!("AggregateBuiltinDistinctCall could not convert args expr to list of expressions: {}", e)))?;
+                Expr::AggregateFunction{
+                    fun,
+                    args,
+                    distinct: true
+                }
+            },
+            TokomakExpr::AggregateUDF(name) => return Err(DataFusionError::Internal(format!("Encountered an AggregateUDF expression with the name {}, these should only occur in a AggregateUDFCall and should be dealt with there", name))),
+
+            TokomakExpr::ScalarUDF(name) => return Err(DataFusionError::Internal(format!("Encountered an ScalarUDF expression with the name {}, these should only occur in a ScalarUDFCall and should be dealt with there", name))),
+            TokomakExpr::AggregateUDFCall([fun, args]) => {
+                let udf_name = match self.get_ref(*fun){
+                    TokomakExpr::AggregateUDF(name) => name.to_string(),
+                    e =>    return Err(DataFusionError::Internal(format!("Expected an AggregateUDF node at index 0 of AggregateUDFCall, found: {:?}",e)))
+                };
+                let fun = match self.udf_reg.get(&udf_name){
+                    Some(s) => s,
+                    None => return Err(DataFusionError::Internal(format!("Did not find the aggregate UDF '{}' in the registry", udf_name))),
+                };
+                let fun = match fun{
+                    UDF::Aggregate(a) =>a.clone() ,
+                    UDF::Scalar(_) => return Err(DataFusionError::Internal(format!("Did not find aggregate UDF named {}. Found a scalar UDF instead.", udf_name))),
+                };
+                let args = self.to_list(*args).map_err(|e| DataFusionError::Internal(format!("AggregateUDFCall could not convert args expr to list of expressions: {}", e)))?;
+                Expr::AggregateUDF{
+                    fun,
+                    args
+                }
+            },
+            TokomakExpr::WindowBuiltinCallUnframed([fun, partition, order , args]) => {
+                let fun = match self.get_ref(*fun){
+                    TokomakExpr::WindowBuiltin(f)=>f.clone(),
+                    e=>return Err(DataFusionError::Internal(format!("WindowBuiltinCallUnframed expected a WindowBuiltin expression found {:?}",e))),
+                };
+                let partition_by = self.to_list(*partition).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform parition expressions: {:?}", e))
+                )?;
+                let order_by = self.to_list(*order).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform order expressions: {:?}", e))
+                )?;
+                let args = self.to_list(*args).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform the argument list: {:?}", e))
+                )?;
+                Expr::WindowFunction{
+                    fun,
+                    partition_by,
+                    order_by,
+                    args,
+                    window_frame: None
+                }
+            },
+            TokomakExpr::WindowBuiltinCallFramed([fun, partition, order, frame, args]) => {
+                let fun = match self.get_ref(*fun){
+                    TokomakExpr::WindowBuiltin(f)=>f.clone(),
+                    e=>return Err(DataFusionError::Internal(format!("WindowBuiltinCallUnframed expected a WindowBuiltin expression found {:?}",e))),
+                };
+                let partition_by = self.to_list(*partition).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform parition expressions: {:?}", e))
+                )?;
+                let order_by = self.to_list(*order).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform order expressions: {:?}", e))
+                )?;
+                let args = self.to_list(*args).map_err(
+                    |e| DataFusionError::Internal(format!("WindowBuiltinCallUnframed could not transform the argument list: {:?}", e))
+                )?;
+                let window_frame = match self.get_ref(*frame){
+                    TokomakExpr::WindowFrame(f)=>f.clone(),
+                    e=> return Err(DataFusionError::Internal(format!("WindowBuiltinCallFramed expected a WindowFrame expression, found: {:?}", e))),
+                };
+                Expr::WindowFunction{
+                    fun,
+                    partition_by,
+                    order_by,
+                    args,
+                    window_frame: Some(window_frame)
+                }
+            },
+            TokomakExpr::Sort([e, sort_spec]) => {
+                let expr = self.convert_to_expr(*e)?;
+                let sort_spec = match self.get_ref(*sort_spec){
+                    TokomakExpr::SortSpec(s)=>s.clone(),
+                    e => return Err(unexpected_tokomak_expr("Sort", "SortSpec", e)),
+                };
+                let (asc, nulls_first)= match sort_spec{
+                    SortSpec::Asc => (true,false),
+                    SortSpec::Desc => (false, false),
+                    SortSpec::AscNullsFirst => (true, true),
+                    SortSpec::DescNullsFirst => (false,true),
+                };
+                Expr::Sort{
+                    expr: Box::new(expr),
+                    asc,
+                    nulls_first
+                }
+            },
+            TokomakExpr::SortSpec(_) => todo!(),
+            TokomakExpr::WindowFrame(_) => todo!(),
+            TokomakExpr::WindowBuiltin(_) => todo!(),
+        };
+        Ok(expr)
+    }
+}
+
+fn unexpected_tokomak_expr(
+    name: &str,
+    expected: &str,
+    found: &TokomakExpr,
+) -> DataFusionError {
+    DataFusionError::Internal(format!(
+        "{} expected a {} expression found: {:?}",
+        name, expected, found
+    ))
+}
+
+struct ExprConverter<'a> {
+    rec_expr: &'a mut RecExpr<TokomakExpr>,
+    udf_registry: &'a mut HashMap<String, UDF>,
+}
+
+impl<'a> ExprConverter<'a> {
+    fn new(
+        rec_expr: &'a mut RecExpr<TokomakExpr>,
+        udf_registry: &'a mut HashMap<String, UDF>,
+    ) -> Self {
+        ExprConverter {
+            rec_expr,
+            udf_registry,
+        }
+    }
+
+    fn add_list(&mut self, exprs: Vec<Expr>) -> Result<Id, DataFusionError> {
+        let list = exprs
+            .into_iter()
+            .map(|expr| self.to_tokomak_expr(expr))
+            .collect::<Result<Vec<Id>, _>>()?;
+        Ok(self.rec_expr.add(TokomakExpr::List(list)))
+    }
+
+    fn to_tokomak_expr(&mut self, expr: Expr) -> Result<Id, DataFusionError> {
+        Ok(match expr {
+            Expr::BinaryExpr { left, op, right } => {
+                let left = self.to_tokomak_expr(*left)?;
+                let right = self.to_tokomak_expr(*right)?;
+                let binary_expr = match op {
+                    Operator::Eq => TokomakExpr::Eq,
+                    Operator::NotEq => TokomakExpr::NotEq,
+                    Operator::Lt => TokomakExpr::Lt,
+                    Operator::LtEq => TokomakExpr::LtEq,
+                    Operator::Gt => TokomakExpr::Gt,
+                    Operator::GtEq => TokomakExpr::GtEq,
+                    Operator::Plus => TokomakExpr::Plus,
+                    Operator::Minus => TokomakExpr::Minus,
+                    Operator::Multiply => TokomakExpr::Multiply,
+                    Operator::Divide => TokomakExpr::Divide,
+                    Operator::Modulo => TokomakExpr::Modulus,
+                    Operator::And => TokomakExpr::And,
+                    Operator::Or => TokomakExpr::Or,
+                    Operator::Like => TokomakExpr::Like,
+                    Operator::NotLike => TokomakExpr::NotLike,
+                    Operator::RegexMatch => TokomakExpr::RegexMatch,
+                    Operator::RegexIMatch => TokomakExpr::RegexIMatch,
+                    Operator::RegexNotMatch => TokomakExpr::RegexNotMatch,
+                    Operator::RegexNotIMatch => TokomakExpr::RegexNotIMatch,
+                };
+                self.rec_expr.add(binary_expr([left, right]))
+            }
+            Expr::Column(c) => self
+                .rec_expr
+                .add(TokomakExpr::Column(Symbol::from(c.flat_name()))),
+            Expr::Literal(s) => self.rec_expr.add(TokomakExpr::Scalar(s.into())),
+            Expr::Not(expr) => {
+                let e = self.to_tokomak_expr(*expr)?;
+                self.rec_expr.add(TokomakExpr::Not(e))
+            }
+            Expr::IsNull(expr) => {
+                let e = self.to_tokomak_expr(*expr)?;
+                self.rec_expr.add(TokomakExpr::IsNull(e))
+            }
+            Expr::IsNotNull(expr) => {
+                let e = self.to_tokomak_expr(*expr)?;
+                self.rec_expr.add(TokomakExpr::IsNotNull(e))
+            }
+            Expr::Negative(expr) => {
+                let e = self.to_tokomak_expr(*expr)?;
+                self.rec_expr.add(TokomakExpr::Negative(e))
+            }
+            Expr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => {
+                let e = self.to_tokomak_expr(*expr)?;
+                let low = self.to_tokomak_expr(*low)?;
+                let high = self.to_tokomak_expr(*high)?;
+                if negated {
+                    self.rec_expr
+                        .add(TokomakExpr::BetweenInverted([e, low, high]))
+                } else {
+                    self.rec_expr.add(TokomakExpr::Between([e, low, high]))
+                }
+            }
+
+            Expr::Cast { expr, data_type } => {
+                let ty = data_type.try_into()?;
+                let e = self.to_tokomak_expr(*expr)?;
+                let t = self.rec_expr.add(TokomakExpr::Type(ty));
+
+                self.rec_expr.add(TokomakExpr::Cast([e, t]))
+            }
+            Expr::TryCast { expr, data_type } => {
+                let ty: TokomakDataType = data_type.try_into()?;
+                let e = self.to_tokomak_expr(*expr)?;
+                let t = self.rec_expr.add(TokomakExpr::Type(ty));
+                self.rec_expr.add(TokomakExpr::TryCast([e, t]))
+            }
+            Expr::ScalarFunction { fun, args } => {
+                let fun_id = self.rec_expr.add(TokomakExpr::ScalarBuiltin(fun));
+                let args_id = self.add_list(args)?;
+                self.rec_expr
+                    .add(TokomakExpr::ScalarBuiltinCall([fun_id, args_id]))
+            }
+            Expr::Alias(expr, _) => self.to_tokomak_expr(*expr)?,
+            Expr::InList {
+                expr,
+                list,
+                negated,
+            } => {
+                let val_expr = self.to_tokomak_expr(*expr)?;
+                let list_id = self.add_list(list)?;
+                match negated {
+                    false => self.rec_expr.add(TokomakExpr::InList([val_expr, list_id])),
+                    true => self
+                        .rec_expr
+                        .add(TokomakExpr::NotInList([val_expr, list_id])),
+                }
+            }
+            Expr::AggregateFunction {
+                fun,
+                args,
+                distinct,
+            } => {
+                let agg_expr = TokomakExpr::AggregateBuiltin(fun);
+                let fun_id = self.rec_expr.add(agg_expr);
+                let args_id = self.add_list(args)?;
+                match distinct {
+                    true => {
+                        self.rec_expr
+                            .add(TokomakExpr::AggregateBuiltinDistinctCall([
+                                fun_id, args_id,
+                            ]))
+                    }
+                    false => self
+                        .rec_expr
+                        .add(TokomakExpr::AggregateBuiltinCall([fun_id, args_id])),
+                }
+            }
+            //Expr::Case { expr, when_then_expr, else_expr } => todo!(),
+            Expr::Sort {
+                expr,
+                asc,
+                nulls_first,
+            } => {
+                let sort_spec = match (asc, nulls_first) {
+                    (true, true) => SortSpec::AscNullsFirst,
+                    (true, false) => SortSpec::Asc,
+                    (false, true) => SortSpec::Desc,
+                    (false, false) => SortSpec::DescNullsFirst,
+                };
+                let expr_id = self.to_tokomak_expr(*expr)?;
+                let spec_id = self.rec_expr.add(TokomakExpr::SortSpec(sort_spec));
+                self.rec_expr.add(TokomakExpr::Sort([expr_id, spec_id]))
+            }
+            Expr::ScalarUDF { fun, args } => {
+                let args_id = self.add_list(args)?;
+                self.udf_registry.add_sudf(fun.clone());
+                let fun_name: Symbol = fun.name.clone().into();
+                let fun_name_id =
+                    self.rec_expr.add(TokomakExpr::ScalarUDF(UDFName(fun_name)));
+                self.rec_expr
+                    .add(TokomakExpr::ScalarUDFCall([fun_name_id, args_id]))
+            }
+            Expr::WindowFunction {
+                fun,
+                args,
+                partition_by,
+                order_by,
+                window_frame,
+            } => {
+                let args_id = self.add_list(args)?;
+                let partition_id = self.add_list(partition_by)?;
+                let order_by_id = self.add_list(order_by)?;
+                let fun_id = self.rec_expr.add(TokomakExpr::WindowBuiltin(fun));
+                match window_frame {
+                    Some(frame) => {
+                        let frame_id = self.rec_expr.add(TokomakExpr::WindowFrame(frame));
+                        self.rec_expr.add(TokomakExpr::WindowBuiltinCallFramed([
+                            fun_id,
+                            partition_id,
+                            order_by_id,
+                            frame_id,
+                            args_id,
+                        ]))
+                    }
+                    None => self.rec_expr.add(TokomakExpr::WindowBuiltinCallUnframed([
+                        fun_id,
+                        partition_id,
+                        order_by_id,
+                        args_id,
+                    ])),
+                }
+            }
+            Expr::AggregateUDF { fun, args } => {
+                let args_id = self.add_list(args)?;
+                self.udf_registry.add_uadf(fun.clone());
+                let fun_name: Symbol = fun.name.clone().into(); //Symbols are leaked at this point in time. Maybe different solution is required.
+                let fun_name_id = self
+                    .rec_expr
+                    .add(TokomakExpr::AggregateUDF(UDFName(fun_name)));
+                self.rec_expr
+                    .add(TokomakExpr::AggregateUDFCall([fun_name_id, args_id]))
+            }
+            //Expr::Wildcard => todo!(),
+            //Expr::ScalarVariable(_) => todo!(),
+
+            // not yet supported
+            e => {
+                return Err(DataFusionError::Internal(format!(
+                    "Expression not yet supported in tokomak optimizer {:?}",
+                    e
+                )))
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SortSpec {
+    Asc,
+    Desc,
+    AscNullsFirst,
+    DescNullsFirst,
+}
+
+impl FromStr for SortSpec {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "asc" => SortSpec::Asc,
+            "desc" => SortSpec::Desc,
+            "asc_nulls" => SortSpec::AscNullsFirst,
+            "desc_nulls" => SortSpec::DescNullsFirst,
+            _ => return Err(DataFusionError::Internal(String::new())),
+        })
+    }
+}
+impl Display for SortSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                SortSpec::Asc => "asc",
+                SortSpec::Desc => "desc",
+                SortSpec::AscNullsFirst => "asc_nulls",
+                SortSpec::DescNullsFirst => "desc_nulls",
+            }
+        )
+    }
+}
+
+pub type Identifier = Symbol;
+#[derive(Debug)]
+pub enum UDF {
+    Scalar(Arc<ScalarUDF>),
+    Aggregate(Arc<AggregateUDF>),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct UDFName(pub Symbol);
+
+impl Display for UDFName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl FromStr for UDFName {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let first_char = s.chars().nth(0).ok_or(DataFusionError::Internal(
+            "Zero length udf naem".to_string(),
+        ))?;
+        if first_char == '?' || first_char.is_numeric() {
+            return Err(DataFusionError::Internal(
+                "Found ? or number as first char".to_string(),
+            ));
+        }
+        Ok(UDFName(Symbol::from_str(s).unwrap()))
+    }
+}
+
+impl OptimizerRule for Tokomak {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        props: &ExecutionProps,
+    ) -> DFResult<LogicalPlan> {
+        let inputs = plan.inputs();
+        let new_inputs: Vec<LogicalPlan> = inputs
+            .iter()
+            .map(|plan| self.optimize(plan, props))
+            .collect::<DFResult<Vec<_>>>()?;
+        // optimize all expressions individual (for now)
+        let mut exprs = vec![];
+        for expr in plan.expressions().iter() {
+            let mut udf_registry = HashMap::new();
+            let mut rec_expr = &mut RecExpr::default();
+            let tok_expr = convert_to_tokomak_expr(expr.clone(), &mut udf_registry)
+                .map_err(|e| {
+                    debug!("Could not convert expression to tokomak expression: {}", e)
+                })
+                .ok();
+            let rc_udf_reg = Rc::new(udf_registry);
+
+            match tok_expr {
+                None => exprs.push(expr.clone()),
+                Some(_expr) => {
+                    let udf_aware = self
+                        .udf_aware_rules
+                        .iter()
+                        .flat_map(|f| (*f).generate_rules(Rc::clone(&rc_udf_reg)))
+                        .collect::<Vec<Rewrite<TokomakExpr, ()>>>();
+                    let runner = Runner::<TokomakExpr, (), ()>::default()
+                        .with_expr(rec_expr)
+                        .run(self.rules.iter().chain(&udf_aware));
+
+                    let mut extractor = Extractor::new(&runner.egraph, AstSize);
+                    let (_, best_expr) = extractor.find_best(runner.roots[0]);
+                    match to_expr(&best_expr, &rc_udf_reg) {
+                        Ok(e) => exprs.push(e),
+                        Err(_) => exprs.push(expr.clone()),
+                    }
+                }
+            }
+        }
+
+        utils::from_plan(plan, &exprs, &new_inputs)
+    }
+
+    fn name(&self) -> &str {
+        "tokomak"
+    }
+}

--- a/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
+++ b/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
@@ -236,13 +236,13 @@ mod test{
 
     fn rewrite_expr(expr: &str)->Result<String, Box<dyn std::error::Error>>{
         let expr: RecExpr<TokomakExpr> = expr.parse()?;
-        println!("unoptomized expr {:?}", expr);
+        //println!("unoptomized expr {:?}", expr);
         let runner = Runner::<TokomakExpr, (), ()>::default()
         .with_expr(&expr)
         .run(&rules());
         let mut extractor = Extractor::new(&runner.egraph, AstSize);
         let (_, best_expr) = extractor.find_best(runner.roots[0]);
-        println!("optimized expr {:?}", best_expr);
+        //println!("optimized expr {:?}", best_expr);
         Ok(format!("{}", best_expr))
     }
     #[test]
@@ -250,12 +250,12 @@ mod test{
 
      
     let expr_expected: Vec<(&'static str, &'static str)> =  vec![ 
-        //("(cast (cast 2  utf8) float32)", "2"),
+        ("(cast (cast 2  utf8) float32)", "2"),
         ("(try_cast 'gibberish' float32)", "NULL"), //Test try cast
         ("(try_cast 4.5 utf8)", "4.5"),
         ("(* 4 (call abs (list -1)))", "4"), //Test function inlining 
-        ("(call_udf udf[pow] (list (+ 2.5 1.5) (- 1 1.5)))","(call_udf udf[pow] (list 4 -0.5))"), //Test const propagation within udf arguments
-        //("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))")
+        ("(call_udf udf[pow] (list (cast (+ 2.5 1.5) uint8) (- 1 1.5)))","(call_udf udf[pow] (list 4 -0.5))"), //Test const propagation within udf arguments
+        //("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))") //FOr testing volatile udf argument optimzation without inlining. requires UDF registry to be availble at the optimize call
     ];
 
     for (expr, expected) in expr_expected{

--- a/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
+++ b/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
@@ -1,15 +1,24 @@
-use std::convert::TryInto;
 use super::super::TokomakDataType;
-use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::{Tokomak, TokomakExpr, scalar::TokomakScalar}, physical_plan::{ColumnarValue, expressions::{CastExpr, TryCastExpr}, functions::{BuiltinScalarFunction, FunctionVolatility, Signature}}, scalar::ScalarValue};
-use arrow::datatypes::DataType;
 use crate::physical_plan::type_coercion::data_types;
+use crate::{
+    error::DataFusionError,
+    logical_plan::Operator,
+    optimizer::tokomak::{scalar::TokomakScalar, Tokomak, TokomakExpr},
+    physical_plan::{
+        expressions::{CastExpr, TryCastExpr},
+        functions::{BuiltinScalarFunction, FunctionVolatility, Signature},
+        ColumnarValue,
+    },
+    scalar::ScalarValue,
+};
+use arrow::datatypes::DataType;
+use std::convert::TryInto;
 
 use super::utils::*;
 use egg::{rewrite as rw, *};
 
-
-fn rules()->Vec<Rewrite<TokomakExpr,()>>{ 
-    let a:Var = "?a".parse().unwrap();
+fn rules() -> Vec<Rewrite<TokomakExpr, ()>> {
+    let a: Var = "?a".parse().unwrap();
     let b: Var = "?b".parse().unwrap();
     //let c: Var = "?c".parse().unwrap();
     //let d: Var = "?d".parse().unwrap();
@@ -17,112 +26,127 @@ fn rules()->Vec<Rewrite<TokomakExpr,()>>{
     let func: Var = "?func".parse().unwrap();
     let args: Var = "?args".parse().unwrap();
     vec![
-    //Move these 4 to simplification    
-    rw!("const-prop-between"; "(and (>= ?e ?a) (<= ?e ?b))"=> "false" if var_gt(a,b)),
-    rw!("const-prop-between_inverted"; "(and (< ?e ?a)(> ?e ?b))" => "true" if var_gt(a,b)),
-    rw!("const-prop-binop-col-eq"; "(= ?a ?a)" => "(is_not_null ?a)"), 
-    rw!("const-prop-binop-col-neq"; "(<> ?a ?a)" => "false"), 
-
-    rw!("const-prop-add"; "(+ ?a ?b)"=>{ const_binop(a,b, Operator::Plus) } ),
-    rw!("const-prop-sub"; "(- ?a ?b)" => { const_binop(a, b, Operator::Minus)}),
-    rw!("const-prop-mul"; "(* ?a ?b)" => { const_binop(a,b, Operator::Multiply) } ),
-    rw!("const-prop-div"; "(/ ?a ?b)" =>{  const_binop(a,b, Operator::Divide)} ),
-    rw!("const-prop-mod"; "(% ?a ?b)" =>{const_binop(a,b, Operator::Modulo)}),
-
-    rw!("const-prop-or"; "(or ?a ?b)" =>{const_binop(a,b, Operator::Or)}),
-    rw!("const-prop-and"; "(and ?a ?b)" =>{const_binop(a,b, Operator::And)}),
-
-
-    rw!("const-prop-binop-eq"; "(= ?a ?b)"=>{ const_binop(a,b, Operator::Eq)} ),
-    rw!("const-prop-binop-neq"; "(<> ?a ?b)"=>{ const_binop(a,b, Operator::NotEq)}),
-
-    rw!("const-prop-binop-gt"; "(> ?a ?b)"=>{ const_binop(a,b, Operator::Gt)} ),
-    rw!("const-prop-binop-gte"; "(>= ?a ?b)"=>{ const_binop(a,b, Operator::GtEq)} ),
-
-    rw!("const-prop-binop-lt"; "(< ?a ?b)"=>{ const_binop(a,b, Operator::Lt)} ),
-    rw!("const-prop-binop-lte"; "(<= ?a ?b)"=>{ const_binop(a,b, Operator::LtEq)} ),
-
-    rw!("const-prop-regex_match"; "(regex_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexMatch)} ),
-    rw!("const-prop-regex_imatch"; "(regex_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexIMatch)} ),
-    rw!("const-prop-regex_not_match"; "(regex_not_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotMatch)} ),
-    rw!("const-prop-regex_not_imatch"; "(regex_not_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotIMatch)} ),
-
-    rw!("const-prop-like"; "(like ?a ?b)"=>{ const_binop(a,b, Operator::Like)} ),
-    rw!("const-prop-not_like"; "(not_like ?a ?b)"=>{ const_binop(a,b, Operator::NotLike)} ),
-
-
-
-    rw!("const-prop-cast"; "(cast ?a ?b)" =>{ ConstCastApplier{value: a, cast_type: b}} ),
-    rw!("const-prop-try_cast"; "(try_cast ?a ?b)" => {ConstTryCastApplier{value: a, cast_type: b}}),
-    rw!("const-prop-call-scalar"; "(call ?func ?args)"=>{ ConstCallApplier{func, args}} if is_immutable_scalar_builtin_function(func))]
-    
+        //Move these 4 to simplification
+        rw!("const-prop-between"; "(and (>= ?e ?a) (<= ?e ?b))"=> "false" if var_gt(a,b)),
+        rw!("const-prop-between_inverted"; "(and (< ?e ?a)(> ?e ?b))" => "true" if var_gt(a,b)),
+        rw!("const-prop-binop-col-eq"; "(= ?a ?a)" => "(is_not_null ?a)"),
+        rw!("const-prop-binop-col-neq"; "(<> ?a ?a)" => "false"),
+        rw!("const-prop-add"; "(+ ?a ?b)"=>{ const_binop(a,b, Operator::Plus) } ),
+        rw!("const-prop-sub"; "(- ?a ?b)" => { const_binop(a, b, Operator::Minus)}),
+        rw!("const-prop-mul"; "(* ?a ?b)" => { const_binop(a,b, Operator::Multiply) } ),
+        rw!("const-prop-div"; "(/ ?a ?b)" =>{  const_binop(a,b, Operator::Divide)} ),
+        rw!("const-prop-mod"; "(% ?a ?b)" =>{const_binop(a,b, Operator::Modulo)}),
+        rw!("const-prop-or"; "(or ?a ?b)" =>{const_binop(a,b, Operator::Or)}),
+        rw!("const-prop-and"; "(and ?a ?b)" =>{const_binop(a,b, Operator::And)}),
+        rw!("const-prop-binop-eq"; "(= ?a ?b)"=>{ const_binop(a,b, Operator::Eq)} ),
+        rw!("const-prop-binop-neq"; "(<> ?a ?b)"=>{ const_binop(a,b, Operator::NotEq)}),
+        rw!("const-prop-binop-gt"; "(> ?a ?b)"=>{ const_binop(a,b, Operator::Gt)} ),
+        rw!("const-prop-binop-gte"; "(>= ?a ?b)"=>{ const_binop(a,b, Operator::GtEq)} ),
+        rw!("const-prop-binop-lt"; "(< ?a ?b)"=>{ const_binop(a,b, Operator::Lt)} ),
+        rw!("const-prop-binop-lte"; "(<= ?a ?b)"=>{ const_binop(a,b, Operator::LtEq)} ),
+        rw!("const-prop-regex_match"; "(regex_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexMatch)} ),
+        rw!("const-prop-regex_imatch"; "(regex_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexIMatch)} ),
+        rw!("const-prop-regex_not_match"; "(regex_not_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotMatch)} ),
+        rw!("const-prop-regex_not_imatch"; "(regex_not_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotIMatch)} ),
+        rw!("const-prop-like"; "(like ?a ?b)"=>{ const_binop(a,b, Operator::Like)} ),
+        rw!("const-prop-not_like"; "(not_like ?a ?b)"=>{ const_binop(a,b, Operator::NotLike)} ),
+        rw!("const-prop-cast"; "(cast ?a ?b)" =>{ ConstCastApplier{value: a, cast_type: b}} ),
+        rw!("const-prop-try_cast"; "(try_cast ?a ?b)" => {ConstTryCastApplier{value: a, cast_type: b}}),
+        rw!("const-prop-call-scalar"; "(call ?func ?args)"=>{ ConstCallApplier{func, args}} if is_immutable_scalar_builtin_function(func)),
+    ]
 }
 
-
-pub fn add_constant_folding_rules(optimizer: &mut Tokomak){
-    for rule in rules(){
+pub fn add_constant_folding_rules(optimizer: &mut Tokomak) {
+    for rule in rules() {
         optimizer.add_rule(rule);
     }
 }
 
-fn is_immutable_scalar_builtin_function(func: Var)->impl Fn(&mut EGraph<TokomakExpr, ()>,  Id,  &Subst)->bool{
-    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst|->bool{
+fn is_immutable_scalar_builtin_function(
+    func: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
         fetch_as_immutable_builtin_scalar_func(func, egraph, id, subst).is_some()
     }
- }
-
-
- fn fetch_as_immutable_builtin_scalar_func(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)-> Option<BuiltinScalarFunction>{
-    egraph[subst[var]].nodes.iter().flat_map(|expr| match expr{
-        TokomakExpr::ScalarBuiltin(f)=> {
-            if f.function_volatility() == FunctionVolatility::Immutable{
-                Some(f.clone())
-            }else{
-                None
-            }
-        },
-        _ => None
-    }).nth(0)
 }
 
+fn fetch_as_immutable_builtin_scalar_func(
+    var: Var,
+    egraph: &mut EGraph<TokomakExpr, ()>,
+    _id: Id,
+    subst: &Subst,
+) -> Option<BuiltinScalarFunction> {
+    egraph[subst[var]]
+        .nodes
+        .iter()
+        .flat_map(|expr| match expr {
+            TokomakExpr::ScalarBuiltin(f) => {
+                if f.function_volatility() == FunctionVolatility::Immutable {
+                    Some(f.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .nth(0)
+}
 
-
-
-
-
-struct ConstCallApplier{
+struct ConstCallApplier {
     pub func: Var,
     pub args: Var,
 }
 
-impl ConstCallApplier{
-    fn apply_one_opt(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst)->Option<Vec<Id>>{
-        let fun = fetch_as_immutable_builtin_scalar_func(self.func, egraph, eclass,subst)?;
-        let args = to_literal_list(self.args,egraph, eclass, subst)?;
+impl ConstCallApplier {
+    fn apply_one_opt(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        eclass: Id,
+        subst: &Subst,
+    ) -> Option<Vec<Id>> {
+        let fun =
+            fetch_as_immutable_builtin_scalar_func(self.func, egraph, eclass, subst)?;
+        let args = to_literal_list(self.args, egraph, eclass, subst)?;
         let num_args = args.len();
 
         let mut func_args = Vec::with_capacity(num_args);
-        for id in args{
-            let scalar = egraph[*id].nodes.iter()
-            .flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} )
-            .nth(0)
-            .map(|s| s)?;
+        for id in args {
+            let scalar = egraph[*id]
+                .nodes
+                .iter()
+                .flat_map(|expr| -> Result<ScalarValue, DataFusionError> {
+                    expr.try_into()
+                })
+                .nth(0)
+                .map(|s| s)?;
             func_args.push(scalar);
         }
-        let func_args = coerce_func_args(&func_args, &crate::physical_plan::functions::signature(&fun)).ok()?;
-        let func_args = func_args.into_iter().map(|s| ColumnarValue::Scalar(s)).collect::<Vec<ColumnarValue>>();
-        let arg_types = func_args.iter().map(|arg| arg.data_type()).collect::<Vec<DataType>>();
-        let _return_ty = crate::physical_plan::functions::return_type(&fun, arg_types.as_slice()).ok()?;
-        let fun_impl = crate::physical_plan::functions::create_immutable_impl(&fun).ok()?;
-        let result:ColumnarValue = (&fun_impl)(&func_args).ok()?;
+        let func_args = coerce_func_args(
+            &func_args,
+            &crate::physical_plan::functions::signature(&fun),
+        )
+        .ok()?;
+        let func_args = func_args
+            .into_iter()
+            .map(|s| ColumnarValue::Scalar(s))
+            .collect::<Vec<ColumnarValue>>();
+        let arg_types = func_args
+            .iter()
+            .map(|arg| arg.data_type())
+            .collect::<Vec<DataType>>();
+        let _return_ty =
+            crate::physical_plan::functions::return_type(&fun, arg_types.as_slice())
+                .ok()?;
+        let fun_impl =
+            crate::physical_plan::functions::create_immutable_impl(&fun).ok()?;
+        let result: ColumnarValue = (&fun_impl)(&func_args).ok()?;
         let val: ScalarValue = ScalarValue::try_from_columnar_value(result).ok()?;
 
         let expr: TokomakExpr = val.try_into().ok()?;
 
-        Some(vec![egraph.add(expr)]) 
+        Some(vec![egraph.add(expr)])
     }
 }
-
 
 fn coerce_func_args(
     values: &[ScalarValue],
@@ -134,7 +158,7 @@ fn coerce_func_args(
 
     let current_types = (values)
         .iter()
-        .map(|e| e.get_datatype() )
+        .map(|e| e.get_datatype())
         .collect::<Vec<DataType>>();
 
     let new_types = data_types(&current_types, signature)?;
@@ -146,122 +170,146 @@ fn coerce_func_args(
         .collect::<Result<Vec<_>, DataFusionError>>()
 }
 
-
-
-
-impl Applier<TokomakExpr, ()> for ConstCallApplier{
-    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
-        match self.apply_one_opt(egraph, eclass, subst){
-            Some(s) =>s,
+impl Applier<TokomakExpr, ()> for ConstCallApplier {
+    fn apply_one(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        eclass: Id,
+        subst: &Subst,
+    ) -> Vec<Id> {
+        match self.apply_one_opt(egraph, eclass, subst) {
+            Some(s) => s,
             None => Vec::new(),
         }
     }
 }
 
-
-struct ConstCastApplier{
+struct ConstCastApplier {
     value: Var,
     cast_type: Var,
 }
 
-fn convert_to_tokomak_type(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<TokomakDataType, DataFusionError>{
-    let expr: Option<&TokomakExpr> = egraph[subst[var]].nodes.iter().find(|e| matches!(e, TokomakExpr::Type(_)));
-    let expr = expr.map(|e| match e{
+fn convert_to_tokomak_type(
+    var: Var,
+    egraph: &mut EGraph<TokomakExpr, ()>,
+    _id: Id,
+    subst: &Subst,
+) -> Result<TokomakDataType, DataFusionError> {
+    let expr: Option<&TokomakExpr> = egraph[subst[var]]
+        .nodes
+        .iter()
+        .find(|e| matches!(e, TokomakExpr::Type(_)));
+    let expr = expr.map(|e| match e {
         TokomakExpr::Type(t) => t.clone(),
-        _ => panic!("Found TokomakExpr which was not TokomakExpr::Type, found {:?}", e),
+        _ => panic!(
+            "Found TokomakExpr which was not TokomakExpr::Type, found {:?}",
+            e
+        ),
     });
-    expr.ok_or_else(|| DataFusionError::Internal("Could not convert to TokomakType".to_string()))
+    expr.ok_or_else(|| {
+        DataFusionError::Internal("Could not convert to TokomakType".to_string())
+    })
 }
 
-impl ConstCastApplier{
-    fn apply_res(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<TokomakExpr>{
+impl ConstCastApplier {
+    fn apply_res(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        id: Id,
+        subst: &Subst,
+    ) -> Option<TokomakExpr> {
         let value = convert_to_scalar_value(self.value, egraph, id, subst).ok()?;
         let ty = convert_to_tokomak_type(self.cast_type, egraph, id, subst).ok()?;
         let ty: DataType = ty.into();
-        let val = CastExpr::cast_scalar_default_options(value,&ty).ok()?;
+        let val = CastExpr::cast_scalar_default_options(value, &ty).ok()?;
         val.try_into().ok()
     }
 }
-impl Applier<TokomakExpr, ()> for ConstCastApplier{
-    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
+impl Applier<TokomakExpr, ()> for ConstCastApplier {
+    fn apply_one(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        eclass: Id,
+        subst: &Subst,
+    ) -> Vec<Id> {
         let cast_const_res = self.apply_res(egraph, eclass, subst);
-        let cast_const_val = match cast_const_res{
-            Some(v)=> v,
-            None=> return Vec::new()
+        let cast_const_val = match cast_const_res {
+            Some(v) => v,
+            None => return Vec::new(),
         };
         vec![egraph.add(cast_const_val)]
     }
 }
 
-
-struct ConstTryCastApplier{
+struct ConstTryCastApplier {
     value: Var,
     cast_type: Var,
 }
 
-
-impl ConstTryCastApplier{
-    fn apply_opt(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<TokomakScalar>{
+impl ConstTryCastApplier {
+    fn apply_opt(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        id: Id,
+        subst: &Subst,
+    ) -> Option<TokomakScalar> {
         let value = convert_to_scalar_value(self.value, egraph, id, subst).ok()?;
         let ty = convert_to_tokomak_type(self.cast_type, egraph, id, subst).ok()?;
         let ty: DataType = ty.into();
-        let val = TryCastExpr::evaluate(ColumnarValue::Scalar(value), &ty).ok()?;// CastExpr::cast_scalar_default_options(value,&ty).ok()?;
+        let val = TryCastExpr::evaluate(ColumnarValue::Scalar(value), &ty).ok()?; // CastExpr::cast_scalar_default_options(value,&ty).ok()?;
         let v = ScalarValue::try_from_columnar_value(val).ok()?.into();
         Some(v)
-        
     }
 }
 
-impl Applier<TokomakExpr, ()> for ConstTryCastApplier{
-    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
-        match self.apply_opt(egraph, eclass, subst){
-            Some(v)=> vec![egraph.add(TokomakExpr::Scalar(v))],
-            None => vec![]
+impl Applier<TokomakExpr, ()> for ConstTryCastApplier {
+    fn apply_one(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        eclass: Id,
+        subst: &Subst,
+    ) -> Vec<Id> {
+        match self.apply_opt(egraph, eclass, subst) {
+            Some(v) => vec![egraph.add(TokomakExpr::Scalar(v))],
+            None => vec![],
         }
     }
 }
 
-
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     use egg::RecExpr;
 
-
-    
-
-
-
-
-
-    fn rewrite_expr(expr: &str)->Result<String, Box<dyn std::error::Error>>{
+    fn rewrite_expr(expr: &str) -> Result<String, Box<dyn std::error::Error>> {
         let expr: RecExpr<TokomakExpr> = expr.parse()?;
         //println!("unoptomized expr {:?}", expr);
         let runner = Runner::<TokomakExpr, (), ()>::default()
-        .with_expr(&expr)
-        .run(&rules());
+            .with_expr(&expr)
+            .run(&rules());
         let mut extractor = Extractor::new(&runner.egraph, AstSize);
         let (_, best_expr) = extractor.find_best(runner.roots[0]);
         //println!("optimized expr {:?}", best_expr);
         Ok(format!("{}", best_expr))
     }
     #[test]
-    fn test_const_prop()->Result<(), Box<dyn std::error::Error>>{
+    fn test_const_prop() -> Result<(), Box<dyn std::error::Error>> {
+        let expr_expected: Vec<(&'static str, &'static str)> = vec![
+            ("(cast (cast 2  utf8) float32)", "2"),
+            ("(try_cast 'gibberish' float32)", "NULL"), //Test try cast
+            ("(try_cast 4.5 utf8)", "4.5"),
+            ("(* 4 (call abs (list -1)))", "4"), //Test function inlining
+            (
+                "(call_udf udf[pow] (list (cast (+ 2.5 1.5) uint8) (- 1 1.5)))",
+                "(call_udf udf[pow] (list 4 -0.5))",
+            ), //Test const propagation within udf arguments
+                                                 //("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))") //FOr testing volatile udf argument optimzation without inlining. requires UDF registry to be availble at the optimize call
+        ];
 
-     
-    let expr_expected: Vec<(&'static str, &'static str)> =  vec![ 
-        ("(cast (cast 2  utf8) float32)", "2"),
-        ("(try_cast 'gibberish' float32)", "NULL"), //Test try cast
-        ("(try_cast 4.5 utf8)", "4.5"),
-        ("(* 4 (call abs (list -1)))", "4"), //Test function inlining 
-        ("(call_udf udf[pow] (list (cast (+ 2.5 1.5) uint8) (- 1 1.5)))","(call_udf udf[pow] (list 4 -0.5))"), //Test const propagation within udf arguments
-        //("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))") //FOr testing volatile udf argument optimzation without inlining. requires UDF registry to be availble at the optimize call
-    ];
-
-    for (expr, expected) in expr_expected{
-        let rewritten_expr = rewrite_expr(  expr)?;
-        assert_eq!(rewritten_expr, expected); 
-    } 
-    Ok(())
+        for (expr, expected) in expr_expected {
+            let rewritten_expr = rewrite_expr(expr)?;
+            assert_eq!(rewritten_expr, expected);
+        }
+        Ok(())
     }
 }

--- a/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
+++ b/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
@@ -1,62 +1,78 @@
 use std::convert::TryInto;
 use super::super::TokomakDataType;
-use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::{Tokomak, TokomakExpr, scalar::TokomakScalar}, physical_plan::{ColumnarValue, expressions::{BinaryExpr, CastExpr, common_binary_type}, functions::{BuiltinScalarFunction, FunctionVolatility, Signature}}, scalar::ScalarValue};
+use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::{Tokomak, TokomakExpr, scalar::TokomakScalar}, physical_plan::{ColumnarValue, expressions::{CastExpr, TryCastExpr}, functions::{BuiltinScalarFunction, FunctionVolatility, Signature}}, scalar::ScalarValue};
 use arrow::datatypes::DataType;
 use crate::physical_plan::type_coercion::data_types;
 
+use super::utils::*;
 use egg::{rewrite as rw, *};
 
 
-fn rules()->Vec<Rewrite<TokomakExpr,()>>{
+fn rules()->Vec<Rewrite<TokomakExpr,()>>{ 
     let a:Var = "?a".parse().unwrap();
     let b: Var = "?b".parse().unwrap();
-    let c: Var = "?c".parse().unwrap();
-    let d: Var = "?d".parse().unwrap();
-    let x: Var ="?x".parse().unwrap();
+    //let c: Var = "?c".parse().unwrap();
+    //let d: Var = "?d".parse().unwrap();
+    //let x: Var ="?x".parse().unwrap();
     let func: Var = "?func".parse().unwrap();
     let args: Var = "?args".parse().unwrap();
-    vec![rw!("const-prop-between"; "(and (>= ?e ?a) (<= ?e ?b))"=> "false" if gt_var(a,b)),
-    rw!("const-prop-between_inverted"; "(and (< ?e ?a) (> ?e ?b))" => "true" if gt_var(a,b)),
+    vec![
+    //Move these 4 to simplification    
+    rw!("const-prop-between"; "(and (>= ?e ?a) (<= ?e ?b))"=> "false" if var_gt(a,b)),
+    rw!("const-prop-between_inverted"; "(and (< ?e ?a)(> ?e ?b))" => "true" if var_gt(a,b)),
+    rw!("const-prop-binop-col-eq"; "(= ?a ?a)" => "(is_not_null ?a)"), 
+    rw!("const-prop-binop-col-neq"; "(<> ?a ?a)" => "false"), 
 
+    rw!("const-prop-add"; "(+ ?a ?b)"=>{ const_binop(a,b, Operator::Plus) } ),
+    rw!("const-prop-sub"; "(- ?a ?b)" => { const_binop(a, b, Operator::Minus)}),
+    rw!("const-prop-mul"; "(* ?a ?b)" => { const_binop(a,b, Operator::Multiply) } ),
+    rw!("const-prop-div"; "(/ ?a ?b)" =>{  const_binop(a,b, Operator::Divide)} ),
+    rw!("const-prop-mod"; "(% ?a ?b)" =>{const_binop(a,b, Operator::Modulo)}),
+
+    rw!("const-prop-or"; "(or ?a ?b)" =>{const_binop(a,b, Operator::Or)}),
+    rw!("const-prop-and"; "(and ?a ?b)" =>{const_binop(a,b, Operator::And)}),
+
+
+    rw!("const-prop-binop-eq"; "(= ?a ?b)"=>{ const_binop(a,b, Operator::Eq)} ),
+    rw!("const-prop-binop-neq"; "(<> ?a ?b)"=>{ const_binop(a,b, Operator::NotEq)}),
+
+    rw!("const-prop-binop-gt"; "(> ?a ?b)"=>{ const_binop(a,b, Operator::Gt)} ),
+    rw!("const-prop-binop-gte"; "(>= ?a ?b)"=>{ const_binop(a,b, Operator::GtEq)} ),
+
+    rw!("const-prop-binop-lt"; "(< ?a ?b)"=>{ const_binop(a,b, Operator::Lt)} ),
+    rw!("const-prop-binop-lte"; "(<= ?a ?b)"=>{ const_binop(a,b, Operator::LtEq)} ),
+
+    rw!("const-prop-regex_match"; "(regex_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexMatch)} ),
+    rw!("const-prop-regex_imatch"; "(regex_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexIMatch)} ),
+    rw!("const-prop-regex_not_match"; "(regex_not_match ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotMatch)} ),
+    rw!("const-prop-regex_not_imatch"; "(regex_not_imatch ?a ?b)"=>{ const_binop(a,b, Operator::RegexNotIMatch)} ),
+
+    rw!("const-prop-like"; "(like ?a ?b)"=>{ const_binop(a,b, Operator::Like)} ),
+    rw!("const-prop-not_like"; "(not_like ?a ?b)"=>{ const_binop(a,b, Operator::NotLike)} ),
+
+
+
+    rw!("const-prop-cast"; "(cast ?a ?b)" =>{ ConstCastApplier{value: a, cast_type: b}} ),
+    rw!("const-prop-try_cast"; "(try_cast ?a ?b)" => {ConstTryCastApplier{value: a, cast_type: b}}),
+    rw!("const-prop-call-scalar"; "(call ?func ?args)"=>{ ConstCallApplier{func, args}} if is_immutable_scalar_builtin_function(func))]
     
-    
-    rw!("const-prop-binop-col-eq"; "(= ?a ?a)" => "(is_not_null ?a)"), //May not be true with nullable columns because NULL != NULL
-    rw!("const-prop-binop-col-neq"; "(<> ?a ?a)" => "false"), //May not be true with nullable columns because NULL != NULL
-    rw!("const-prop-binop-eq"; "(= ?a ?b)"=>{ const_binop(a,b, Operator::Eq)} if can_perform_const_binary_op(a,b, Operator::Eq)),
-    rw!("const-prop-binop-neq"; "(<> ?a ?b)"=>{ const_binop(a,b, Operator::NotEq)} if can_perform_const_binary_op(a,b, Operator::NotEq)),
-
-    rw!("const-prop-binop-gt"; "(> ?a ?b)"=>{ const_binop(a,b, Operator::Gt)} if can_perform_const_binary_op(a,b, Operator::Gt)),
-    rw!("const-prop-binop-gte"; "(>= ?a ?b)"=>{ const_binop(a,b, Operator::GtEq)} if can_perform_const_binary_op(a,b, Operator::GtEq)),
-
-    rw!("const-prop-binop-lt"; "(< ?a ?b)"=>{ const_binop(a,b, Operator::Lt)} if can_perform_const_binary_op(a,b, Operator::Lt)),
-    rw!("const-prop-binop-lte"; "(<= ?a ?b)"=>{ const_binop(a,b, Operator::LtEq)} if can_perform_const_binary_op(a,b, Operator::LtEq)),
-
-
-    rw!("const-prop-binop-add"; "(+ ?a ?b)"=>{ const_binop(a,b, Operator::Plus) } if can_convert_both_to_scalar_value(a,b) ),
-    rw!("const-prop-binop-sub"; "(- ?a ?b)" => { const_binop(a, b, Operator::Minus)} if can_convert_both_to_scalar_value(a,b)),
-    rw!("const-prop-binop-mul"; "(* ?a ?b)" => { const_binop(a,b, Operator::Multiply) } if can_convert_both_to_scalar_value(a,b)),
-    rw!("const-prop-binop-div"; "(/ ?a ?b)" =>{  const_binop(a,b, Operator::Divide)} if can_convert_both_to_scalar_value(a,b)),
-
-    rw!("const-cast"; "(cast ?a ?b)" =>{ ConstCastApplier{value: a, cast_type: b}} if can_convert_to_scalar_value(a) ),
-    rw!("const-call-scalar"; "(call ?func ?args)"=>{ ConstCallApplier{func, args}} if is_immutable_scalar_builtin_function(func))]
 }
 
 
-fn add_constant_folding_rules(optimizer: &mut Tokomak){
+pub fn add_constant_folding_rules(optimizer: &mut Tokomak){
     for rule in rules(){
         optimizer.add_rule(rule);
     }
 }
 
-fn can_convert_both_to_scalar_value(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, _id: Id, subst: &Subst| -> bool{
-        let lexpr = egraph[subst[lhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
-        let rexpr = egraph[subst[rhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
-        lexpr.is_some() && rexpr.is_some()
+fn is_immutable_scalar_builtin_function(func: Var)->impl Fn(&mut EGraph<TokomakExpr, ()>,  Id,  &Subst)->bool{
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst|->bool{
+        fetch_as_immutable_builtin_scalar_func(func, egraph, id, subst).is_some()
     }
-}
+ }
 
-fn fetch_as_immutable_builtin_scalar_func(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<BuiltinScalarFunction>{
+
+ fn fetch_as_immutable_builtin_scalar_func(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)-> Option<BuiltinScalarFunction>{
     egraph[subst[var]].nodes.iter().flat_map(|expr| match expr{
         TokomakExpr::ScalarBuiltin(f)=> {
             if f.function_volatility() == FunctionVolatility::Immutable{
@@ -69,139 +85,8 @@ fn fetch_as_immutable_builtin_scalar_func(var: Var, egraph: &mut EGraph<TokomakE
     }).nth(0)
 }
 
-fn is_immutable_scalar_builtin_function(func: Var)->impl Fn(&mut EGraph<TokomakExpr, ()>,  Id,  &Subst)->bool{
-    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst|->bool{
-        fetch_as_immutable_builtin_scalar_func(func, egraph, id, subst).is_some()
-    }
- }
-
-fn can_convert_to_scalar_value(var: Var)-> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst)-> bool{
-    move |egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst| -> bool{
-        let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
-        expr.is_some()
-    }
-}
 
 
-
-fn gt_var(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
-            return false;
-        }
-        let lt = const_binop(lhs, rhs, Operator::Gt);
-        let t_expr = match lt.evaluate(egraph,id, subst){
-            Some(s) => s,
-            None => return false,
-        };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
-            _ => return false,
-        }
-
-    }
-}
-
-fn convert_to_scalar_value(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<ScalarValue, DataFusionError>{
-    let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value()).ok_or_else(|| DataFusionError::Internal("Could not find a node that was convertable to scalar value".to_string()))?;
-    expr.try_into()
-}
-
-
-
-fn binop_type_coercion(mut lhs: ScalarValue,mut rhs:ScalarValue, op: &Operator)->Result<(ScalarValue, ScalarValue), DataFusionError>{
-    let lhs_dt = lhs.get_datatype();
-    let rhs_dt = rhs.get_datatype();
-    let common_datatype = common_binary_type(&lhs_dt, &op, &rhs_dt)?;
-    
-    if lhs_dt != common_datatype{
-        lhs = cast(lhs, &common_datatype)?;
-    }
-    if rhs_dt != common_datatype{
-        rhs = cast(rhs, &common_datatype)?;
-    }
-    Ok((lhs, rhs))
-}
-
-fn cast(val: ScalarValue, cast_type: &DataType)->Result<ScalarValue, DataFusionError>{
-    CastExpr::cast_scalar_default_options(val, cast_type)
-}
-
-fn can_perform_const_binary_op(lhs: Var, rhs: Var, op: Operator)->impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst)-> bool{
-    move |egraph:  &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool{
-        let lhs_lit = convert_to_scalar_value(lhs, egraph, id, subst);
-        if lhs_lit.is_err(){
-            return false;
-        }
-        let lhs_lit = lhs_lit.unwrap();
-
-        let rhs_lit = convert_to_scalar_value(rhs, egraph, id, subst);
-        if rhs_lit.is_err(){
-            return false;
-        }
-        let rhs_lit = rhs_lit.unwrap();
-        let res  = binop_type_coercion(lhs_lit, rhs_lit, &op);
-        if res.is_err(){
-            return false;
-        }
-        return true;
-    }
-}
-
-fn const_binop(lhs: Var, rhs: Var, op: Operator)->ConstBinop<impl  Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, impl Fn(&&TokomakExpr)->bool>{
-    ConstBinop(lhs, rhs, |e| e.can_convert_to_scalar_value(), move |l, r|->Option<TokomakExpr>{
-        let mut lhs : ScalarValue = (&l).try_into().ok()?;
-        let mut rhs: ScalarValue = (&r).try_into().ok()?;
-        let ldt = lhs.get_datatype();
-        let rdt = rhs.get_datatype();
-        if ldt != rdt{
-            let common_dt = common_binary_type(&ldt, &op, &rdt).ok()?;
-            if ldt != common_dt {
-                lhs = CastExpr::cast_scalar_default_options(lhs, &common_dt).ok()?;
-            }
-            if rdt != common_dt{
-                rhs = CastExpr::cast_scalar_default_options(rhs, &common_dt).ok()?;
-            }
-        }
-        
-        
-        let res = BinaryExpr::evaluate_values( crate::physical_plan::ColumnarValue::Scalar(lhs), crate::physical_plan::ColumnarValue::Scalar(rhs), &op,1).ok()?;
-        let scalar =ScalarValue::try_from_columnar_value(res).ok()?;
-        
-        let t_expr: TokomakExpr = scalar.try_into().unwrap();
-        Some(t_expr)
-    })
-}
-
-
-
-struct ConstBinop<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool + 'static>(pub Var, pub Var, pub M, pub F);
-
-impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> ConstBinop<F, M>{
-    fn evaluate(&self, egraph: &mut EGraph<TokomakExpr, ()>, _: Id, subst: &Subst)->Option<TokomakExpr>{
-        let lhs = egraph[subst[self.0]].nodes.iter().find(|expr| self.2(expr));
-        let lhs = match lhs{
-            Some(v)=>v,
-            None => return None,
-        }.clone();
-        let rhs =  egraph[subst[self.1]].nodes.iter().find(|expr| self.2(expr));
-        let rhs = match rhs{
-            Some(v)=>v,
-            None => return None,
-        }.clone();
-        self.3(lhs, rhs)
-
-    }
-}
-
-impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> Applier<TokomakExpr, ()> for ConstBinop<F, M>{
-    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst) -> Vec<Id> {
-        match self.evaluate(egraph, id, subst){
-            Some(e) => vec![egraph.add(e)],
-            None => Vec::new(),
-        }
-    }
-}
 
 
 
@@ -227,7 +112,7 @@ impl ConstCallApplier{
         let func_args = coerce_func_args(&func_args, &crate::physical_plan::functions::signature(&fun)).ok()?;
         let func_args = func_args.into_iter().map(|s| ColumnarValue::Scalar(s)).collect::<Vec<ColumnarValue>>();
         let arg_types = func_args.iter().map(|arg| arg.data_type()).collect::<Vec<DataType>>();
-        let return_ty = crate::physical_plan::functions::return_type(&fun, arg_types.as_slice()).ok()?;
+        let _return_ty = crate::physical_plan::functions::return_type(&fun, arg_types.as_slice()).ok()?;
         let fun_impl = crate::physical_plan::functions::create_immutable_impl(&fun).ok()?;
         let result:ColumnarValue = (&fun_impl)(&func_args).ok()?;
         let val: ScalarValue = ScalarValue::try_from_columnar_value(result).ok()?;
@@ -309,40 +194,39 @@ impl Applier<TokomakExpr, ()> for ConstCastApplier{
 }
 
 
-fn is_literal(expr: Id, egraph: & EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->bool{
-    let res = egraph[expr].nodes.iter().flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} ).nth(0);
-    if res.is_none(){
-        return false;
-    }
-    true
-}
-
-fn to_literal_list<'a>(var: Var, egraph: &'a EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->Option<&'a [Id]>{
-    for expr in egraph[subst[var]].nodes.iter(){
-        match expr{
-            TokomakExpr::List(ref l)=>{
-                if l.iter().all(|expr|  is_literal(*expr,egraph, id, subst)){
-                    return Some(l.as_slice());
-                }
-            }
-            _=>(),
-        } 
-    }
-    None
+struct ConstTryCastApplier{
+    value: Var,
+    cast_type: Var,
 }
 
 
+impl ConstTryCastApplier{
+    fn apply_opt(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<TokomakScalar>{
+        let value = convert_to_scalar_value(self.value, egraph, id, subst).ok()?;
+        let ty = convert_to_tokomak_type(self.cast_type, egraph, id, subst).ok()?;
+        let ty: DataType = ty.into();
+        let val = TryCastExpr::evaluate(ColumnarValue::Scalar(value), &ty).ok()?;// CastExpr::cast_scalar_default_options(value,&ty).ok()?;
+        let v = ScalarValue::try_from_columnar_value(val).ok()?.into();
+        Some(v)
+        
+    }
+}
+
+impl Applier<TokomakExpr, ()> for ConstTryCastApplier{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
+        match self.apply_opt(egraph, eclass, subst){
+            Some(v)=> vec![egraph.add(TokomakExpr::Scalar(v))],
+            None => vec![]
+        }
+    }
+}
 
 
 #[cfg(test)]
 mod test{
     use super::*;
-    use std::{rc::Rc, sync::Arc};
-
-    use arrow::{array::{ArrayRef, Float64Array}, datatypes::DataType};
     use egg::RecExpr;
 
-    use crate::physical_plan::{functions::FunctionVolatility, udaf::AggregateUDF, udf::ScalarUDF};
 
     
 
@@ -366,10 +250,12 @@ mod test{
 
      
     let expr_expected: Vec<(&'static str, &'static str)> =  vec![ 
-        ("(cast (cast 2  utf8) float32)", "2"),
-        ("(* 4 (call abs (list -1)))", "4"),
-        ("(call_udf pow (list (+ 2.5 1.5) (- 1 1.5)))","(call_udf pow (list 4 -0.5))"), //Test udf inlining
-        ("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))")
+        //("(cast (cast 2  utf8) float32)", "2"),
+        ("(try_cast 'gibberish' float32)", "NULL"), //Test try cast
+        ("(try_cast 4.5 utf8)", "4.5"),
+        ("(* 4 (call abs (list -1)))", "4"), //Test function inlining 
+        ("(call_udf udf[pow] (list (+ 2.5 1.5) (- 1 1.5)))","(call_udf udf[pow] (list 4 -0.5))"), //Test const propagation within udf arguments
+        //("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))")
     ];
 
     for (expr, expected) in expr_expected{

--- a/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
+++ b/datafusion/src/optimizer/tokomak/rules/constant_folding.rs
@@ -1,0 +1,381 @@
+use std::convert::TryInto;
+use super::super::TokomakDataType;
+use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::{Tokomak, TokomakExpr, scalar::TokomakScalar}, physical_plan::{ColumnarValue, expressions::{BinaryExpr, CastExpr, common_binary_type}, functions::{BuiltinScalarFunction, FunctionVolatility, Signature}}, scalar::ScalarValue};
+use arrow::datatypes::DataType;
+use crate::physical_plan::type_coercion::data_types;
+
+use egg::{rewrite as rw, *};
+
+
+fn rules()->Vec<Rewrite<TokomakExpr,()>>{
+    let a:Var = "?a".parse().unwrap();
+    let b: Var = "?b".parse().unwrap();
+    let c: Var = "?c".parse().unwrap();
+    let d: Var = "?d".parse().unwrap();
+    let x: Var ="?x".parse().unwrap();
+    let func: Var = "?func".parse().unwrap();
+    let args: Var = "?args".parse().unwrap();
+    vec![rw!("const-prop-between"; "(and (>= ?e ?a) (<= ?e ?b))"=> "false" if gt_var(a,b)),
+    rw!("const-prop-between_inverted"; "(and (< ?e ?a) (> ?e ?b))" => "true" if gt_var(a,b)),
+
+    
+    
+    rw!("const-prop-binop-col-eq"; "(= ?a ?a)" => "(is_not_null ?a)"), //May not be true with nullable columns because NULL != NULL
+    rw!("const-prop-binop-col-neq"; "(<> ?a ?a)" => "false"), //May not be true with nullable columns because NULL != NULL
+    rw!("const-prop-binop-eq"; "(= ?a ?b)"=>{ const_binop(a,b, Operator::Eq)} if can_perform_const_binary_op(a,b, Operator::Eq)),
+    rw!("const-prop-binop-neq"; "(<> ?a ?b)"=>{ const_binop(a,b, Operator::NotEq)} if can_perform_const_binary_op(a,b, Operator::NotEq)),
+
+    rw!("const-prop-binop-gt"; "(> ?a ?b)"=>{ const_binop(a,b, Operator::Gt)} if can_perform_const_binary_op(a,b, Operator::Gt)),
+    rw!("const-prop-binop-gte"; "(>= ?a ?b)"=>{ const_binop(a,b, Operator::GtEq)} if can_perform_const_binary_op(a,b, Operator::GtEq)),
+
+    rw!("const-prop-binop-lt"; "(< ?a ?b)"=>{ const_binop(a,b, Operator::Lt)} if can_perform_const_binary_op(a,b, Operator::Lt)),
+    rw!("const-prop-binop-lte"; "(<= ?a ?b)"=>{ const_binop(a,b, Operator::LtEq)} if can_perform_const_binary_op(a,b, Operator::LtEq)),
+
+
+    rw!("const-prop-binop-add"; "(+ ?a ?b)"=>{ const_binop(a,b, Operator::Plus) } if can_convert_both_to_scalar_value(a,b) ),
+    rw!("const-prop-binop-sub"; "(- ?a ?b)" => { const_binop(a, b, Operator::Minus)} if can_convert_both_to_scalar_value(a,b)),
+    rw!("const-prop-binop-mul"; "(* ?a ?b)" => { const_binop(a,b, Operator::Multiply) } if can_convert_both_to_scalar_value(a,b)),
+    rw!("const-prop-binop-div"; "(/ ?a ?b)" =>{  const_binop(a,b, Operator::Divide)} if can_convert_both_to_scalar_value(a,b)),
+
+    rw!("const-cast"; "(cast ?a ?b)" =>{ ConstCastApplier{value: a, cast_type: b}} if can_convert_to_scalar_value(a) ),
+    rw!("const-call-scalar"; "(call ?func ?args)"=>{ ConstCallApplier{func, args}} if is_immutable_scalar_builtin_function(func))]
+}
+
+
+fn add_constant_folding_rules(optimizer: &mut Tokomak){
+    for rule in rules(){
+        optimizer.add_rule(rule);
+    }
+}
+
+fn can_convert_both_to_scalar_value(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, _id: Id, subst: &Subst| -> bool{
+        let lexpr = egraph[subst[lhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+        let rexpr = egraph[subst[rhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+        lexpr.is_some() && rexpr.is_some()
+    }
+}
+
+fn fetch_as_immutable_builtin_scalar_func(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<BuiltinScalarFunction>{
+    egraph[subst[var]].nodes.iter().flat_map(|expr| match expr{
+        TokomakExpr::ScalarBuiltin(f)=> {
+            if f.function_volatility() == FunctionVolatility::Immutable{
+                Some(f.clone())
+            }else{
+                None
+            }
+        },
+        _ => None
+    }).nth(0)
+}
+
+fn is_immutable_scalar_builtin_function(func: Var)->impl Fn(&mut EGraph<TokomakExpr, ()>,  Id,  &Subst)->bool{
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst|->bool{
+        fetch_as_immutable_builtin_scalar_func(func, egraph, id, subst).is_some()
+    }
+ }
+
+fn can_convert_to_scalar_value(var: Var)-> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst)-> bool{
+    move |egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst| -> bool{
+        let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+        expr.is_some()
+    }
+}
+
+
+
+fn gt_var(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::Gt);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+fn convert_to_scalar_value(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<ScalarValue, DataFusionError>{
+    let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value()).ok_or_else(|| DataFusionError::Internal("Could not find a node that was convertable to scalar value".to_string()))?;
+    expr.try_into()
+}
+
+
+
+fn binop_type_coercion(mut lhs: ScalarValue,mut rhs:ScalarValue, op: &Operator)->Result<(ScalarValue, ScalarValue), DataFusionError>{
+    let lhs_dt = lhs.get_datatype();
+    let rhs_dt = rhs.get_datatype();
+    let common_datatype = common_binary_type(&lhs_dt, &op, &rhs_dt)?;
+    
+    if lhs_dt != common_datatype{
+        lhs = cast(lhs, &common_datatype)?;
+    }
+    if rhs_dt != common_datatype{
+        rhs = cast(rhs, &common_datatype)?;
+    }
+    Ok((lhs, rhs))
+}
+
+fn cast(val: ScalarValue, cast_type: &DataType)->Result<ScalarValue, DataFusionError>{
+    CastExpr::cast_scalar_default_options(val, cast_type)
+}
+
+fn can_perform_const_binary_op(lhs: Var, rhs: Var, op: Operator)->impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst)-> bool{
+    move |egraph:  &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool{
+        let lhs_lit = convert_to_scalar_value(lhs, egraph, id, subst);
+        if lhs_lit.is_err(){
+            return false;
+        }
+        let lhs_lit = lhs_lit.unwrap();
+
+        let rhs_lit = convert_to_scalar_value(rhs, egraph, id, subst);
+        if rhs_lit.is_err(){
+            return false;
+        }
+        let rhs_lit = rhs_lit.unwrap();
+        let res  = binop_type_coercion(lhs_lit, rhs_lit, &op);
+        if res.is_err(){
+            return false;
+        }
+        return true;
+    }
+}
+
+fn const_binop(lhs: Var, rhs: Var, op: Operator)->ConstBinop<impl  Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, impl Fn(&&TokomakExpr)->bool>{
+    ConstBinop(lhs, rhs, |e| e.can_convert_to_scalar_value(), move |l, r|->Option<TokomakExpr>{
+        let mut lhs : ScalarValue = (&l).try_into().ok()?;
+        let mut rhs: ScalarValue = (&r).try_into().ok()?;
+        let ldt = lhs.get_datatype();
+        let rdt = rhs.get_datatype();
+        if ldt != rdt{
+            let common_dt = common_binary_type(&ldt, &op, &rdt).ok()?;
+            if ldt != common_dt {
+                lhs = CastExpr::cast_scalar_default_options(lhs, &common_dt).ok()?;
+            }
+            if rdt != common_dt{
+                rhs = CastExpr::cast_scalar_default_options(rhs, &common_dt).ok()?;
+            }
+        }
+        
+        
+        let res = BinaryExpr::evaluate_values( crate::physical_plan::ColumnarValue::Scalar(lhs), crate::physical_plan::ColumnarValue::Scalar(rhs), &op,1).ok()?;
+        let scalar =ScalarValue::try_from_columnar_value(res).ok()?;
+        
+        let t_expr: TokomakExpr = scalar.try_into().unwrap();
+        Some(t_expr)
+    })
+}
+
+
+
+struct ConstBinop<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool + 'static>(pub Var, pub Var, pub M, pub F);
+
+impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> ConstBinop<F, M>{
+    fn evaluate(&self, egraph: &mut EGraph<TokomakExpr, ()>, _: Id, subst: &Subst)->Option<TokomakExpr>{
+        let lhs = egraph[subst[self.0]].nodes.iter().find(|expr| self.2(expr));
+        let lhs = match lhs{
+            Some(v)=>v,
+            None => return None,
+        }.clone();
+        let rhs =  egraph[subst[self.1]].nodes.iter().find(|expr| self.2(expr));
+        let rhs = match rhs{
+            Some(v)=>v,
+            None => return None,
+        }.clone();
+        self.3(lhs, rhs)
+
+    }
+}
+
+impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> Applier<TokomakExpr, ()> for ConstBinop<F, M>{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst) -> Vec<Id> {
+        match self.evaluate(egraph, id, subst){
+            Some(e) => vec![egraph.add(e)],
+            None => Vec::new(),
+        }
+    }
+}
+
+
+
+struct ConstCallApplier{
+    pub func: Var,
+    pub args: Var,
+}
+
+impl ConstCallApplier{
+    fn apply_one_opt(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst)->Option<Vec<Id>>{
+        let fun = fetch_as_immutable_builtin_scalar_func(self.func, egraph, eclass,subst)?;
+        let args = to_literal_list(self.args,egraph, eclass, subst)?;
+        let num_args = args.len();
+
+        let mut func_args = Vec::with_capacity(num_args);
+        for id in args{
+            let scalar = egraph[*id].nodes.iter()
+            .flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} )
+            .nth(0)
+            .map(|s| s)?;
+            func_args.push(scalar);
+        }
+        let func_args = coerce_func_args(&func_args, &crate::physical_plan::functions::signature(&fun)).ok()?;
+        let func_args = func_args.into_iter().map(|s| ColumnarValue::Scalar(s)).collect::<Vec<ColumnarValue>>();
+        let arg_types = func_args.iter().map(|arg| arg.data_type()).collect::<Vec<DataType>>();
+        let return_ty = crate::physical_plan::functions::return_type(&fun, arg_types.as_slice()).ok()?;
+        let fun_impl = crate::physical_plan::functions::create_immutable_impl(&fun).ok()?;
+        let result:ColumnarValue = (&fun_impl)(&func_args).ok()?;
+        let val: ScalarValue = ScalarValue::try_from_columnar_value(result).ok()?;
+
+        let expr: TokomakExpr = val.try_into().ok()?;
+
+        Some(vec![egraph.add(expr)]) 
+    }
+}
+
+
+fn coerce_func_args(
+    values: &[ScalarValue],
+    signature: &Signature,
+) -> Result<Vec<ScalarValue>, DataFusionError> {
+    if values.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let current_types = (values)
+        .iter()
+        .map(|e| e.get_datatype() )
+        .collect::<Vec<DataType>>();
+
+    let new_types = data_types(&current_types, signature)?;
+
+    (&values)
+        .iter()
+        .enumerate()
+        .map(|(i, value)| cast(value.clone(), &new_types[i]))
+        .collect::<Result<Vec<_>, DataFusionError>>()
+}
+
+
+
+
+impl Applier<TokomakExpr, ()> for ConstCallApplier{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
+        match self.apply_one_opt(egraph, eclass, subst){
+            Some(s) =>s,
+            None => Vec::new(),
+        }
+    }
+}
+
+
+struct ConstCastApplier{
+    value: Var,
+    cast_type: Var,
+}
+
+fn convert_to_tokomak_type(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<TokomakDataType, DataFusionError>{
+    let expr: Option<&TokomakExpr> = egraph[subst[var]].nodes.iter().find(|e| matches!(e, TokomakExpr::Type(_)));
+    let expr = expr.map(|e| match e{
+        TokomakExpr::Type(t) => t.clone(),
+        _ => panic!("Found TokomakExpr which was not TokomakExpr::Type, found {:?}", e),
+    });
+    expr.ok_or_else(|| DataFusionError::Internal("Could not convert to TokomakType".to_string()))
+}
+
+impl ConstCastApplier{
+    fn apply_res(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)-> Option<TokomakExpr>{
+        let value = convert_to_scalar_value(self.value, egraph, id, subst).ok()?;
+        let ty = convert_to_tokomak_type(self.cast_type, egraph, id, subst).ok()?;
+        let ty: DataType = ty.into();
+        let val = CastExpr::cast_scalar_default_options(value,&ty).ok()?;
+        val.try_into().ok()
+    }
+}
+impl Applier<TokomakExpr, ()> for ConstCastApplier{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
+        let cast_const_res = self.apply_res(egraph, eclass, subst);
+        let cast_const_val = match cast_const_res{
+            Some(v)=> v,
+            None=> return Vec::new()
+        };
+        vec![egraph.add(cast_const_val)]
+    }
+}
+
+
+fn is_literal(expr: Id, egraph: & EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->bool{
+    let res = egraph[expr].nodes.iter().flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} ).nth(0);
+    if res.is_none(){
+        return false;
+    }
+    true
+}
+
+fn to_literal_list<'a>(var: Var, egraph: &'a EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->Option<&'a [Id]>{
+    for expr in egraph[subst[var]].nodes.iter(){
+        match expr{
+            TokomakExpr::List(ref l)=>{
+                if l.iter().all(|expr|  is_literal(*expr,egraph, id, subst)){
+                    return Some(l.as_slice());
+                }
+            }
+            _=>(),
+        } 
+    }
+    None
+}
+
+
+
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    use std::{rc::Rc, sync::Arc};
+
+    use arrow::{array::{ArrayRef, Float64Array}, datatypes::DataType};
+    use egg::RecExpr;
+
+    use crate::physical_plan::{functions::FunctionVolatility, udaf::AggregateUDF, udf::ScalarUDF};
+
+    
+
+
+
+
+
+    fn rewrite_expr(expr: &str)->Result<String, Box<dyn std::error::Error>>{
+        let expr: RecExpr<TokomakExpr> = expr.parse()?;
+        println!("unoptomized expr {:?}", expr);
+        let runner = Runner::<TokomakExpr, (), ()>::default()
+        .with_expr(&expr)
+        .run(&rules());
+        let mut extractor = Extractor::new(&runner.egraph, AstSize);
+        let (_, best_expr) = extractor.find_best(runner.roots[0]);
+        println!("optimized expr {:?}", best_expr);
+        Ok(format!("{}", best_expr))
+    }
+    #[test]
+    fn test_const_prop()->Result<(), Box<dyn std::error::Error>>{
+
+     
+    let expr_expected: Vec<(&'static str, &'static str)> =  vec![ 
+        ("(cast (cast 2  utf8) float32)", "2"),
+        ("(* 4 (call abs (list -1)))", "4"),
+        ("(call_udf pow (list (+ 2.5 1.5) (- 1 1.5)))","(call_udf pow (list 4 -0.5))"), //Test udf inlining
+        ("(call_udf pow_vol (list (+ 2.5 1.5) (- 1 1.5)))", "(call_udf pow_vol (list 4 -0.5))")
+    ];
+
+    for (expr, expected) in expr_expected{
+        let rewritten_expr = rewrite_expr(  expr)?;
+        assert_eq!(rewritten_expr, expected); 
+    } 
+    Ok(())
+    }
+}

--- a/datafusion/src/optimizer/tokomak/rules/mod.rs
+++ b/datafusion/src/optimizer/tokomak/rules/mod.rs
@@ -1,0 +1,8 @@
+
+
+
+mod constant_folding;
+mod simplification;
+
+
+

--- a/datafusion/src/optimizer/tokomak/rules/mod.rs
+++ b/datafusion/src/optimizer/tokomak/rules/mod.rs
@@ -1,8 +1,8 @@
 
 
 
-mod constant_folding;
-mod simplification;
-
+pub mod constant_folding;
+pub mod simplification;
+pub mod utils;
 
 

--- a/datafusion/src/optimizer/tokomak/rules/mod.rs
+++ b/datafusion/src/optimizer/tokomak/rules/mod.rs
@@ -1,8 +1,3 @@
-
-
-
 pub mod constant_folding;
 pub mod simplification;
 pub mod utils;
-
-

--- a/datafusion/src/optimizer/tokomak/rules/simplification.rs
+++ b/datafusion/src/optimizer/tokomak/rules/simplification.rs
@@ -152,4 +152,39 @@ mod tests {
             "(and (= 1 2) (or ?boo (or ?foo ?bar)))"
         )
     }
+    #[test]
+    fn test_between_same(){
+        let expr = "(between ?x ?same ?same)".parse().unwrap();
+        let runner = Runner::<TokomakExpr, (), ()>::default()
+        .with_expr(&expr)
+        .run(&rules());
+
+        let mut extractor = Extractor::new(&runner.egraph, AstSize);
+
+        let (_, best_expr) = extractor.find_best(runner.roots[0]);
+        
+
+        assert_eq!(
+            format!("{}", best_expr),
+            "(= ?x ?same)"
+        ) 
+    }
+
+    #[test]
+    fn test_between_inverted_same(){
+        let expr = "(between_inverted ?x ?same ?same)".parse().unwrap();
+        let runner = Runner::<TokomakExpr, (), ()>::default()
+        .with_expr(&expr)
+        .run(&rules());
+
+        let mut extractor = Extractor::new(&runner.egraph, AstSize);
+
+        let (_, best_expr) = extractor.find_best(runner.roots[0]);
+        
+
+        assert_eq!(
+            format!("{}", best_expr),
+            "(<> ?x ?same)"
+        ) 
+    }
 }

--- a/datafusion/src/optimizer/tokomak/rules/simplification.rs
+++ b/datafusion/src/optimizer/tokomak/rules/simplification.rs
@@ -1,0 +1,180 @@
+
+use crate::{error::DataFusionError, logical_plan::Operator, physical_plan::expressions::{BinaryExpr, CastExpr, common_binary_type}, scalar::ScalarValue};
+
+use super::super::{Tokomak, TokomakExpr};
+use arrow::datatypes::DataType;
+use egg::{rewrite as rw, *};
+use std::convert::{TryFrom, TryInto};
+
+pub fn add_simplification_rules(optimizer: &mut Tokomak){
+    let a:Var = "?a".parse().unwrap();
+    let b: Var = "?b".parse().unwrap();
+    let c: Var = "?c".parse().unwrap();
+    let d: Var = "?d".parse().unwrap();
+    let x: Var ="?x".parse().unwrap();
+    let rules= vec![
+        rw!("commute-add"; "(+ ?x ?y)" => "(+ ?y ?x)"),
+        rw!("commute-mul"; "(* ?x ?y)" => "(* ?y ?x)"),
+        rw!("commute-and"; "(and ?x ?y)" => "(and ?y ?x)"),
+        rw!("commute-or"; "(or ?x ?y)" => "(or ?y ?x)"),
+        rw!("commute-eq"; "(= ?x ?y)" => "(= ?y ?x)"),
+        rw!("commute-neq"; "(<> ?x ?y)" => "(<> ?y ?x)"),
+        rw!("converse-gt"; "(> ?x ?y)" => "(< ?y ?x)"),
+        rw!("converse-gte"; "(>= ?x ?y)" => "(<= ?y ?x)"),
+        rw!("converse-lt"; "(< ?x ?y)" => "(> ?y ?x)"),
+        rw!("converse-lte"; "(<= ?x ?y)" => "(>= ?y ?x)"),
+        rw!("add-0"; "(+ ?x 0)" => "?x"),
+        rw!("add-assoc"; "(+ (+ ?a ?b) ?c)" => "(+ ?a (+ ?b ?c))"),
+        rw!("minus-0"; "(- ?x 0)" => "?x"),
+        rw!("mul-1"; "(* ?x 1)" => "?x"),
+        rw!("div-1"; "(/ ?x 1)" => "?x"),
+        rw!("dist-and-or"; "(or (and ?a ?b) (and ?a ?c))" => "(and ?a (or ?b ?c))"),
+        rw!("dist-or-and"; "(and (or ?a ?b) (or ?a ?c))" => "(or ?a (and ?b ?c))"),
+        rw!("not-not"; "(not (not ?x))" => "?x"),
+        rw!("or-same"; "(or ?x ?x)" => "?x"),
+        rw!("and-same"; "(and ?x ?x)" => "?x"),
+        rw!("and-true"; "(and true ?x)"=> "?x"),
+        rw!("0-minus"; "(- 0 ?x)"=> "(negative ?x)"),
+        rw!("and-false"; "(and false ?x)"=> "false"),
+        rw!("or-false"; "(or false ?x)"=> "?x"),
+        rw!("or-true"; "(or true ?x)"=> "true"),
+        rw!("between-same"; "(between ?e ?a ?a)"=> "(= ?e ?a)"),
+        rw!("expand-between"; "(between ?e ?a ?b)" => "(and (>= ?e ?a) (<= ?e ?b))"),
+        rw!("between_inverted-same"; "(between_inverted ?e ?a ?a)" => "(<> ?e ?a)" ),
+        rw!("expand-between_inverted"; "(between_inverted ?e ?a ?b)" => "(and (< ?e ?a) (> ?e ?b))"),
+        rw!("between_inverted-not-between"; "(between_inverted ?e ?a ?b)" => "(not (between ?e ?a ?b))"),
+        rw!("between-or-union"; "(or (between ?x ?a ?b) (between ?x ?c ?d))" => { BetweenMergeApplier{
+            common_comparison: x,
+            lhs_lower: a,
+            lhs_upper: b,
+            rhs_upper: d,
+            rhs_lower: c,
+        }}),
+    ];
+    for rule in rules{
+        optimizer.add_rule(rule)
+    }
+}
+
+
+
+struct BetweenMergeApplier{
+    pub common_comparison: Var,
+    pub lhs_lower: Var, 
+    pub lhs_upper: Var, 
+    pub rhs_lower: Var, 
+    pub rhs_upper: Var
+}
+
+impl BetweenMergeApplier{
+    fn try_merge(&self,egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst )->Result<(TokomakExpr, TokomakExpr), DataFusionError>{
+        let lhs_low = convert_to_scalar_value(self.lhs_lower, egraph, id, subst)?;
+        let lhs_high = convert_to_scalar_value(self.lhs_upper, egraph, id, subst)?;
+        let rhs_low = convert_to_scalar_value(self.rhs_lower, egraph, id, subst)?;
+        let rhs_high = convert_to_scalar_value(self.rhs_upper, egraph, id, subst)?;
+
+        //Check if one is contained within another
+        let rhs_high_in_lhs = gte(rhs_high.clone(), lhs_low.clone())? && lte(rhs_high.clone(), lhs_high.clone())?;
+        let rhs_low_in_lhs = gte(rhs_low.clone(), lhs_low.clone())? && lte(rhs_low.clone(), lhs_high.clone())?;
+        let is_overlap = rhs_high_in_lhs || rhs_low_in_lhs;
+        if is_overlap{
+            let new_lower = min(lhs_low, rhs_low)?;
+            let new_high = max(lhs_high, rhs_high)?;
+            return Ok((new_lower.into(),new_high.into()))
+        }
+        Err(DataFusionError::Internal(String::new()))
+    }
+}
+
+
+fn convert_to_scalar_value(var: Var, egraph: &mut EGraph<TokomakExpr,()>, _id: Id, subst: &Subst)->Result<ScalarValue, DataFusionError>{
+    let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value()).ok_or_else(|| DataFusionError::Internal("Could not find a node that was convertable to scalar value".to_string()))?;
+    expr.try_into()
+}
+
+
+fn min(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
+    let ret_val = if lt(x.clone(), y.clone())?{
+        x
+    }else{
+        y
+    };
+    Ok(ret_val)
+}
+
+fn max(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
+    let ret_val = if gt(x.clone(), y.clone())?{
+        x
+    }else{
+        y
+    };
+    Ok(ret_val)
+}
+
+fn lt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::Lt)?;
+    res.try_into()
+}
+
+fn lte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::LtEq)?;
+    res.try_into()
+}
+
+fn gt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::Gt)?;
+    res.try_into()
+}
+
+fn gte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::GtEq)?;
+    res.try_into()
+}
+
+fn cast(val: ScalarValue, cast_type: &DataType)->Result<ScalarValue, DataFusionError>{
+    CastExpr::cast_scalar_default_options(val, cast_type)
+}
+
+
+fn scalar_binop(lhs: ScalarValue, rhs:ScalarValue, op: &Operator)->Result<ScalarValue, DataFusionError>{
+    let (lhs, rhs) = binop_type_coercion(lhs, rhs, &op)?;
+    let res = BinaryExpr::evaluate_values(crate::physical_plan::ColumnarValue::Scalar(lhs),crate::physical_plan::ColumnarValue::Scalar(rhs),&op, 1)?;
+    match res{
+        crate::physical_plan::ColumnarValue::Scalar(s)=> Ok(s),
+        crate::physical_plan::ColumnarValue::Array(arr)=>{
+            if arr.len() == 1 {
+                ScalarValue::try_from_array(&arr, 0)
+            }else{
+                Err(DataFusionError::Internal(format!("Could not convert an array of length {} to a scalar", arr.len())))
+            }
+        }
+    }
+}
+
+fn binop_type_coercion(mut lhs: ScalarValue,mut rhs:ScalarValue, op: &Operator)->Result<(ScalarValue, ScalarValue), DataFusionError>{
+    let lhs_dt = lhs.get_datatype();
+    let rhs_dt = rhs.get_datatype();
+    let common_datatype = common_binary_type(&lhs_dt, &op, &rhs_dt)?;
+    if lhs_dt != common_datatype{
+        lhs = cast(lhs, &common_datatype)?;
+    }
+    if rhs_dt != common_datatype{
+        rhs = cast(rhs, &common_datatype)?;
+    }
+    Ok((lhs, rhs))
+}
+
+impl Applier<TokomakExpr, ()> for BetweenMergeApplier{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, eclass: Id, subst: &Subst) -> Vec<Id> {
+        let (lower, upper) = match self.try_merge(egraph, eclass, subst){
+            Ok(new_range)=>new_range,
+            Err(_) => return Vec::new(),
+        };
+        let lower_id = egraph.add(lower);
+        let upper_id = egraph.add(upper);
+        let common_compare = egraph[subst[self.common_comparison]].id;
+        let new_between = TokomakExpr::Between([common_compare, lower_id, upper_id]);
+        let new_between_id = egraph.add(new_between);
+        vec![new_between_id]
+    }
+}

--- a/datafusion/src/optimizer/tokomak/rules/utils.rs
+++ b/datafusion/src/optimizer/tokomak/rules/utils.rs
@@ -1,290 +1,376 @@
-
+use crate::{
+    error::DataFusionError,
+    logical_plan::Operator,
+    optimizer::tokomak::scalar::TokomakScalar,
+    physical_plan::expressions::{common_binary_type, BinaryExpr, CastExpr},
+    scalar::ScalarValue,
+};
 use arrow::datatypes::DataType;
-use egg::{ *};
-use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::scalar::TokomakScalar, physical_plan::expressions::{BinaryExpr, CastExpr, common_binary_type}, scalar::ScalarValue};
+use egg::*;
 
-use super::super::{TokomakExpr};
+use super::super::TokomakExpr;
 use std::convert::TryInto;
 
-pub fn convert_to_scalar_value(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<ScalarValue, DataFusionError>{
-    let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value()).ok_or_else(|| DataFusionError::Internal("Could not find a node that was convertable to scalar value".to_string()))?;
+pub fn convert_to_scalar_value(
+    var: Var,
+    egraph: &mut EGraph<TokomakExpr, ()>,
+    _id: Id,
+    subst: &Subst,
+) -> Result<ScalarValue, DataFusionError> {
+    let expr = egraph[subst[var]]
+        .nodes
+        .iter()
+        .find(|e| e.can_convert_to_scalar_value())
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "Could not find a node that was convertable to scalar value".to_string(),
+            )
+        })?;
     expr.try_into()
 }
 
-
-
-
-pub fn scalar_binop(lhs: ScalarValue, rhs:ScalarValue, op: &Operator)->Result<ScalarValue, DataFusionError>{
+pub fn scalar_binop(
+    lhs: ScalarValue,
+    rhs: ScalarValue,
+    op: &Operator,
+) -> Result<ScalarValue, DataFusionError> {
     let (lhs, rhs) = binop_type_coercion(lhs, rhs, &op)?;
-    let res = BinaryExpr::evaluate_values(crate::physical_plan::ColumnarValue::Scalar(lhs),crate::physical_plan::ColumnarValue::Scalar(rhs),&op, 1)?;
-    match res{
-        crate::physical_plan::ColumnarValue::Scalar(s)=> Ok(s),
-        crate::physical_plan::ColumnarValue::Array(arr)=>{
+    let res = BinaryExpr::evaluate_values(
+        crate::physical_plan::ColumnarValue::Scalar(lhs),
+        crate::physical_plan::ColumnarValue::Scalar(rhs),
+        &op,
+        1,
+    )?;
+    match res {
+        crate::physical_plan::ColumnarValue::Scalar(s) => Ok(s),
+        crate::physical_plan::ColumnarValue::Array(arr) => {
             if arr.len() == 1 {
                 ScalarValue::try_from_array(&arr, 0)
-            }else{
-                Err(DataFusionError::Internal(format!("Could not convert an array of length {} to a scalar", arr.len())))
+            } else {
+                Err(DataFusionError::Internal(format!(
+                    "Could not convert an array of length {} to a scalar",
+                    arr.len()
+                )))
             }
         }
     }
 }
 
-
-pub fn cast(val: ScalarValue, cast_type: &DataType)->Result<ScalarValue, DataFusionError>{
+pub fn cast(
+    val: ScalarValue,
+    cast_type: &DataType,
+) -> Result<ScalarValue, DataFusionError> {
     CastExpr::cast_scalar_default_options(val, cast_type)
 }
 
-
-pub fn binop_type_coercion(mut lhs: ScalarValue,mut rhs:ScalarValue, op: &Operator)->Result<(ScalarValue, ScalarValue), DataFusionError>{
+pub fn binop_type_coercion(
+    mut lhs: ScalarValue,
+    mut rhs: ScalarValue,
+    op: &Operator,
+) -> Result<(ScalarValue, ScalarValue), DataFusionError> {
     let lhs_dt = lhs.get_datatype();
     let rhs_dt = rhs.get_datatype();
     let common_datatype = common_binary_type(&lhs_dt, &op, &rhs_dt)?;
-    if lhs_dt != common_datatype{
+    if lhs_dt != common_datatype {
         lhs = cast(lhs, &common_datatype)?;
     }
-    if rhs_dt != common_datatype{
+    if rhs_dt != common_datatype {
         rhs = cast(rhs, &common_datatype)?;
     }
     Ok((lhs, rhs))
 }
 
-
-pub fn min(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
-    let ret_val = if lt(x.clone(), y.clone())?{
-        x
-    }else{
-        y
-    };
+pub fn min(x: ScalarValue, y: ScalarValue) -> Result<ScalarValue, DataFusionError> {
+    let ret_val = if lt(x.clone(), y.clone())? { x } else { y };
     Ok(ret_val)
 }
 
-pub fn max(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
-    let ret_val = if gt(x.clone(), y.clone())?{
-        x
-    }else{
-        y
-    };
+pub fn max(x: ScalarValue, y: ScalarValue) -> Result<ScalarValue, DataFusionError> {
+    let ret_val = if gt(x.clone(), y.clone())? { x } else { y };
     Ok(ret_val)
 }
 
-pub fn lt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+pub fn lt(lhs: ScalarValue, rhs: ScalarValue) -> Result<bool, DataFusionError> {
     let res = scalar_binop(lhs, rhs, &Operator::Lt)?;
     res.try_into()
 }
 
-pub fn lte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+pub fn lte(lhs: ScalarValue, rhs: ScalarValue) -> Result<bool, DataFusionError> {
     let res = scalar_binop(lhs, rhs, &Operator::LtEq)?;
     res.try_into()
 }
 
-pub fn gt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+pub fn gt(lhs: ScalarValue, rhs: ScalarValue) -> Result<bool, DataFusionError> {
     let res = scalar_binop(lhs, rhs, &Operator::Gt)?;
     res.try_into()
 }
 
-pub fn gte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+pub fn gte(lhs: ScalarValue, rhs: ScalarValue) -> Result<bool, DataFusionError> {
     let res = scalar_binop(lhs, rhs, &Operator::GtEq)?;
     res.try_into()
 }
 
-
-pub fn var_gt(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_gt(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::Gt);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-pub fn var_lt(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_lt(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::Lt);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-pub fn var_gte(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_gte(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::GtEq);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-pub fn var_lte(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_lte(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::LtEq);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-pub fn var_eq(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_eq(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::Eq);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-pub fn var_neq(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
-        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+pub fn var_neq(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst| -> bool {
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst) {
             return false;
         }
         let lt = const_binop(lhs, rhs, Operator::NotEq);
-        let t_expr = match lt.evaluate(egraph,id, subst){
+        let t_expr = match lt.evaluate(egraph, id, subst) {
             Some(s) => s,
             None => return false,
         };
-        match t_expr{
-            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+        match t_expr {
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v))) => return v,
             _ => return false,
         }
-
     }
 }
 
-
-pub fn can_convert_both_to_scalar_value(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
-    move |egraph: &mut EGraph<TokomakExpr,()>, _id: Id, subst: &Subst| -> bool{
-        let lexpr = egraph[subst[lhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
-        let rexpr = egraph[subst[rhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+pub fn can_convert_both_to_scalar_value(
+    lhs: Var,
+    rhs: Var,
+) -> impl Fn(&mut EGraph<TokomakExpr, ()>, Id, &Subst) -> bool {
+    move |egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst| -> bool {
+        let lexpr = egraph[subst[lhs]]
+            .nodes
+            .iter()
+            .find(|e| e.can_convert_to_scalar_value());
+        let rexpr = egraph[subst[rhs]]
+            .nodes
+            .iter()
+            .find(|e| e.can_convert_to_scalar_value());
         lexpr.is_some() && rexpr.is_some()
     }
 }
 
-pub struct ConstBinop<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool + 'static>(pub Var, pub Var, pub M, pub F);
+pub struct ConstBinop<
+    F: Fn(TokomakExpr, TokomakExpr) -> Option<TokomakExpr>,
+    M: Fn(&&TokomakExpr) -> bool + 'static,
+>(pub Var, pub Var, pub M, pub F);
 
-impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> ConstBinop<F, M>{
-    fn evaluate(&self, egraph: &mut EGraph<TokomakExpr, ()>, _: Id, subst: &Subst)->Option<TokomakExpr>{
+impl<
+        F: Fn(TokomakExpr, TokomakExpr) -> Option<TokomakExpr>,
+        M: Fn(&&TokomakExpr) -> bool,
+    > ConstBinop<F, M>
+{
+    fn evaluate(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        _: Id,
+        subst: &Subst,
+    ) -> Option<TokomakExpr> {
         let lhs = egraph[subst[self.0]].nodes.iter().find(|expr| self.2(expr));
-        let lhs = match lhs{
-            Some(v)=>v,
+        let lhs = match lhs {
+            Some(v) => v,
             None => return None,
-        }.clone();
-        let rhs =  egraph[subst[self.1]].nodes.iter().find(|expr| self.2(expr));
-        let rhs = match rhs{
-            Some(v)=>v,
+        }
+        .clone();
+        let rhs = egraph[subst[self.1]].nodes.iter().find(|expr| self.2(expr));
+        let rhs = match rhs {
+            Some(v) => v,
             None => return None,
-        }.clone();
+        }
+        .clone();
         self.3(lhs, rhs)
-
     }
 }
 
-impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> Applier<TokomakExpr, ()> for ConstBinop<F, M>{
-    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst) -> Vec<Id> {
-        match self.evaluate(egraph, id, subst){
+impl<
+        F: Fn(TokomakExpr, TokomakExpr) -> Option<TokomakExpr>,
+        M: Fn(&&TokomakExpr) -> bool,
+    > Applier<TokomakExpr, ()> for ConstBinop<F, M>
+{
+    fn apply_one(
+        &self,
+        egraph: &mut EGraph<TokomakExpr, ()>,
+        id: Id,
+        subst: &Subst,
+    ) -> Vec<Id> {
+        match self.evaluate(egraph, id, subst) {
             Some(e) => vec![egraph.add(e)],
             None => Vec::new(),
         }
     }
 }
 
-
-
-
-pub fn const_binop(lhs: Var, rhs: Var, op: Operator)->ConstBinop<impl  Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, impl Fn(&&TokomakExpr)->bool>{
-    ConstBinop(lhs, rhs, |e| e.can_convert_to_scalar_value(), move |l, r|->Option<TokomakExpr>{
-        let mut lhs : ScalarValue = (&l).try_into().ok()?;
-        let mut rhs: ScalarValue = (&r).try_into().ok()?;
-        let ldt = lhs.get_datatype();
-        let rdt = rhs.get_datatype();
-        if ldt != rdt{
-            let common_dt = common_binary_type(&ldt, &op, &rdt).ok()?;
-            if ldt != common_dt {
-                lhs = CastExpr::cast_scalar_default_options(lhs, &common_dt).ok()?;
+pub fn const_binop(
+    lhs: Var,
+    rhs: Var,
+    op: Operator,
+) -> ConstBinop<
+    impl Fn(TokomakExpr, TokomakExpr) -> Option<TokomakExpr>,
+    impl Fn(&&TokomakExpr) -> bool,
+> {
+    ConstBinop(
+        lhs,
+        rhs,
+        |e| e.can_convert_to_scalar_value(),
+        move |l, r| -> Option<TokomakExpr> {
+            let mut lhs: ScalarValue = (&l).try_into().ok()?;
+            let mut rhs: ScalarValue = (&r).try_into().ok()?;
+            let ldt = lhs.get_datatype();
+            let rdt = rhs.get_datatype();
+            if ldt != rdt {
+                let common_dt = common_binary_type(&ldt, &op, &rdt).ok()?;
+                if ldt != common_dt {
+                    lhs = CastExpr::cast_scalar_default_options(lhs, &common_dt).ok()?;
+                }
+                if rdt != common_dt {
+                    rhs = CastExpr::cast_scalar_default_options(rhs, &common_dt).ok()?;
+                }
             }
-            if rdt != common_dt{
-                rhs = CastExpr::cast_scalar_default_options(rhs, &common_dt).ok()?;
-            }
-        }
-        
-        
-        let res = BinaryExpr::evaluate_values( crate::physical_plan::ColumnarValue::Scalar(lhs), crate::physical_plan::ColumnarValue::Scalar(rhs), &op,1).ok()?;
-        let scalar =ScalarValue::try_from_columnar_value(res).ok()?;
-        
-        let t_expr: TokomakExpr = scalar.try_into().unwrap();
-        Some(t_expr)
-    })
+
+            let res = BinaryExpr::evaluate_values(
+                crate::physical_plan::ColumnarValue::Scalar(lhs),
+                crate::physical_plan::ColumnarValue::Scalar(rhs),
+                &op,
+                1,
+            )
+            .ok()?;
+            let scalar = ScalarValue::try_from_columnar_value(res).ok()?;
+
+            let t_expr: TokomakExpr = scalar.try_into().unwrap();
+            Some(t_expr)
+        },
+    )
 }
 
-pub fn is_literal(expr: Id, egraph: & EGraph<TokomakExpr, ()>, _id: Id, _subst: &Subst)->bool{
-    let res = egraph[expr].nodes.iter().flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} ).nth(0);
-    if res.is_none(){
+pub fn is_literal(
+    expr: Id,
+    egraph: &EGraph<TokomakExpr, ()>,
+    _id: Id,
+    _subst: &Subst,
+) -> bool {
+    let res = egraph[expr]
+        .nodes
+        .iter()
+        .flat_map(|expr| -> Result<ScalarValue, DataFusionError> { expr.try_into() })
+        .nth(0);
+    if res.is_none() {
         return false;
     }
     true
 }
 
-pub fn to_literal_list<'a>(var: Var, egraph: &'a EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->Option<&'a [Id]>{
-    for expr in egraph[subst[var]].nodes.iter(){
-        match expr{
-            TokomakExpr::List(ref l)=>{
-                if l.iter().all(|expr|  is_literal(*expr,egraph, id, subst)){
+pub fn to_literal_list<'a>(
+    var: Var,
+    egraph: &'a EGraph<TokomakExpr, ()>,
+    id: Id,
+    subst: &Subst,
+) -> Option<&'a [Id]> {
+    for expr in egraph[subst[var]].nodes.iter() {
+        match expr {
+            TokomakExpr::List(ref l) => {
+                if l.iter().all(|expr| is_literal(*expr, egraph, id, subst)) {
                     return Some(l.as_slice());
                 }
             }
-            _=>(),
-        } 
+            _ => (),
+        }
     }
     None
 }
-
-
-
-
-

--- a/datafusion/src/optimizer/tokomak/rules/utils.rs
+++ b/datafusion/src/optimizer/tokomak/rules/utils.rs
@@ -1,0 +1,290 @@
+
+use arrow::datatypes::DataType;
+use egg::{ *};
+use crate::{error::DataFusionError, logical_plan::Operator, optimizer::tokomak::scalar::TokomakScalar, physical_plan::expressions::{BinaryExpr, CastExpr, common_binary_type}, scalar::ScalarValue};
+
+use super::super::{TokomakExpr};
+use std::convert::TryInto;
+
+pub fn convert_to_scalar_value(var: Var, egraph: &mut EGraph<TokomakExpr, ()>, _id: Id, subst: &Subst)->Result<ScalarValue, DataFusionError>{
+    let expr = egraph[subst[var]].nodes.iter().find(|e| e.can_convert_to_scalar_value()).ok_or_else(|| DataFusionError::Internal("Could not find a node that was convertable to scalar value".to_string()))?;
+    expr.try_into()
+}
+
+
+
+
+pub fn scalar_binop(lhs: ScalarValue, rhs:ScalarValue, op: &Operator)->Result<ScalarValue, DataFusionError>{
+    let (lhs, rhs) = binop_type_coercion(lhs, rhs, &op)?;
+    let res = BinaryExpr::evaluate_values(crate::physical_plan::ColumnarValue::Scalar(lhs),crate::physical_plan::ColumnarValue::Scalar(rhs),&op, 1)?;
+    match res{
+        crate::physical_plan::ColumnarValue::Scalar(s)=> Ok(s),
+        crate::physical_plan::ColumnarValue::Array(arr)=>{
+            if arr.len() == 1 {
+                ScalarValue::try_from_array(&arr, 0)
+            }else{
+                Err(DataFusionError::Internal(format!("Could not convert an array of length {} to a scalar", arr.len())))
+            }
+        }
+    }
+}
+
+
+pub fn cast(val: ScalarValue, cast_type: &DataType)->Result<ScalarValue, DataFusionError>{
+    CastExpr::cast_scalar_default_options(val, cast_type)
+}
+
+
+pub fn binop_type_coercion(mut lhs: ScalarValue,mut rhs:ScalarValue, op: &Operator)->Result<(ScalarValue, ScalarValue), DataFusionError>{
+    let lhs_dt = lhs.get_datatype();
+    let rhs_dt = rhs.get_datatype();
+    let common_datatype = common_binary_type(&lhs_dt, &op, &rhs_dt)?;
+    if lhs_dt != common_datatype{
+        lhs = cast(lhs, &common_datatype)?;
+    }
+    if rhs_dt != common_datatype{
+        rhs = cast(rhs, &common_datatype)?;
+    }
+    Ok((lhs, rhs))
+}
+
+
+pub fn min(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
+    let ret_val = if lt(x.clone(), y.clone())?{
+        x
+    }else{
+        y
+    };
+    Ok(ret_val)
+}
+
+pub fn max(x: ScalarValue, y: ScalarValue)->Result<ScalarValue, DataFusionError>{
+    let ret_val = if gt(x.clone(), y.clone())?{
+        x
+    }else{
+        y
+    };
+    Ok(ret_val)
+}
+
+pub fn lt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::Lt)?;
+    res.try_into()
+}
+
+pub fn lte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::LtEq)?;
+    res.try_into()
+}
+
+pub fn gt(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::Gt)?;
+    res.try_into()
+}
+
+pub fn gte(lhs: ScalarValue, rhs:ScalarValue)->Result<bool, DataFusionError>{
+    let res = scalar_binop(lhs, rhs, &Operator::GtEq)?;
+    res.try_into()
+}
+
+
+pub fn var_gt(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::Gt);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+pub fn var_lt(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::Lt);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+pub fn var_gte(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::GtEq);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+pub fn var_lte(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::LtEq);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+pub fn var_eq(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::Eq);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+pub fn var_neq(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, id: Id, subst: &Subst| -> bool{
+        if !can_convert_both_to_scalar_value(lhs, rhs)(egraph, id, subst){
+            return false;
+        }
+        let lt = const_binop(lhs, rhs, Operator::NotEq);
+        let t_expr = match lt.evaluate(egraph,id, subst){
+            Some(s) => s,
+            None => return false,
+        };
+        match t_expr{
+            TokomakExpr::Scalar(TokomakScalar::Boolean(Some(v)))=> return v,
+            _ => return false,
+        }
+
+    }
+}
+
+
+pub fn can_convert_both_to_scalar_value(lhs: Var, rhs: Var)->impl Fn(&mut EGraph<TokomakExpr,()>, Id, &Subst) -> bool{
+    move |egraph: &mut EGraph<TokomakExpr,()>, _id: Id, subst: &Subst| -> bool{
+        let lexpr = egraph[subst[lhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+        let rexpr = egraph[subst[rhs]].nodes.iter().find(|e| e.can_convert_to_scalar_value());
+        lexpr.is_some() && rexpr.is_some()
+    }
+}
+
+pub struct ConstBinop<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool + 'static>(pub Var, pub Var, pub M, pub F);
+
+impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> ConstBinop<F, M>{
+    fn evaluate(&self, egraph: &mut EGraph<TokomakExpr, ()>, _: Id, subst: &Subst)->Option<TokomakExpr>{
+        let lhs = egraph[subst[self.0]].nodes.iter().find(|expr| self.2(expr));
+        let lhs = match lhs{
+            Some(v)=>v,
+            None => return None,
+        }.clone();
+        let rhs =  egraph[subst[self.1]].nodes.iter().find(|expr| self.2(expr));
+        let rhs = match rhs{
+            Some(v)=>v,
+            None => return None,
+        }.clone();
+        self.3(lhs, rhs)
+
+    }
+}
+
+impl<F: Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, M: Fn(&&TokomakExpr)->bool> Applier<TokomakExpr, ()> for ConstBinop<F, M>{
+    fn apply_one(&self, egraph: &mut EGraph<TokomakExpr, ()>, id: Id, subst: &Subst) -> Vec<Id> {
+        match self.evaluate(egraph, id, subst){
+            Some(e) => vec![egraph.add(e)],
+            None => Vec::new(),
+        }
+    }
+}
+
+
+
+
+pub fn const_binop(lhs: Var, rhs: Var, op: Operator)->ConstBinop<impl  Fn (TokomakExpr, TokomakExpr)->Option<TokomakExpr>, impl Fn(&&TokomakExpr)->bool>{
+    ConstBinop(lhs, rhs, |e| e.can_convert_to_scalar_value(), move |l, r|->Option<TokomakExpr>{
+        let mut lhs : ScalarValue = (&l).try_into().ok()?;
+        let mut rhs: ScalarValue = (&r).try_into().ok()?;
+        let ldt = lhs.get_datatype();
+        let rdt = rhs.get_datatype();
+        if ldt != rdt{
+            let common_dt = common_binary_type(&ldt, &op, &rdt).ok()?;
+            if ldt != common_dt {
+                lhs = CastExpr::cast_scalar_default_options(lhs, &common_dt).ok()?;
+            }
+            if rdt != common_dt{
+                rhs = CastExpr::cast_scalar_default_options(rhs, &common_dt).ok()?;
+            }
+        }
+        
+        
+        let res = BinaryExpr::evaluate_values( crate::physical_plan::ColumnarValue::Scalar(lhs), crate::physical_plan::ColumnarValue::Scalar(rhs), &op,1).ok()?;
+        let scalar =ScalarValue::try_from_columnar_value(res).ok()?;
+        
+        let t_expr: TokomakExpr = scalar.try_into().unwrap();
+        Some(t_expr)
+    })
+}
+
+pub fn is_literal(expr: Id, egraph: & EGraph<TokomakExpr, ()>, _id: Id, _subst: &Subst)->bool{
+    let res = egraph[expr].nodes.iter().flat_map(|expr|->Result<ScalarValue, DataFusionError>{ expr.try_into()} ).nth(0);
+    if res.is_none(){
+        return false;
+    }
+    true
+}
+
+pub fn to_literal_list<'a>(var: Var, egraph: &'a EGraph<TokomakExpr, ()>, id: Id, subst: &Subst)->Option<&'a [Id]>{
+    for expr in egraph[subst[var]].nodes.iter(){
+        match expr{
+            TokomakExpr::List(ref l)=>{
+                if l.iter().all(|expr|  is_literal(*expr,egraph, id, subst)){
+                    return Some(l.as_slice());
+                }
+            }
+            _=>(),
+        } 
+    }
+    None
+}
+
+
+
+
+

--- a/datafusion/src/optimizer/tokomak/scalar.rs
+++ b/datafusion/src/optimizer/tokomak/scalar.rs
@@ -1,0 +1,251 @@
+use crate::{error::DataFusionError, physical_plan::udf::ScalarUDF, scalar::ScalarValue};
+use arrow::datatypes::DataType;
+use ordered_float::OrderedFloat;
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum TokomakScalar {
+    /// true or false value
+    Boolean(Option<bool>),
+    /// 32bit float
+    Float32(Option<OrderedFloat<f32>>),
+    /// 64bit float
+    Float64(Option<OrderedFloat<f64>>),
+    /// signed 8bit int
+    Int8(Option<i8>),
+    /// signed 16bit int
+    Int16(Option<i16>),
+    /// signed 32bit int
+    Int32(Option<i32>),
+    /// signed 64bit int
+    Int64(Option<i64>),
+    /// unsigned 8bit int
+    UInt8(Option<u8>),
+    /// unsigned 16bit int
+    UInt16(Option<u16>),
+    /// unsigned 32bit int
+    UInt32(Option<u32>),
+    /// unsigned 64bit int
+    UInt64(Option<u64>),
+    /// utf-8 encoded string.
+    Utf8(Option<String>),
+    /// utf-8 encoded string representing a LargeString's arrow type.
+    LargeUtf8(Option<String>),
+    /// binary
+    Binary(Option<Vec<u8>>),
+    /// large binary
+    LargeBinary(Option<Vec<u8>>),
+    /// list of nested ScalarValue (boxed to reduce size_of(ScalarValue))
+    #[allow(clippy::box_vec)]
+    List(Option<Box<Vec<TokomakScalar>>>, Box<DataType>),
+    /// Date stored as a signed 32bit int
+    Date32(Option<i32>),
+    /// Date stored as a signed 64bit int
+    Date64(Option<i64>),
+    /// Timestamp Second
+    TimestampSecond(Option<i64>),
+    /// Timestamp Milliseconds
+    TimestampMillisecond(Option<i64>),
+    /// Timestamp Microseconds
+    TimestampMicrosecond(Option<i64>),
+    /// Timestamp Nanoseconds
+    TimestampNanosecond(Option<i64>),
+    /// Interval with YearMonth unit
+    IntervalYearMonth(Option<i32>),
+    /// Interval with DayTime unit
+    IntervalDayTime(Option<i64>),
+}
+
+//This is mostly for convience's sake when testing the optimizer so this implmentation is shoddy
+impl std::str::FromStr for TokomakScalar {
+    type Err = DataFusionError;
+    fn from_str(s: &str) -> Result<TokomakScalar, DataFusionError> {
+        let value = if let Ok(val) = s.parse() {
+            TokomakScalar::Boolean(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::UInt8(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Int8(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::UInt16(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Int16(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::UInt32(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Int32(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::UInt64(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Int64(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Float32(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Float64(Some(val))
+        } else if let Ok(val) = s.parse() {
+            TokomakScalar::Boolean(Some(val))
+        } else {
+            let first_char = match s.chars().nth(0) {
+                Some(c) => c,
+                _ => return Err(DataFusionError::Internal(String::new())),
+            };
+            if first_char == '?'
+                || first_char.is_numeric()
+                || first_char.is_ascii_graphic()
+                || first_char.is_ascii_punctuation()
+            {
+                return Err(DataFusionError::Internal(String::new()));
+            }
+            TokomakScalar::Utf8(Some(s.to_string()))
+        };
+        Ok(value)
+    }
+}
+
+impl From<ScalarValue> for TokomakScalar {
+    fn from(val: ScalarValue) -> Self {
+        match val {
+            ScalarValue::Boolean(v) => TokomakScalar::Boolean(v),
+            ScalarValue::Float32(v) => TokomakScalar::Float32(v.map(OrderedFloat::from)),
+            ScalarValue::Float64(v) => TokomakScalar::Float64(v.map(OrderedFloat::from)),
+            ScalarValue::Int8(v) => TokomakScalar::Int8(v),
+            ScalarValue::Int16(v) => TokomakScalar::Int16(v),
+            ScalarValue::Int32(v) => TokomakScalar::Int32(v),
+            ScalarValue::Int64(v) => TokomakScalar::Int64(v),
+            ScalarValue::UInt8(v) => TokomakScalar::UInt8(v),
+            ScalarValue::UInt16(v) => TokomakScalar::UInt16(v),
+            ScalarValue::UInt32(v) => TokomakScalar::UInt32(v),
+            ScalarValue::UInt64(v) => TokomakScalar::UInt64(v),
+            ScalarValue::Utf8(v) => TokomakScalar::Utf8(v),
+            ScalarValue::LargeUtf8(v) => TokomakScalar::LargeUtf8(v),
+            ScalarValue::Binary(v) => TokomakScalar::Binary(v),
+            ScalarValue::LargeBinary(v) => TokomakScalar::LargeBinary(v),
+            ScalarValue::List(v, d) => TokomakScalar::List(
+                v.map(|list| {
+                    Box::new(list.into_iter().map(|item| item.into()).collect())
+                }),
+                d,
+            ),
+            ScalarValue::Date32(v) => TokomakScalar::Date32(v),
+            ScalarValue::Date64(v) => TokomakScalar::Date64(v),
+            ScalarValue::TimestampSecond(v) => TokomakScalar::TimestampSecond(v),
+            ScalarValue::TimestampMillisecond(v) => {
+                TokomakScalar::TimestampMillisecond(v)
+            }
+            ScalarValue::TimestampMicrosecond(v) => {
+                TokomakScalar::TimestampMicrosecond(v)
+            }
+            ScalarValue::TimestampNanosecond(v) => TokomakScalar::TimestampNanosecond(v),
+            ScalarValue::IntervalYearMonth(v) => TokomakScalar::IntervalYearMonth(v),
+            ScalarValue::IntervalDayTime(v) => TokomakScalar::IntervalDayTime(v),
+        }
+    }
+}
+impl From<TokomakScalar> for ScalarValue {
+    fn from(val: TokomakScalar) -> Self {
+        match val {
+            TokomakScalar::Boolean(v) => ScalarValue::Boolean(v),
+            TokomakScalar::Float32(v) => ScalarValue::Float32(v.map(|f| f.0)),
+            TokomakScalar::Float64(v) => ScalarValue::Float64(v.map(|f| f.0)),
+            TokomakScalar::Int8(v) => ScalarValue::Int8(v),
+            TokomakScalar::Int16(v) => ScalarValue::Int16(v),
+            TokomakScalar::Int32(v) => ScalarValue::Int32(v),
+            TokomakScalar::Int64(v) => ScalarValue::Int64(v),
+            TokomakScalar::UInt8(v) => ScalarValue::UInt8(v),
+            TokomakScalar::UInt16(v) => ScalarValue::UInt16(v),
+            TokomakScalar::UInt32(v) => ScalarValue::UInt32(v),
+            TokomakScalar::UInt64(v) => ScalarValue::UInt64(v),
+            TokomakScalar::Utf8(v) => ScalarValue::Utf8(v),
+            TokomakScalar::LargeUtf8(v) => ScalarValue::LargeUtf8(v),
+            TokomakScalar::Binary(v) => ScalarValue::Binary(v),
+            TokomakScalar::LargeBinary(v) => ScalarValue::LargeBinary(v),
+            TokomakScalar::List(v, d) => ScalarValue::List(
+                v.map(|list| {
+                    Box::new(list.into_iter().map(|item| item.into()).collect())
+                }),
+                d,
+            ),
+            TokomakScalar::Date32(v) => ScalarValue::Date32(v),
+            TokomakScalar::Date64(v) => ScalarValue::Date64(v),
+            TokomakScalar::TimestampSecond(v) => ScalarValue::TimestampSecond(v),
+            TokomakScalar::TimestampMillisecond(v) => {
+                ScalarValue::TimestampMillisecond(v)
+            }
+            TokomakScalar::TimestampMicrosecond(v) => {
+                ScalarValue::TimestampMicrosecond(v)
+            }
+            TokomakScalar::TimestampNanosecond(v) => ScalarValue::TimestampNanosecond(v),
+            TokomakScalar::IntervalYearMonth(v) => ScalarValue::IntervalYearMonth(v),
+            TokomakScalar::IntervalDayTime(v) => ScalarValue::IntervalDayTime(v),
+        }
+    }
+}
+
+macro_rules! format_option {
+    ($F:expr, $EXPR:expr) => {{
+        match $EXPR {
+            Some(e) => write!($F, "{}", e),
+            None => write!($F, "NULL"),
+        }
+    }};
+}
+
+impl std::fmt::Display for TokomakScalar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            TokomakScalar::Boolean(e) => format_option!(f, e)?,
+            TokomakScalar::Float32(e) => format_option!(f, e)?,
+            TokomakScalar::Float64(e) => format_option!(f, e)?,
+            TokomakScalar::Int8(e) => format_option!(f, e)?,
+            TokomakScalar::Int16(e) => format_option!(f, e)?,
+            TokomakScalar::Int32(e) => format_option!(f, e)?,
+            TokomakScalar::Int64(e) => format_option!(f, e)?,
+            TokomakScalar::UInt8(e) => format_option!(f, e)?,
+            TokomakScalar::UInt16(e) => format_option!(f, e)?,
+            TokomakScalar::UInt32(e) => format_option!(f, e)?,
+            TokomakScalar::UInt64(e) => format_option!(f, e)?,
+            TokomakScalar::TimestampSecond(e) => format_option!(f, e)?,
+            TokomakScalar::TimestampMillisecond(e) => format_option!(f, e)?,
+            TokomakScalar::TimestampMicrosecond(e) => format_option!(f, e)?,
+            TokomakScalar::TimestampNanosecond(e) => format_option!(f, e)?,
+            TokomakScalar::Utf8(e) => format_option!(f, e)?,
+            TokomakScalar::LargeUtf8(e) => format_option!(f, e)?,
+            TokomakScalar::Binary(e) => match e {
+                Some(l) => write!(
+                    f,
+                    "{}",
+                    l.iter()
+                        .map(|v| format!("{}", v))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?,
+                None => write!(f, "NULL")?,
+            },
+            TokomakScalar::LargeBinary(e) => match e {
+                Some(l) => write!(
+                    f,
+                    "{}",
+                    l.iter()
+                        .map(|v| format!("{}", v))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?,
+                None => write!(f, "NULL")?,
+            },
+            TokomakScalar::List(e, _) => match e {
+                Some(l) => write!(
+                    f,
+                    "{}",
+                    l.iter()
+                        .map(|v| format!("{}", v))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?,
+                None => write!(f, "NULL")?,
+            },
+            TokomakScalar::Date32(e) => format_option!(f, e)?,
+            TokomakScalar::Date64(e) => format_option!(f, e)?,
+            TokomakScalar::IntervalDayTime(e) => format_option!(f, e)?,
+            TokomakScalar::IntervalYearMonth(e) => format_option!(f, e)?,
+        };
+        Ok(())
+    }
+}

--- a/datafusion/src/optimizer/tokomak/scalar.rs
+++ b/datafusion/src/optimizer/tokomak/scalar.rs
@@ -90,18 +90,19 @@ impl std::str::FromStr for TokomakScalar {
             if (first_char == '?'
                 || first_char.is_numeric()
                 || first_char.is_ascii_graphic())
-                && (first_char.is_ascii_punctuation() && !(first_char == '\'' || first_char == '"'))
+                && (first_char.is_ascii_punctuation()
+                    && !(first_char == '\'' || first_char == '"'))
             {
                 //println!("Could not parse: {}",first_char.is_ascii_punctuation() && !(first_char == '\'' || first_char == '"'));
                 return Err(DataFusionError::Internal(String::new()));
             }
             let mut str_in = s;
             if first_char == '"' || first_char == '\'' {
-                str_in = match &str_in[1..].strip_suffix(first_char){
+                str_in = match &str_in[1..].strip_suffix(first_char) {
                     Some(v) => v,
                     None => return Err(DataFusionError::Internal(String::new())),
                 };
-            }else{
+            } else {
                 return Err(DataFusionError::Internal(String::new()));
             }
             TokomakScalar::Utf8(Some(str_in.to_string()))

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -47,7 +47,7 @@ pub type StateTypeFunction =
     Arc<dyn Fn(&DataType) -> Result<Arc<Vec<DataType>>> + Send + Sync>;
 
 /// Enum of all built-in scalar functions
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AggregateFunction {
     /// count
     Count,

--- a/datafusion/src/physical_plan/expressions/binary.rs
+++ b/datafusion/src/physical_plan/expressions/binary.rs
@@ -512,9 +512,13 @@ pub fn binary_operator_data_type(
     }
 }
 
-
-impl BinaryExpr{
-    pub (crate) fn evaluate_values(left_value: ColumnarValue, right_value: ColumnarValue, op: &Operator, num_rows:usize)->Result<ColumnarValue>{
+impl BinaryExpr {
+    pub(crate) fn evaluate_values(
+        left_value: ColumnarValue,
+        right_value: ColumnarValue,
+        op: &Operator,
+        num_rows: usize,
+    ) -> Result<ColumnarValue> {
         let left_data_type = left_value.data_type();
         let right_data_type = right_value.data_type();
 
@@ -547,8 +551,14 @@ impl BinaryExpr{
             left_value.into_array(num_rows),
             right_value.into_array(num_rows),
         );
-        BinaryExpr::evaluate_with_resolved_args(left, &left_data_type, right, &right_data_type, op)
-            .map(|a| ColumnarValue::Array(a))
+        BinaryExpr::evaluate_with_resolved_args(
+            left,
+            &left_data_type,
+            right,
+            &right_data_type,
+            op,
+        )
+        .map(|a| ColumnarValue::Array(a))
     }
 }
 impl PhysicalExpr for BinaryExpr {
@@ -583,7 +593,7 @@ impl BinaryExpr {
         //&self,
         array: &ArrayRef,
         scalar: &ScalarValue,
-        op: &Operator
+        op: &Operator,
     ) -> Result<Option<Result<ArrayRef>>> {
         let scalar_result = match op {
             Operator::Lt => binary_array_op_scalar!(array, scalar.clone(), lt),
@@ -651,7 +661,7 @@ impl BinaryExpr {
         //&self,
         scalar: &ScalarValue,
         array: &ArrayRef,
-        op: &Operator
+        op: &Operator,
     ) -> Result<Option<Result<ArrayRef>>> {
         let scalar_result = match op {
             Operator::Lt => binary_array_op_scalar!(array, scalar.clone(), gt),
@@ -678,7 +688,7 @@ impl BinaryExpr {
         left_data_type: &DataType,
         right: Arc<dyn Array>,
         right_data_type: &DataType,
-        op: &Operator
+        op: &Operator,
     ) -> Result<ArrayRef> {
         match op {
             Operator::Like => binary_string_array_op!(left, right, like),

--- a/datafusion/src/physical_plan/expressions/cast.rs
+++ b/datafusion/src/physical_plan/expressions/cast.rs
@@ -95,6 +95,18 @@ impl PhysicalExpr for CastExpr {
     }
 }
 
+
+impl CastExpr{
+    pub(crate) fn cast_scalar_default_options(scalar: ScalarValue, cast_type: &DataType)->Result<ScalarValue>{
+        CastExpr::cast_scalar_type(scalar, cast_type, &DEFAULT_DATAFUSION_CAST_OPTIONS)
+    }
+    pub(crate) fn cast_scalar_type(scalar: ScalarValue, cast_type: &DataType, cast_options: &CastOptions)->Result<ScalarValue>{
+        let col = ColumnarValue::Scalar(scalar);
+        let cast_array = cast_column(&col, cast_type, &cast_options)?;
+        ScalarValue::try_from_columnar_value(cast_array)
+    }
+}
+
 /// Internal cast function for casting ColumnarValue -> ColumnarValue for cast_type
 pub fn cast_column(
     value: &ColumnarValue,

--- a/datafusion/src/physical_plan/expressions/cast.rs
+++ b/datafusion/src/physical_plan/expressions/cast.rs
@@ -95,12 +95,18 @@ impl PhysicalExpr for CastExpr {
     }
 }
 
-
-impl CastExpr{
-    pub(crate) fn cast_scalar_default_options(scalar: ScalarValue, cast_type: &DataType)->Result<ScalarValue>{
+impl CastExpr {
+    pub(crate) fn cast_scalar_default_options(
+        scalar: ScalarValue,
+        cast_type: &DataType,
+    ) -> Result<ScalarValue> {
         CastExpr::cast_scalar_type(scalar, cast_type, &DEFAULT_DATAFUSION_CAST_OPTIONS)
     }
-    pub(crate) fn cast_scalar_type(scalar: ScalarValue, cast_type: &DataType, cast_options: &CastOptions)->Result<ScalarValue>{
+    pub(crate) fn cast_scalar_type(
+        scalar: ScalarValue,
+        cast_type: &DataType,
+        cast_options: &CastOptions,
+    ) -> Result<ScalarValue> {
         let col = ColumnarValue::Scalar(scalar);
         let cast_array = cast_column(&col, cast_type, &cast_options)?;
         ScalarValue::try_from_columnar_value(cast_array)

--- a/datafusion/src/physical_plan/expressions/mod.rs
+++ b/datafusion/src/physical_plan/expressions/mod.rs
@@ -55,7 +55,7 @@ pub mod helpers {
 }
 
 pub use average::{avg_return_type, Avg, AvgAccumulator};
-pub use binary::{binary, binary_operator_data_type, BinaryExpr};
+pub use binary::{binary, binary_operator_data_type, BinaryExpr, common_binary_type};
 pub use case::{case, CaseExpr};
 pub use cast::{
     cast, cast_column, cast_with_options, CastExpr, DEFAULT_DATAFUSION_CAST_OPTIONS,

--- a/datafusion/src/physical_plan/expressions/mod.rs
+++ b/datafusion/src/physical_plan/expressions/mod.rs
@@ -55,7 +55,7 @@ pub mod helpers {
 }
 
 pub use average::{avg_return_type, Avg, AvgAccumulator};
-pub use binary::{binary, binary_operator_data_type, BinaryExpr, common_binary_type};
+pub use binary::{binary, binary_operator_data_type, common_binary_type, BinaryExpr};
 pub use case::{case, CaseExpr};
 pub use cast::{
     cast, cast_column, cast_with_options, CastExpr, DEFAULT_DATAFUSION_CAST_OPTIONS,

--- a/datafusion/src/physical_plan/expressions/try_cast.rs
+++ b/datafusion/src/physical_plan/expressions/try_cast.rs
@@ -54,11 +54,13 @@ impl TryCastExpr {
         &self.cast_type
     }
 
-    pub(crate) fn evaluate(value: ColumnarValue, cast_type: &DataType)->Result<ColumnarValue>{
+    pub(crate) fn evaluate(
+        value: ColumnarValue,
+        cast_type: &DataType,
+    ) -> Result<ColumnarValue> {
         match value {
             ColumnarValue::Array(array) => Ok(ColumnarValue::Array(kernels::cast::cast(
-                &array,
-                cast_type,
+                &array, cast_type,
             )?)),
             ColumnarValue::Scalar(scalar) => {
                 let scalar_array = scalar.to_array();

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -226,6 +226,7 @@ pub enum BuiltinScalarFunction {
 }
 
 impl BuiltinScalarFunction {
+    ///Returns the volatility of the function see [FunctionVolatility] for more information about the categories of volatiltiy
     pub fn function_volatility(&self)->FunctionVolatility{
         match self{
             BuiltinScalarFunction::Random | BuiltinScalarFunction::Now => FunctionVolatility::Volatile,

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -94,7 +94,7 @@ pub type ReturnTypeFunction =
     Arc<dyn Fn(&[DataType]) -> Result<Arc<DataType>> + Send + Sync>;
 
 /// Enum of all built-in scalar functions
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BuiltinScalarFunction {
     // math functions
     /// abs
@@ -226,6 +226,14 @@ pub enum BuiltinScalarFunction {
 }
 
 impl BuiltinScalarFunction {
+    pub fn function_volatility(&self)->FunctionVolatility{
+        match self{
+            BuiltinScalarFunction::Random | BuiltinScalarFunction::Now => FunctionVolatility::Volatile,
+            _=>FunctionVolatility::Immutable,
+        }
+            
+    }
+
     /// an allowlist of functions to take zero arguments, so that they will get special treatment
     /// while executing.
     fn supports_zero_argument(&self) -> bool {
@@ -483,6 +491,11 @@ pub fn return_type(
     }
 }
 
+
+
+
+
+
 #[cfg(feature = "crypto_expressions")]
 macro_rules! invoke_if_crypto_expressions_feature_flag {
     ($FUNC:ident, $NAME:expr) => {{
@@ -541,6 +554,29 @@ macro_rules! invoke_if_unicode_expressions_feature_flag {
             )))
         }
     };
+}
+
+///Function volatility determines when a function can be inlined or in the future have evaluations elided when the arguments are the same
+///Immutable - a pure function which always remains the same 
+///Stable - Maybe not required?. Used for functions which can modify the db but are stable for multiple calls in statement
+///Volatile - Functions where output can vary for each call.
+///For more information see https://www.postgresql.org/docs/current/xfunc-volatility.html
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum FunctionVolatility{
+    ///Immutable - a pure function which always remains the same 
+    Immutable=0, 
+    ///Stable - Maybe not required?. Used for functions which can modify the db but are stable for multiple calls in statement is this relevant for datafusion as in mem?
+    Stable=1,
+    ///Volatile - Functions where output can vary for each call.
+    Volatile=2
+}
+
+
+impl Default for FunctionVolatility{
+    fn default() -> Self {
+        FunctionVolatility::Volatile
+    }
 }
 
 /// Create a physical scalar function.
@@ -1083,7 +1119,7 @@ pub fn create_physical_expr(
 }
 
 /// the signatures supported by the function `fun`.
-fn signature(fun: &BuiltinScalarFunction) -> Signature {
+pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
     // note: the physical expression must accept the type returned by this function or the execution panics.
 
     // for now, the list is small, as we do not have many built-in functions.
@@ -1427,6 +1463,419 @@ where
         }
     })
 }
+
+pub(crate) fn create_immutable_impl(fun : &BuiltinScalarFunction)->Result<ScalarFunctionImplementation>{
+    let fun_expr: ScalarFunctionImplementation = Arc::new(match fun {
+        // math functions
+        BuiltinScalarFunction::Abs => math_expressions::abs,
+        BuiltinScalarFunction::Acos => math_expressions::acos,
+        BuiltinScalarFunction::Asin => math_expressions::asin,
+        BuiltinScalarFunction::Atan => math_expressions::atan,
+        BuiltinScalarFunction::Ceil => math_expressions::ceil,
+        BuiltinScalarFunction::Cos => math_expressions::cos,
+        BuiltinScalarFunction::Exp => math_expressions::exp,
+        BuiltinScalarFunction::Floor => math_expressions::floor,
+        BuiltinScalarFunction::Log => math_expressions::log10,
+        BuiltinScalarFunction::Ln => math_expressions::ln,
+        BuiltinScalarFunction::Log10 => math_expressions::log10,
+        BuiltinScalarFunction::Log2 => math_expressions::log2,
+        BuiltinScalarFunction::Random => math_expressions::random,
+        BuiltinScalarFunction::Round => math_expressions::round,
+        BuiltinScalarFunction::Signum => math_expressions::signum,
+        BuiltinScalarFunction::Sin => math_expressions::sin,
+        BuiltinScalarFunction::Sqrt => math_expressions::sqrt,
+        BuiltinScalarFunction::Tan => math_expressions::tan,
+        BuiltinScalarFunction::Trunc => math_expressions::trunc,
+
+        // string functions
+        BuiltinScalarFunction::Array => array_expressions::array,
+        BuiltinScalarFunction::Ascii => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::ascii::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::ascii::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function ascii",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::BitLength => |args| match &args[0] {
+            ColumnarValue::Array(v) => Ok(ColumnarValue::Array(bit_length(v.as_ref())?)),
+            ColumnarValue::Scalar(v) => match v {
+                ScalarValue::Utf8(v) => Ok(ColumnarValue::Scalar(ScalarValue::Int32(
+                    v.as_ref().map(|x| (x.len() * 8) as i32),
+                ))),
+                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::Scalar(
+                    ScalarValue::Int64(v.as_ref().map(|x| (x.len() * 8) as i64)),
+                )),
+                _ => unreachable!(),
+            },
+        },
+        BuiltinScalarFunction::Btrim => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::btrim::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::btrim::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function btrim",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::CharacterLength => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    character_length,
+                    Int32Type,
+                    "character_length"
+                );
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    character_length,
+                    Int64Type,
+                    "character_length"
+                );
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function character_length",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Chr => {
+            |args| make_scalar_function(string_expressions::chr)(args)
+        }
+        BuiltinScalarFunction::Concat => string_expressions::concat,
+        BuiltinScalarFunction::ConcatWithSeparator => {
+            |args| make_scalar_function(string_expressions::concat_ws)(args)
+        }
+        BuiltinScalarFunction::DatePart => datetime_expressions::date_part,
+        BuiltinScalarFunction::DateTrunc => datetime_expressions::date_trunc,
+        BuiltinScalarFunction::InitCap => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::initcap::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::initcap::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function initcap",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Left => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(left, i32, "left");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(left, i64, "left");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function left",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Lower => string_expressions::lower,
+        BuiltinScalarFunction::Lpad => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(lpad, i32, "lpad");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(lpad, i64, "lpad");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function lpad",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Ltrim => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::ltrim::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::ltrim::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function ltrim",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::MD5 => {
+            invoke_if_crypto_expressions_feature_flag!(md5, "md5")
+        }
+        BuiltinScalarFunction::NullIf => nullif_func,
+        BuiltinScalarFunction::OctetLength => |args| match &args[0] {
+            ColumnarValue::Array(v) => Ok(ColumnarValue::Array(length(v.as_ref())?)),
+            ColumnarValue::Scalar(v) => match v {
+                ScalarValue::Utf8(v) => Ok(ColumnarValue::Scalar(ScalarValue::Int32(
+                    v.as_ref().map(|x| x.len() as i32),
+                ))),
+                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::Scalar(
+                    ScalarValue::Int64(v.as_ref().map(|x| x.len() as i64)),
+                )),
+                _ => unreachable!(),
+            },
+        },
+        BuiltinScalarFunction::RegexpMatch => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_regex_expressions_feature_flag!(
+                    regexp_match,
+                    i32,
+                    "regexp_match"
+                );
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_regex_expressions_feature_flag!(
+                    regexp_match,
+                    i64,
+                    "regexp_match"
+                );
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function regexp_match",
+                other
+            ))),
+        },
+        BuiltinScalarFunction::RegexpReplace => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_regex_expressions_feature_flag!(
+                    regexp_replace,
+                    i32,
+                    "regexp_replace"
+                );
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_regex_expressions_feature_flag!(
+                    regexp_replace,
+                    i64,
+                    "regexp_replace"
+                );
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function regexp_replace",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Repeat => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::repeat::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::repeat::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function repeat",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Replace => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::replace::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::replace::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function replace",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Reverse => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(reverse, i32, "reverse");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(reverse, i64, "reverse");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function reverse",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Right => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(right, i32, "right");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(right, i64, "right");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function right",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Rpad => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(rpad, i32, "rpad");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(rpad, i64, "rpad");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function rpad",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Rtrim => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::rtrim::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::rtrim::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function rtrim",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::SHA224 => {
+            invoke_if_crypto_expressions_feature_flag!(sha224, "sha224")
+        }
+        BuiltinScalarFunction::SHA256 => {
+            invoke_if_crypto_expressions_feature_flag!(sha256, "sha256")
+        }
+        BuiltinScalarFunction::SHA384 => {
+            invoke_if_crypto_expressions_feature_flag!(sha384, "sha384")
+        }
+        BuiltinScalarFunction::SHA512 => {
+            invoke_if_crypto_expressions_feature_flag!(sha512, "sha512")
+        }
+        BuiltinScalarFunction::SplitPart => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::split_part::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::split_part::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function split_part",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::StartsWith => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::starts_with::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::starts_with::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function starts_with",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Strpos => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    strpos, Int32Type, "strpos"
+                );
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    strpos, Int64Type, "strpos"
+                );
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function strpos",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Substr => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(substr, i32, "substr");
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func =
+                    invoke_if_unicode_expressions_feature_flag!(substr, i64, "substr");
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function substr",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::ToHex => |args| match args[0].data_type() {
+            DataType::Int32 => {
+                make_scalar_function(string_expressions::to_hex::<Int32Type>)(args)
+            }
+            DataType::Int64 => {
+                make_scalar_function(string_expressions::to_hex::<Int64Type>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function to_hex",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::ToTimestamp => datetime_expressions::to_timestamp,
+        BuiltinScalarFunction::Translate => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    translate,
+                    i32,
+                    "translate"
+                );
+                make_scalar_function(func)(args)
+            }
+            DataType::LargeUtf8 => {
+                let func = invoke_if_unicode_expressions_feature_flag!(
+                    translate,
+                    i64,
+                    "translate"
+                );
+                make_scalar_function(func)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function translate",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Trim => |args| match args[0].data_type() {
+            DataType::Utf8 => {
+                make_scalar_function(string_expressions::btrim::<i32>)(args)
+            }
+            DataType::LargeUtf8 => {
+                make_scalar_function(string_expressions::btrim::<i64>)(args)
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function trim",
+                other,
+            ))),
+        },
+        BuiltinScalarFunction::Upper => string_expressions::upper,
+        f => return Err(DataFusionError::Internal(format!("The function {} is not immutable", f )))
+    });
+    Ok(fun_expr)
+}
+
+
+
 
 #[cfg(test)]
 mod tests {

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -227,12 +227,13 @@ pub enum BuiltinScalarFunction {
 
 impl BuiltinScalarFunction {
     ///Returns the volatility of the function see [FunctionVolatility] for more information about the categories of volatiltiy
-    pub fn function_volatility(&self)->FunctionVolatility{
-        match self{
-            BuiltinScalarFunction::Random | BuiltinScalarFunction::Now => FunctionVolatility::Volatile,
-            _=>FunctionVolatility::Immutable,
+    pub fn function_volatility(&self) -> FunctionVolatility {
+        match self {
+            BuiltinScalarFunction::Random | BuiltinScalarFunction::Now => {
+                FunctionVolatility::Volatile
+            }
+            _ => FunctionVolatility::Immutable,
         }
-            
     }
 
     /// an allowlist of functions to take zero arguments, so that they will get special treatment
@@ -492,11 +493,6 @@ pub fn return_type(
     }
 }
 
-
-
-
-
-
 #[cfg(feature = "crypto_expressions")]
 macro_rules! invoke_if_crypto_expressions_feature_flag {
     ($FUNC:ident, $NAME:expr) => {{
@@ -558,23 +554,22 @@ macro_rules! invoke_if_unicode_expressions_feature_flag {
 }
 
 ///Function volatility determines when a function can be inlined or in the future have evaluations elided when the arguments are the same
-///Immutable - a pure function which always remains the same 
+///Immutable - a pure function which always remains the same
 ///Stable - Maybe not required?. Used for functions which can modify the db but are stable for multiple calls in statement
 ///Volatile - Functions where output can vary for each call.
 ///For more information see https://www.postgresql.org/docs/current/xfunc-volatility.html
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u32)]
-pub enum FunctionVolatility{
-    ///Immutable - a pure function which always remains the same 
-    Immutable=0, 
+pub enum FunctionVolatility {
+    ///Immutable - a pure function which always remains the same
+    Immutable = 0,
     ///Stable - Maybe not required?. Used for functions which can modify the db but are stable for multiple calls in statement is this relevant for datafusion as in mem?
-    Stable=1,
+    Stable = 1,
     ///Volatile - Functions where output can vary for each call.
-    Volatile=2
+    Volatile = 2,
 }
 
-
-impl Default for FunctionVolatility{
+impl Default for FunctionVolatility {
     fn default() -> Self {
         FunctionVolatility::Volatile
     }
@@ -1465,7 +1460,9 @@ where
     })
 }
 
-pub(crate) fn create_immutable_impl(fun : &BuiltinScalarFunction)->Result<ScalarFunctionImplementation>{
+pub(crate) fn create_immutable_impl(
+    fun: &BuiltinScalarFunction,
+) -> Result<ScalarFunctionImplementation> {
     let fun_expr: ScalarFunctionImplementation = Arc::new(match fun {
         // math functions
         BuiltinScalarFunction::Abs => math_expressions::abs,
@@ -1870,13 +1867,15 @@ pub(crate) fn create_immutable_impl(fun : &BuiltinScalarFunction)->Result<Scalar
             ))),
         },
         BuiltinScalarFunction::Upper => string_expressions::upper,
-        f => return Err(DataFusionError::Internal(format!("The function {} is not immutable", f )))
+        f => {
+            return Err(DataFusionError::Internal(format!(
+                "The function {} is not immutable",
+                f
+            )))
+        }
     });
     Ok(fun_expr)
 }
-
-
-
 
 #[cfg(test)]
 mod tests {

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -402,7 +402,7 @@ pub enum ColumnarValue {
 }
 
 impl ColumnarValue {
-    fn data_type(&self) -> DataType {
+    pub fn data_type(&self) -> DataType {
         match self {
             ColumnarValue::Array(array_value) => array_value.data_type().clone(),
             ColumnarValue::Scalar(scalar_value) => scalar_value.get_datatype(),

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -402,6 +402,7 @@ pub enum ColumnarValue {
 }
 
 impl ColumnarValue {
+    ///Returns the data type of the columnar value
     pub fn data_type(&self) -> DataType {
         match self {
             ColumnarValue::Array(array_value) => array_value.data_type().clone(),

--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -100,12 +100,13 @@ impl ScalarUDF {
         }
     }
     /// Create a new ScalarUDF with the specified volatility
-    pub fn with_volatility(name: &str,
+    pub fn with_volatility(
+        name: &str,
         signature: &Signature,
         return_type: &ReturnTypeFunction,
-        fun: &ScalarFunctionImplementation, 
+        fun: &ScalarFunctionImplementation,
         volatility: FunctionVolatility,
-    )->Self{
+    ) -> Self {
         Self {
             name: name.to_owned(),
             signature: signature.clone(),

--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -25,6 +25,7 @@ use arrow::datatypes::Schema;
 use crate::error::Result;
 use crate::{logical_plan::Expr, physical_plan::PhysicalExpr};
 
+use super::functions::FunctionVolatility;
 use super::{
     functions::{
         ReturnTypeFunction, ScalarFunctionExpr, ScalarFunctionImplementation, Signature,
@@ -42,6 +43,8 @@ pub struct ScalarUDF {
     pub signature: Signature,
     /// Return type
     pub return_type: ReturnTypeFunction,
+    /// Volatility of the UDF
+    pub volatility: FunctionVolatility,
     /// actual implementation
     ///
     /// The fn param is the wrapped function but be aware that the function will
@@ -81,7 +84,7 @@ impl PartialOrd for ScalarUDF {
 }
 
 impl ScalarUDF {
-    /// Create a new ScalarUDF
+    /// Create a new ScalarUDF, the function is assumed to be volatile
     pub fn new(
         name: &str,
         signature: &Signature,
@@ -92,6 +95,22 @@ impl ScalarUDF {
             name: name.to_owned(),
             signature: signature.clone(),
             return_type: return_type.clone(),
+            volatility: Default::default(),
+            fun: fun.clone(),
+        }
+    }
+    /// Create a new ScalarUDF with the specified volatility
+    pub fn with_volatility(name: &str,
+        signature: &Signature,
+        return_type: &ReturnTypeFunction,
+        fun: &ScalarFunctionImplementation, 
+        volatility: FunctionVolatility,
+    )->Self{
+        Self {
+            name: name.to_owned(),
+            signature: signature.clone(),
+            return_type: return_type.clone(),
+            volatility,
             fun: fun.clone(),
         }
     }

--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::{fmt, str::FromStr};
 
 /// WindowFunction
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowFunction {
     /// window function that leverages an aggregate function
     AggregateFunction(AggregateFunction),
@@ -90,7 +90,7 @@ impl fmt::Display for WindowFunction {
 }
 
 /// An aggregate function that is part of a built-in window function
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Ord)]
 pub enum BuiltInWindowFunction {
     /// number of the current row within its partition, counting from 1
     RowNumber,

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -17,7 +17,7 @@
 
 //! This module provides ScalarValue, an enum that can be used for storage of single elements
 
-use crate::error::{DataFusionError, Result};
+use crate::{error::{DataFusionError, Result}, physical_plan::ColumnarValue};
 use arrow::{
     array::*,
     datatypes::{
@@ -907,7 +907,12 @@ impl ScalarValue {
             ),
         }
     }
-
+    pub (crate) fn try_from_columnar_value(val: ColumnarValue)->Result<Self>{
+        match val{
+            ColumnarValue::Array(s) => ScalarValue::try_from_array(&s, 0),
+            ColumnarValue::Scalar(s) => Ok(s),
+        }
+    }
     /// Converts a value in `array` at `index` into a ScalarValue
     pub fn try_from_array(array: &ArrayRef, index: usize) -> Result<Self> {
         // handle NULL value

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -17,7 +17,10 @@
 
 //! This module provides ScalarValue, an enum that can be used for storage of single elements
 
-use crate::{error::{DataFusionError, Result}, physical_plan::ColumnarValue};
+use crate::{
+    error::{DataFusionError, Result},
+    physical_plan::ColumnarValue,
+};
 use arrow::{
     array::*,
     datatypes::{
@@ -907,8 +910,8 @@ impl ScalarValue {
             ),
         }
     }
-    pub (crate) fn try_from_columnar_value(val: ColumnarValue)->Result<Self>{
-        match val{
+    pub(crate) fn try_from_columnar_value(val: ColumnarValue) -> Result<Self> {
+        match val {
             ColumnarValue::Array(s) => ScalarValue::try_from_array(&s, 0),
             ColumnarValue::Scalar(s) => Ok(s),
         }


### PR DESCRIPTION
Related to #440

Looking on some feedback on a Tokomak based optimizer. I've added support for nearly all expressions as well as  a number of simplification rules and constant folding rules. This is very much a work in progress as a number of the matching and conversion functions are pretty ugly and the expression parsing is pretty bad at the moment. I mostly wanted to get input on a couple things.

 A bunch of these optimizations require the ability to execute expressions on literal values.  I think the best way to allow external evaluation without implementing everything twice is for the physical expressions that it makes sense to execute on literal expressions to have the core logic for evaluation split out into an associated function. 

The main risk I see with implementing it this way is that some physical expressions like BinaryExpr insert new type casting expressions in to the tree when they are constructed and it would be easy to miss updating the corresponding code in the optimizer.

I also added function volatility categories that are copy pasted from Postgres's definition, which has three categories: immutable, stable, and volatile. I'm not sure if datafusion needs a stable category  though as that is for functions which will return the same values for the same arguments within a transaction.

Work that needs to be done before I'd consider this ready to even consider merging:

- Clean up functions in utils
- Determine how configurable the optimizer should be? Should users be able to register their own rewrite rules? Or just select which optimization categories to run or neither?
- Clean up how expressions are parsed. Currently there is some pretty hacky code so that the udf in the expression 
``` (call udf[pow] (list 1 2))```
   is parsed as a call to a udf and not a call expressions with a string as the second argument. While this isn't hugely important if the optimizer doesn't allow user defined rewrite rules it can make writing patterns involving strings and udfs brittle.
- More tests
- Determine if some classes like TokomakScalar and TokomakDatatype can be removed in favor of modifying their arrow/datafusion equivalents.
- Change the datatypes involving time to avoid using brackets. I haven't tested this but I'm fairly certain that that would break how s expressions are parsed by egg.
- Add support for expressions calling windowed functions. 
