### PR TITLE
Update release instructions

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -290,10 +290,11 @@ following commands
 If there is a ballista release, run
 
 ```shell
-(cd ballista/rust/client && cargo publish)
 (cd ballista/rust/core && cargo publish)
 (cd ballista/rust/executor && cargo publish)
 (cd ballista/rust/scheduler && cargo publish)
+(cd ballista/rust/client && cargo publish)
+(cd datafusion-cli && cargo publish)
 ```
 
 ### Publish on PyPI


### PR DESCRIPTION
Re https://github.com/apache/arrow-datafusion/issues/890

Tweaks while following https://github.com/apache/arrow-datafusion/issues/890#issuecomment-973198963 from @houqp 

1. Changed the order of publishing ballista crates to crates.io to be correct (`core` must be published first)
2. Add instructions for publishing `datafusion-cli`

