### PR TITLE
WIP Support NULL literals in Binary expressions, add some missing LargeStringArray implementations

### DIFF
--- a/datafusion/src/logical_plan/operators.rs
+++ b/datafusion/src/logical_plan/operators.rs
@@ -66,6 +66,36 @@ pub enum Operator {
     RegexNotIMatch,
 }
 
+impl Operator {
+    /// Return an iterator over all variants of this enum
+    pub fn iter() -> impl Iterator<Item = Operator> {
+        vec![
+            Self::Eq,
+            Self::NotEq,
+            Self::Lt,
+            Self::LtEq,
+            Self::Gt,
+            Self::GtEq,
+            Self::Plus,
+            Self::Minus,
+            Self::Multiply,
+            Self::Divide,
+            Self::Modulo,
+            Self::And,
+            Self::Or,
+            Self::Like,
+            Self::NotLike,
+            Self::IsDistinctFrom,
+            Self::IsNotDistinctFrom,
+            Self::RegexMatch,
+            Self::RegexIMatch,
+            Self::RegexNotMatch,
+            Self::RegexNotIMatch,
+        ]
+        .into_iter()
+    }
+}
+
 impl fmt::Display for Operator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let display = match &self {

--- a/datafusion/src/physical_plan/expressions/binary.rs
+++ b/datafusion/src/physical_plan/expressions/binary.rs
@@ -47,8 +47,7 @@ use crate::physical_plan::{ColumnarValue, PhysicalExpr};
 use crate::scalar::ScalarValue;
 
 use super::coercion::{
-    eq_coercion, like_coercion, numerical_coercion, order_coercion,
-    string_coercion,
+    eq_coercion, like_coercion, numerical_coercion, order_coercion, string_coercion,
 };
 
 /// Binary expression
@@ -1633,22 +1632,12 @@ mod tests {
     fn do_null_test(input: &ArrayRef, null: &ScalarValue, op: Operator) {
         let input_type = input.data_type();
 
-        let string_type = match input_type {
-            DataType::Utf8 | DataType::LargeUtf8 => true,
-            _ => false,
-        };
-
-        let bool_type = match input_type {
-            DataType::Boolean => true,
-            _ => false,
-        };
-
-        let unsigned_type = match input_type {
-            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
-                true
-            }
-            _ => false,
-        };
+        let string_type = matches!(input_type, DataType::Utf8 | DataType::LargeUtf8);
+        let bool_type = matches!(input_type, DataType::Boolean);
+        let unsigned_type = matches!(
+            input_type,
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64
+        );
 
         // skip operator / input combinations that don't make sense
         let skip = match op {
@@ -1714,7 +1703,7 @@ mod tests {
             &result,
             "Mismatch running {}\n\n{:#?}\n\n{:#?}:\n\n{:#?}",
             &expr,
-            pretty_format_array("input", &input),
+            pretty_format_array("input", input),
             pretty_format_array("expected", &expected),
             pretty_format_array("result", &result),
         );
@@ -1732,7 +1721,7 @@ mod tests {
             &result,
             "Mismatch running {}\n\n{:#?}\n\n{:#?}:\n\n{:#?}",
             &expr,
-            pretty_format_array("input", &input),
+            pretty_format_array("input", input),
             pretty_format_array("expected", &expected),
             pretty_format_array("result", &result),
         );
@@ -1743,7 +1732,7 @@ mod tests {
 
         let formatted = pretty::pretty_format_batches(&[batch]).unwrap();
         std::iter::once(format!("DataType: {}", array.data_type()))
-            .chain(formatted.split("\n").map(|s| s.to_string()))
+            .chain(formatted.split('\n').map(|s| s.to_string()))
             .collect()
     }
 

--- a/datafusion/src/physical_plan/expressions/column.rs
+++ b/datafusion/src/physical_plan/expressions/column.rs
@@ -87,7 +87,7 @@ impl PhysicalExpr for Column {
     }
 }
 
-/// Create a column expression
+/// Create a column reference as a physical expression
 pub fn col(name: &str, schema: &Schema) -> Result<Arc<dyn PhysicalExpr>> {
     Ok(Arc::new(Column::new_with_schema(name, schema)?))
 }

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -453,7 +453,7 @@ macro_rules! eq_array_primitive {
 }
 
 impl ScalarValue {
-    /// Getter for the `DataType` of the value
+    /// Return the `DataType` of this value
     pub fn get_datatype(&self) -> DataType {
         match self {
             ScalarValue::Boolean(_) => DataType::Boolean,


### PR DESCRIPTION
# NOT YET WORKING / READY FOR REVIEW

I thought this was ready but when adding new tests it is not. Thus leaving it as a draft, but still needs more work


# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/1179

 # Rationale for this change
Binary operations  to literal NULL don't work in DataFusion. While seemingly a corner case, we sometimes generate such predicates during rewrites in IOx making supporting such expressions important.


# What changes are included in this PR?
1. Add special cast handling for null `ScalarValues`
2. Add tests

Note this is far from a comprehensive solution -- it is a localized fix for binary expression evaluation. The more comprehsive fix is discussed by @Dandandan  and @Jimexist  on #1179 -- see https://github.com/apache/arrow-datafusion/issues/1179#issuecomment-952997737

However, I think this PR should be merged because:
1.  includes additional test coverage that will be helpful when we do the more comprehensive fix and it 
2. It selfishly helps me in IOx for the short term

# Are there any user-facing changes?
Fewer errors, no breaking changes

# Follow on work
- [ ] TODO File arrow-rs ticket about underflow when subtracting from null array
- [ ] TODO File tickets for supporting null constants in other exprs (like in function call parameters, CASE, etc)
- [ ] TODO file tickets for casting from NUll to other types in arrow