### PR TITLE
add filename completer for create table statement

### DIFF
--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -16,10 +16,12 @@
 // under the License.
 
 //! Helper that helps with interactive editing, including multi-line parsing and validation,
-//! hinting and auto-completion, etc.
+//! and auto-completion for file name during creating external table.
 
-use datafusion::sql::parser::DFParser;
+use datafusion::sql::parser::{DFParser, Statement};
 use rustyline::completion::Completer;
+use rustyline::completion::FilenameCompleter;
+use rustyline::completion::Pair;
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
@@ -31,7 +33,9 @@ use rustyline::Helper;
 use rustyline::Result;
 
 #[derive(Default)]
-pub(crate) struct CliHelper {}
+pub(crate) struct CliHelper {
+    completer: FilenameCompleter,
+}
 
 impl Highlighter for CliHelper {}
 
@@ -39,8 +43,34 @@ impl Hinter for CliHelper {
     type Hint = String;
 }
 
+/// returns true if the current position is after the open quote for
+/// creating an external table.
+fn is_open_quote_for_location(line: &str, pos: usize) -> bool {
+    let mut sql = line[..pos].to_string();
+    sql.push('\'');
+    if let Ok(stmts) = DFParser::parse_sql(&sql) {
+        if let Some(Statement::CreateExternalTable(_)) = stmts.last() {
+            return true;
+        }
+    }
+    false
+}
+
 impl Completer for CliHelper {
-    type Candidate = String;
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> std::result::Result<(usize, Vec<Pair>), ReadlineError> {
+        if is_open_quote_for_location(line, pos) {
+            self.completer.complete(line, pos, ctx)
+        } else {
+            Ok((0, Vec::with_capacity(0)))
+        }
+    }
 }
 
 impl Validator for CliHelper {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

add filename completer for create table statement.

after you type `create external table name stored as parquet location '` i.e. after the open quote the completer will delegate to the filename based completer to help you input filename

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
