### PR TITLE
(NOT FOR MERGING) Demonstrate tests passing when `validate_full` is called

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ exclude = ["python"]
 [profile.release]
 lto = true
 codegen-units = 1
+
+
+[patch.crates-io]
+arrow = { git = "https://github.com/alamb/arrow-rs.git", branch = "alamb/full_array_data_construction_validation_df" }
+parquet = { git = "https://github.com/alamb/arrow-rs.git", branch = "alamb/full_array_data_construction_validation_df" }


### PR DESCRIPTION
This is a PR that demonstrates that the validation code in https://github.com/apache/arrow-rs/pull/921 passes the `datafusion` tests pass (using https://github.com/alamb/arrow-rs/tree/alamb/full_array_data_construction_validation_df which has the changes in from https://github.com/apache/arrow-rs/pull/921 cherry-picked to `active_release`)
