### PR TITLE
Make cli handle multiple whitespaces

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -90,7 +90,8 @@ pub async fn exec_from_repl(ctx: &mut Context, print_options: &PrintOptions) {
         match rl.readline("❯ ") {
             Ok(line) if line.starts_with('\\') => {
                 rl.add_history_entry(line.trim_end());
-                if let Ok(cmd) = &line[1..].parse::<Command>() {
+                let command = line.split_whitespace().collect::<Vec<_>>().join(" ");
+                if let Ok(cmd) = &command[1..].parse::<Command>() {
                     match cmd {
                         Command::Quit => break,
                         _ => {


### PR DESCRIPTION
# Which issue does this PR close?
The cli cannot handle whitespace like
```
❯ \?
'\? ' is not a valid command
❯ \quiet true
'\quiet true ' is not a valid command
```
The PR fixes this issue by removing the consecutive whitespaces.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
