### PR TITLE
Removed deprecated with_concurrency

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -893,15 +893,6 @@ impl ExecutionConfig {
         Default::default()
     }
 
-    /// Deprecated. Use with_target_partitions instead.
-    #[deprecated(
-        since = "5.1.0",
-        note = "This method is deprecated in favor of `with_target_partitions`."
-    )]
-    pub fn with_concurrency(self, n: usize) -> Self {
-        self.with_target_partitions(n)
-    }
-
     /// Customize target_partitions
     pub fn with_target_partitions(mut self, n: usize) -> Self {
         // partition count must be greater than zero


### PR DESCRIPTION
# Which issue does this PR close?

Closes #684.

 # Rationale for this change
I think that over-tracking these kinds of small API changes is very costly, and that users know that given the current state of maturity of Datafusion, they might need to adapt some small things at each version bump 😃.
