### PR TITLE
Adds note on compatible rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ DataFusion is designed to be extensible at all points. To that end, you can prov
 - [x] User Defined `LogicalPlan` nodes
 - [x] User Defined `ExecutionPlan` nodes
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
 # Supported SQL
 
 This library currently supports many SQL constructs, including

--- a/ballista/rust/client/README.md
+++ b/ballista/rust/client/README.md
@@ -35,6 +35,10 @@ Ballista can be deployed as a standalone cluster and also supports [Kubernetes](
 case, the scheduler can be configured to use [etcd](https://etcd.io/) as a backing store to (eventually) provide
 redundancy in the case of a scheduler failing.
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
 ## Starting a cluster
 
 There are numerous ways to start a Ballista cluster, including support for Docker and


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1043 

# What changes are included in this PR?
As explained in the issue, there is a need to document the Rust compiler version compatibility. This adds a note in the respective `README` files that indicate that we only support the latest stable rust version.

# Are there any user-facing changes?
No
