### PR TITLE
Add dependencies to ballista example documentation

### DIFF
--- a/ballista/rust/client/README.md
+++ b/ballista/rust/client/README.md
@@ -80,6 +80,15 @@ RUST_LOG=info ballista-executor --bind-port 50052 -c 4
 Ballista provides a `BallistaContext` as a starting point for creating queries. DataFrames can be created
 by invoking the `read_csv`, `read_parquet`, and `sql` methods.
 
+To build a simple ballista example, add the following dependencies to your `Cargo.toml` file:
+
+```toml
+[dependencies]
+ballista = "0.6"
+datafusion = "6.0"
+tokio = "1.0"
+```
+
 The following example runs a simple aggregate SQL query against a CSV file from the
 [New York Taxi and Limousine Commission](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page)
 data set.
@@ -120,3 +129,5 @@ async fn main() -> Result<()> {
    Ok(())
 }
 ```
+
+More [examples](https://github.com/apache/arrow-datafusion/tree/master/ballista-examples) can be found in the arrow-datafusion repository.


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1340.

 # Rationale for this change
It includes Cargo.toml minimal dependencies needed for compile ballista example from documentation

# Are there any user-facing changes?
N/A