### PR TITLE
Add PSQL comparison tests for except, intersect

### DIFF
--- a/integration-tests/sqls/simple_except.sql
+++ b/integration-tests/sqls/simple_except.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT * FROM (
+    SELECT c2
+    FROM test t1
+    EXCEPT
+    SELECT c2
+    FROM test t2
+    WHERE c2 IN (3, 4)
+) s
+ORDER BY c2

--- a/integration-tests/sqls/simple_except_all.sql
+++ b/integration-tests/sqls/simple_except_all.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT * FROM (
+    SELECT c2
+    FROM test t1
+    EXCEPT ALL
+    SELECT c2
+    FROM test t2
+    WHERE c2 IN (3, 4)
+) s
+ORDER BY c2

--- a/integration-tests/sqls/simple_intersect.sql
+++ b/integration-tests/sqls/simple_intersect.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT * FROM (
+    SELECT c2
+    FROM test t1
+    INTERSECT
+    SELECT c2
+    FROM test t2
+    WHERE c2 IN (3, 4)
+) s
+ORDER BY c2

--- a/integration-tests/sqls/simple_intersect_all.sql
+++ b/integration-tests/sqls/simple_intersect_all.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT * FROM (
+    SELECT c2
+    FROM test t1
+    INTERSECT ALL
+    SELECT c2
+    FROM test t2
+    WHERE c2 IN (3, 4)
+) s
+ORDER BY c2

--- a/integration-tests/test_psql_parity.py
+++ b/integration-tests/test_psql_parity.py
@@ -77,7 +77,7 @@ test_files = set(root.glob("*.sql"))
 
 class TestPsqlParity:
     def test_tests_count(self):
-        assert len(test_files) == 16, "tests are missed"
+        assert len(test_files) == 20, "tests are missed"
 
     @pytest.mark.parametrize("fname", test_files)
     def test_sql_file(self, fname):


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1286.

Note: While testing this the build of `ballista-scheduler` failed multiple times, apparently due to https://github.com/rust-lang/rust/issues/84970 (incremental compilation flakiness). See https://github.com/mrob95/arrow-datafusion/runs/4200142294?check_suite_focus=true for an example. Adding `cargo clean -p ballista-scheduler` before `cargo build` fixed it.