### PR TITLE
add \q as quit command and add \? for help

### DIFF
--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Command within CLI
+
+use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty;
+use datafusion::error::{DataFusionError, Result};
+use std::str::FromStr;
+use std::sync::Arc;
+
+/// Command
+#[derive(Debug)]
+pub enum Command {
+    Quit,
+    Help,
+}
+
+impl Command {
+    pub fn execute(&self) -> Result<()> {
+        match self {
+            Self::Help => pretty::print_batches(&[all_commands_info()])
+                .map_err(|e| DataFusionError::Execution(e.to_string())),
+            Self::Quit => Err(DataFusionError::Execution(
+                "Unexpected quit, this should be handled outside".into(),
+            )),
+        }
+    }
+
+    fn get_name_and_description(&self) -> (&str, &str) {
+        match self {
+            Self::Quit => ("\\q", "quit datafusion-cli"),
+            Self::Help => ("\\?", "help"),
+        }
+    }
+}
+
+const ALL_COMMANDS: [Command; 2] = [Command::Quit, Command::Help];
+
+fn all_commands_info() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("Command", DataType::Utf8, false),
+        Field::new("Description", DataType::Utf8, false),
+    ]));
+    let (names, description): (Vec<&str>, Vec<&str>) = ALL_COMMANDS
+        .iter()
+        .map(|c| c.get_name_and_description())
+        .unzip();
+    RecordBatch::try_new(
+        schema,
+        [names, description]
+            .into_iter()
+            .map(|i| Arc::new(StringArray::from(i)) as ArrayRef)
+            .collect::<Vec<_>>(),
+    )
+    .expect("This should not fail")
+}
+
+impl FromStr for Command {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "q" => Ok(Self::Quit),
+            "?" => Ok(Self::Help),
+            _ => Err(()),
+        }
+    }
+}

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -19,6 +19,7 @@
 #![allow(unused_imports)]
 pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+pub mod command;
 pub mod context;
 pub mod exec;
 pub mod print_format;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1216 

 # Rationale for this change

add \q as quit command and add \? for help

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

```
> select 1;
+----------+
| Int64(1) |
+----------+
| 1        |
+----------+
1 row in set. Query took 0.005 seconds.
> \?
+---------+---------------------+
| Command | Description         |
+---------+---------------------+
| \q      | quit datafusion-cli |
| \?      | help                |
+---------+---------------------+
> \q
```

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
