### PR TITLE
[WIP]Make scheduler prefer assign the task with same jobId to same executo…

### DIFF
--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -201,6 +201,7 @@ impl SchedulerGrpc for SchedulerServer {
                     error!("{}", msg);
                     tonic::Status::internal(msg)
                 })?;
+            let mut job_ids = vec![];
             for task_status in task_status {
                 self.state
                     .save_task_status(&task_status)
@@ -210,11 +211,12 @@ impl SchedulerGrpc for SchedulerServer {
                         error!("{}", msg);
                         tonic::Status::internal(msg)
                     })?;
+                job_ids.push(task_status.partition_id.as_ref().unwrap().job_id.clone());
             }
             let task: Result<Option<_>, Status> = if can_accept_task {
                 let plan = self
                     .state
-                    .assign_next_schedulable_task(&metadata.id)
+                    .assign_next_schedulable_task(&metadata.id, job_ids)
                     .await
                     .map_err(|e| {
                         let msg = format!("Error finding next assignable task: {}", e);


### PR DESCRIPTION
…r to improve locality

# Which issue does this PR close?
#1336 

 # Rationale for this change
``
plan1 -> shuffle wirte -> plan2
``
Make p1 and p2 run on the same executor may avoid sending intermediate results.
Describe the solution you'd like

# What changes are included in this PR?

1. executors need record which jobs have been run
2. executors ask tasks with prefer job id
3. If prefer job already done, need send back to executor and executor remove the record

Question 1:
if executor can not get prefer task ? will the task still hang there or request other Job

only a draft, look forward for your opinions? 😊😊😊 