### PR TITLE
python: update docs to use new APIs

### DIFF
--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           source venv/bin/activate
           flake8 python --ignore=E501
-          black --line-length 79 --check python
+          black --line-length 79 --diff --check python
       - name: Run tests
         run: |
           source venv/bin/activate

--- a/docs/source/python/index.rst
+++ b/docs/source/python/index.rst
@@ -39,10 +39,9 @@ Simple usage:
 .. code-block:: python
 
    import datafusion
+   from datafusion import functions as f
+   from datafusion import col
    import pyarrow
-
-   # an alias
-   f = datafusion.functions
 
    # create a context
    ctx = datafusion.ExecutionContext()
@@ -56,8 +55,8 @@ Simple usage:
 
    # create a new statement
    df = df.select(
-       f.col("a") + f.col("b"),
-       f.col("a") - f.col("b"),
+       col("a") + col("b"),
+       col("a") - col("b"),
    )
 
    # execute and collect the first (and only) batch
@@ -77,7 +76,7 @@ UDFs
 
    udf = f.udf(is_null, [pyarrow.int64()], pyarrow.bool_())
 
-   df = df.select(udf(f.col("a")))
+   df = df.select(udf(col("a")))
 
 
 UDAF
@@ -117,7 +116,7 @@ UDAF
 
    df = df.aggregate(
        [],
-       [udaf(f.col("a"))]
+       [udaf(col("a"))]
    )
 
 

--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -28,6 +28,7 @@ from ._internal import (
     ScalarUDF,
 )
 
+
 __all__ = [
     "DataFrame",
     "ExecutionContext",
@@ -61,10 +62,16 @@ def column(value):
     return Expression.column(value)
 
 
+col = column
+
+
 def literal(value):
     if not isinstance(value, pa.Scalar):
         value = pa.scalar(value)
     return Expression.literal(value)
+
+
+lit = literal
 
 
 def udf(func, input_types, return_type, volatility, name=None):

--- a/python/src/expression.rs
+++ b/python/src/expression.rs
@@ -90,6 +90,10 @@ impl PyObjectProtocol for PyExpr {
         };
         expr.into()
     }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!("{}", self.expr))
+    }
 }
 
 #[pymethods]


### PR DESCRIPTION
# Rationale for this change

The example in our python user doc is not working with the latest binding implementation. Found this while validating https://github.com/apache/arrow-datafusion/pull/1253

# What changes are included in this PR?

* Added tests
* Fixed python docs
* Implemented `__str__` for PyExpr

# Are there any user-facing changes?

NO
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
