### PR TITLE
Add a command to switch output format in cli

### DIFF
--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -19,7 +19,8 @@
 
 use crate::context::Context;
 use crate::functions::{display_all_functions, Function};
-use crate::print_options::PrintOptions;
+use crate::print_format::PrintFormat;
+use crate::print_options::{self, PrintOptions};
 use datafusion::arrow::array::{ArrayRef, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -38,6 +39,11 @@ pub enum Command {
     ListFunctions,
     SearchFunctions(String),
     QuietMode(Option<bool>),
+    OutputFormat(Option<String>),
+}
+
+pub enum OutputFormat {
+    ChangeFormat(String),
 }
 
 impl Command {
@@ -94,6 +100,9 @@ impl Command {
                     Err(DataFusionError::Execution(msg))
                 }
             }
+            Self::OutputFormat(_) => Err(DataFusionError::Execution(
+                "Unexpected change output format, this should be handled outside".into(),
+            )),
         }
     }
 
@@ -106,11 +115,14 @@ impl Command {
             Self::ListFunctions => ("\\h", "function list"),
             Self::SearchFunctions(_) => ("\\h function", "search function"),
             Self::QuietMode(_) => ("\\quiet (true|false)?", "print or set quiet mode"),
+            Self::OutputFormat(_) => {
+                ("\\pset [NAME [VALUE]]", "set table output option\n(format)")
+            }
         }
     }
 }
 
-const ALL_COMMANDS: [Command; 7] = [
+const ALL_COMMANDS: [Command; 8] = [
     Command::ListTables,
     Command::DescribeTable(String::new()),
     Command::Quit,
@@ -118,6 +130,7 @@ const ALL_COMMANDS: [Command; 7] = [
     Command::ListFunctions,
     Command::SearchFunctions(String::new()),
     Command::QuietMode(None),
+    Command::OutputFormat(None),
 ];
 
 fn all_commands_info() -> RecordBatch {
@@ -162,7 +175,43 @@ impl FromStr for Command {
                 Self::QuietMode(Some(false))
             }
             ("quiet", None) => Self::QuietMode(None),
+            ("pset", Some(subcommand)) => {
+                Self::OutputFormat(Some(subcommand.to_string()))
+            }
+            ("pset", None) => Self::OutputFormat(None),
             _ => return Err(()),
         })
+    }
+}
+
+impl FromStr for OutputFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
+            (a, Some(b))
+        } else {
+            (s, None)
+        };
+        Ok(match (c, arg) {
+            ("format", Some(format)) => Self::ChangeFormat(format.to_string()),
+            _ => return Err(()),
+        })
+    }
+}
+
+impl OutputFormat {
+    pub async fn execute(&self, print_options: &mut PrintOptions) -> Result<()> {
+        match self {
+            Self::ChangeFormat(format) => {
+                if let Ok(format) = PrintFormat::from_str(format) {
+                    print_options.format = format;
+                    println!("Output format is {}.", print_options.format);
+                    Ok(())
+                } else {
+                    Err(DataFusionError::Execution(format!("{} is not a valid format type [possible values: csv, tsv, table, json, ndjson]", format)))
+                }
+            }
+        }
     }
 }

--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -204,7 +204,7 @@ impl OutputFormat {
     pub async fn execute(&self, print_options: &mut PrintOptions) -> Result<()> {
         match self {
             Self::ChangeFormat(format) => {
-                if let Ok(format) = PrintFormat::from_str(format) {
+                if let Ok(format) = format.parse::<PrintFormat>() {
                     print_options.format = format;
                     println!("Output format is {}.", print_options.format);
                     Ok(())

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -96,12 +96,14 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &mut PrintOptions)
                         Command::Quit => break,
                         Command::OutputFormat(subcommand) => {
                             if let Some(subcommand) = subcommand {
-                                if let Ok(command) = OutputFormat::from_str(subcommand) {
+                                if let Ok(command) = subcommand.parse::<OutputFormat>() {
                                     if let Err(e) =
                                         command.execute(&mut print_options).await
                                     {
                                         eprintln!("{}", e)
                                     }
+                                } else {
+                                    eprintln!("'\\{}' is not a valid command", &line[1..]);
                                 }
                             } else {
                                 println!("Output format is {}.", print_options.format);

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -18,12 +18,13 @@
 //! Execution functions
 
 use crate::{
-    command::Command,
+    command::{Command, OutputFormat},
     context::Context,
     helper::CliHelper,
     print_format::{all_print_formats, PrintFormat},
     print_options::PrintOptions,
 };
+use clap::SubCommand;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty;
 use datafusion::error::{DataFusionError, Result};
@@ -79,7 +80,7 @@ pub async fn exec_from_lines(
 }
 
 /// run and execute SQL statements and commands against a context with the given print options
-pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
+pub async fn exec_from_repl(ctx: &mut Context, print_options: &mut PrintOptions) {
     let mut rl = Editor::<CliHelper>::new();
     rl.set_helper(Some(CliHelper::default()));
     rl.load_history(".history").ok();
@@ -93,6 +94,19 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
                 if let Ok(cmd) = &line[1..].parse::<Command>() {
                     match cmd {
                         Command::Quit => break,
+                        Command::OutputFormat(subcommand) => {
+                            if let Some(subcommand) = subcommand {
+                                if let Ok(command) = OutputFormat::from_str(subcommand) {
+                                    if let Err(e) =
+                                        command.execute(&mut print_options).await
+                                    {
+                                        eprintln!("{}", e)
+                                    }
+                                }
+                            } else {
+                                println!("Output format is {}.", print_options.format);
+                            }
+                        }
                         _ => {
                             if let Err(e) = cmd.execute(ctx, &mut print_options).await {
                                 eprintln!("{}", e)

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -103,7 +103,10 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &mut PrintOptions)
                                         eprintln!("{}", e)
                                     }
                                 } else {
-                                    eprintln!("'\\{}' is not a valid command", &line[1..]);
+                                    eprintln!(
+                                        "'\\{}' is not a valid command",
+                                        &line[1..]
+                                    );
                                 }
                             } else {
                                 println!("Output format is {}.", print_options.format);

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -137,7 +137,7 @@ pub async fn main() -> Result<()> {
         .parse::<PrintFormat>()
         .expect("Invalid format");
 
-    let print_options = PrintOptions { format, quiet };
+    let mut print_options = PrintOptions { format, quiet };
 
     if let Some(file_paths) = matches.values_of("file") {
         let files = file_paths
@@ -148,7 +148,7 @@ pub async fn main() -> Result<()> {
             exec::exec_from_lines(&mut ctx, &mut reader, &print_options).await;
         }
     } else {
-        exec::exec_from_repl(&mut ctx, &print_options).await;
+        exec::exec_from_repl(&mut ctx, &mut print_options).await;
     }
 
     Ok(())


### PR DESCRIPTION
fixes #1267

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

```
DataFusion CLI v5.1.0-SNAPSHOT

❯ \?
+------------------+-----------------------------------------------------------------------+
| Command          | Description                                                           |
+------------------+-----------------------------------------------------------------------+
| \d               | list tables                                                           |
| \d name          | describe table                                                        |
| \q               | quit datafusion-cli                                                   |
| \?               | help                                                                  |
| \format <format> | change output format [possible values: csv, tsv, table, json, ndjson] |
+------------------+-----------------------------------------------------------------------+
5 rows in set. Query took 0.005 seconds.
❯ \format json
❯ \?
[{"Command":"\\d","Description":"list tables"},{"Command":"\\d name","Description":"describe table"},{"Command":"\\q","Description":"quit datafusion-cli"},{"Command":"\\?","Description":"help"},{"Command":"\\format <format>","Description":"change output format [possible values: csv, tsv, table, json, ndjson]"}]
5 rows in set. Query took 0.001 seconds.
❯ \format invalid_format
invalid_format is not a valid format type [possible values: csv, tsv, table, json, ndjson]

```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
