### PR TITLE
fix: Min/Max aggregation data type should not be dictionary

### DIFF
--- a/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/datafusion/src/physical_plan/expressions/min_max.rs
@@ -38,6 +38,15 @@ use arrow::{
 
 use super::format_state_name;
 
+// min/max aggregation only returns a value for each group
+// and should not be a Dictionary data type anymore
+fn min_max_aggregate_data_type(input_type: DataType) -> DataType {
+    match input_type {
+        DataType::Dictionary(_, value_type) => (*value_type).clone(),
+        _ => input_type.clone(),
+    }
+}
+
 /// MAX aggregate expression
 #[derive(Debug)]
 pub struct Max {
@@ -72,7 +81,7 @@ impl AggregateExpr for Max {
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,
-            self.data_type.clone(),
+            min_max_aggregate_data_type(self.data_type.clone()),
             self.nullable,
         ))
     }
@@ -80,7 +89,7 @@ impl AggregateExpr for Max {
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(vec![Field::new(
             &format_state_name(&self.name, "max"),
-            self.data_type.clone(),
+            min_max_aggregate_data_type(self.data_type.clone()),
             true,
         )])
     }
@@ -394,7 +403,7 @@ impl AggregateExpr for Min {
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,
-            self.data_type.clone(),
+            min_max_aggregate_data_type(self.data_type.clone()),
             self.nullable,
         ))
     }
@@ -402,7 +411,7 @@ impl AggregateExpr for Min {
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(vec![Field::new(
             &format_state_name(&self.name, "min"),
-            self.data_type.clone(),
+            min_max_aggregate_data_type(self.data_type.clone()),
             true,
         )])
     }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -137,8 +137,6 @@ impl HashAggregateExec {
         input_schema: SchemaRef,
     ) -> Result<Self> {
         let schema = create_schema(&input.schema(), &group_expr, &aggr_expr, mode)?;
-        println!(" +++++ Schema created for the aggregate: \n {:#?}", schema.clone() );
-        println!(" +++++ Input Schema of the aggregate: \n {:#?}", input_schema.clone());
 
         let schema = Arc::new(schema);
 
@@ -210,7 +208,6 @@ impl ExecutionPlan for HashAggregateExec {
     }
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
-        println!(" ============== RUNNING HashAggregateExec");
         let input = self.input.execute(partition).await?;
         let group_expr = self.group_expr.iter().map(|x| x.0.clone()).collect();
 
@@ -781,9 +778,6 @@ async fn compute_hash_aggregate(
     let timer = elapsed_compute.timer();
     let batch = finalize_aggregation(&accumulators, &mode)
         .map(|columns| {
-            println!(" =================== RecordBatch::try_new in HashAggregare's compute_hash_aggregate");
-            println!("    ================ schema: {:#?}", schema.clone());
-            println!("    ================ columns: {:#?}", columns);
             RecordBatch::try_new(schema.clone(), columns)
         })
         .map_err(DataFusionError::into_arrow_external_error)?;
@@ -974,10 +968,6 @@ fn create_batch_from_map(
         .zip(output_schema.fields().iter())
         .map(|(col, desired_field)| cast(col, desired_field.data_type()))
         .collect::<ArrowResult<Vec<_>>>()?;
-
-        println!(" =================== RecordBatch::try_new in HashAggregare's create_batch_from_map");
-        println!("    ================ schema: {:#?}", output_schema.clone());
-        println!("    ================ columns: {:#?}", columns);
 
     RecordBatch::try_new(Arc::new(output_schema.to_owned()), columns)
 }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -777,9 +777,7 @@ async fn compute_hash_aggregate(
     // 2. convert values to a record batch
     let timer = elapsed_compute.timer();
     let batch = finalize_aggregation(&accumulators, &mode)
-        .map(|columns| {
-            RecordBatch::try_new(schema.clone(), columns)
-        })
+        .map(|columns| RecordBatch::try_new(schema.clone(), columns))
         .map_err(DataFusionError::into_arrow_external_error)?;
     timer.done();
     batch

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -503,7 +503,6 @@ impl DefaultPhysicalPlanner {
                         })
                         .collect::<Result<Vec<_>>>()?;
 
-                    println!(" ++++++++++++++++++++++++++ schema to HashAggregateExec in create_initial_plan for AggregateMode::Partial: \n {:#?}", physical_input_schema.clone());
                     let initial_aggr = Arc::new(HashAggregateExec::try_new(
                         AggregateMode::Partial,
                         groups.clone(),
@@ -548,7 +547,6 @@ impl DefaultPhysicalPlanner {
                         (initial_aggr, AggregateMode::Final)
                     };
 
-                    println!(" ++++++++++++++++++++++++++ schema to HashAggregateExec in create_initial_plan: \n {:#?}", physical_input_schema.clone());
                     Ok(Arc::new(HashAggregateExec::try_new(
                         next_partition_mode,
                         final_group
@@ -1424,7 +1422,10 @@ impl DefaultPhysicalPlanner {
             new_plan = optimizer.optimize(new_plan, &ctx_state.config)?;
             observer(new_plan.as_ref(), optimizer.as_ref())
         }
-        debug!("Optimized physical plan short version:\n{}\n", displayable(new_plan.as_ref()).indent().to_string());
+        debug!(
+            "Optimized physical plan short version:\n{}\n",
+            displayable(new_plan.as_ref()).indent().to_string()
+        );
         debug!("Optimized physical plan:\n{:?}", new_plan);
         Ok(new_plan)
     }

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1418,15 +1418,14 @@ impl DefaultPhysicalPlanner {
     {
         let optimizers = &ctx_state.config.physical_optimizers;
         debug!("Physical plan:\n{:?}", plan);
-        println!("NGA NGA NGA ============== Physical plan:\n{:?}", plan);
 
         let mut new_plan = plan;
         for optimizer in optimizers {
             new_plan = optimizer.optimize(new_plan, &ctx_state.config)?;
             observer(new_plan.as_ref(), optimizer.as_ref())
         }
+        debug!("Optimized physical plan short version:\n{}\n", displayable(new_plan.as_ref()).indent().to_string());
         debug!("Optimized physical plan:\n{:?}", new_plan);
-        println!("NGA NGA NGA ============== Optimized physical plan:\n{:?}", new_plan);
         Ok(new_plan)
     }
 }

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1424,7 +1424,7 @@ impl DefaultPhysicalPlanner {
         }
         debug!(
             "Optimized physical plan short version:\n{}\n",
-            displayable(new_plan.as_ref()).indent().to_string()
+            displayable(new_plan.as_ref()).indent()
         );
         debug!("Optimized physical plan:\n{:?}", new_plan);
         Ok(new_plan)

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -503,6 +503,7 @@ impl DefaultPhysicalPlanner {
                         })
                         .collect::<Result<Vec<_>>>()?;
 
+                    println!(" ++++++++++++++++++++++++++ schema to HashAggregateExec in create_initial_plan for AggregateMode::Partial: \n {:#?}", physical_input_schema.clone());
                     let initial_aggr = Arc::new(HashAggregateExec::try_new(
                         AggregateMode::Partial,
                         groups.clone(),
@@ -547,6 +548,7 @@ impl DefaultPhysicalPlanner {
                         (initial_aggr, AggregateMode::Final)
                     };
 
+                    println!(" ++++++++++++++++++++++++++ schema to HashAggregateExec in create_initial_plan: \n {:#?}", physical_input_schema.clone());
                     Ok(Arc::new(HashAggregateExec::try_new(
                         next_partition_mode,
                         final_group
@@ -1416,6 +1418,7 @@ impl DefaultPhysicalPlanner {
     {
         let optimizers = &ctx_state.config.physical_optimizers;
         debug!("Physical plan:\n{:?}", plan);
+        println!("NGA NGA NGA ============== Physical plan:\n{:?}", plan);
 
         let mut new_plan = plan;
         for optimizer in optimizers {
@@ -1423,6 +1426,7 @@ impl DefaultPhysicalPlanner {
             observer(new_plan.as_ref(), optimizer.as_ref())
         }
         debug!("Optimized physical plan:\n{:?}", new_plan);
+        println!("NGA NGA NGA ============== Optimized physical plan:\n{:?}", new_plan);
         Ok(new_plan)
     }
 }

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3946,6 +3946,13 @@ async fn query_on_string_dictionary() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Arc::new(table))?;
 
+    // aggregation min
+    let sql = "SELECT MIN(d1) FROM test";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["one"]];
+    assert_eq!(expected, actual);
+
+
     // Basic SELECT
     let sql = "SELECT * FROM test";
     let actual = execute(&mut ctx, sql).await;

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3946,13 +3946,6 @@ async fn query_on_string_dictionary() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Arc::new(table))?;
 
-    // aggregation min
-    let sql = "SELECT MIN(d1) FROM test";
-    let actual = execute(&mut ctx, sql).await;
-    let expected = vec![vec!["one"]];
-    assert_eq!(expected, actual);
-
-
     // Basic SELECT
     let sql = "SELECT * FROM test";
     let actual = execute(&mut ctx, sql).await;
@@ -3981,6 +3974,12 @@ async fn query_on_string_dictionary() -> Result<()> {
     let sql = "SELECT COUNT(d1) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["2"]];
+    assert_eq!(expected, actual);
+
+    // aggregation min
+    let sql = "SELECT MIN(d1) FROM test";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["one"]];
     assert_eq!(expected, actual);
 
     // grouping

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -3982,6 +3982,12 @@ async fn query_on_string_dictionary() -> Result<()> {
     let expected = vec![vec!["one"]];
     assert_eq!(expected, actual);
 
+    // aggregation max
+    let sql = "SELECT MAX(d1) FROM test";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["three"]];
+    assert_eq!(expected, actual);
+
     // grouping
     let sql = "SELECT d1, COUNT(*) FROM test group by d1";
     let mut actual = execute(&mut ctx, sql).await;


### PR DESCRIPTION
# Which issue does this PR close? 


<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1234

 # Rationale for this change
Since Min/Max Aggregation only returns one value per group, it should not be Dictionary which is mostly used for many values

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
If Data Type of the input of the Min/Max aggregate is Dictionary, make data type of min/max aggregate the data type of the `value` of the Dictionary.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
The min/max(dictionary string) now no longer panics
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
