### PR TITLE
Simplify file struct abstractions

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -596,7 +596,7 @@ message FilterExecNode {
   PhysicalExprNode expr = 2;
 }
 
-message FilePartition {
+message FileGroup {
   repeated PartitionedFile files = 1;
 }
 
@@ -606,7 +606,7 @@ message ScanLimit {
 }
 
 message ParquetScanExecNode {
-  repeated FilePartition partitions = 1;
+  repeated FileGroup file_groups = 1;
   Schema schema = 2;
   uint32 batch_size = 4;
   repeated uint32 projection = 6;

--- a/datafusion/src/datasource/datasource.rs
+++ b/datafusion/src/datasource/datasource.rs
@@ -71,6 +71,9 @@ pub trait TableProvider: Sync + Send {
     }
 
     /// Create an ExecutionPlan that will scan the table.
+    /// The table provider will be usually responsible of grouping
+    /// the source data into partitions that can be efficiently
+    /// parallelized or distributed.
     async fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -155,22 +155,6 @@ impl std::fmt::Display for PartitionedFile {
     }
 }
 
-#[derive(Debug, Clone)]
-/// A collection of files that should be read in a single task
-pub struct FilePartition {
-    /// The index of the partition among all partitions
-    pub index: usize,
-    /// The contained files of the partition
-    pub files: Vec<PartitionedFile>,
-}
-
-impl std::fmt::Display for FilePartition {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let files: Vec<String> = self.files.iter().map(|f| f.to_string()).collect();
-        write!(f, "{}", files.join(", "))
-    }
-}
-
 fn create_max_min_accs(
     schema: &Schema,
 ) -> (Vec<Option<MaxAccumulator>>, Vec<Option<MinAccumulator>>) {

--- a/datafusion/src/physical_plan/file_format/mod.rs
+++ b/datafusion/src/physical_plan/file_format/mod.rs
@@ -26,3 +26,26 @@ pub use self::parquet::ParquetExec;
 pub use avro::AvroExec;
 pub use csv::CsvExec;
 pub use json::NdJsonExec;
+
+use crate::datasource::PartitionedFile;
+use std::fmt::{Display, Formatter, Result};
+
+/// A wrapper to customize partitioned file display
+#[derive(Debug)]
+struct FileGroupsDisplay<'a>(&'a [Vec<PartitionedFile>]);
+
+impl<'a> Display for FileGroupsDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        let parts: Vec<_> = self
+            .0
+            .iter()
+            .map(|pp| {
+                pp.iter()
+                    .map(|pf| pf.file_meta.path())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .collect();
+        write!(f, "[{}]", parts.join(", "))
+    }
+}

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -23,6 +23,7 @@ use std::{any::Any, convert::TryInto};
 
 use crate::datasource::file_format::parquet::ChunkObjectReader;
 use crate::datasource::object_store::ObjectStore;
+use crate::datasource::PartitionedFile;
 use crate::{
     error::{DataFusionError, Result},
     logical_plan::{Column, Expr},
@@ -59,14 +60,12 @@ use tokio::{
 
 use async_trait::async_trait;
 
-use crate::datasource::{FilePartition, PartitionedFile};
-
 /// Execution plan for scanning one or more Parquet partitions
 #[derive(Debug, Clone)]
 pub struct ParquetExec {
     object_store: Arc<dyn ObjectStore>,
-    /// Parquet partitions to read
-    partitions: Vec<ParquetPartition>,
+    /// List of parquet files, grouped by output partition
+    file_groups: Vec<Vec<PartitionedFile>>,
     /// Schema after projection is applied
     schema: SchemaRef,
     /// Projection for which columns to load
@@ -81,23 +80,6 @@ pub struct ParquetExec {
     predicate_builder: Option<PruningPredicate>,
     /// Optional limit of the number of rows
     limit: Option<usize>,
-}
-
-/// Represents one partition of a Parquet data set and this currently means one Parquet file.
-///
-/// In the future it would be good to support subsets of files based on ranges of row groups
-/// so that we can better parallelize reads of large files across available cores (see
-/// [ARROW-10995](https://issues.apache.org/jira/browse/ARROW-10995)).
-///
-/// We may also want to support reading Parquet files that are partitioned based on a key and
-/// in this case we would want this partition struct to represent multiple files for a given
-/// partition key (see [ARROW-11019](https://issues.apache.org/jira/browse/ARROW-11019)).
-#[derive(Debug, Clone)]
-pub struct ParquetPartition {
-    /// The Parquet filename for this partition
-    pub file_partition: FilePartition,
-    /// Execution metrics
-    metrics: ExecutionPlanMetricsSet,
 }
 
 /// Stores metrics about the parquet execution for a particular parquet file
@@ -115,7 +97,7 @@ impl ParquetExec {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         object_store: Arc<dyn ObjectStore>,
-        files: Vec<Vec<PartitionedFile>>,
+        file_groups: Vec<Vec<PartitionedFile>>,
         statistics: Statistics,
         schema: SchemaRef,
         projection: Option<Vec<usize>>,
@@ -123,16 +105,8 @@ impl ParquetExec {
         batch_size: usize,
         limit: Option<usize>,
     ) -> Self {
-        debug!("Creating ParquetExec, desc: {:?}, projection {:?}, predicate: {:?}, limit: {:?}",
-        files, projection, predicate, limit);
-
-        let metrics = ExecutionPlanMetricsSet::new();
-
-        let partitions = files
-            .into_iter()
-            .enumerate()
-            .map(|(i, f)| ParquetPartition::new(f, i, metrics.clone()))
-            .collect::<Vec<_>>();
+        debug!("Creating ParquetExec, files: {:?}, projection {:?}, predicate: {:?}, limit: {:?}",
+        file_groups, projection, predicate, limit);
 
         let metrics = ExecutionPlanMetricsSet::new();
         let predicate_creation_errors =
@@ -162,7 +136,7 @@ impl ParquetExec {
 
         Self {
             object_store,
-            partitions,
+            file_groups,
             schema: projected_schema,
             projection,
             metrics,
@@ -204,11 +178,8 @@ impl ParquetExec {
     }
 
     /// List of data files
-    pub fn partitions(&self) -> Vec<&[PartitionedFile]> {
-        self.partitions
-            .iter()
-            .map(|fp| fp.file_partition.files.as_slice())
-            .collect()
+    pub fn file_groups(&self) -> &[Vec<PartitionedFile>] {
+        &self.file_groups
     }
     /// Optional projection for which columns to load
     pub fn projection(&self) -> &[usize] {
@@ -222,20 +193,6 @@ impl ParquetExec {
     /// Limit in nr. of rows
     pub fn limit(&self) -> Option<usize> {
         self.limit
-    }
-}
-
-impl ParquetPartition {
-    /// Create a new parquet partition
-    pub fn new(
-        files: Vec<PartitionedFile>,
-        index: usize,
-        metrics: ExecutionPlanMetricsSet,
-    ) -> Self {
-        Self {
-            file_partition: FilePartition { index, files },
-            metrics,
-        }
     }
 }
 
@@ -279,7 +236,7 @@ impl ExecutionPlan for ParquetExec {
 
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
-        Partitioning::UnknownPartitioning(self.partitions.len())
+        Partitioning::UnknownPartitioning(self.file_groups.len())
     }
 
     fn with_new_children(
@@ -304,7 +261,7 @@ impl ExecutionPlan for ParquetExec {
             Receiver<ArrowResult<RecordBatch>>,
         ) = channel(2);
 
-        let partition = self.partitions[partition_index].clone();
+        let partition = self.file_groups[partition_index].clone();
         let metrics = self.metrics.clone();
         let projection = self.projection.clone();
         let predicate_builder = self.predicate_builder.clone();
@@ -338,18 +295,12 @@ impl ExecutionPlan for ParquetExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                let files: Vec<_> = self
-                    .partitions
-                    .iter()
-                    .map(|pp| format!("{}", pp.file_partition))
-                    .collect();
-
                 write!(
                     f,
-                    "ParquetExec: batch_size={}, limit={:?}, partitions=[{}]",
+                    "ParquetExec: batch_size={}, limit={:?}, partitions={}",
                     self.batch_size,
                     self.limit,
-                    files.join(", ")
+                    super::FileGroupsDisplay(&self.file_groups)
                 )
             }
         }
@@ -493,7 +444,7 @@ fn build_row_group_predicate(
 fn read_partition(
     object_store: &dyn ObjectStore,
     partition_index: usize,
-    partition: ParquetPartition,
+    partition: Vec<PartitionedFile>,
     metrics: ExecutionPlanMetricsSet,
     projection: &[usize],
     predicate_builder: &Option<PruningPredicate>,
@@ -502,8 +453,7 @@ fn read_partition(
     limit: Option<usize>,
 ) -> Result<()> {
     let mut total_rows = 0;
-    let all_files = partition.file_partition.files;
-    'outer: for partitioned_file in all_files {
+    'outer: for partitioned_file in partition {
         let file_metrics = ParquetFileMetrics::new(
             partition_index,
             &*partitioned_file.file_meta.path(),


### PR DESCRIPTION
 # Rationale for this change
Currently we have many abstractions that sound very similar: `PartitionedFile`, `FilePartition`, `ParquetPartition`. This is an attempt to simplify the code by removing `FilePartition` and `ParquetPartition`.

# What changes are included in this PR?
- removal of `FilePartition` and `ParquetPartition`
- simplification of the file display in the parquet exec plan with the `FileGroupsDisplay` wrapper
- `FileGroupsDisplay` was not applied to the CSV, Avro and Json exec plans as those will be handled in a separate PR

# Are there any user-facing changes?
`FilePartition` was publicly accessible but not really part of the public API
