### PR TITLE
switch to postgres dialect for sql parsing

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -59,7 +59,7 @@ impl Column {
     pub fn from_qualified_name(flat_name: &str) -> Self {
         use sqlparser::tokenizer::Token;
 
-        let dialect = sqlparser::dialect::GenericDialect {};
+        let dialect = sqlparser::dialect::PostgreSqlDialect {};
         let mut tokenizer = sqlparser::tokenizer::Tokenizer::new(&dialect, flat_name);
         if let Ok(tokens) = tokenizer.tokenize() {
             if let [Token::Word(relation), Token::Period, Token::Word(name)] =

--- a/datafusion/src/sql/parser.rs
+++ b/datafusion/src/sql/parser.rs
@@ -21,7 +21,7 @@
 
 use sqlparser::{
     ast::{ColumnDef, ColumnOptionDef, Statement as SQLStatement, TableConstraint},
-    dialect::{keywords::Keyword, Dialect, GenericDialect},
+    dialect::{keywords::Keyword, Dialect, PostgreSqlDialect},
     parser::{Parser, ParserError},
     tokenizer::{Token, Tokenizer},
 };
@@ -98,7 +98,7 @@ pub struct DFParser<'a> {
 impl<'a> DFParser<'a> {
     /// Parse the specified tokens
     pub fn new(sql: &str) -> Result<Self, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::new_with_dialect(sql, dialect)
     }
 
@@ -117,7 +117,7 @@ impl<'a> DFParser<'a> {
 
     /// Parse a SQL statement and produce a set of statements with dialect
     pub fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::parse_sql_with_dialect(sql, dialect)
     }
 


### PR DESCRIPTION

 # Rationale for this change

We claimed to be postgresql compatible, so should switch to use the postgresql dialect instead.

# What changes are included in this PR?

switch to postgresql dialect for sql parsing.

# Are there any user-facing changes?

Yes, previous working invalid postgresl query will stop working.
