### PR TITLE
Fix bug of twice projection when creating ParquetExec during deserialization (#1210)

### DIFF
--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -143,7 +143,7 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                 let projection = scan.projection.iter().map(|i| *i as usize).collect();
                 let statistics = convert_required!(scan.statistics)?;
 
-                Ok(Arc::new(ParquetExec::new(
+                Ok(Arc::new(ParquetExec::new_for_deserialization(
                     Arc::new(LocalFileSystem {}),
                     scan.file_groups
                         .iter()
@@ -151,7 +151,7 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                         .collect::<Vec<Vec<PartitionedFile>>>(),
                     statistics,
                     schema,
-                    Some(projection),
+                    projection,
                     // TODO predicate should be de-serialized
                     None,
                     scan.batch_size as usize,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1210 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When creating the ParquetExec during deserialization, we should avoid do the projection.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
