### PR TITLE
Clean up spawned task on `SortStream` drop

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -58,7 +58,7 @@ num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
-pin-project-lite= "^0.2.0"
+pin-project-lite= "^0.2.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }
 tokio-stream = "0.1"
 log = "^0.4"


### PR DESCRIPTION
This is only the first part for #1103.

I just want to check that the approach is OK. I think the testing infrastructure designed here (`BlockingExec` and `BlockingStream`) can later easily be reused. I you agree I would move it to `datafusion::test::exec` and add a bit more documentation.

The `pin-project-lite` update is required for `PinnedDrop`.