### PR TITLE
binary expression should simplify when either operant is null

### DIFF
--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -84,7 +84,7 @@ fn is_true(expr: &Expr) -> bool {
     }
 }
 
-fn is_null(expr: &Expr) -> bool {
+fn is_literal_null(expr: &Expr) -> bool {
     match expr {
         Expr::Literal(v) => v.is_null(),
         _ => false,
@@ -100,6 +100,8 @@ fn is_false(expr: &Expr) -> bool {
 
 fn simplify(expr: &Expr) -> Expr {
     match expr {
+        Expr::BinaryExpr { left, .. } if is_literal_null(left) => *left.clone(),
+        Expr::BinaryExpr { right, .. } if is_literal_null(right) => *right.clone(),
         Expr::BinaryExpr {
             left,
             op: Operator::Or,
@@ -155,11 +157,6 @@ fn simplify(expr: &Expr) -> Expr {
             op: Operator::Divide,
             right,
         } if is_one(right) => simplify(left),
-        Expr::BinaryExpr {
-            left,
-            op: Operator::Divide,
-            right,
-        } if left == right && is_null(left) => *left.clone(),
         Expr::BinaryExpr {
             left,
             op: Operator::Divide,
@@ -453,7 +450,7 @@ mod tests {
     fn test_simplify_and_and_false() -> Result<()> {
         let expr =
             binary_expr(lit(ScalarValue::Boolean(None)), Operator::And, lit(false));
-        let expr_eq = lit(false);
+        let expr_eq = null;
 
         assert_eq!(simplify(&expr), expr_eq);
         Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

binary expression should simplify when either operant is null

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
