### PR TITLE
simplify optimized build documentation

### DIFF
--- a/docs/source/user-guide/library.md
+++ b/docs/source/user-guide/library.md
@@ -38,9 +38,8 @@ worth noting that using the settings in the `[profile.release]` section will sig
 ```toml
 [dependencies]
 datafusion = { version = "5.0" , features = ["simd"]}
-tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "^1.0", features = ["rt-multi-thread"] }
 snmalloc-rs = {version = "0.2", features= ["cache-friendly"]}
-num_cpus = "1.0"
 
 [profile.release]
 lto = true


### PR DESCRIPTION

 # Rationale for this change

Some of the instructions in the optimized build section are not needed

# What changes are included in this PR?

Remove unused build config.

# Are there any user-facing changes?

no