### PR TITLE
Add support of HDFS as remote object store

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 readme = "../README.md"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-keywords = [ "arrow", "query", "sql" ]
+keywords = ["arrow", "query", "sql"]
 include = [
     "benches/*.rs",
     "src/**/*.rs",
@@ -48,6 +48,8 @@ pyarrow = ["pyo3", "arrow/pyarrow"]
 force_hash_collisions = []
 # Used to enable the avro format
 avro = ["avro-rs", "num-traits"]
+# Used to enable hdfs as remote object store
+hdfs = ["fs-hdfs"]
 
 [dependencies]
 ahash = "0.7"
@@ -60,7 +62,7 @@ num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
-pin-project-lite= "^0.2.7"
+pin-project-lite = "^0.2.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }
 tokio-stream = "0.1"
 log = "^0.4"
@@ -77,6 +79,8 @@ rand = "0.8"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 num-traits = { version = "0.2", optional = true }
 pyo3 = { version = "0.14", optional = true }
+fs-hdfs = { version = "^0.1.3", optional = true }
+uuid = { version = "^0.8", features = ["v4"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/datafusion/src/datasource/object_store/hdfs.rs
+++ b/datafusion/src/datasource/object_store/hdfs.rs
@@ -1,0 +1,253 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Object store that represents the HDFS File System.
+use std::fmt::Debug;
+use std::io::Read;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{NaiveDateTime, Utc};
+use futures::AsyncRead;
+use futures::{stream, StreamExt};
+use hdfs::hdfs::{FileStatus, HdfsErr, HdfsFile, HdfsFs};
+
+use crate::datasource::object_store::{
+    FileMeta, FileMetaStream, ListEntryStream, ObjectReader, ObjectReaderStream,
+    ObjectStore, SizedFile,
+};
+use crate::datasource::PartitionedFile;
+use crate::error::{DataFusionError, Result};
+
+/// scheme for HDFS File System
+pub static HDFS_SCHEME: &'static str = "hdfs";
+
+/// Hadoop File.
+#[derive(Clone, Debug)]
+pub struct HadoopFile {
+    inner: HdfsFile,
+}
+
+unsafe impl Send for HadoopFile {}
+
+unsafe impl Sync for HadoopFile {}
+
+impl Read for HadoopFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner
+            .read(buf)
+            .map(|read_len| read_len as usize)
+            .map_err(|e| to_error(e))
+    }
+}
+
+/// Hadoop File System as Object Store.
+#[derive(Clone, Debug)]
+pub struct HadoopFileSystem {
+    inner: HdfsFs,
+}
+
+impl HadoopFileSystem {
+    /// Get HdfsFs configured by default configuration files
+    pub fn new() -> Result<Self> {
+        HdfsFs::default()
+            .map(|fs| HadoopFileSystem { inner: fs })
+            .map_err(|e| DataFusionError::IoError(to_error(e)))
+    }
+
+    /// Wrap the known HdfsFs. Only used for testing
+    pub fn wrap(inner: HdfsFs) -> Self {
+        HadoopFileSystem { inner }
+    }
+
+    /// Open a HdfsFile with specified path
+    pub fn open(&self, path: &str) -> Result<HadoopFile> {
+        self.inner
+            .open(path)
+            .map(|file| HadoopFile { inner: file })
+            .map_err(|e| DataFusionError::IoError(to_error(e)))
+    }
+
+    /// Find out the files directly under a directory
+    fn find_files_in_dir(
+        &self,
+        path: String,
+        to_visit: &mut Vec<String>,
+    ) -> Result<Vec<FileMeta>> {
+        let mut files = Vec::new();
+
+        let children = self
+            .inner
+            .list_status(path.as_str())
+            .map_err(|e| to_error(e))?;
+        for child in children {
+            let child_path = child.name();
+            if child.is_directory() {
+                to_visit.push(child_path.to_string());
+            } else {
+                files.push(get_meta(child_path.to_owned(), child));
+            }
+        }
+
+        Ok(files)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for HadoopFileSystem {
+    fn get_relative_path<'a>(&self, uri: &'a str) -> &'a str {
+        let mut result = uri;
+        if let Some((scheme, path_without_schema)) = uri.split_once("://") {
+            assert_eq!(scheme, HDFS_SCHEME);
+            let start_index = path_without_schema.find("/").unwrap();
+            let (_host_address, path) = path_without_schema.split_at(start_index);
+            result = path;
+        }
+        result
+    }
+
+    async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
+        // TODO list all of the files under a directory, including directly and indirectly
+        let files = self.find_files_in_dir(prefix.to_string(), &mut Vec::new())?;
+        get_files_in_dir(files).await
+    }
+
+    async fn list_dir(
+        &self,
+        _prefix: &str,
+        _delimiter: Option<String>,
+    ) -> Result<ListEntryStream> {
+        todo!()
+    }
+
+    fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>> {
+        Ok(Arc::new(HadoopFileReader::new(
+            Arc::new(self.clone()),
+            file,
+        )?))
+    }
+}
+
+async fn get_files_in_dir(files: Vec<FileMeta>) -> Result<FileMetaStream> {
+    Ok(Box::pin(stream::iter(files).map(Ok)))
+}
+
+fn get_meta(path: String, file_status: FileStatus) -> FileMeta {
+    FileMeta {
+        sized_file: SizedFile {
+            path,
+            size: file_status.len() as u64,
+        },
+        last_modified: Some(chrono::DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp(file_status.last_modified(), 0),
+            Utc,
+        )),
+    }
+}
+
+/// Create a stream of `ObjectReader` by converting each file in the `files` vector
+/// into instances of `HadoopFileReader`
+pub fn hadoop_object_reader_stream(
+    fs: Arc<HadoopFileSystem>,
+    files: Vec<String>,
+) -> ObjectReaderStream {
+    Box::pin(
+        futures::stream::iter(files)
+            .map(move |f| Ok(hadoop_object_reader(fs.clone(), f))),
+    )
+}
+
+/// Helper method to convert a file location to a `LocalFileReader`
+pub fn hadoop_object_reader(
+    fs: Arc<HadoopFileSystem>,
+    file: String,
+) -> Arc<dyn ObjectReader> {
+    fs.file_reader(
+        hadoop_unpartitioned_file(fs.clone(), file)
+            .file_meta
+            .sized_file,
+    )
+    .expect("File not found")
+}
+
+/// Helper method to fetch the file size and date at given path and create a `FileMeta`
+pub fn hadoop_unpartitioned_file(
+    fs: Arc<HadoopFileSystem>,
+    file: String,
+) -> PartitionedFile {
+    let file_status = fs.inner.get_file_status(&file).ok().unwrap();
+    PartitionedFile {
+        file_meta: get_meta(file, file_status),
+        partition_values: vec![],
+    }
+}
+
+struct HadoopFileReader {
+    fs: Arc<HadoopFileSystem>,
+    file: SizedFile,
+}
+
+impl HadoopFileReader {
+    fn new(fs: Arc<HadoopFileSystem>, file: SizedFile) -> Result<Self> {
+        Ok(Self { fs, file })
+    }
+}
+
+#[async_trait]
+impl ObjectReader for HadoopFileReader {
+    async fn chunk_reader(
+        &self,
+        _start: u64,
+        _length: usize,
+    ) -> Result<Box<dyn AsyncRead>> {
+        todo!(
+            "implement once async file readers are available (arrow-rs#78, arrow-rs#111)"
+        )
+    }
+
+    fn sync_chunk_reader(
+        &self,
+        start: u64,
+        length: usize,
+    ) -> Result<Box<dyn Read + Send + Sync>> {
+        let file = self.fs.open(&self.file.path)?;
+        file.inner.seek(start);
+        Ok(Box::new(file.take(length as u64)))
+    }
+
+    fn length(&self) -> u64 {
+        self.file.size
+    }
+}
+
+fn to_error(err: HdfsErr) -> std::io::Error {
+    match err {
+        HdfsErr::FileNotFound(err_str) => {
+            std::io::Error::new(std::io::ErrorKind::NotFound, err_str.as_str())
+        }
+        HdfsErr::FileAlreadyExists(err_str) => {
+            std::io::Error::new(std::io::ErrorKind::AlreadyExists, err_str.as_str())
+        }
+        HdfsErr::CannotConnectToNameNode(err_str) => {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, err_str.as_str())
+        }
+        HdfsErr::InvalidUrl(err_str) => {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, err_str.as_str())
+        }
+        HdfsErr::Unknown => std::io::Error::new(std::io::ErrorKind::Other, "Unknown"),
+    }
+}

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use futures::{stream, AsyncRead, StreamExt};
 
 use crate::datasource::object_store::{
-    FileMeta, FileMetaStream, ListEntryStream, ObjectReader, ObjectStore,
+    FileMeta, FileMetaStream, ListEntryStream, ObjectReader, ObjectStore, LOCAL_SCHEME,
 };
 use crate::datasource::PartitionedFile;
 use crate::error::DataFusionError;
@@ -39,6 +39,15 @@ pub struct LocalFileSystem;
 
 #[async_trait]
 impl ObjectStore for LocalFileSystem {
+    fn get_relative_path<'a>(&self, uri: &'a str) -> &'a str {
+        let mut result = uri;
+        if let Some((scheme, path)) = uri.split_once("://") {
+            assert_eq!(scheme, LOCAL_SCHEME);
+            result = path;
+        }
+        result
+    }
+
     async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
         list_all(prefix.to_owned()).await
     }

--- a/datafusion/src/test/object_store.rs
+++ b/datafusion/src/test/object_store.rs
@@ -49,6 +49,10 @@ impl TestObjectStore {
 
 #[async_trait]
 impl ObjectStore for TestObjectStore {
+    fn get_relative_path<'a>(&self, uri: &'a str) -> &'a str {
+        uri
+    }
+
     async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
         let prefix = prefix.to_owned();
         Ok(Box::pin(

--- a/datafusion/src/test_util.rs
+++ b/datafusion/src/test_util.rs
@@ -19,6 +19,9 @@
 
 use std::{env, error::Error, path::PathBuf};
 
+#[cfg(feature = "hdfs")]
+pub mod hdfs;
+
 /// Compares formatted output of a record batch with an expected
 /// vector of strings, with the result of pretty formatting record
 /// batches. This is a macro so errors appear on the correct line

--- a/datafusion/src/test_util/hdfs.rs
+++ b/datafusion/src/test_util/hdfs.rs
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! It's a utility for testing with data source in hdfs.
+//! The hdfs data source will be prepared by copying local parquet file.
+//! Users don't need to care about the trial things, like data moving, data cleaning up, etc.
+//! ```ignore
+//! use crate::test::hdfs::run_hdfs_test;
+//!
+//! #[tokio::test]
+//! async fn test_data_on_hdfs() -> Result<()> {
+//!     run_hdfs_test("alltypes_plain.parquet".to_string(), |filename_hdfs| {
+//!         Box::pin(async move {
+//!             ...
+//!         })
+//!     })
+//!     .await
+//! }
+//! ```
+
+use std::pin::Pin;
+
+use futures::Future;
+use hdfs::minidfs;
+use hdfs::util::HdfsUtil;
+use uuid::Uuid;
+
+use crate::datasource::object_store::hdfs::HadoopFileSystem;
+use crate::error::Result;
+
+/// Run test after related data prepared
+pub async fn run_hdfs_test<F>(filename: String, test: F) -> Result<()>
+where
+    F: FnOnce(
+        HadoopFileSystem,
+        String,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
+{
+    let (hdfs, tmp_dir, dst_file) = setup_with_hdfs_data(&filename);
+
+    let result = test(hdfs, dst_file).await;
+
+    teardown(&tmp_dir);
+
+    result
+}
+
+/// Prepare hdfs parquet file by copying local parquet file to hdfs
+fn setup_with_hdfs_data(filename: &str) -> (HadoopFileSystem, String, String) {
+    let uuid = Uuid::new_v4().to_string();
+    let tmp_dir = format!("/{}", uuid);
+
+    let dfs = minidfs::get_dfs();
+    let fs = dfs.get_hdfs().ok().unwrap();
+    assert!(fs.mkdir(&tmp_dir).is_ok());
+
+    // Source
+    let testdata = crate::test_util::parquet_test_data();
+    let src_path = format!("{}/{}", testdata, filename);
+
+    // Destination
+    let dst_path = format!("{}/{}", tmp_dir, filename);
+
+    // Copy to hdfs
+    assert!(HdfsUtil::copy_file_to_hdfs(dfs.clone(), &src_path, &dst_path).is_ok());
+
+    (
+        HadoopFileSystem::wrap(fs),
+        tmp_dir,
+        format!("{}{}", dfs.namenode_addr(), dst_path),
+    )
+}
+
+/// Cleanup testing files in hdfs
+fn teardown(tmp_dir: &str) {
+    let dfs = minidfs::get_dfs();
+    let fs = dfs.get_hdfs().ok().unwrap();
+    assert!(fs.delete(&tmp_dir, true).is_ok());
+}

--- a/datafusion/tests/path_partition.rs
+++ b/datafusion/tests/path_partition.rs
@@ -346,6 +346,10 @@ impl MirroringObjectStore {
 
 #[async_trait]
 impl ObjectStore for MirroringObjectStore {
+    fn get_relative_path<'a>(&self, uri: &'a str) -> &'a str {
+        uri
+    }
+
     async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
         let prefix = prefix.to_owned();
         let size = self.file_size;

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -18,19 +18,18 @@
 //! This module contains end to end tests of running SQL queries using
 //! DataFusion
 
-use std::convert::TryFrom;
-use std::sync::Arc;
-
-use chrono::prelude::*;
-use chrono::Duration;
-
 extern crate arrow;
 extern crate datafusion;
+
+use std::convert::TryFrom;
+use std::sync::Arc;
 
 use arrow::{
     array::*, datatypes::*, record_batch::RecordBatch,
     util::display::array_value_to_string,
 };
+use chrono::prelude::*;
+use chrono::Duration;
 
 use datafusion::assert_batches_eq;
 use datafusion::assert_batches_sorted_eq;
@@ -5519,4 +5518,76 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
     let expected = vec![vec!["0"], vec!["4"], vec!["8"]];
     assert_eq!(expected, actual);
     Ok(())
+}
+
+#[cfg(test)]
+#[cfg(feature = "hdfs")]
+mod hdfs {
+    use std::pin::Pin;
+
+    use futures::Future;
+
+    use datafusion::datasource::object_store::hdfs::HDFS_SCHEME;
+    use datafusion::test_util::hdfs::run_hdfs_test;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn parquet_query() {
+        run_with_register_alltypes_parquet(|mut ctx| {
+            Box::pin(async move {
+                // NOTE that string_col is actually a binary column and does not have the UTF8 logical type
+                // so we need an explicit cast
+                let sql = "SELECT id, CAST(string_col AS varchar) FROM alltypes_plain";
+                let actual = execute_to_batches(&mut ctx, sql).await;
+                let expected = vec![
+                    "+----+-----------------------------------------+",
+                    "| id | CAST(alltypes_plain.string_col AS Utf8) |",
+                    "+----+-----------------------------------------+",
+                    "| 4  | 0                                       |",
+                    "| 5  | 1                                       |",
+                    "| 6  | 0                                       |",
+                    "| 7  | 1                                       |",
+                    "| 2  | 0                                       |",
+                    "| 3  | 1                                       |",
+                    "| 0  | 0                                       |",
+                    "| 1  | 1                                       |",
+                    "+----+-----------------------------------------+",
+                ];
+
+                assert_batches_eq!(expected, &actual);
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Run query after table registered with parquet file on hdfs
+    pub async fn run_with_register_alltypes_parquet<F>(test_query: F) -> Result<()>
+    where
+        F: FnOnce(
+                ExecutionContext,
+            )
+                -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>
+            + Send
+            + 'static,
+    {
+        run_hdfs_test("alltypes_plain.parquet".to_string(), |fs, filename_hdfs| {
+            Box::pin(async move {
+                let mut ctx = ExecutionContext::new();
+                ctx.register_object_store(HDFS_SCHEME, Arc::new(fs));
+                let table_name = "alltypes_plain";
+                println!(
+                    "Register table {} with parquet file {}",
+                    table_name, filename_hdfs
+                );
+                ctx.register_parquet(table_name, &filename_hdfs).await?;
+
+                test_query(ctx).await
+            })
+        })
+        .await
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1060. It's a refactor version of PR #1062.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently, we can only read parquet files from local file system. It would be nice to add support to read parquet files that reside on HDFS.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Introduced hdfs as one of the object store. With the feature of hdfs, it will depend on the fs-hdfs crate which provides the Rust client to hdfs. Then we can run some sql-based unit test with data on hdfs.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
One example for querying on the hdfs data can be seen in the method of hdfs.run_with_register_alltypes_parquet in  tests/sql.rs. Firstly create a **HadoopFileSystem**. Then register it with **hdfs** scheme.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
