### PR TITLE
Add a LogicalPlanBuilder::schema() function

### DIFF
--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -94,6 +94,11 @@ impl LogicalPlanBuilder {
         Self { plan }
     }
 
+    /// Return the output schema of the plan build so far
+    pub fn schema(&self) -> &DFSchemaRef {
+        self.plan.schema()
+    }
+
     /// Create an empty relation.
     ///
     /// `produce_one_row` set to true means this empty node needs to produce a placeholder row.
@@ -678,6 +683,18 @@ mod tests {
         assert_eq!(expected, format!("{:?}", plan));
 
         Ok(())
+    }
+
+    #[test]
+    fn plan_builder_schema() {
+        let schema = employee_schema();
+        let plan =
+            LogicalPlanBuilder::scan_empty(Some("employee_csv"), &schema, None).unwrap();
+
+        let expected =
+            DFSchema::try_from_qualified_schema("employee_csv", &schema).unwrap();
+
+        assert_eq!(&expected, plan.schema().as_ref())
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Resolves https://github.com/apache/arrow-datafusion/issues/1074

 # Rationale for this change
I have code in IOx (https://github.com/influxdata/influxdb_iox/pull/2756) that builds up custom plans using `LogicalPlanBuilder` and for one of those steps I find myself needing to `cast` expressions (will link PR) but casting requires access to the input schema for which I have to use code like this:


```rust
let temp_plan = plan_builder.build().unwrap();
let schema = temp_plan.schema();
```

I would like a function so I can do
```rust
let schema = plan_builder.schema();
```


# What changes are included in this PR?
Add `LogicalPlanBuilder::schema()` function

# Are there any user-facing changes?

Yes there is new function, so it is backwards compatible