### PR TITLE
ignore case of `with header row` in sql when creating external table

### DIFF
--- a/datafusion/src/sql/parser.rs
+++ b/datafusion/src/sql/parser.rs
@@ -294,7 +294,14 @@ impl<'a> DFParser<'a> {
     }
 
     fn consume_token(&mut self, expected: &Token) -> bool {
-        self.parser.consume_token(expected)
+        let token = self.parser.peek_token().to_string().to_uppercase();
+        let token = Token::make_keyword(&token);
+        if token == *expected {
+            self.parser.next_token();
+            true
+        } else {
+            false
+        }
     }
 
     fn parse_csv_has_header(&mut self) -> bool {

--- a/datafusion/src/sql/parser.rs
+++ b/datafusion/src/sql/parser.rs
@@ -367,7 +367,7 @@ mod tests {
         });
         expect_parse_ok(sql, expected)?;
 
-        // positive case: it is ok for case insensitive sql with `WITH HEADER ROW` tokens
+        // positive case: it is ok for case insensitive sql stmt with `WITH HEADER ROW` tokens
         let sqls = vec![
             "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH HEADER ROW LOCATION 'foo.csv'",
             "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV with header row LOCATION 'foo.csv'"


### PR DESCRIPTION
Resolves https://github.com/apache/arrow-datafusion/issues/1242

Currently, creating an external table using `datafusion-cli` with this sql:

```SQL
CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV with header row LOCATION 'foo.csv'
```
will fail when `with header row` tokens are in lower case. This pr is a fix. 