### PR TITLE
Transfer right join to left join

### DIFF
--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -38,7 +38,7 @@ pub enum JoinType {
     Inner,
     /// Left Join
     Left,
-    /// Right Join
+    /// Right Join: will be transferred to Left Join
     Right,
     /// Full Join
     Full,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This ticket transfers `Right Join` to `Left Join`. This will facilitate logic optimization, including predicate push-down, join order exchange, and some future optimization, with one less processing case, and our code logic will also be simplified.

BTW, postgres also did the thing.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
