### PR TITLE
Metadata is kept in projections for non-derived columns

### DIFF
--- a/datafusion/src/test_util.rs
+++ b/datafusion/src/test_util.rs
@@ -18,6 +18,7 @@
 //! Utility functions to make testing DataFusion based crates easier
 
 use std::{env, error::Error, path::PathBuf, sync::Arc};
+use std::collections::BTreeMap;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 
@@ -229,8 +230,10 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
 
 /// Get the schema for the aggregate_test_* csv files
 pub fn aggr_test_schema() -> SchemaRef {
-    Arc::new(Schema::new(vec![
-        Field::new("c1", DataType::Utf8, false),
+    let mut f1 = Field::new("c1", DataType::Utf8, false);
+    f1.set_metadata(Some(BTreeMap::from_iter(vec![("testing".into(), "test".into())].into_iter())));
+    let schema = Schema::new(vec![
+        f1,
         Field::new("c2", DataType::UInt32, false),
         Field::new("c3", DataType::Int8, false),
         Field::new("c4", DataType::Int16, false),
@@ -243,7 +246,9 @@ pub fn aggr_test_schema() -> SchemaRef {
         Field::new("c11", DataType::Float32, false),
         Field::new("c12", DataType::Float64, false),
         Field::new("c13", DataType::Utf8, false),
-    ]))
+    ]);
+
+    Arc::new(schema)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1361 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

I believe this will carry over the metadata in columns by checking for the column in the schema first and if it doesn't exist using the previous logic of re-constructing the field.

# Are there any user-facing changes?
Column metadata will persist in projections

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
