### PR TITLE
Add function volatility to Signature

### DIFF
--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -22,6 +22,7 @@ use datafusion::arrow::{
     record_batch::RecordBatch,
 };
 
+use datafusion::physical_plan::functions::Volatility;
 use datafusion::{error::Result, logical_plan::create_udaf, physical_plan::Accumulator};
 use datafusion::{prelude::*, scalar::ScalarValue};
 use std::sync::Arc;
@@ -137,6 +138,7 @@ async fn main() -> Result<()> {
         DataType::Float64,
         // the return type; DataFusion expects this to match the type returned by `evaluate`.
         Arc::new(DataType::Float64),
+        Volatility::Immutable,
         // This is the accumulator factory; DataFusion uses it to create new accumulators.
         Arc::new(|| Ok(Box::new(GeometricMean::new()))),
         // This is the description of the state. `state()` must match the types here.

--- a/datafusion-examples/examples/simple_udf.rs
+++ b/datafusion-examples/examples/simple_udf.rs
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::{arrow::{
-    array::{ArrayRef, Float32Array, Float64Array},
-    datatypes::DataType,
-    record_batch::RecordBatch,
-}, physical_plan::functions::Volatility};
+use datafusion::{
+    arrow::{
+        array::{ArrayRef, Float32Array, Float64Array},
+        datatypes::DataType,
+        record_batch::RecordBatch,
+    },
+    physical_plan::functions::Volatility,
+};
 
 use datafusion::prelude::*;
 use datafusion::{error::Result, physical_plan::functions::make_scalar_function};

--- a/datafusion-examples/examples/simple_udf.rs
+++ b/datafusion-examples/examples/simple_udf.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::arrow::{
+use datafusion::{arrow::{
     array::{ArrayRef, Float32Array, Float64Array},
     datatypes::DataType,
     record_batch::RecordBatch,
-};
+}, physical_plan::functions::Volatility};
 
 use datafusion::prelude::*;
 use datafusion::{error::Result, physical_plan::functions::make_scalar_function};
@@ -112,6 +112,7 @@ async fn main() -> Result<()> {
         vec![DataType::Float64, DataType::Float64],
         // returns f64
         Arc::new(DataType::Float64),
+        Volatility::Immutable,
         pow,
     );
 

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1043,7 +1043,7 @@ impl FunctionRegistry for ExecutionContextState {
 mod tests {
     use super::*;
     use crate::logical_plan::{binary_expr, lit, Operator};
-    use crate::physical_plan::functions::{Volatility, make_scalar_function};
+    use crate::physical_plan::functions::{make_scalar_function, Volatility};
     use crate::physical_plan::{collect, collect_partitioned};
     use crate::test;
     use crate::variable::VarType;

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1043,7 +1043,7 @@ impl FunctionRegistry for ExecutionContextState {
 mod tests {
     use super::*;
     use crate::logical_plan::{binary_expr, lit, Operator};
-    use crate::physical_plan::functions::make_scalar_function;
+    use crate::physical_plan::functions::{Volatility, make_scalar_function};
     use crate::physical_plan::{collect, collect_partitioned};
     use crate::test;
     use crate::variable::VarType;
@@ -2727,6 +2727,7 @@ mod tests {
             "MY_FUNC",
             vec![DataType::Int32],
             Arc::new(DataType::Int32),
+            Volatility::Immutable,
             myfunc,
         ));
 
@@ -2805,6 +2806,7 @@ mod tests {
             "MY_AVG",
             DataType::Float64,
             Arc::new(DataType::Float64),
+            Volatility::Immutable,
             Arc::new(|| Ok(Box::new(AvgAccumulator::try_new(&DataType::Float64)?))),
             Arc::new(vec![DataType::UInt64, DataType::Float64]),
         );
@@ -3017,6 +3019,7 @@ mod tests {
             "my_add",
             vec![DataType::Int32, DataType::Int32],
             Arc::new(DataType::Int32),
+            Volatility::Immutable,
             myfunc,
         ));
 
@@ -3144,6 +3147,7 @@ mod tests {
             "my_avg",
             DataType::Float64,
             Arc::new(DataType::Float64),
+            Volatility::Immutable,
             Arc::new(|| Ok(Box::new(AvgAccumulator::try_new(&DataType::Float64)?))),
             Arc::new(vec![DataType::UInt64, DataType::Float64]),
         );

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -222,6 +222,7 @@ mod tests {
 
     use super::*;
     use crate::logical_plan::*;
+    use crate::physical_plan::functions::Volatility;
     use crate::{assert_batches_sorted_eq, execution::context::ExecutionContext};
     use crate::{datasource::csv::CsvReadOptions, physical_plan::ColumnarValue};
     use crate::{physical_plan::functions::ScalarFunctionImplementation, test};
@@ -358,6 +359,7 @@ mod tests {
             "my_fn",
             vec![DataType::Float64],
             Arc::new(DataType::Float64),
+            Volatility::Immutable,
             my_fn,
         ));
 

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1603,7 +1603,12 @@ pub fn create_udf(
     fun: ScalarFunctionImplementation,
 ) -> ScalarUDF {
     let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(return_type.clone()));
-    ScalarUDF::new(name, &Signature::Exact(input_types, volatility), &return_type, &fun)
+    ScalarUDF::new(
+        name,
+        &Signature::Exact(input_types, volatility),
+        &return_type,
+        &fun,
+    )
 }
 
 /// Creates a new UDAF with a specific signature, state type and return type.

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1605,7 +1605,7 @@ pub fn create_udf(
     let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(return_type.clone()));
     ScalarUDF::new(
         name,
-        &Signature::Exact(input_types, volatility),
+        &Signature::exact(input_types, volatility),
         &return_type,
         &fun,
     )
@@ -1626,7 +1626,7 @@ pub fn create_udaf(
     let state_type: StateTypeFunction = Arc::new(move |_| Ok(state_type.clone()));
     AggregateUDF::new(
         name,
-        &Signature::Exact(vec![input_type], volatility),
+        &Signature::exact(vec![input_type], volatility),
         &return_type,
         &accumulator,
         &state_type,

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -21,6 +21,7 @@
 pub use super::Operator;
 use crate::error::{DataFusionError, Result};
 use crate::logical_plan::{window_frames, DFField, DFSchema, LogicalPlan};
+use crate::physical_plan::functions::Volatility;
 use crate::physical_plan::{
     aggregates, expressions::binary_operator_data_type, functions, udf::ScalarUDF,
     window_functions,
@@ -1598,10 +1599,11 @@ pub fn create_udf(
     name: &str,
     input_types: Vec<DataType>,
     return_type: Arc<DataType>,
+    volatility: Volatility,
     fun: ScalarFunctionImplementation,
 ) -> ScalarUDF {
     let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(return_type.clone()));
-    ScalarUDF::new(name, &Signature::Exact(input_types), &return_type, &fun)
+    ScalarUDF::new(name, &Signature::Exact(input_types, volatility), &return_type, &fun)
 }
 
 /// Creates a new UDAF with a specific signature, state type and return type.
@@ -1611,6 +1613,7 @@ pub fn create_udaf(
     name: &str,
     input_type: DataType,
     return_type: Arc<DataType>,
+    volatility: Volatility,
     accumulator: AccumulatorFunctionImplementation,
     state_type: Arc<Vec<DataType>>,
 ) -> AggregateUDF {
@@ -1618,7 +1621,7 @@ pub fn create_udaf(
     let state_type: StateTypeFunction = Arc::new(move |_| Ok(state_type.clone()));
     AggregateUDF::new(
         name,
-        &Signature::Exact(vec![input_type]),
+        &Signature::Exact(vec![input_type], volatility),
         &return_type,
         &accumulator,
         &state_type,

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -194,7 +194,7 @@ static DATES: &[DataType] = &[DataType::Date32, DataType::Date64];
 pub fn signature(fun: &AggregateFunction) -> Signature {
     // note: the physical expression must accept the type returned by this function or the execution panics.
     match fun {
-        AggregateFunction::Count => Signature::Any(1, Volatility::Immutable),
+        AggregateFunction::Count => Signature::any(1, Volatility::Immutable),
         AggregateFunction::Min | AggregateFunction::Max => {
             let valid = STRINGS
                 .iter()
@@ -203,10 +203,10 @@ pub fn signature(fun: &AggregateFunction) -> Signature {
                 .chain(DATES.iter())
                 .cloned()
                 .collect::<Vec<_>>();
-            Signature::Uniform(1, valid, Volatility::Immutable)
+            Signature::uniform(1, valid, Volatility::Immutable)
         }
         AggregateFunction::Avg | AggregateFunction::Sum => {
-            Signature::Uniform(1, NUMERICS.to_vec(), Volatility::Immutable)
+            Signature::uniform(1, NUMERICS.to_vec(), Volatility::Immutable)
         }
     }
 }

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -26,11 +26,7 @@
 //! * Signature: see `Signature`
 //! * Return type: a function `(arg_types) -> return_type`. E.g. for min, ([f32]) -> f32, ([f64]) -> f64.
 
-use super::{
-    functions::Signature,
-    type_coercion::{coerce, data_types},
-    Accumulator, AggregateExpr, PhysicalExpr,
-};
+use super::{Accumulator, AggregateExpr, PhysicalExpr, functions::{Signature, Volatility}, type_coercion::{coerce, data_types}};
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::distinct_expressions;
 use crate::physical_plan::expressions;
@@ -194,7 +190,7 @@ static DATES: &[DataType] = &[DataType::Date32, DataType::Date64];
 pub fn signature(fun: &AggregateFunction) -> Signature {
     // note: the physical expression must accept the type returned by this function or the execution panics.
     match fun {
-        AggregateFunction::Count => Signature::Any(1),
+        AggregateFunction::Count => Signature::Any(1, Volatility::Immutable),
         AggregateFunction::Min | AggregateFunction::Max => {
             let valid = STRINGS
                 .iter()
@@ -203,10 +199,10 @@ pub fn signature(fun: &AggregateFunction) -> Signature {
                 .chain(DATES.iter())
                 .cloned()
                 .collect::<Vec<_>>();
-            Signature::Uniform(1, valid)
+            Signature::Uniform(1, valid,Volatility::Immutable)
         }
         AggregateFunction::Avg | AggregateFunction::Sum => {
-            Signature::Uniform(1, NUMERICS.to_vec())
+            Signature::Uniform(1, NUMERICS.to_vec(),Volatility::Immutable)
         }
     }
 }

--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -26,7 +26,11 @@
 //! * Signature: see `Signature`
 //! * Return type: a function `(arg_types) -> return_type`. E.g. for min, ([f32]) -> f32, ([f64]) -> f64.
 
-use super::{Accumulator, AggregateExpr, PhysicalExpr, functions::{Signature, Volatility}, type_coercion::{coerce, data_types}};
+use super::{
+    functions::{Signature, Volatility},
+    type_coercion::{coerce, data_types},
+    Accumulator, AggregateExpr, PhysicalExpr,
+};
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::distinct_expressions;
 use crate::physical_plan::expressions;
@@ -199,10 +203,10 @@ pub fn signature(fun: &AggregateFunction) -> Signature {
                 .chain(DATES.iter())
                 .cloned()
                 .collect::<Vec<_>>();
-            Signature::Uniform(1, valid,Volatility::Immutable)
+            Signature::Uniform(1, valid, Volatility::Immutable)
         }
         AggregateFunction::Avg | AggregateFunction::Sum => {
-            Signature::Uniform(1, NUMERICS.to_vec(),Volatility::Immutable)
+            Signature::Uniform(1, NUMERICS.to_vec(), Volatility::Immutable)
         }
     }
 }

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -56,26 +56,91 @@ use fmt::{Debug, Formatter};
 use std::convert::From;
 use std::{any::Any, fmt, str::FromStr, sync::Arc};
 
-/// A function's signature, which defines the function's supported argument types.
+/// A function's type signature, which defines the function's supported argument types.
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
-pub enum Signature {
+pub enum TypeSignature {
     /// arbitrary number of arguments of an common type out of a list of valid types
     // A function such as `concat` is `Variadic(vec![DataType::Utf8, DataType::LargeUtf8])`
-    Variadic(Vec<DataType>, Volatility),
+    Variadic(Vec<DataType>),
     /// arbitrary number of arguments of an arbitrary but equal type
     // A function such as `array` is `VariadicEqual`
     // The first argument decides the type used for coercion
-    VariadicEqual(Volatility),
+    VariadicEqual,
     /// fixed number of arguments of an arbitrary but equal type out of a list of valid types
     // A function of one argument of f64 is `Uniform(1, vec![DataType::Float64])`
     // A function of one argument of f64 or f32 is `Uniform(1, vec![DataType::Float32, DataType::Float64])`
-    Uniform(usize, Vec<DataType>, Volatility),
+    Uniform(usize, Vec<DataType>),
     /// exact number of arguments of an exact type
-    Exact(Vec<DataType>, Volatility),
+    Exact(Vec<DataType>),
     /// fixed number of arguments of arbitrary types
-    Any(usize, Volatility),
+    Any(usize),
     /// One of a list of signatures
-    OneOf(Vec<Signature>),
+    OneOf(Vec<TypeSignature>),
+}
+
+///The Signature of a function defines its supported input types as well as its volatility.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Signature {
+    /// type_signature - The types that the function accepts. See [TypeSignature] for more information.
+    pub type_signature: TypeSignature,
+    /// volatility - The volatility of the function. See [Volatility] for more information.
+    pub volatility: Volatility,
+}
+
+impl Signature {
+    /// new - Creates a new Signature from any type signature and the volatility.
+    pub fn new(type_signature: TypeSignature, volatility: Volatility) -> Self {
+        Signature {
+            type_signature,
+            volatility,
+        }
+    }
+    /// variadic - Creates a variadic signature that represents an arbitrary number of arguments all from a type in common_types.
+    pub fn variadic(common_types: Vec<DataType>, volatility: Volatility) -> Self {
+        Self {
+            type_signature: TypeSignature::Variadic(common_types),
+            volatility,
+        }
+    }
+    /// variadic_equal - Creates a variadic signature that represents an arbitrary number of arguments of the same type.
+    pub fn variadic_equal(volatility: Volatility) -> Self {
+        Self {
+            type_signature: TypeSignature::VariadicEqual,
+            volatility,
+        }
+    }
+    /// uniform - Creates a function with a fixed number of arguments of the same type, which must be from valid_types.
+    pub fn uniform(
+        arg_count: usize,
+        valid_types: Vec<DataType>,
+        volatility: Volatility,
+    ) -> Self {
+        Self {
+            type_signature: TypeSignature::Uniform(arg_count, valid_types),
+            volatility,
+        }
+    }
+    /// exact - Creates a signture which must match the types in exact_types in order.
+    pub fn exact(exact_types: Vec<DataType>, volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::Exact(exact_types),
+            volatility,
+        }
+    }
+    /// any - Creates a signature which can a be made of any type but of a specified number
+    pub fn any(arg_count: usize, volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::Any(arg_count),
+            volatility,
+        }
+    }
+    /// one_of Creates a signature which can match any of the [TypeSignature]s which are passed in.
+    pub fn one_of(type_signatures: Vec<TypeSignature>, volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::OneOf(type_signatures),
+            volatility,
+        }
+    }
 }
 
 ///A function's volatility, which defines the functions eligibility for certain optimizations
@@ -1107,12 +1172,12 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
 
     // for now, the list is small, as we do not have many built-in functions.
     match fun {
-        BuiltinScalarFunction::Array => Signature::Variadic(
+        BuiltinScalarFunction::Array => Signature::variadic(
             array_expressions::SUPPORTED_ARRAY_TYPES.to_vec(),
             Volatility::Immutable,
         ),
         BuiltinScalarFunction::Concat | BuiltinScalarFunction::ConcatWithSeparator => {
-            Signature::Variadic(vec![DataType::Utf8], Volatility::Immutable)
+            Signature::variadic(vec![DataType::Utf8], Volatility::Immutable)
         }
         BuiltinScalarFunction::Ascii
         | BuiltinScalarFunction::BitLength
@@ -1127,61 +1192,60 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
         | BuiltinScalarFunction::SHA384
         | BuiltinScalarFunction::SHA512
         | BuiltinScalarFunction::Trim
-        | BuiltinScalarFunction::Upper => Signature::Uniform(
+        | BuiltinScalarFunction::Upper => Signature::uniform(
             1,
             vec![DataType::Utf8, DataType::LargeUtf8],
             Volatility::Immutable,
         ),
         BuiltinScalarFunction::Btrim
         | BuiltinScalarFunction::Ltrim
-        | BuiltinScalarFunction::Rtrim => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8], Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
-        ]),
+        | BuiltinScalarFunction::Rtrim => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8]),
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+            ],
+            Volatility::Immutable,
+        ),
         BuiltinScalarFunction::Chr | BuiltinScalarFunction::ToHex => {
-            Signature::Uniform(1, vec![DataType::Int64], Volatility::Immutable)
+            Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable)
         }
-        BuiltinScalarFunction::Lpad | BuiltinScalarFunction::Rpad => {
-            Signature::OneOf(vec![
-                Signature::Exact(
-                    vec![DataType::Utf8, DataType::Int64],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::LargeUtf8, DataType::Int64],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::Utf8, DataType::Int64, DataType::Utf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::LargeUtf8, DataType::Int64, DataType::Utf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::Utf8, DataType::Int64, DataType::LargeUtf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::LargeUtf8, DataType::Int64, DataType::LargeUtf8],
-                    Volatility::Immutable,
-                ),
-            ])
-        }
+        BuiltinScalarFunction::Lpad | BuiltinScalarFunction::Rpad => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Int64]),
+                TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Int64]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Int64,
+                    DataType::Utf8,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::Int64,
+                    DataType::Utf8,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Int64,
+                    DataType::LargeUtf8,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::Int64,
+                    DataType::LargeUtf8,
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
         BuiltinScalarFunction::Left
         | BuiltinScalarFunction::Repeat
-        | BuiltinScalarFunction::Right => Signature::OneOf(vec![
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-        ]),
-        BuiltinScalarFunction::ToTimestamp => Signature::Uniform(
+        | BuiltinScalarFunction::Right => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Int64]),
+                TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Int64]),
+            ],
+            Volatility::Immutable,
+        ),
+        BuiltinScalarFunction::ToTimestamp => Signature::uniform(
             1,
             vec![
                 DataType::Utf8,
@@ -1192,7 +1256,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
             ],
             Volatility::Immutable,
         ),
-        BuiltinScalarFunction::ToTimestampMillis => Signature::Uniform(
+        BuiltinScalarFunction::ToTimestampMillis => Signature::uniform(
             1,
             vec![
                 DataType::Utf8,
@@ -1203,7 +1267,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
             ],
             Volatility::Immutable,
         ),
-        BuiltinScalarFunction::ToTimestampMicros => Signature::Uniform(
+        BuiltinScalarFunction::ToTimestampMicros => Signature::uniform(
             1,
             vec![
                 DataType::Utf8,
@@ -1214,7 +1278,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
             ],
             Volatility::Immutable,
         ),
-        BuiltinScalarFunction::ToTimestampSeconds => Signature::Uniform(
+        BuiltinScalarFunction::ToTimestampSeconds => Signature::uniform(
             1,
             vec![
                 DataType::Utf8,
@@ -1225,154 +1289,146 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
             ],
             Volatility::Immutable,
         ),
-        BuiltinScalarFunction::DateTrunc => Signature::Exact(
+        BuiltinScalarFunction::DateTrunc => Signature::exact(
             vec![
                 DataType::Utf8,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             ],
             Volatility::Immutable,
         ),
-        BuiltinScalarFunction::DatePart => Signature::OneOf(vec![
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Date32],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Date64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Timestamp(TimeUnit::Second, None)],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![
+        BuiltinScalarFunction::DatePart => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Date32]),
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Date64]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Timestamp(TimeUnit::Second, None),
+                ]),
+                TypeSignature::Exact(vec![
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Microsecond, None),
-                ],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![
+                ]),
+                TypeSignature::Exact(vec![
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Millisecond, None),
-                ],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![
+                ]),
+                TypeSignature::Exact(vec![
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
-                ],
-                Volatility::Immutable,
-            ),
-        ]),
-        BuiltinScalarFunction::SplitPart => Signature::OneOf(vec![
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Utf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Utf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::LargeUtf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::LargeUtf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-        ]),
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
+        BuiltinScalarFunction::SplitPart => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Int64,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::Utf8,
+                    DataType::Int64,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::LargeUtf8,
+                    DataType::Int64,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::LargeUtf8,
+                    DataType::Int64,
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
 
         BuiltinScalarFunction::Strpos | BuiltinScalarFunction::StartsWith => {
-            Signature::OneOf(vec![
-                Signature::Exact(
-                    vec![DataType::Utf8, DataType::Utf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::Utf8, DataType::LargeUtf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::LargeUtf8, DataType::Utf8],
-                    Volatility::Immutable,
-                ),
-                Signature::Exact(
-                    vec![DataType::LargeUtf8, DataType::LargeUtf8],
-                    Volatility::Immutable,
-                ),
-            ])
-        }
-
-        BuiltinScalarFunction::Substr => Signature::OneOf(vec![
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Int64, DataType::Int64],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Int64, DataType::Int64],
-                Volatility::Immutable,
-            ),
-        ]),
-
-        BuiltinScalarFunction::Replace | BuiltinScalarFunction::Translate => {
-            Signature::OneOf(vec![Signature::Exact(
-                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
-                Volatility::Immutable,
-            )])
-        }
-        BuiltinScalarFunction::RegexpReplace => Signature::OneOf(vec![
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
+            Signature::one_of(
                 vec![
-                    DataType::Utf8,
-                    DataType::Utf8,
-                    DataType::Utf8,
-                    DataType::Utf8,
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::LargeUtf8]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::LargeUtf8]),
                 ],
                 Volatility::Immutable,
-            ),
-        ]),
+            )
+        }
+
+        BuiltinScalarFunction::Substr => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Int64]),
+                TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Int64]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Int64,
+                    DataType::Int64,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::Int64,
+                    DataType::Int64,
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
+
+        BuiltinScalarFunction::Replace | BuiltinScalarFunction::Translate => {
+            Signature::one_of(
+                vec![TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ])],
+                Volatility::Immutable,
+            )
+        }
+        BuiltinScalarFunction::RegexpReplace => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
 
         BuiltinScalarFunction::NullIf => {
-            Signature::Uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), Volatility::Immutable)
+            Signature::uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), Volatility::Immutable)
         }
-        BuiltinScalarFunction::RegexpMatch => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Utf8],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
-                Volatility::Immutable,
-            ),
-            Signature::Exact(
-                vec![DataType::LargeUtf8, DataType::Utf8, DataType::Utf8],
-                Volatility::Immutable,
-            ),
-        ]),
-        BuiltinScalarFunction::Random => Signature::Exact(vec![], Volatility::Volatile),
+        BuiltinScalarFunction::RegexpMatch => Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+                TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::LargeUtf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ]),
+            ],
+            Volatility::Immutable,
+        ),
+        BuiltinScalarFunction::Random => Signature::exact(vec![], Volatility::Volatile),
         // math expressions expect 1 argument of type f64 or f32
         // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
         // return the best approximation for it (in f64).
         // We accept f32 because in this case it is clear that the best approximation
         // will be as good as the number of digits in the number
-        _ => Signature::Uniform(
+        _ => Signature::uniform(
             1,
             vec![DataType::Float64, DataType::Float32],
             Volatility::Immutable,

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -78,10 +78,9 @@ pub enum Signature {
     OneOf(Vec<Signature>),
 }
 
-
 ///A function's volatility, which defines the functions eligibility for certain optimizations
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-pub enum Volatility{
+pub enum Volatility {
     /// Immutable - An immutable function will always return the same output when given the same input.
     Immutable,
     /// Volatile - A volatile function may change the return value from evaluation to evaluation. Mutiple invocations of a volatile function may return different results when used in the same query
@@ -1098,11 +1097,12 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
 
     // for now, the list is small, as we do not have many built-in functions.
     match fun {
-        BuiltinScalarFunction::Array => {
-            Signature::Variadic(array_expressions::SUPPORTED_ARRAY_TYPES.to_vec(),Volatility::Immutable)
-        }
+        BuiltinScalarFunction::Array => Signature::Variadic(
+            array_expressions::SUPPORTED_ARRAY_TYPES.to_vec(),
+            Volatility::Immutable,
+        ),
         BuiltinScalarFunction::Concat | BuiltinScalarFunction::ConcatWithSeparator => {
-            Signature::Variadic(vec![DataType::Utf8],Volatility::Immutable)
+            Signature::Variadic(vec![DataType::Utf8], Volatility::Immutable)
         }
         BuiltinScalarFunction::Ascii
         | BuiltinScalarFunction::BitLength
@@ -1117,45 +1117,59 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
         | BuiltinScalarFunction::SHA384
         | BuiltinScalarFunction::SHA512
         | BuiltinScalarFunction::Trim
-        | BuiltinScalarFunction::Upper => {
-            Signature::Uniform(1, vec![DataType::Utf8, DataType::LargeUtf8],Volatility::Immutable)
-        }
+        | BuiltinScalarFunction::Upper => Signature::Uniform(
+            1,
+            vec![DataType::Utf8, DataType::LargeUtf8],
+            Volatility::Immutable,
+        ),
         BuiltinScalarFunction::Btrim
         | BuiltinScalarFunction::Ltrim
         | BuiltinScalarFunction::Rtrim => Signature::OneOf(vec![
             Signature::Exact(vec![DataType::Utf8], Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8],Volatility::Immutable),
+            Signature::Exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
         ]),
         BuiltinScalarFunction::Chr | BuiltinScalarFunction::ToHex => {
-            Signature::Uniform(1, vec![DataType::Int64],Volatility::Immutable)
+            Signature::Uniform(1, vec![DataType::Int64], Volatility::Immutable)
         }
         BuiltinScalarFunction::Lpad | BuiltinScalarFunction::Rpad => {
             Signature::OneOf(vec![
-                Signature::Exact(vec![DataType::Utf8, DataType::Int64],Volatility::Immutable),
-                Signature::Exact(vec![DataType::LargeUtf8, DataType::Int64],Volatility::Immutable),
-                Signature::Exact(vec![DataType::Utf8, DataType::Int64, DataType::Utf8],Volatility::Immutable),
-                Signature::Exact(vec![
-                    DataType::LargeUtf8,
-                    DataType::Int64,
-                    DataType::Utf8,
-                ],Volatility::Immutable),
-                Signature::Exact(vec![
-                    DataType::Utf8,
-                    DataType::Int64,
-                    DataType::LargeUtf8,
-                ],Volatility::Immutable),
-                Signature::Exact(vec![
-                    DataType::LargeUtf8,
-                    DataType::Int64,
-                    DataType::LargeUtf8,
-                ],Volatility::Immutable),
+                Signature::Exact(
+                    vec![DataType::Utf8, DataType::Int64],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::LargeUtf8, DataType::Int64],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::Utf8, DataType::Int64, DataType::Utf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::LargeUtf8, DataType::Int64, DataType::Utf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::Utf8, DataType::Int64, DataType::LargeUtf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::LargeUtf8, DataType::Int64, DataType::LargeUtf8],
+                    Volatility::Immutable,
+                ),
             ])
         }
         BuiltinScalarFunction::Left
         | BuiltinScalarFunction::Repeat
         | BuiltinScalarFunction::Right => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Int64],Volatility::Immutable),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
         ]),
         BuiltinScalarFunction::ToTimestamp => Signature::Uniform(
             1,
@@ -1165,7 +1179,8 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
-            ],Volatility::Immutable
+            ],
+            Volatility::Immutable,
         ),
         BuiltinScalarFunction::ToTimestampMillis => Signature::Uniform(
             1,
@@ -1175,7 +1190,8 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
-            ],Volatility::Immutable
+            ],
+            Volatility::Immutable,
         ),
         BuiltinScalarFunction::ToTimestampMicros => Signature::Uniform(
             1,
@@ -1185,7 +1201,8 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
-            ],Volatility::Immutable
+            ],
+            Volatility::Immutable,
         ),
         BuiltinScalarFunction::ToTimestampSeconds => Signature::Uniform(
             1,
@@ -1195,92 +1212,161 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
-            ],Volatility::Immutable
+            ],
+            Volatility::Immutable,
         ),
-        BuiltinScalarFunction::DateTrunc => Signature::Exact(vec![
-            DataType::Utf8,
-            DataType::Timestamp(TimeUnit::Nanosecond, None),
-        ],Volatility::Immutable),
-        BuiltinScalarFunction::DatePart => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Date32],Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::Date64],Volatility::Immutable),
-            Signature::Exact(vec![
-                DataType::Utf8,
-                DataType::Timestamp(TimeUnit::Second, None),
-            ],Volatility::Immutable),
-            Signature::Exact(vec![
-                DataType::Utf8,
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-            ],Volatility::Immutable),
-            Signature::Exact(vec![
-                DataType::Utf8,
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-            ],Volatility::Immutable),
-            Signature::Exact(vec![
+        BuiltinScalarFunction::DateTrunc => Signature::Exact(
+            vec![
                 DataType::Utf8,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
-            ],Volatility::Immutable),
+            ],
+            Volatility::Immutable,
+        ),
+        BuiltinScalarFunction::DatePart => Signature::OneOf(vec![
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Date32],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Date64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Timestamp(TimeUnit::Second, None)],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![
+                    DataType::Utf8,
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                ],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![
+                    DataType::Utf8,
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                ],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![
+                    DataType::Utf8,
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ],
+                Volatility::Immutable,
+            ),
         ]),
         BuiltinScalarFunction::SplitPart => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Utf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::LargeUtf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![
-                DataType::LargeUtf8,
-                DataType::LargeUtf8,
-                DataType::Int64,
-            ],Volatility::Immutable),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Utf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Utf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::LargeUtf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::LargeUtf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
         ]),
 
         BuiltinScalarFunction::Strpos | BuiltinScalarFunction::StartsWith => {
             Signature::OneOf(vec![
-                Signature::Exact(vec![DataType::Utf8, DataType::Utf8],Volatility::Immutable),
-                Signature::Exact(vec![DataType::Utf8, DataType::LargeUtf8],Volatility::Immutable),
-                Signature::Exact(vec![DataType::LargeUtf8, DataType::Utf8],Volatility::Immutable),
-                Signature::Exact(vec![DataType::LargeUtf8, DataType::LargeUtf8],Volatility::Immutable),
+                Signature::Exact(
+                    vec![DataType::Utf8, DataType::Utf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::Utf8, DataType::LargeUtf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::LargeUtf8, DataType::Utf8],
+                    Volatility::Immutable,
+                ),
+                Signature::Exact(
+                    vec![DataType::LargeUtf8, DataType::LargeUtf8],
+                    Volatility::Immutable,
+                ),
             ])
         }
 
         BuiltinScalarFunction::Substr => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::Int64, DataType::Int64],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Int64, DataType::Int64],Volatility::Immutable),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Int64, DataType::Int64],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Int64, DataType::Int64],
+                Volatility::Immutable,
+            ),
         ]),
 
         BuiltinScalarFunction::Replace | BuiltinScalarFunction::Translate => {
-            Signature::OneOf(vec![Signature::Exact(vec![
-                DataType::Utf8,
-                DataType::Utf8,
-                DataType::Utf8,
-            ],Volatility::Immutable)])
+            Signature::OneOf(vec![Signature::Exact(
+                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
+                Volatility::Immutable,
+            )])
         }
         BuiltinScalarFunction::RegexpReplace => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],Volatility::Immutable),
-            Signature::Exact(vec![
-                DataType::Utf8,
-                DataType::Utf8,
-                DataType::Utf8,
-                DataType::Utf8,
-            ],Volatility::Immutable),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                    DataType::Utf8,
+                ],
+                Volatility::Immutable,
+            ),
         ]),
 
         BuiltinScalarFunction::NullIf => {
-            Signature::Uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(),Volatility::Immutable)
+            Signature::Uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), Volatility::Immutable)
         }
         BuiltinScalarFunction::RegexpMatch => Signature::OneOf(vec![
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Utf8],Volatility::Immutable),
-            Signature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],Volatility::Immutable),
-            Signature::Exact(vec![DataType::LargeUtf8, DataType::Utf8, DataType::Utf8],Volatility::Immutable),
+            Signature::Exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Utf8],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
+                Volatility::Immutable,
+            ),
+            Signature::Exact(
+                vec![DataType::LargeUtf8, DataType::Utf8, DataType::Utf8],
+                Volatility::Immutable,
+            ),
         ]),
-        BuiltinScalarFunction::Random => Signature::Exact(vec![],Volatility::Volatile),
+        BuiltinScalarFunction::Random => Signature::Exact(vec![], Volatility::Volatile),
         // math expressions expect 1 argument of type f64 or f32
         // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
         // return the best approximation for it (in f64).
         // We accept f32 because in this case it is clear that the best approximation
         // will be as good as the number of digits in the number
-        _ => Signature::Uniform(1, vec![DataType::Float64, DataType::Float32], Volatility::Immutable),
+        _ => Signature::Uniform(
+            1,
+            vec![DataType::Float64, DataType::Float32],
+            Volatility::Immutable,
+        ),
     }
 }
 

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -81,9 +81,11 @@ pub enum Signature {
 ///A function's volatility, which defines the functions eligibility for certain optimizations
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Volatility {
-    /// Immutable - An immutable function will always return the same output when given the same input.
+    /// Immutable - An immutable function will always return the same output when given the same input. An example of this is [BuiltinScalarFunction::Cos].
     Immutable,
-    /// Volatile - A volatile function may change the return value from evaluation to evaluation. Mutiple invocations of a volatile function may return different results when used in the same query
+    /// Stable - A stable function may return different values given the same input accross different queries but must return the same value for a given input within a query. An example of this is [BuiltinScalarFunction::Now].
+    Stable,
+    /// Volatile - A volatile function may change the return value from evaluation to evaluation. Mutiple invocations of a volatile function may return different results when used in the same query. An example of this is [BuiltinScalarFunction::Random].
     Volatile,
 }
 
@@ -242,6 +244,14 @@ impl BuiltinScalarFunction {
             self,
             BuiltinScalarFunction::Random | BuiltinScalarFunction::Now
         )
+    }
+    /// Returns the [Volatility] of the builtin function.  
+    pub fn volatility(&self) -> Volatility {
+        match self {
+            BuiltinScalarFunction::Random => Volatility::Volatile,
+            BuiltinScalarFunction::Now => Volatility::Stable,
+            _ => Volatility::Immutable,
+        }
     }
 }
 

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -313,9 +313,75 @@ impl BuiltinScalarFunction {
     /// Returns the [Volatility] of the builtin function.  
     pub fn volatility(&self) -> Volatility {
         match self {
-            BuiltinScalarFunction::Random => Volatility::Volatile,
+
+            //Immutable scalar builtins
+            BuiltinScalarFunction::Abs => Volatility::Immutable,
+            BuiltinScalarFunction::Acos => Volatility::Immutable,
+            BuiltinScalarFunction::Asin => Volatility::Immutable,
+            BuiltinScalarFunction::Atan => Volatility::Immutable,
+            BuiltinScalarFunction::Ceil => Volatility::Immutable,
+            BuiltinScalarFunction::Cos => Volatility::Immutable,
+            BuiltinScalarFunction::Exp => Volatility::Immutable,
+            BuiltinScalarFunction::Floor => Volatility::Immutable,
+            BuiltinScalarFunction::Ln => Volatility::Immutable,
+            BuiltinScalarFunction::Log => Volatility::Immutable,
+            BuiltinScalarFunction::Log10 => Volatility::Immutable,
+            BuiltinScalarFunction::Log2 => Volatility::Immutable,
+            BuiltinScalarFunction::Round => Volatility::Immutable,
+            BuiltinScalarFunction::Signum => Volatility::Immutable,
+            BuiltinScalarFunction::Sin => Volatility::Immutable,
+            BuiltinScalarFunction::Sqrt => Volatility::Immutable,
+            BuiltinScalarFunction::Tan => Volatility::Immutable,
+            BuiltinScalarFunction::Trunc => Volatility::Immutable,
+            BuiltinScalarFunction::Array => Volatility::Immutable,
+            BuiltinScalarFunction::Ascii => Volatility::Immutable,
+            BuiltinScalarFunction::BitLength => Volatility::Immutable,
+            BuiltinScalarFunction::Btrim => Volatility::Immutable,
+            BuiltinScalarFunction::CharacterLength => Volatility::Immutable,
+            BuiltinScalarFunction::Chr => Volatility::Immutable,
+            BuiltinScalarFunction::Concat => Volatility::Immutable,
+            BuiltinScalarFunction::ConcatWithSeparator => Volatility::Immutable,
+            BuiltinScalarFunction::DatePart => Volatility::Immutable,
+            BuiltinScalarFunction::DateTrunc => Volatility::Immutable,
+            BuiltinScalarFunction::InitCap => Volatility::Immutable,
+            BuiltinScalarFunction::Left => Volatility::Immutable,
+            BuiltinScalarFunction::Lpad => Volatility::Immutable,
+            BuiltinScalarFunction::Lower => Volatility::Immutable,
+            BuiltinScalarFunction::Ltrim => Volatility::Immutable,
+            BuiltinScalarFunction::MD5 => Volatility::Immutable,
+            BuiltinScalarFunction::NullIf => Volatility::Immutable,
+            BuiltinScalarFunction::OctetLength => Volatility::Immutable,
+            
+            BuiltinScalarFunction::RegexpReplace => Volatility::Immutable,
+            BuiltinScalarFunction::Repeat => Volatility::Immutable,
+            BuiltinScalarFunction::Replace => Volatility::Immutable,
+            BuiltinScalarFunction::Reverse => Volatility::Immutable,
+            BuiltinScalarFunction::Right => Volatility::Immutable,
+            BuiltinScalarFunction::Rpad => Volatility::Immutable,
+            BuiltinScalarFunction::Rtrim => Volatility::Immutable,
+            BuiltinScalarFunction::SHA224 => Volatility::Immutable,
+            BuiltinScalarFunction::SHA256 => Volatility::Immutable,
+            BuiltinScalarFunction::SHA384 => Volatility::Immutable,
+            BuiltinScalarFunction::SHA512 => Volatility::Immutable,
+            BuiltinScalarFunction::SplitPart => Volatility::Immutable,
+            BuiltinScalarFunction::StartsWith => Volatility::Immutable,
+            BuiltinScalarFunction::Strpos => Volatility::Immutable,
+            BuiltinScalarFunction::Substr => Volatility::Immutable,
+            BuiltinScalarFunction::ToHex => Volatility::Immutable,
+            BuiltinScalarFunction::ToTimestamp => Volatility::Immutable,
+            BuiltinScalarFunction::ToTimestampMillis => Volatility::Immutable,
+            BuiltinScalarFunction::ToTimestampMicros => Volatility::Immutable,
+            BuiltinScalarFunction::ToTimestampSeconds => Volatility::Immutable,
+            BuiltinScalarFunction::Translate => Volatility::Immutable,
+            BuiltinScalarFunction::Trim => Volatility::Immutable,
+            BuiltinScalarFunction::Upper => Volatility::Immutable,
+            BuiltinScalarFunction::RegexpMatch => Volatility::Immutable,
+
+            //Stable builtin functions
             BuiltinScalarFunction::Now => Volatility::Stable,
-            _ => Volatility::Immutable,
+
+            //Volatile builtin functions
+            BuiltinScalarFunction::Random => Volatility::Volatile,
         }
     }
 }
@@ -1174,10 +1240,10 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
     match fun {
         BuiltinScalarFunction::Array => Signature::variadic(
             array_expressions::SUPPORTED_ARRAY_TYPES.to_vec(),
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::Concat | BuiltinScalarFunction::ConcatWithSeparator => {
-            Signature::variadic(vec![DataType::Utf8], Volatility::Immutable)
+            Signature::variadic(vec![DataType::Utf8], fun.volatility())
         }
         BuiltinScalarFunction::Ascii
         | BuiltinScalarFunction::BitLength
@@ -1195,7 +1261,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
         | BuiltinScalarFunction::Upper => Signature::uniform(
             1,
             vec![DataType::Utf8, DataType::LargeUtf8],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::Btrim
         | BuiltinScalarFunction::Ltrim
@@ -1204,10 +1270,10 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 TypeSignature::Exact(vec![DataType::Utf8]),
                 TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::Chr | BuiltinScalarFunction::ToHex => {
-            Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable)
+            Signature::uniform(1, vec![DataType::Int64], fun.volatility())
         }
         BuiltinScalarFunction::Lpad | BuiltinScalarFunction::Rpad => Signature::one_of(
             vec![
@@ -1234,7 +1300,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::LargeUtf8,
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::Left
         | BuiltinScalarFunction::Repeat
@@ -1243,7 +1309,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 TypeSignature::Exact(vec![DataType::Utf8, DataType::Int64]),
                 TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Int64]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::ToTimestamp => Signature::uniform(
             1,
@@ -1254,7 +1320,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::ToTimestampMillis => Signature::uniform(
             1,
@@ -1265,7 +1331,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::ToTimestampMicros => Signature::uniform(
             1,
@@ -1276,7 +1342,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::ToTimestampSeconds => Signature::uniform(
             1,
@@ -1287,14 +1353,14 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::DateTrunc => Signature::exact(
             vec![
                 DataType::Utf8,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::DatePart => Signature::one_of(
             vec![
@@ -1317,7 +1383,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
         BuiltinScalarFunction::SplitPart => Signature::one_of(
             vec![
@@ -1342,7 +1408,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Int64,
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
 
         BuiltinScalarFunction::Strpos | BuiltinScalarFunction::StartsWith => {
@@ -1353,7 +1419,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8]),
                     TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::LargeUtf8]),
                 ],
-                Volatility::Immutable,
+                fun.volatility(),
             )
         }
 
@@ -1372,7 +1438,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Int64,
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
 
         BuiltinScalarFunction::Replace | BuiltinScalarFunction::Translate => {
@@ -1382,7 +1448,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                     DataType::Utf8,
                 ])],
-                Volatility::Immutable,
+                fun.volatility(),
             )
         }
         BuiltinScalarFunction::RegexpReplace => Signature::one_of(
@@ -1399,11 +1465,11 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
 
         BuiltinScalarFunction::NullIf => {
-            Signature::uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), Volatility::Immutable)
+            Signature::uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), fun.volatility())
         }
         BuiltinScalarFunction::RegexpMatch => Signature::one_of(
             vec![
@@ -1420,9 +1486,9 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                 ]),
             ],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
-        BuiltinScalarFunction::Random => Signature::exact(vec![], Volatility::Volatile),
+        BuiltinScalarFunction::Random => Signature::exact(vec![], fun.volatility()),
         // math expressions expect 1 argument of type f64 or f32
         // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
         // return the best approximation for it (in f64).
@@ -1431,7 +1497,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
         _ => Signature::uniform(
             1,
             vec![DataType::Float64, DataType::Float32],
-            Volatility::Immutable,
+            fun.volatility(),
         ),
     }
 }

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -313,7 +313,6 @@ impl BuiltinScalarFunction {
     /// Returns the [Volatility] of the builtin function.  
     pub fn volatility(&self) -> Volatility {
         match self {
-
             //Immutable scalar builtins
             BuiltinScalarFunction::Abs => Volatility::Immutable,
             BuiltinScalarFunction::Acos => Volatility::Immutable,
@@ -351,7 +350,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::MD5 => Volatility::Immutable,
             BuiltinScalarFunction::NullIf => Volatility::Immutable,
             BuiltinScalarFunction::OctetLength => Volatility::Immutable,
-            
+
             BuiltinScalarFunction::RegexpReplace => Volatility::Immutable,
             BuiltinScalarFunction::Repeat => Volatility::Immutable,
             BuiltinScalarFunction::Replace => Volatility::Immutable,

--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -21,6 +21,7 @@
 //! see also https://www.postgresql.org/docs/current/functions-window.html
 
 use crate::error::{DataFusionError, Result};
+use crate::physical_plan::functions::Volatility;
 use crate::physical_plan::{
     aggregates, aggregates::AggregateFunction, functions::Signature,
     type_coercion::data_types, windows::find_ranges_in_range, PhysicalExpr,
@@ -200,19 +201,19 @@ pub(super) fn signature_for_built_in(fun: &BuiltInWindowFunction) -> Signature {
         | BuiltInWindowFunction::Rank
         | BuiltInWindowFunction::DenseRank
         | BuiltInWindowFunction::PercentRank
-        | BuiltInWindowFunction::CumeDist => Signature::Any(0),
+        | BuiltInWindowFunction::CumeDist => Signature::Any(0,Volatility::Immutable),
         BuiltInWindowFunction::Lag | BuiltInWindowFunction::Lead => {
             Signature::OneOf(vec![
-                Signature::Any(1),
-                Signature::Any(2),
-                Signature::Any(3),
+                Signature::Any(1,Volatility::Immutable,),
+                Signature::Any(2,Volatility::Immutable,),
+                Signature::Any(3,Volatility::Immutable,),
             ])
         }
         BuiltInWindowFunction::FirstValue | BuiltInWindowFunction::LastValue => {
-            Signature::Any(1)
+            Signature::Any(1,Volatility::Immutable,)
         }
-        BuiltInWindowFunction::Ntile => Signature::Exact(vec![DataType::UInt64]),
-        BuiltInWindowFunction::NthValue => Signature::Any(2),
+        BuiltInWindowFunction::Ntile => Signature::Exact(vec![DataType::UInt64],Volatility::Immutable,),
+        BuiltInWindowFunction::NthValue => Signature::Any(2,Volatility::Immutable,),
     }
 }
 

--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -21,7 +21,7 @@
 //! see also https://www.postgresql.org/docs/current/functions-window.html
 
 use crate::error::{DataFusionError, Result};
-use crate::physical_plan::functions::Volatility;
+use crate::physical_plan::functions::{TypeSignature, Volatility};
 use crate::physical_plan::{
     aggregates, aggregates::AggregateFunction, functions::Signature,
     type_coercion::data_types, windows::find_ranges_in_range, PhysicalExpr,
@@ -201,21 +201,22 @@ pub(super) fn signature_for_built_in(fun: &BuiltInWindowFunction) -> Signature {
         | BuiltInWindowFunction::Rank
         | BuiltInWindowFunction::DenseRank
         | BuiltInWindowFunction::PercentRank
-        | BuiltInWindowFunction::CumeDist => Signature::Any(0, Volatility::Immutable),
-        BuiltInWindowFunction::Lag | BuiltInWindowFunction::Lead => {
-            Signature::OneOf(vec![
-                Signature::Any(1, Volatility::Immutable),
-                Signature::Any(2, Volatility::Immutable),
-                Signature::Any(3, Volatility::Immutable),
-            ])
-        }
+        | BuiltInWindowFunction::CumeDist => Signature::any(0, Volatility::Immutable),
+        BuiltInWindowFunction::Lag | BuiltInWindowFunction::Lead => Signature::one_of(
+            vec![
+                TypeSignature::Any(1),
+                TypeSignature::Any(2),
+                TypeSignature::Any(3),
+            ],
+            Volatility::Immutable,
+        ),
         BuiltInWindowFunction::FirstValue | BuiltInWindowFunction::LastValue => {
-            Signature::Any(1, Volatility::Immutable)
+            Signature::any(1, Volatility::Immutable)
         }
         BuiltInWindowFunction::Ntile => {
-            Signature::Exact(vec![DataType::UInt64], Volatility::Immutable)
+            Signature::exact(vec![DataType::UInt64], Volatility::Immutable)
         }
-        BuiltInWindowFunction::NthValue => Signature::Any(2, Volatility::Immutable),
+        BuiltInWindowFunction::NthValue => Signature::any(2, Volatility::Immutable),
     }
 }
 

--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -201,19 +201,21 @@ pub(super) fn signature_for_built_in(fun: &BuiltInWindowFunction) -> Signature {
         | BuiltInWindowFunction::Rank
         | BuiltInWindowFunction::DenseRank
         | BuiltInWindowFunction::PercentRank
-        | BuiltInWindowFunction::CumeDist => Signature::Any(0,Volatility::Immutable),
+        | BuiltInWindowFunction::CumeDist => Signature::Any(0, Volatility::Immutable),
         BuiltInWindowFunction::Lag | BuiltInWindowFunction::Lead => {
             Signature::OneOf(vec![
-                Signature::Any(1,Volatility::Immutable,),
-                Signature::Any(2,Volatility::Immutable,),
-                Signature::Any(3,Volatility::Immutable,),
+                Signature::Any(1, Volatility::Immutable),
+                Signature::Any(2, Volatility::Immutable),
+                Signature::Any(3, Volatility::Immutable),
             ])
         }
         BuiltInWindowFunction::FirstValue | BuiltInWindowFunction::LastValue => {
-            Signature::Any(1,Volatility::Immutable,)
+            Signature::Any(1, Volatility::Immutable)
         }
-        BuiltInWindowFunction::Ntile => Signature::Exact(vec![DataType::UInt64],Volatility::Immutable,),
-        BuiltInWindowFunction::NthValue => Signature::Any(2,Volatility::Immutable,),
+        BuiltInWindowFunction::Ntile => {
+            Signature::Exact(vec![DataType::UInt64], Volatility::Immutable)
+        }
+        BuiltInWindowFunction::NthValue => Signature::Any(2, Volatility::Immutable),
     }
 }
 

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1843,6 +1843,7 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
 mod tests {
     use super::*;
     use crate::datasource::empty::EmptyTable;
+    use crate::physical_plan::functions::Volatility;
     use crate::{logical_plan::create_udf, sql::parser::DFParser};
     use functions::ScalarFunctionImplementation;
 
@@ -3539,6 +3540,7 @@ mod tests {
                     "my_sqrt",
                     vec![DataType::Float64],
                     Arc::new(DataType::Float64),
+                    Volatility::Immutable,
                     f,
                 ))),
                 _ => None,

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -37,6 +37,7 @@ use datafusion::assert_batches_sorted_eq;
 use datafusion::logical_plan::LogicalPlan;
 #[cfg(feature = "avro")]
 use datafusion::physical_plan::avro::AvroReadOptions;
+use datafusion::physical_plan::functions::Volatility;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::ExecutionPlanVisitor;
@@ -846,6 +847,7 @@ fn create_ctx() -> Result<ExecutionContext> {
         "custom_sqrt",
         vec![DataType::Float64],
         Arc::new(DataType::Float64),
+        Volatility::Immutable,
         Arc::new(custom_sqrt),
     ));
 

--- a/python/src/context.rs
+++ b/python/src/context.rs
@@ -170,8 +170,8 @@ impl ExecutionContext {
         name: &str,
         func: PyObject,
         args_types: Vec<PyDataType>,
-        volatility: PyVolatility,
         return_type: PyDataType,
+        volatility: PyVolatility,
     ) {
         let function =
             functions::create_udf(func, args_types, return_type, volatility, name);

--- a/python/src/context.rs
+++ b/python/src/context.rs
@@ -173,7 +173,8 @@ impl ExecutionContext {
         volatility: PyVolatility,
         return_type: PyDataType,
     ) {
-        let function = functions::create_udf(func, args_types, return_type,volatility, name);
+        let function =
+            functions::create_udf(func, args_types, return_type, volatility, name);
 
         self.ctx.register_udf(function.function);
     }

--- a/python/src/context.rs
+++ b/python/src/context.rs
@@ -31,7 +31,7 @@ use datafusion::prelude::CsvReadOptions;
 
 use crate::dataframe;
 use crate::errors;
-use crate::functions;
+use crate::functions::{self, PyVolatility};
 use crate::to_rust;
 use crate::types::PyDataType;
 
@@ -170,9 +170,10 @@ impl ExecutionContext {
         name: &str,
         func: PyObject,
         args_types: Vec<PyDataType>,
+        volatility: PyVolatility,
         return_type: PyDataType,
     ) {
-        let function = functions::create_udf(func, args_types, return_type, name);
+        let function = functions::create_udf(func, args_types, return_type,volatility, name);
 
         self.ctx.register_udf(function.function);
     }

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -271,8 +271,8 @@ fn udaf(
     accumulator: PyObject,
     input_type: PyDataType,
     return_type: PyDataType,
-    volatility: PyVolatility,
     state_type: Vec<PyDataType>,
+    volatility: PyVolatility,
     py: Python,
 ) -> PyResult<expression::AggregateUDF> {
     let name = accumulator

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -201,31 +201,31 @@ define_unary_function!(min);
 define_unary_function!(max);
 define_unary_function!(count);
 
-
-
-
-#[pyclass(name="Volatility", module="datafusion.functions")]
+#[pyclass(name = "Volatility", module = "datafusion.functions")]
 #[derive(Clone)]
-pub struct PyVolatility{
-    pub(crate) volatility: Volatility
+pub struct PyVolatility {
+    pub(crate) volatility: Volatility,
 }
 
-
-
-
 #[pymethods]
-impl PyVolatility{
+impl PyVolatility {
     #[staticmethod]
-    fn immutable()->Self{
-        Self{volatility: Volatility::Immutable}
+    fn immutable() -> Self {
+        Self {
+            volatility: Volatility::Immutable,
+        }
     }
     #[staticmethod]
-    fn stable()->Self{
-        Self{volatility: Volatility::Stable}
+    fn stable() -> Self {
+        Self {
+            volatility: Volatility::Stable,
+        }
     }
     #[staticmethod]
-    fn volatile()->Self{
-        Self{volatility: Volatility::Volatile}
+    fn volatile() -> Self {
+        Self {
+            volatility: Volatility::Volatile,
+        }
     }
 }
 
@@ -262,7 +262,7 @@ fn udf(
 ) -> PyResult<expression::ScalarUDF> {
     let name = fun.getattr(py, "__qualname__")?.extract::<String>(py)?;
 
-    Ok(create_udf(fun, input_types,  return_type,volatility, &name))
+    Ok(create_udf(fun, input_types, return_type, volatility, &name))
 }
 
 /// Creates a new udf.

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -20,6 +20,7 @@ use crate::udf;
 use crate::{expression, types::PyDataType};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_plan;
+use datafusion::physical_plan::functions::Volatility;
 use pyo3::{prelude::*, types::PyTuple, wrap_pyfunction};
 use std::sync::Arc;
 
@@ -200,10 +201,39 @@ define_unary_function!(min);
 define_unary_function!(max);
 define_unary_function!(count);
 
+
+
+
+#[pyclass(name="Volatility", module="datafusion.functions")]
+#[derive(Clone)]
+pub struct PyVolatility{
+    pub(crate) volatility: Volatility
+}
+
+
+
+
+#[pymethods]
+impl PyVolatility{
+    #[staticmethod]
+    fn immutable()->Self{
+        Self{volatility: Volatility::Immutable}
+    }
+    #[staticmethod]
+    fn stable()->Self{
+        Self{volatility: Volatility::Stable}
+    }
+    #[staticmethod]
+    fn volatile()->Self{
+        Self{volatility: Volatility::Volatile}
+    }
+}
+
 pub(crate) fn create_udf(
     fun: PyObject,
     input_types: Vec<PyDataType>,
     return_type: PyDataType,
+    volatility: PyVolatility,
     name: &str,
 ) -> expression::ScalarUDF {
     let input_types: Vec<DataType> =
@@ -215,6 +245,7 @@ pub(crate) fn create_udf(
             name,
             input_types,
             return_type,
+            volatility.volatility,
             udf::array_udf(fun),
         ),
     }
@@ -226,11 +257,12 @@ fn udf(
     fun: PyObject,
     input_types: Vec<PyDataType>,
     return_type: PyDataType,
+    volatility: PyVolatility,
     py: Python,
 ) -> PyResult<expression::ScalarUDF> {
     let name = fun.getattr(py, "__qualname__")?.extract::<String>(py)?;
 
-    Ok(create_udf(fun, input_types, return_type, &name))
+    Ok(create_udf(fun, input_types,  return_type,volatility, &name))
 }
 
 /// Creates a new udf.
@@ -239,6 +271,7 @@ fn udaf(
     accumulator: PyObject,
     input_type: PyDataType,
     return_type: PyDataType,
+    volatility: PyVolatility,
     state_type: Vec<PyDataType>,
     py: Python,
 ) -> PyResult<expression::AggregateUDF> {
@@ -255,6 +288,7 @@ fn udaf(
             &name,
             input_type,
             return_type,
+            volatility.volatility,
             udaf::array_udaf(accumulator),
             state_type,
         ),
@@ -262,6 +296,7 @@ fn udaf(
 }
 
 pub fn init(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyVolatility>()?;
     module.add_function(wrap_pyfunction!(abs, module)?)?;
     module.add_function(wrap_pyfunction!(acos, module)?)?;
     module.add_function(wrap_pyfunction!(array, module)?)?;

--- a/python/tests/test_df.py
+++ b/python/tests/test_df.py
@@ -81,7 +81,12 @@ def test_limit(df):
 
 def test_udf(df):
     # is_null is a pa function over arrays
-    udf = f.udf(lambda x: x.is_null(), [pa.int64()], pa.bool_(), f.Volatility.immutable())
+    udf = f.udf(
+        lambda x: x.is_null(),
+        [pa.int64()],
+        pa.bool_(),
+        f.Volatility.immutable(),
+    )
 
     df = df.select(udf(f.col("a")))
     result = df.collect()[0].column(0)

--- a/python/tests/test_df.py
+++ b/python/tests/test_df.py
@@ -81,7 +81,7 @@ def test_limit(df):
 
 def test_udf(df):
     # is_null is a pa function over arrays
-    udf = f.udf(lambda x: x.is_null(), [pa.int64()], pa.bool_())
+    udf = f.udf(lambda x: x.is_null(), [pa.int64()], pa.bool_(), f.Volatility.immutable())
 
     df = df.select(udf(f.col("a")))
     result = df.collect()[0].column(0)

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -20,6 +20,7 @@ import pyarrow as pa
 import pytest
 
 from datafusion import ExecutionContext
+from datafusion import functions as f
 from . import generic as helpers
 
 
@@ -198,7 +199,9 @@ def test_udf(
         tmp_path / "a.parquet", pa.array(input_values)
     )
     ctx.register_parquet("t", path)
-    ctx.register_udf("udf", fn, input_types, output_type)
+    ctx.register_udf(
+        "udf", fn, input_types, output_type, f.Volatility.immutable()
+    )
 
     batches = ctx.sql("SELECT udf(a) AS tt FROM t").collect()
     result = batches[0].column(0)

--- a/python/tests/test_udaf.py
+++ b/python/tests/test_udaf.py
@@ -62,7 +62,13 @@ def df():
 
 
 def test_aggregate(df):
-    udaf = f.udaf(Accumulator, pa.float64(), pa.float64(), [pa.float64()])
+    udaf = f.udaf(
+        Accumulator,
+        pa.float64(),
+        pa.float64(),
+        [pa.float64()],
+        f.Volatility.immutable(),
+    )
 
     df = df.aggregate([], [udaf(f.col("a"))])
 
@@ -73,7 +79,13 @@ def test_aggregate(df):
 
 
 def test_group_by(df):
-    udaf = f.udaf(Accumulator, pa.float64(), pa.float64(), [pa.float64()])
+    udaf = f.udaf(
+        Accumulator,
+        pa.float64(),
+        pa.float64(),
+        [pa.float64()],
+        f.Volatility.immutable(),
+    )
 
     df = df.aggregate([f.col("b")], [udaf(f.col("a"))])
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1069.

 # Rationale for this change
Make volatility a first class concept for functions.
# What changes are included in this PR?

Renamed the Signature enum to TypeSignature and added Signature struct which currently has 2 fields, type_signature and volatility. I initially tried adding another field containing the volatility to the original Signature enum but this felt clunky and while it could potential allow for conditionally stable\immutable functions with the OneOf variant that seemed like a fairly niche optimization.  

# Are there any user-facing changes?
Yes Signature was renamed and volatility has been added. There are breaking changes to the public API from this, could someone add the `api-break` label? I don't have permission to add labels.
