### PR TITLE
Fix build with `--no-default-features`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,12 @@ jobs:
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"
+      - name: Check DataFusion Build without default features
+        run: |
+          cargo check --no-default-features -p datafusion
+        env:
+          CARGO_HOME: "/github/home/.cargo"
+          CARGO_TARGET_DIR: "/github/home/target"
 
   # test the crate
   linux-test:

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -41,7 +41,7 @@ path = "src/lib.rs"
 default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 simd = ["arrow/simd"]
 crypto_expressions = ["md-5", "sha2", "blake2", "blake3"]
-regex_expressions = ["regex", "lazy_static"]
+regex_expressions = ["regex"]
 unicode_expressions = ["unicode-segmentation"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = []
@@ -70,7 +70,7 @@ blake3 = { version = "1.0", optional = true }
 ordered-float = "2.0"
 unicode-segmentation = { version = "^1.7.1", optional = true }
 regex = { version = "^1.4.3", optional = true }
-lazy_static = { version = "^1.4.0", optional = true }
+lazy_static = { version = "^1.4.0" }
 smallvec = { version = "1.6", features = ["union"] }
 rand = "0.8"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -236,9 +236,5 @@ pub(crate) mod field_util;
 pub mod test;
 pub mod test_util;
 
-#[macro_use]
-#[cfg(feature = "regex_expressions")]
-extern crate lazy_static;
-
 #[cfg(doctest)]
 doc_comment::doctest!("../../README.md", readme_example_test);

--- a/datafusion/src/physical_plan/file_format/mod.rs
+++ b/datafusion/src/physical_plan/file_format/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     datasource::{object_store::ObjectStore, PartitionedFile},
     scalar::ScalarValue,
 };
+use lazy_static::lazy_static;
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/datafusion/src/physical_plan/regex_expressions.rs
+++ b/datafusion/src/physical_plan/regex_expressions.rs
@@ -28,6 +28,7 @@ use crate::error::{DataFusionError, Result};
 use arrow::array::{ArrayRef, GenericStringArray, StringOffsetSizeTrait};
 use arrow::compute;
 use hashbrown::HashMap;
+use lazy_static::lazy_static;
 use regex::Regex;
 
 macro_rules! downcast_string_arg {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1217

 # Rationale for this change
https://github.com/apache/arrow-datafusion/pull/1141 added an explicit dependence on `lazy_static` but `lazy_static` is feature flagged under `regex_expressions` at the moment (which is strange as it is already a transitive dependency -- see the output of `cargo tree -i lazy_static --no-default-features`

# What changes are included in this PR?
1. Fix `lazy_static` include
2. Add check to CI for building without default features

# Are there any user-facing changes?
Build is fixed

