### PR TITLE
[crypto] add `blake3` algorithm to `digest` function

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/lib.rs"
 [features]
 default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 simd = ["arrow/simd"]
-crypto_expressions = ["md-5", "sha2", "blake2"]
+crypto_expressions = ["md-5", "sha2", "blake2", "blake3"]
 regex_expressions = ["regex", "lazy_static"]
 unicode_expressions = ["unicode-segmentation"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
@@ -65,6 +65,7 @@ log = "^0.4"
 md-5 = { version = "^0.9.1", optional = true }
 sha2 = { version = "^0.9.1", optional = true }
 blake2 = { version = "^0.9.2", optional = true }
+blake3 = { version = "1.0", optional = true }
 ordered-float = "2.0"
 unicode-segmentation = { version = "^1.7.1", optional = true }
 regex = { version = "^1.4.3", optional = true }

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -4079,6 +4079,10 @@ async fn test_crypto_expressions() -> Result<()> {
         "digest('tom','blake2s')",
         "5fc3f2b3a07cade5023c3df566e4d697d3823ba1b72bfb3e84cf7e768b2e7529"
     );
+    test_expression!(
+        "digest('','blake3')",
+        "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Add blake3, following #1094 

Closes #1101 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

yes the `digest` function now supports using `blake3` as the second parameter

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
