### PR TITLE
Fix index out of bounds for stats on nested fields

### DIFF
--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -124,7 +124,7 @@ impl FileFormat for ParquetFormat {
 fn summarize_min_max(
     max_values: &mut Vec<Option<MaxAccumulator>>,
     min_values: &mut Vec<Option<MinAccumulator>>,
-    fields: &Vec<&Field>,
+    fields: &Vec<Field>,
     i: usize,
     stat: &ParquetStatistics,
 ) {
@@ -279,9 +279,6 @@ fn fetch_statistics(object_reader: Arc<dyn ObjectReader>) -> Result<Statistics> 
             .columns()
             .iter()
             .flat_map(|c| c.statistics().map(|stats| stats.null_count()));
-
-        let cols_vec: Vec<u64> = columns_null_counts.clone().collect();
-        let cols_vec_num = cols_vec.len();
 
         for (i, cnt) in columns_null_counts.enumerate() {
             null_counts[i] += cnt as usize


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1383

 # Rationale for this change

This is a step in supporting nested fields in data fusion being read from parquet in 

# What changes are included in this PR?

This adds a helper method to get the flattened schema. This is similar to how the columns are stored in the parquet metadata section.

# Are there any user-facing changes?

No.
