### PR TITLE
collect table stats by default for listing table

### DIFF
--- a/datafusion/src/datasource/listing/table.rs
+++ b/datafusion/src/datasource/listing/table.rs
@@ -304,6 +304,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_table_stats_by_default() -> Result<()> {
+        let testdata = crate::test_util::parquet_test_data();
+        let filename = format!("{}/{}", testdata, "alltypes_plain.parquet");
+        let opt = ListingOptions::new(Arc::new(ParquetFormat::default()));
+        let schema = opt
+            .infer_schema(Arc::new(LocalFileSystem {}), &filename)
+            .await?;
+        let table =
+            ListingTable::new(Arc::new(LocalFileSystem {}), filename, schema, opt);
+        let exec = table.scan(&None, 1024, &[], None).await?;
+        assert_eq!(exec.statistics().num_rows, Some(8));
+        assert_eq!(exec.statistics().total_byte_size, Some(671));
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn read_empty_table() -> Result<()> {
         let store = TestObjectStore::new_arc(&[("table/p1=v1/file.avro", 100)]);
 

--- a/datafusion/src/datasource/listing/table.rs
+++ b/datafusion/src/datasource/listing/table.rs
@@ -76,7 +76,7 @@ impl ListingOptions {
             file_extension: String::new(),
             format,
             table_partition_cols: vec![],
-            collect_stat: false,
+            collect_stat: true,
             target_partitions: 1,
         }
     }


### PR DESCRIPTION
# Rationale for this change

I noticed this when I bump datafusion to in roapi and one of our tests started to fail. Two reasons that I think changing to true might be better:

* For serious production use-cases, collecting stats should make a big different in performance for cases where it could help. It would be good to default to the more performant setup. Ignoring stats seems to be the less common use-case that we can ask users to manually specify it.
* Be backwards compatible.

@rdettai curious what's your thought on this.

I will add a test case to guard against regression if everyone agrees with the direction.

# What changes are included in this PR?

Default value for `collect_stat` changed to `true`.

# Are there any user-facing changes?

Yes, reverting back to the 5.x behavior.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
