### PR TITLE
#1268: allow datafusion-cli to toggle quiet flag within CLI

### DIFF
--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -37,6 +37,7 @@ pub enum Command {
     DescribeTable(String),
     ListFunctions,
     SearchFunctions(String),
+    QuietMode(bool),
 }
 
 impl Command {
@@ -64,6 +65,7 @@ impl Command {
                     .print_batches(&batches, now)
                     .map_err(|e| DataFusionError::Execution(e.to_string()))
             }
+            Self::QuietMode(_) => Ok(()),
             Self::Quit => Err(DataFusionError::Execution(
                 "Unexpected quit, this should be handled outside".into(),
             )),
@@ -89,17 +91,19 @@ impl Command {
             Self::Help => ("\\?", "help"),
             Self::ListFunctions => ("\\h", "function list"),
             Self::SearchFunctions(_) => ("\\h function", "search function"),
+            Self::QuietMode(_) => ("\\quiet", "set quiet mode"),
         }
     }
 }
 
-const ALL_COMMANDS: [Command; 6] = [
+const ALL_COMMANDS: [Command; 7] = [
     Command::ListTables,
     Command::DescribeTable(String::new()),
     Command::Quit,
     Command::Help,
     Command::ListFunctions,
     Command::SearchFunctions(String::new()),
+    Command::QuietMode(false),
 ];
 
 fn all_commands_info() -> RecordBatch {
@@ -137,6 +141,7 @@ impl FromStr for Command {
             ("?", None) => Self::Help,
             ("h", None) => Self::ListFunctions,
             ("h", Some(function)) => Self::SearchFunctions(function.into()),
+            ("quiet", Some(b)) => Self::QuietMode(b == "true"),
             _ => return Err(()),
         })
     }

--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -44,7 +44,7 @@ impl Command {
     pub async fn execute(
         &self,
         ctx: &mut Context,
-        print_options: &PrintOptions,
+        print_options: &mut PrintOptions,
     ) -> Result<()> {
         let now = Instant::now();
         match self {
@@ -65,7 +65,10 @@ impl Command {
                     .print_batches(&batches, now)
                     .map_err(|e| DataFusionError::Execution(e.to_string()))
             }
-            Self::QuietMode(_) => Ok(()),
+            Self::QuietMode(quiet) => {
+                print_options.quiet = *quiet;
+                Ok(())
+            }
             Self::Quit => Err(DataFusionError::Execution(
                 "Unexpected quit, this should be handled outside".into(),
             )),

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -84,6 +84,8 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
     rl.set_helper(Some(CliHelper::default()));
     rl.load_history(".history").ok();
 
+    let mut print_options = print_options.clone();
+
     loop {
         match rl.readline("❯ ") {
             Ok(line) if line.starts_with('\\') => {
@@ -91,8 +93,11 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
                 if let Ok(cmd) = &line[1..].parse::<Command>() {
                     match cmd {
                         Command::Quit => break,
+                        Command::QuietMode(quiet) => {
+                            print_options.quiet = *quiet;
+                        }
                         _ => {
-                            if let Err(e) = cmd.execute(ctx, print_options).await {
+                            if let Err(e) = cmd.execute(ctx, &print_options).await {
                                 eprintln!("{}", e)
                             }
                         }
@@ -103,7 +108,7 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
             }
             Ok(line) => {
                 rl.add_history_entry(line.trim_end());
-                match exec_and_print(ctx, print_options, line).await {
+                match exec_and_print(ctx, &print_options, line).await {
                     Ok(_) => {}
                     Err(err) => eprintln!("{:?}", err),
                 }

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -93,11 +93,8 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
                 if let Ok(cmd) = &line[1..].parse::<Command>() {
                     match cmd {
                         Command::Quit => break,
-                        Command::QuietMode(quiet) => {
-                            print_options.quiet = *quiet;
-                        }
                         _ => {
-                            if let Err(e) = cmd.execute(ctx, &print_options).await {
+                            if let Err(e) = cmd.execute(ctx, &mut print_options).await {
                                 eprintln!("{}", e)
                             }
                         }

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -72,3 +72,37 @@ The DataFusion CLI can also connect to a Ballista scheduler for query execution.
 ```bash
 datafusion-cli --host localhost --port 50050
 ```
+
+## Cli commands
+
+Available commands inside DataFusion CLI are:
+
+- Quit
+
+```bash
+> \q
+```
+
+- Help
+
+```bash
+> \?
+```
+
+- ListTables
+
+```bash
+> \d
+```
+
+- DescribeTable
+
+```bash
+> \d table_name
+```
+
+- QuietMode
+
+```
+> \quiet [true|false]
+```


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1268.

 # Rationale for this change
Allow to toggle quiet mode inside de datafusion-cli.

# What changes are included in this PR?
Adds a datafusion-cli command (QuietMode bool) to change the print_options quiet mode in runtime.

# Are there any user-facing changes?
A new command is introduced into the datafusion-cli repl.

Updated docs/source/user-guide/cli.md