### PR TITLE
Minimize features

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -30,7 +30,7 @@ build = "build.rs"
 simd = ["datafusion/simd"]
 
 [dependencies]
-ahash = "0.7"
+ahash = { version = "0.7", default-features = false }
 async-trait = "0.1.36"
 futures = "0.3"
 hashbrown = "0.11"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -41,7 +41,7 @@ sqlparser = "0.13"
 tokio = "1.0"
 tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 
 arrow-flight = { version = "6.4.0"  }
 

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -57,7 +57,7 @@ parquet = { version = "6.4.0", features = ["arrow"] }
 sqlparser = "0.13"
 paste = "^1.0"
 num_cpus = "1.13.0"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.7"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -50,7 +50,7 @@ force_hash_collisions = []
 avro = ["avro-rs", "num-traits"]
 
 [dependencies]
-ahash = "0.7"
+ahash = { version = "0.7", default-features = false }
 hashbrown = { version = "0.11", features = ["raw"] }
 arrow = { version = "6.4.0", features = ["prettyprint"] }
 parquet = { version = "6.4.0", features = ["arrow"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1398.

 # Rationale for this change

Give projects depending on datafusion more choice in what features to enable.

# What changes are included in this PR?

Disabling default features for chrono and ahash in datafusion and ballista.

# Are there any user-facing changes?

If projects depending on datafusion/ballista are making use of the coincidence that they turn on chrono or ahash features, this might mean they have to turn on the features themselves, but that would be a bug in that project's use of the crates.

