### PR TITLE
Test upgrade to arrow 7.x with new prost/tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,11 @@ exclude = ["python"]
 [profile.release]
 lto = true
 codegen-units = 1
+
+
+# experimentally try arrow 6.x with upgraded prost/tonic
+# from https://github.com/apache/arrow-rs/pull/945
+[patch.crates-io]
+arrow = { git = "https://github.com/alamb/arrow-rs.git", branch = "alamb/try_backporting_deps" }
+arrow-flight = { git = "https://github.com/alamb/arrow-rs.git", branch = "alamb/try_backporting_deps" }
+parquet = { git = "https://github.com/alamb/arrow-rs.git", branch = "alamb/try_backporting_deps" }

--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -32,8 +32,8 @@ rust-version = "1.56"
 arrow-flight = { version = "6.1.0" }
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client" }
-prost = "0.8"
-tonic = "0.5"
+prost = "0.9"
+tonic = "0.6"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,11 +35,11 @@ async-trait = "0.1.36"
 futures = "0.3"
 hashbrown = "0.11"
 log = "0.4"
-prost = "0.8"
+prost = "0.9"
 serde = {version = "1", features = ["derive"]}
 sqlparser = "0.12.0"
 tokio = "1.0"
-tonic = "0.5"
+tonic = "0.6"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4"
 
@@ -51,4 +51,4 @@ datafusion = { path = "../../../datafusion", version = "5.1.0" }
 tempfile = "3"
 
 [build-dependencies]
-tonic-build = { version = "0.5" }
+tonic-build = { version = "0.6" }

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -43,7 +43,7 @@ snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = "0.5"
+tonic = "0.6"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -44,13 +44,13 @@ http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
 parse_arg = "0.1.3"
-prost = "0.8"
+prost = "0.9"
 rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
-tonic = "0.5"
+tonic = "0.6"
 tower = { version = "0.4" }
 warp = "0.3"
 
@@ -60,7 +60,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]
 configure_me_codegen = "0.4.1"
-tonic-build = { version = "0.5" }
+tonic-build = { version = "0.6" }
 
 [package.metadata.configure_me.bin]
 scheduler = "scheduler_config_spec.toml"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -36,8 +36,8 @@ required-features = ["datafusion/avro"]
 [dev-dependencies]
 arrow-flight = { version = "6.1.0" }
 datafusion = { path = "../datafusion" }
-prost = "0.8"
-tonic = "0.5"
+prost = "0.9"
+tonic = "0.6"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 num_cpus = "1.13.0"


### PR DESCRIPTION
# Rationale for this change
Test what would happen if we upgraded `prost` and `tonic` dependencies  in the arrow-rs 6.x line (aka what would happen if we merged https://github.com/apache/arrow-rs/pull/945)?

# What changes are included in this PR?
temporarily override arrow to use  https://github.com/apache/arrow-rs/pull/945

# Are there any user-facing changes?
No