### PR TITLE
Clean up spawned task on drop for `RepartitionExec`, `SortPreservingMergeExec`, `WindowAggExec`

### DIFF
--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -927,12 +927,12 @@ mod tests {
 
         let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 2));
         let refs = blocking_exec.refs();
-        let sort_exec = Arc::new(RepartitionExec::try_new(
+        let repartition_exec = Arc::new(RepartitionExec::try_new(
             blocking_exec,
             Partitioning::UnknownPartitioning(1),
         )?);
 
-        let fut = collect(sort_exec);
+        let fut = collect(repartition_exec);
         let mut fut = fut.boxed();
 
         assert_is_pending(&mut fut);

--- a/datafusion/src/physical_plan/sort.rs
+++ b/datafusion/src/physical_plan/sort.rs
@@ -497,7 +497,7 @@ mod tests {
         let schema =
             Arc::new(Schema::new(vec![Field::new("a", DataType::Float32, true)]));
 
-        let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema)));
+        let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 1));
         let refs = blocking_exec.refs();
         let sort_exec = Arc::new(SortExec::try_new(
             vec![PhysicalSortExpr {

--- a/datafusion/src/physical_plan/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sort_preserving_merge.rs
@@ -1307,7 +1307,7 @@ mod tests {
 
         let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 2));
         let refs = blocking_exec.refs();
-        let sort_exec = Arc::new(SortPreservingMergeExec::new(
+        let sort_preserving_merge_exec = Arc::new(SortPreservingMergeExec::new(
             vec![PhysicalSortExpr {
                 expr: col("a", &schema)?,
                 options: SortOptions::default(),
@@ -1316,7 +1316,7 @@ mod tests {
             1,
         ));
 
-        let fut = collect(sort_exec);
+        let fut = collect(sort_preserving_merge_exec);
         let mut fut = fut.boxed();
 
         assert_is_pending(&mut fut);

--- a/datafusion/src/physical_plan/windows/mod.rs
+++ b/datafusion/src/physical_plan/windows/mod.rs
@@ -274,7 +274,7 @@ mod tests {
 
         let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 1));
         let refs = blocking_exec.refs();
-        let sort_exec = Arc::new(WindowAggExec::try_new(
+        let window_agg_exec = Arc::new(WindowAggExec::try_new(
             vec![create_window_expr(
                 &WindowFunction::AggregateFunction(AggregateFunction::Count),
                 "count".to_owned(),
@@ -288,7 +288,7 @@ mod tests {
             schema,
         )?);
 
-        let fut = collect(sort_exec);
+        let fut = collect(window_agg_exec);
         let mut fut = fut.boxed();
 
         assert_is_pending(&mut fut);

--- a/datafusion/src/physical_plan/windows/mod.rs
+++ b/datafusion/src/physical_plan/windows/mod.rs
@@ -174,16 +174,20 @@ pub(crate) fn find_ranges_in_range<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Weak;
+
     use super::*;
     use crate::datasource::object_store::local::LocalFileSystem;
     use crate::physical_plan::aggregates::AggregateFunction;
     use crate::physical_plan::expressions::col;
     use crate::physical_plan::file_format::CsvExec;
     use crate::physical_plan::{collect, Statistics};
+    use crate::test::exec::BlockingExec;
     use crate::test::{self, aggr_test_schema};
     use arrow::array::*;
-    use arrow::datatypes::SchemaRef;
+    use arrow::datatypes::{DataType, Field, SchemaRef};
     use arrow::record_batch::RecordBatch;
+    use futures::FutureExt;
 
     fn create_test_schema(partitions: usize) -> Result<(Arc<CsvExec>, SchemaRef)> {
         let schema = test::aggr_test_schema();
@@ -261,6 +265,50 @@ mod tests {
         let min: &Int8Array = as_primitive_array(&columns[2]);
         assert_eq!(min.value(0), -117);
         assert_eq!(min.value(99), -117);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_drop_cancel() -> Result<()> {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Float32, true)]));
+
+        let blocking_exec = Arc::new(BlockingExec::new(Arc::clone(&schema), 1));
+        let refs = blocking_exec.refs();
+        let sort_exec = Arc::new(WindowAggExec::try_new(
+            vec![create_window_expr(
+                &WindowFunction::AggregateFunction(AggregateFunction::Count),
+                "count".to_owned(),
+                &[col("a", &schema)?],
+                &[],
+                &[],
+                Some(WindowFrame::default()),
+                schema.as_ref(),
+            )?],
+            blocking_exec,
+            schema,
+        )?);
+
+        let fut = collect(sort_exec);
+        let mut fut = fut.boxed();
+
+        let waker = futures::task::noop_waker();
+        let mut cx = futures::task::Context::from_waker(&waker);
+        let poll = fut.poll_unpin(&mut cx);
+
+        assert!(poll.is_pending());
+        drop(fut);
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if dbg!(Weak::strong_count(&refs)) == 0 {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
 
         Ok(())
     }

--- a/datafusion/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/src/physical_plan/windows/window_agg_exec.rs
@@ -39,6 +39,7 @@ use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tokio::task::JoinHandle;
 
 /// Window execution plan
 #[derive(Debug)]
@@ -219,14 +220,21 @@ fn compute_window_aggregates(
 }
 
 pin_project! {
-  /// stream for window aggregation plan
-  pub struct WindowAggStream {
-      schema: SchemaRef,
-      #[pin]
-      output: futures::channel::oneshot::Receiver<ArrowResult<RecordBatch>>,
-      finished: bool,
-      baseline_metrics: BaselineMetrics,
-  }
+    /// stream for window aggregation plan
+    pub struct WindowAggStream {
+        schema: SchemaRef,
+        join_handle: JoinHandle<()>,
+        #[pin]
+        output: futures::channel::oneshot::Receiver<ArrowResult<RecordBatch>>,
+        finished: bool,
+        baseline_metrics: BaselineMetrics,
+    }
+
+    impl PinnedDrop for WindowAggStream {
+        fn drop(this: Pin<&mut Self>) {
+            this.join_handle.abort();
+        }
+    }
 }
 
 impl WindowAggStream {
@@ -240,16 +248,19 @@ impl WindowAggStream {
         let (tx, rx) = futures::channel::oneshot::channel();
         let schema_clone = schema.clone();
         let elapsed_compute = baseline_metrics.elapsed_compute().clone();
-        tokio::spawn(async move {
+        let join_handle = tokio::spawn(async move {
             let schema = schema_clone.clone();
             let result =
                 WindowAggStream::process(input, window_expr, schema, elapsed_compute)
                     .await;
-            tx.send(result)
+
+            // failing here is OK, the receiver is gone and does not care about the result
+            tx.send(result).ok();
         });
 
         Self {
             schema,
+            join_handle,
             output: rx,
             finished: false,
             baseline_metrics,

--- a/datafusion/src/test/exec.rs
+++ b/datafusion/src/test/exec.rs
@@ -482,15 +482,19 @@ pub struct BlockingExec {
     /// Schema that is mocked by this plan.
     schema: SchemaRef,
 
+    /// Number of output partitions.
+    n_partitions: usize,
+
     /// Ref-counting helper to check if the plan and the produced stream are still in memory.
     refs: Arc<()>,
 }
 
 impl BlockingExec {
-    /// Create new [`BlockingExec`] with a give schema.
-    pub fn new(schema: SchemaRef) -> Self {
+    /// Create new [`BlockingExec`] with a give schema and number of partitions.
+    pub fn new(schema: SchemaRef, n_partitions: usize) -> Self {
         Self {
             schema,
+            n_partitions,
             refs: Default::default(),
         }
     }
@@ -521,7 +525,7 @@ impl ExecutionPlan for BlockingExec {
     }
 
     fn output_partitioning(&self) -> Partitioning {
-        Partitioning::UnknownPartitioning(1)
+        Partitioning::UnknownPartitioning(self.n_partitions)
     }
 
     fn with_new_children(


### PR DESCRIPTION
Follow up to #1105 and the second part of #1103.

I've improved the testing a bit to make these kinds of tests less repetitive. The changes are mostly trivial except for `RepartitionExec`, because there:

1. we must only kill the background tasks once ALL consumers are gone, hence the ~`Arc<AbortOnDrop>`~ `Arc<AbortOnDropMany<()>>`
2. ~the nested task structure is a bit more tricky to get right, hence the new `WaitForTask` struct that replaces the async `wait_for_task` function. It does the same thing but ensures that the captured join handle is aborted on drop.~ (no longer the case due to the new `AbortOnDrop` helpers)