### PR TITLE
WIP: Add output_partitions_size for CoalescePartitionsExec

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -738,6 +738,7 @@ message CoalesceBatchesExecNode {
 
 message CoalescePartitionsExecNode {
   PhysicalPlanNode input = 1;
+  uint32 output_partitions_size = 2;
 }
 
 message PhysicalHashRepartition {

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -493,7 +493,7 @@ mod tests {
 
     #[tokio::test]
     async fn test() -> Result<()> {
-        let input_plan = Arc::new(CoalescePartitionsExec::new(create_input_plan()?));
+        let input_plan = Arc::new(CoalescePartitionsExec::new(create_input_plan()?, 1));
         let work_dir = TempDir::new()?;
         let query_stage = ShuffleWriterExec::try_new(
             "jobOne".to_owned(),

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -186,7 +186,10 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
             }
             PhysicalPlanType::Merge(merge) => {
                 let input: Arc<dyn ExecutionPlan> = convert_box_required!(merge.input)?;
-                Ok(Arc::new(CoalescePartitionsExec::new(input)))
+                Ok(Arc::new(CoalescePartitionsExec::new(
+                    input,
+                    merge.output_partitions_size as usize,
+                )))
             }
             PhysicalPlanType::Repartition(repart) => {
                 let input: Arc<dyn ExecutionPlan> = convert_box_required!(repart.input)?;

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -353,6 +353,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                 physical_plan_type: Some(PhysicalPlanType::Merge(Box::new(
                     protobuf::CoalescePartitionsExecNode {
                         input: Some(Box::new(input)),
+                        output_partitions_size: exec.output_partitions_size() as u32,
                     },
                 ))),
             })

--- a/datafusion/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/src/physical_optimizer/aggregate_statistics.rs
@@ -325,7 +325,7 @@ mod tests {
         )?;
 
         // We introduce an intermediate optimization step between the partial and final aggregtator
-        let coalesce = CoalescePartitionsExec::new(Arc::new(partial_agg));
+        let coalesce = CoalescePartitionsExec::new(Arc::new(partial_agg), 1);
 
         let final_agg = HashAggregateExec::try_new(
             AggregateMode::Final,

--- a/datafusion/src/physical_optimizer/merge_exec.rs
+++ b/datafusion/src/physical_optimizer/merge_exec.rs
@@ -60,7 +60,7 @@ impl PhysicalOptimizerRule for AddCoalescePartitionsExec {
                             if child.output_partitioning().partition_count() == 1 {
                                 child.clone()
                             } else {
-                                Arc::new(CoalescePartitionsExec::new(child.clone()))
+                                Arc::new(CoalescePartitionsExec::new(child.clone(), 1))
                             }
                         })
                         .collect(),

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -147,7 +147,7 @@ impl ExecutionPlan for CrossJoinExec {
                     let start = Instant::now();
 
                     // merge all left parts into a single stream
-                    let merge = CoalescePartitionsExec::new(self.left.clone());
+                    let merge = CoalescePartitionsExec::new(self.left.clone(), 1);
                     let stream = merge.execute(0).await?;
 
                     // Load all batches and count the rows

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -1090,7 +1090,7 @@ mod tests {
         ];
         assert_batches_sorted_eq!(expected, &result);
 
-        let merge = Arc::new(CoalescePartitionsExec::new(partial_aggregate));
+        let merge = Arc::new(CoalescePartitionsExec::new(partial_aggregate, 1));
 
         let final_group: Vec<Arc<dyn PhysicalExpr>> = (0..groups.len())
             .map(|i| col(&groups[i].1, &input_schema))

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -280,7 +280,7 @@ impl ExecutionPlan for HashJoinExec {
                             let start = Instant::now();
 
                             // merge all left parts into a single stream
-                            let merge = CoalescePartitionsExec::new(self.left.clone());
+                            let merge = CoalescePartitionsExec::new(self.left.clone(), 1);
                             let stream = merge.execute(0).await?;
 
                             // This operation performs 2 steps at once:

--- a/datafusion/src/physical_plan/limit.rs
+++ b/datafusion/src/physical_plan/limit.rs
@@ -413,8 +413,10 @@ mod tests {
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
 
-        let limit =
-            GlobalLimitExec::new(Arc::new(CoalescePartitionsExec::new(Arc::new(csv))), 7);
+        let limit = GlobalLimitExec::new(
+            Arc::new(CoalescePartitionsExec::new(Arc::new(csv), 1)),
+            7,
+        );
 
         // the result should contain 4 batches (one per input partition)
         let iter = limit.execute(0).await?;

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -324,7 +324,7 @@ pub async fn execute_stream(
         1 => plan.execute(0).await,
         _ => {
             // merge into a single partition
-            let plan = CoalescePartitionsExec::new(plan.clone());
+            let plan = CoalescePartitionsExec::new(plan.clone(), 1);
             // CoalescePartitionsExec must produce a single partition
             assert_eq!(1, plan.output_partitioning().partition_count());
             plan.execute(0).await

--- a/datafusion/src/physical_plan/sort.rs
+++ b/datafusion/src/physical_plan/sort.rs
@@ -359,7 +359,7 @@ mod tests {
                     options: SortOptions::default(),
                 },
             ],
-            Arc::new(CoalescePartitionsExec::new(Arc::new(csv))),
+            Arc::new(CoalescePartitionsExec::new(Arc::new(csv), 1)),
         )?);
 
         let result: Vec<RecordBatch> = collect(sort_exec).await?;

--- a/datafusion/src/physical_plan/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sort_preserving_merge.rs
@@ -921,7 +921,7 @@ mod tests {
         src: Arc<dyn ExecutionPlan>,
         sort: Vec<PhysicalSortExpr>,
     ) -> RecordBatch {
-        let merge = Arc::new(CoalescePartitionsExec::new(src));
+        let merge = Arc::new(CoalescePartitionsExec::new(src, 1));
         let sort_exec = Arc::new(SortExec::try_new(sort, merge).unwrap());
         let mut result = collect(sort_exec).await.unwrap();
         assert_eq!(result.len(), 1);

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -2519,7 +2519,7 @@ async fn csv_explain_analyze() {
     // Only test basic plumbing and try to avoid having to change too
     // many things. explain_analyze_baseline_metrics covers the values
     // in greater depth
-    let needle = "CoalescePartitionsExec, metrics=[output_rows=5, elapsed_compute=";
+    let needle = "CoalescePartitionsExec: output_partitions_size=1, metrics=[output_rows=5, elapsed_compute=";
     assert_contains!(&formatted, needle);
 
     let verbose_needle = "Output Rows";
@@ -4736,7 +4736,7 @@ async fn test_physical_plan_display_indent() {
     let expected = vec![
         "GlobalLimitExec: limit=10",
         "  SortExec: [the_min@2 DESC]",
-        "    CoalescePartitionsExec",
+        "    CoalescePartitionsExec: output_partitions_size=1",
         "      ProjectionExec: expr=[c1@0 as c1, MAX(aggregate_test_100.c12)@1 as MAX(aggregate_test_100.c12), MIN(aggregate_test_100.c12)@2 as the_min]",
         "        HashAggregateExec: mode=FinalPartitioned, gby=[c1@0 as c1], aggr=[MAX(aggregate_test_100.c12), MIN(aggregate_test_100.c12)]",
         "          CoalesceBatchesExec: target_batch_size=4096",


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/112

First of all, I add output partitions config for CoalescePartitionsExec.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
