### PR TITLE
Add timezome string to stablize test

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -3890,8 +3890,8 @@ mod tests {
     async fn create_external_table_with_timestamps() {
         let mut ctx = ExecutionContext::new();
 
-        let data = "Jorge,2018-12-13T12:12:10.011-00:00\n\
-                    Andrew,2018-11-13T17:11:10.011-00:00";
+        let data = "Jorge,2018-12-13T12:12:10.011Z\n\
+                    Andrew,2018-11-13T17:11:10.011Z";
 
         let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join("timestamps.csv");

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -3890,8 +3890,8 @@ mod tests {
     async fn create_external_table_with_timestamps() {
         let mut ctx = ExecutionContext::new();
 
-        let data = "Jorge,2018-12-13T12:12:10.011\n\
-                    Andrew,2018-11-13T17:11:10.011";
+        let data = "Jorge,2018-12-13T12:12:10.011-00:00\n\
+                    Andrew,2018-11-13T17:11:10.011-00:00";
 
         let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join("timestamps.csv");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closed #1262.

Fix test failure locally:

```
failures:

---- execution::context::tests::create_external_table_with_timestamps stdout ----
thread 'execution::context::tests::create_external_table_with_timestamps' panicked at 'assertion failed: `(left == right)`
  left: `["+--------+-------------------------+", "| name   | ts                      |", "+--------+-------------------------+", "| Andrew | 2018-11-13 17:11:10.011 |", "| Jorge  | 2018-12-13 12:12:10.011 |", "+--------+-------------------------+"]`,
 right: `["+--------+-------------------------+", "| name   | ts                      |", "+--------+-------------------------+", "| Andrew | 2018-11-14 01:11:10.011 |", "| Jorge  | 2018-12-13 20:12:10.011 |", "+--------+-------------------------+"]`: 

expected:

[
    "+--------+-------------------------+",
    "| name   | ts                      |",
    "+--------+-------------------------+",
    "| Andrew | 2018-11-13 17:11:10.011 |",
    "| Jorge  | 2018-12-13 12:12:10.011 |",
    "+--------+-------------------------+",
]
actual:

[
    "+--------+-------------------------+",
    "| name   | ts                      |",
    "+--------+-------------------------+",
    "| Andrew | 2018-11-14 01:11:10.011 |",
    "| Jorge  | 2018-12-13 20:12:10.011 |",
    "+--------+-------------------------+",
]

', datafusion/src/execution/context.rs:3932:9
```

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To stablize test for developers.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adding timzome strings to stablize test locally.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
