### PR TITLE
chore: remove unused dependency in ballista-examples

### DIFF
--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -29,7 +29,6 @@ publish = false
 rust-version = "1.56"
 
 [dependencies]
-arrow-flight = { version = "6.2.0" }
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0"}
 prost = "0.8"


### PR DESCRIPTION

 # Rationale for this change

Found this while upgrading arrow flight for the arrow2 PR. arrow flight is not explicitly used in ballista example

# What changes are included in this PR?

Remove unused dependency
