### PR TITLE
Fix typo in comment

### DIFF
--- a/datafusion/src/physical_plan/window_functions.rs
+++ b/datafusion/src/physical_plan/window_functions.rs
@@ -97,7 +97,7 @@ pub enum BuiltInWindowFunction {
     RowNumber,
     /// rank of the current row with gaps; same as row_number of its first peer
     Rank,
-    /// ank of the current row without gaps; this function counts peer groups
+    /// rank of the current row without gaps; this function counts peer groups
     DenseRank,
     /// relative rank of the current row: (rank - 1) / (total rows - 1)
     PercentRank,


### PR DESCRIPTION
# Which issue does this PR close?
None, it is a typo fix - I'm guessing something this trivial doesn't need to be tracked in release notes and therefore doesn't need an issue.

 # Rationale for this change
Fixes a trivial typo in documentation for window functions.

# Are there any user-facing changes?
No
