### PR TITLE
Add Roadmap to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ are mapped to Arrow types according to the following table
 | `CUSTOM`      | _Not yet supported_               |
 | `ARRAY`       | _Not yet supported_               |
 
+# Roadmap
+
+Please see [Roadmap](docs/source/specification/roadmap.md) for information of where the project is headed.
+
 # Architecture Overview
 
 There is no formal document describing DataFusion's architecture yet, but the following presentations offer a good overview of its different components and how they interact together.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ Table of content
    :maxdepth: 1
    :caption: Specification
 
+   specification/roadmap
    specification/invariants
    specification/output-field-name-semantic
 

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -1,4 +1,4 @@
-\<!---
+<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements. See the NOTICE file
 distributed with this work for additional information
@@ -44,7 +44,7 @@ to provide:
 1. Best-in-class single node query performance
 2. A feature-complete declarative SQL query interface compatible with PostgreSQL
 3. A feature-rich procedural interface for creating and running execution plans
-4. High performance, erogonomic extensibility points at at every layer
+4. High performance, data race free, erogonomic extensibility points at at every layer
 
 The
 
@@ -52,8 +52,8 @@ The
 
 - Complete support list on [status](https://github.com/apache/arrow-datafusion/blob/master/README.md#status)
 - Timestamp Arithmetic [#194](https://github.com/apache/arrow-datafusion/issues/194)
-- SQL Parser extension point
-- Support for nested structures (fields, lists, structs)
+- SQL Parser extension point [#533](https://github.com/apache/arrow-datafusion/issues/533)
+- Support for nested structures (fields, lists, structs) [#119](https://github.com/apache/arrow-datafusion/issues/119)
 - Remaining Set Operators (`INTERSECT` / `EXCEPT`) [#1082](https://github.com/apache/arrow-datafusion/issues/1082)
 - Run all queries from the TPCH benchmark (see [milestone](https://github.com/apache/arrow-datafusion/milestone/2) for more details)
 
@@ -64,9 +64,10 @@ The
 
 ## Runtime / Infrastructure
 
-- Better support for reading data from remote filesystems (e.g. S3) without caching it locally
+- Better support for reading data from remote filesystems (e.g. S3) without caching it locally [#907](https://github.com/apache/arrow-datafusion/issues/907) [#1060](https://github.com/apache/arrow-datafusion/issues/1060)
 - Migrate to some sort of arrow2 based implementation (see [milestone](https://github.com/apache/arrow-datafusion/milestone/3) for more details)
-
+- Add DataFusion to h2oai/db-benchmark [147](https://github.com/apache/arrow-datafusion/issues/147)
+- Improve build time [348](https://github.com/apache/arrow-datafusion/issues/348)
 ## Resource Management
 
 - Finer grain control and limit of runtime memory [#587](https://github.com/apache/arrow-datafusion/issues/587) and CPU usage [#54](https://github.com/apache/arrow-datafusion/issues/64)

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -60,10 +60,16 @@ to provide:
 
 - Additional constant folding / partial evaluation [#1070](https://github.com/apache/arrow-datafusion/issues/1070)
 - More sophisticated cost based optimizer for join ordering
-Implement advanced query optimization framework (Tokomak) #440
-## Runtime / Infrastructure
+- Implement advanced query optimization framework (Tokomak) #440
+
+## Datasources
 
 - Better support for reading data from remote filesystems (e.g. S3) without caching it locally [#907](https://github.com/apache/arrow-datafusion/issues/907) [#1060](https://github.com/apache/arrow-datafusion/issues/1060)
+- Support for partitioned datasources [#1139](https://github.com/apache/arrow-datafusion/issues/1139) and make the integration of other table formats (Delta, Iceberg...) simpler
+- Improve performances of file format datasources (parallelize file listings, async Arrow readers, file chunk prefetching capability...)
+
+## Runtime / Infrastructure
+
 - Migrate to some sort of arrow2 based implementation (see [milestone](https://github.com/apache/arrow-datafusion/milestone/3) for more details)
 - Add DataFusion to h2oai/db-benchmark [147](https://github.com/apache/arrow-datafusion/issues/147)
 - Improve build time [348](https://github.com/apache/arrow-datafusion/issues/348)

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -67,6 +67,7 @@ to provide:
 - Migrate to some sort of arrow2 based implementation (see [milestone](https://github.com/apache/arrow-datafusion/milestone/3) for more details)
 - Add DataFusion to h2oai/db-benchmark [147](https://github.com/apache/arrow-datafusion/issues/147)
 - Improve build time [348](https://github.com/apache/arrow-datafusion/issues/348)
+
 ## Resource Management
 
 - Finer grain control and limit of runtime memory [#587](https://github.com/apache/arrow-datafusion/issues/587) and CPU usage [#54](https://github.com/apache/arrow-datafusion/issues/64)

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -77,7 +77,13 @@ TBD
 
 ## DataFusion CLI (`datafusion-cli`)
 
-TODO: add relevant parts of https://github.com/apache/arrow-datafusion/issues/1096
+Note: There are some additional thoughts on a datafusion-cli vision on [#1096](https://github.com/apache/arrow-datafusion/issues/1096#issuecomment-939418770).
+
+- Better abstraction between REPL parsing and queries so that commands are separated and handled correctly
+- Connect to the `Statistics` subsystem and have the cli print out more stats for query debugging, etc.
+- Improved error handling for interactive use and shell scripting usage
+- publishing to apt, brew, and possible NuGet registry so that people can use it more easily
+- adopt a shorter name, like dfcli?
 
 ## Ballista
 

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -20,39 +20,42 @@ under the License.
 # Roadmap
 
 This document describes high level goals of the DataFusion and
-Ballista development community. It is not meant to restrict, but
-rather help newcomers understand the broader context of where other
-parts of the community is headed, and inspire additional
-contributions.
+Ballista development community. It is not meant to restrict
+possibilities, but rather help newcomers understand the broader
+context of where the community is headed, and inspire
+additional contributions.
 
-DataFusion and Ballista, are part of the [Apache
+DataFusion and Ballista are part of the [Apache
 Arrow](https://arrow.apache.org/) project and governed by the Apache
-Software Foundation governance model. Thus it is an entirely driven by
-volunteer contributions, and we welcome contributions for items not on
+Software Foundation governance model. These projects are entirely driven by
+volunteers, and we welcome contributions for items not on
 this roadmap. However, before submitting a large PR, we strongly
 suggest you read the [before
 starting](https://arrow.apache.org/docs/developers/contributing.html#before-starting)
-recommendations to minimize code review surprises.
+recommendations to minimize surprises during code review.
 
 # DataFusion
 
-## Vision
-
-DataFusion's goal is to become _the de facto query engine_ of choice
+DataFusion's goal is to become the embedded query engine of choice
 for new analytic applications, by leveraging the unique features of
-Rust and [Apache Arrow](https://arrow.apache.org/) to provide:
+[Rust](https://www.rust-lang.org/) and [Apache Arrow](https://arrow.apache.org/)
+to provide:
 
-1. Best-in-class query performance for a single node
-2. A feature-complete declarative query interface via (most of) PostgreSQL
+1. Best-in-class single node query performance
+2. A feature-complete declarative SQL query interface compatible with PostgreSQL
 3. A feature-rich procedural interface for creating and running execution plans
 4. High performance, erogonomic extensibility points at at every layer
 
-## SQL Language
+The
+
+## Additional SQL Language Features
 
 - Complete support list on [status](https://github.com/apache/arrow-datafusion/blob/master/README.md#status)
 - Timestamp Arithmetic [#194](https://github.com/apache/arrow-datafusion/issues/194)
 - SQL Parser extension point
 - Support for nested structures (fields, lists, structs)
+- Remaining Set Operators (`INTERSECT` / `EXCEPT`) [#1082](https://github.com/apache/arrow-datafusion/issues/1082)
+- Run all queries from the TPCH benchmark (see [milestone](https://github.com/apache/arrow-datafusion/milestone/2) for more details)
 
 ## Query Optimizer
 
@@ -62,7 +65,7 @@ Rust and [Apache Arrow](https://arrow.apache.org/) to provide:
 ## Runtime / Infrastructure
 
 - Better support for reading data from remote filesystems (e.g. S3) without caching it locally
-- [arrow2](https://github.com/apache/arrow-datafusion/milestone/3)
+- Migrate to some sort of arrow2 based implementation (see [milestone](https://github.com/apache/arrow-datafusion/milestone/3) for more details)
 
 ## Resource Management
 

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -1,0 +1,83 @@
+\<!---
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Roadmap
+
+This document describes high level goals of the DataFusion and
+Ballista development community. It is not meant to restrict, but
+rather help newcomers understand the broader context of where other
+parts of the community is headed, and inspire additional
+contributions.
+
+DataFusion and Ballista, are part of the [Apache
+Arrow](https://arrow.apache.org/) project and governed by the Apache
+Software Foundation governance model. Thus it is an entirely driven by
+volunteer contributions, and we welcome contributions for items not on
+this roadmap. However, before submitting a large PR, we strongly
+suggest you read the [before
+starting](https://arrow.apache.org/docs/developers/contributing.html#before-starting)
+recommendations to minimize code review surprises.
+
+# DataFusion
+
+## Vision
+
+DataFusion's goal is to become _the de facto query engine_ of choice
+for new analytic applications, by leveraging the unique features of
+Rust and [Apache Arrow](https://arrow.apache.org/) to provide:
+
+1. Best-in-class query performance for a single node
+2. A feature-complete declarative query interface via (most of) PostgreSQL
+3. A feature-rich procedural interface for creating and running execution plans
+4. High performance, erogonomic extensibility points at at every layer
+
+## SQL Language
+
+- Complete support list on [status](https://github.com/apache/arrow-datafusion/blob/master/README.md#status)
+- Timestamp Arithmetic [#194](https://github.com/apache/arrow-datafusion/issues/194)
+- SQL Parser extension point
+- Support for nested structures (fields, lists, structs)
+
+## Query Optimizer
+
+- Additional constant folding / partial evaluation [#1070](https://github.com/apache/arrow-datafusion/issues/1070)
+- More sophisticated cost based optimizer for join ordering
+
+## Runtime / Infrastructure
+
+- Better support for reading data from remote filesystems (e.g. S3) without caching it locally
+- [arrow2](https://github.com/apache/arrow-datafusion/milestone/3)
+
+## Resource Management
+
+- Finer grain control and limit of runtime memory and CPU usage
+
+## Python Interface
+
+TBD
+
+## DataFusion CLI (`datafusion-cli`)
+
+TODO: add relevant parts of https://github.com/apache/arrow-datafusion/issues/1096
+
+## Ballista
+
+# Vision
+
+TBD

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -69,7 +69,7 @@ The
 
 ## Resource Management
 
-- Finer grain control and limit of runtime memory and CPU usage
+- Finer grain control and limit of runtime memory [#587](https://github.com/apache/arrow-datafusion/issues/587) and CPU usage [#54](https://github.com/apache/arrow-datafusion/issues/64)
 
 ## Python Interface
 

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -27,12 +27,12 @@ additional contributions.
 
 DataFusion and Ballista are part of the [Apache
 Arrow](https://arrow.apache.org/) project and governed by the Apache
-Software Foundation governance model. These projects are entirely driven by
-volunteers, and we welcome contributions for items not on
+Software Foundation governance model. These projects are entirely
+driven by volunteers, and we welcome contributions for items not on
 this roadmap. However, before submitting a large PR, we strongly
-suggest you read the [before
-starting](https://arrow.apache.org/docs/developers/contributing.html#before-starting)
-recommendations to minimize surprises during code review.
+suggest you start a coversation using a github issue or the
+dev@arrow.apache.org mailing list to make review efficient and avoid
+surprises.
 
 # DataFusion
 
@@ -42,11 +42,10 @@ for new analytic applications, by leveraging the unique features of
 to provide:
 
 1. Best-in-class single node query performance
-2. A feature-complete declarative SQL query interface compatible with PostgreSQL
-3. A feature-rich procedural interface for creating and running execution plans
-4. High performance, data race free, erogonomic extensibility points at at every layer
-
-The
+2. A Declarative SQL query interface compatible with PostgreSQL
+3. A Dataframe API, similar to those offered by Pandas and Spark
+4. A Procedural API for programatically creating and running execution plans
+5. High performance, data race free, erogonomic extensibility points at at every layer
 
 ## Additional SQL Language Features
 

--- a/docs/source/specification/roadmap.md
+++ b/docs/source/specification/roadmap.md
@@ -60,7 +60,7 @@ to provide:
 
 - Additional constant folding / partial evaluation [#1070](https://github.com/apache/arrow-datafusion/issues/1070)
 - More sophisticated cost based optimizer for join ordering
-
+Implement advanced query optimization framework (Tokomak) #440
 ## Runtime / Infrastructure
 
 - Better support for reading data from remote filesystems (e.g. S3) without caching it locally [#907](https://github.com/apache/arrow-datafusion/issues/907) [#1060](https://github.com/apache/arrow-datafusion/issues/1060)


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1102 suggested by @xudong963 

** All Suggestions Welcome **

 # Rationale for this change
1. Coordinate development work
2. Help Developers new to datafusion to understand where we are going

See also: 
* [mailing list discussion](https://lists.apache.org/thread.html/rdd45ae81adba2d3589752f6c3fd9ead9576e70e2352240e59c9225c1%40%3Cdev.arrow.apache.org%3E)
* https://news.ycombinator.com/item?id=28290616
* [Crowd Sourced Roadmap Jan 2021](https://docs.google.com/document/d/1qspsOM_dknOxJKdGvKbC1aoVoO0M3i6x1CIo58mmN2Y/edit)

# What changes are included in this PR?
Add roadmap to docs published on https://arrow.apache.org/datafusion/

# Are there any user-facing changes?
Docs
