### PR TITLE
Fix some `BuiltinScalarFunction` panics with zero arguments

### DIFF
--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -506,6 +506,13 @@ pub fn return_type(
     // Note that this function *must* return the same type that the respective physical expression returns
     // or the execution panics.
 
+    if arg_types.is_empty() && !fun.supports_zero_argument() {
+        return Err(DataFusionError::Internal(format!(
+            "builtin scalar function {} does not support empty arguments",
+            fun
+        )));
+    }
+
     // verify that this is a valid set of data types for this function
     data_types(arg_types, &signature(fun))?;
 
@@ -621,18 +628,10 @@ pub fn return_type(
         | BuiltinScalarFunction::Sin
         | BuiltinScalarFunction::Sqrt
         | BuiltinScalarFunction::Tan
-        | BuiltinScalarFunction::Trunc => {
-            if arg_types.is_empty() {
-                return Err(DataFusionError::Internal(format!(
-                    "builtin scalar function {} does not support empty arguments",
-                    fun
-                )));
-            }
-            match arg_types[0] {
-                DataType::Float32 => Ok(DataType::Float32),
-                _ => Ok(DataType::Float64),
-            }
-        }
+        | BuiltinScalarFunction::Trunc => match arg_types[0] {
+            DataType::Float32 => Ok(DataType::Float32),
+            _ => Ok(DataType::Float64),
+        },
     }
 }
 


### PR DESCRIPTION
Return Err when `BuiltinScalarFunction` requires at least one argument but received none.

I'm searching a right place to write tests. Any advice is helpful.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1243

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Use `supports_zero_argument()` seems a quick fix.
I tried to match `Signature` to cover more cases but it seems overwork for this case. Since other `Signature` inconsistencies will be caught in the type coercion. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
