### PR TITLE
add the youtube link's time anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Please see [Roadmap](docs/source/specification/roadmap.md) for information of wh
 
 There is no formal document describing DataFusion's architecture yet, but the following presentations offer a good overview of its different components and how they interact together.
 
-- (March 2021): The DataFusion architecture is described in _Query Engine Design and the Rust-Based DataFusion in Apache Arrow_: [recording](https://www.youtube.com/watch?v=K6eCAVEk4kU) (DataFusion content starts ~ 15 minutes in) and [slides](https://www.slideshare.net/influxdata/influxdb-iox-tech-talks-query-engine-design-and-the-rustbased-datafusion-in-apache-arrow-244161934)
+- (March 2021): The DataFusion architecture is described in _Query Engine Design and the Rust-Based DataFusion in Apache Arrow_: [recording](https://www.youtube.com/watch?v=K6eCAVEk4kU) (DataFusion content starts [~ 15 minutes in](https://www.youtube.com/watch?v=K6eCAVEk4kU&t=875s)) and [slides](https://www.slideshare.net/influxdata/influxdb-iox-tech-talks-query-engine-design-and-the-rustbased-datafusion-in-apache-arrow-244161934)
 - (Feburary 2021): How DataFusion is used within the Ballista Project is described in \*Ballista: Distributed Compute with Rust and Apache Arrow: [recording](https://www.youtube.com/watch?v=ZZHQaOap9pQ)
 
 # Developer's guide


### PR DESCRIPTION
# Which issue does this PR close?

nope

# Rationale for this change

In the 'Architecture Overview' section of the README, the link goes to the IOx talk by default, this PR adds a time anchor to the link, so we can view the datafusion talk directly on clicking the link.

# What changes are included in this PR?

- change README

# Are there any user-facing changes?

nope