### PR TITLE
avoid unnecessary qualified column parsing in CSE optimzer

### DIFF
--- a/datafusion/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/src/optimizer/common_subexpr_eliminate.rs
@@ -270,7 +270,7 @@ fn build_project_plan(
 
     fields.extend_from_slice(input.schema().fields());
     input.schema().fields().iter().for_each(|field| {
-        project_exprs.push(col(&field.qualified_name()));
+        project_exprs.push(Expr::Column(field.qualified_column()));
     });
 
     let mut schema = DFSchema::new(fields)?;


### PR DESCRIPTION

 # Rationale for this change

We can produce qualified column directly from qualified field.
There is no need to serialize to string and parse it again with
sqlpaser.

Relates to https://github.com/apache/arrow-datafusion/pull/1078


# What changes are included in this PR?

Convert to qualifed column directly from qualified dffield.

# Are there any user-facing changes?

No.