### PR TITLE
fix 1250, add editor support for datafusion cli with validation

### DIFF
--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helper that helps with interactive editing, including multi-line parsing and validation,
+//! hinting and auto-completion, etc.
+
+use datafusion::sql::parser::DFParser;
+use rustyline::completion::Completer;
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::ValidationContext;
+use rustyline::validate::ValidationResult;
+use rustyline::validate::Validator;
+use rustyline::Context;
+use rustyline::Helper;
+use rustyline::Result;
+
+#[derive(Default)]
+pub(crate) struct CliHelper {}
+
+impl Highlighter for CliHelper {}
+
+impl Hinter for CliHelper {
+    type Hint = String;
+}
+
+impl Completer for CliHelper {
+    type Candidate = String;
+}
+
+impl Validator for CliHelper {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult> {
+        let input = ctx.input().trim_end();
+        if let Some(sql) = input.strip_suffix(';') {
+            match DFParser::parse_sql(sql) {
+                Ok(statements) if statements.is_empty() => Ok(ValidationResult::Invalid(
+                    Some("  🤔 You entered an empty statement".to_string()),
+                )),
+                Ok(statements) if statements.len() > 1 => Ok(ValidationResult::Invalid(
+                    Some("  🤔 You entered more than one statement".to_string()),
+                )),
+                Ok(_statements) => Ok(ValidationResult::Valid(None)),
+                Err(err) => Ok(ValidationResult::Invalid(Some(format!(
+                    "  🤔 Invalid statement: {}",
+                    err
+                )))),
+            }
+        } else if input.starts_with('\\') {
+            // command
+            Ok(ValidationResult::Valid(None))
+        } else {
+            Ok(ValidationResult::Incomplete)
+        }
+    }
+}
+
+impl Helper for CliHelper {}

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -22,5 +22,6 @@ pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod command;
 pub mod context;
 pub mod exec;
+pub mod helper;
 pub mod print_format;
 pub mod print_options;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1250

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

### correct sql input

```
❯ select cos(2.0);
+------------------------------+
| Float64(-0.4161468365471424) |
+------------------------------+
| -0.4161468365471424          |
+------------------------------+
1 row in set. Query took 0.004 seconds.
```

### invalid SQL

```
❯ from a join b select 9;  🤔 Invalid statement: sql parser error: Expected an SQL statement, found: from
```

### correct command input

```
❯ \d
+---------------+--------------------+------------+------------+
| table_catalog | table_schema       | table_name | table_type |
+---------------+--------------------+------------+------------+
| datafusion    | information_schema | tables     | VIEW       |
| datafusion    | information_schema | columns    | VIEW       |
+---------------+--------------------+------------+------------+
2 rows in set. Query took 0.004 seconds.
```

### empty statement

```
❯ ;  🤔 You entered an empty statement
```

### multiple statement

```
❯ select 1; select 2;  🤔 You entered more than one statement
```

### multiline editing

```
❯ select
1



+

2



;
+----------+
| Int64(3) |
+----------+
| 3        |
+----------+
1 row in set. Query took 0.002 seconds.
```

### edge case with comment

```
❯ -- select 1;  🤔 You entered an empty statement
```

```
❯ select -- 1
2


;
+----------+
| Int64(2) |
+----------+
| 2        |
+----------+
1 row in set. Query took 0.001 seconds.
```

```
❯


select ';     '









;
+----------------+
| Utf8(";     ") |
+----------------+
| ;              |
+----------------+
1 row in set. Query took 0.001 seconds.
```

```
❯ select -- select
-- select
-- --
1;
+----------+
| Int64(1) |
+----------+
| 1        |
+----------+
1 row in set. Query took 0.001 seconds.
```


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
