### PR TITLE
Generalized constant folding

### DIFF
--- a/datafusion/src/physical_plan/expressions/mod.rs
+++ b/datafusion/src/physical_plan/expressions/mod.rs
@@ -52,60 +52,7 @@ mod try_cast;
 
 /// Module with some convenient methods used in expression building
 pub mod helpers {
-
     pub use super::min_max::{max, min};
-
-    use crate::error::{DataFusionError, Result};
-    use crate::logical_plan::{DFSchema, Expr};
-    use crate::scalar::ScalarValue;
-    use arrow::datatypes::{DataType, Field};
-    use arrow::record_batch::RecordBatch;
-    ///Evaluate calculates the value of scalar expressions. This function may panic if non-constant expressions are present within the expression
-    pub fn evaluate(expr: &Expr) -> Result<ScalarValue> {
-        if let Expr::Literal(s) = expr {
-            return Ok(s.clone());
-        }
-        //The dummy column name shouldn't really matter as only scalar expressions will be evaluated
-        static DUMMY_COL_NAME: &str = ".";
-        let dummy_df_schema = DFSchema::empty();
-        let dummy_input_schema = arrow::datatypes::Schema::new(vec![Field::new(
-            DUMMY_COL_NAME,
-            DataType::Float64,
-            true,
-        )]);
-        let ctx_state = crate::execution::context::ExecutionContextState::new();
-
-        let planner = crate::physical_plan::planner::DefaultPhysicalPlanner::default();
-        let phys_expr = planner.create_physical_expr(
-            expr,
-            &dummy_df_schema,
-            &dummy_input_schema,
-            &ctx_state,
-        )?;
-        let col = {
-            let mut builder = arrow::array::Float64Array::builder(1);
-            builder.append_null()?;
-            builder.finish()
-        };
-        let record_batch = RecordBatch::try_new(
-            std::sync::Arc::new(dummy_input_schema),
-            vec![std::sync::Arc::new(col)],
-        )?;
-        let col_val = phys_expr.evaluate(&record_batch)?;
-        match col_val {
-            crate::physical_plan::ColumnarValue::Array(a) => {
-                if a.len() != 1 {
-                    Err(DataFusionError::Execution(format!(
-                        "Could not evaluate the expressison, found a result of length {}",
-                        a.len()
-                    )))
-                } else {
-                    Ok(ScalarValue::try_from_array(&a, 0)?)
-                }
-            }
-            crate::physical_plan::ColumnarValue::Scalar(s) => Ok(s),
-        }
-    }
 }
 
 pub use average::{avg_return_type, Avg, AvgAccumulator};

--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -97,7 +97,7 @@ impl ScalarUDF {
         }
     }
     ///Returns the volatilaty of the UDF
-    pub fn volatility(&self)->Volatility{
+    pub fn volatility(&self) -> Volatility {
         self.signature.volatility
     }
 

--- a/datafusion/src/physical_plan/udf.rs
+++ b/datafusion/src/physical_plan/udf.rs
@@ -25,6 +25,7 @@ use arrow::datatypes::Schema;
 use crate::error::Result;
 use crate::{logical_plan::Expr, physical_plan::PhysicalExpr};
 
+use super::functions::Volatility;
 use super::{
     functions::{
         ReturnTypeFunction, ScalarFunctionExpr, ScalarFunctionImplementation, Signature,
@@ -94,6 +95,10 @@ impl ScalarUDF {
             return_type: return_type.clone(),
             fun: fun.clone(),
         }
+    }
+    ///Returns the volatilaty of the UDF
+    pub fn volatility(&self)->Volatility{
+        self.signature.volatility
     }
 
     /// creates a logical expression with a call of the UDF


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1070.

# What changes are included in this PR?
Added an evaluate function which evaluates literal scalar expressions using the existing physical expression implementation. Reworked ConstantFolding optimizer using the evaluate function to perform more generalized constant folding. The optimizer now traverses the expression tree depth first returning whether the expression is made up of literal expressions. When an expression that has multiple children is encountered all children expressions are checked to see if they are literals, if so then it simply returns that the expression is literal. If one of the child expressions is not literal then all literal child expressions are evaluated and then non literal is returned. For expressions that can never be evaluated in a scalar manner, such as aggregate or window expressions, the children are traversed but the expression itself will never be evaluated.

# Are there any user-facing changes?
The added evaluate function is currently public to allow usage of the function from other crates in the workspace.
