### PR TITLE
avoid SNAPSHOT in version

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-benchmarks"
 description = "Apache Arrow Benchmarks"
-version = "4.0.0-SNAPSHOT"
+version = "5.0.0"
 edition = "2021"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-datafusion"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-examples"
 description = "DataFusion usage examples"
-version = "4.0.0-SNAPSHOT"
+version = "5.0.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -130,6 +130,11 @@ test_source_distribution() {
   cargo build
   cargo test --all
 
+  if ( find -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
+    echo "Cargo.toml version should not contain SNAPSHOT for releases"
+    exit 1
+  fi
+
   pushd datafusion
     cargo publish --dry-run
   popd


### PR DESCRIPTION


 # Rationale for this change

Addresses the issue identified by @Jimexist at https://github.com/Homebrew/homebrew-core/pull/89562#issuecomment-972500226

# What changes are included in this PR?

Remove SNAPSHOT from versions and add automation to catch it on releases.

# Are there any user-facing changes?

no
