### PR TITLE
Ordering by index in select expression

### DIFF
--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -33,7 +33,6 @@ use crate::logical_plan::{
     DFSchemaRef, DropTable, Expr, LogicalPlan, LogicalPlanBuilder, Operator, PlanType,
     ToDFSchema, ToStringifiedPlan,
 };
-
 use crate::optimizer::utils::exprlist_to_columns;
 use crate::prelude::JoinType;
 use crate::scalar::ScalarValue;
@@ -655,7 +654,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 return Err(DataFusionError::NotImplemented(format!(
                     "Unsupported ast node {:?} in create_relation",
                     relation
-                )))
+                )));
             }
         };
         if let Some(alias) = alias {
@@ -1026,14 +1025,44 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     /// convert sql OrderByExpr to Expr::Sort
     fn order_by_to_sort_expr(&self, e: &OrderByExpr, schema: &DFSchema) -> Result<Expr> {
+        let OrderByExpr {
+            asc,
+            expr,
+            nulls_first,
+        } = e;
+
+        let expr = match &expr {
+            SQLExpr::Value(Value::Number(v, _)) => {
+                let field_index = v
+                    .parse::<usize>()
+                    .map_err(|err| DataFusionError::Plan(err.to_string()))?;
+
+                if field_index == 0 {
+                    return Err(DataFusionError::Plan(format!(
+                        "Order by index starts at 1 for column indexes"
+                    )));
+                } else if schema.fields().len() < field_index {
+                    return Err(DataFusionError::Plan(format!(
+                        "Order by column out of bounds, specified: {}, max: {}",
+                        field_index,
+                        schema.fields().len()
+                    )));
+                }
+
+                let field = schema.field(field_index - 1);
+                let col_ident = SQLExpr::Identifier(Ident::new(field.qualified_name()));
+                self.sql_expr_to_logical_expr(&col_ident, schema)?
+            }
+            e => self.sql_expr_to_logical_expr(e, schema)?,
+        };
         Ok({
-            let asc = e.asc.unwrap_or(true);
+            let asc = asc.unwrap_or(true);
             Expr::Sort {
-                expr: Box::new(self.sql_expr_to_logical_expr(&e.expr, schema)?),
+                expr: Box::new(expr),
                 asc,
                 // when asc is true, by default nulls last to be consistent with postgres
                 // postgres rule: https://www.postgresql.org/docs/current/queries-order.html
-                nulls_first: e.nulls_first.unwrap_or(!asc),
+                nulls_first: nulls_first.unwrap_or(!asc),
             }
         })
     }
@@ -1192,14 +1221,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 match expr {
                     // optimization: if it's a number literal, we apply the negative operator
                     // here directly to calculate the new literal.
-                    SQLExpr::Value(Value::Number(n,_)) => match n.parse::<i64>() {
+                    SQLExpr::Value(Value::Number(n, _)) => match n.parse::<i64>() {
                         Ok(n) => Ok(lit(-n)),
                         Err(_) => Ok(lit(-n
                             .parse::<f64>()
                             .map_err(|_e| {
                                 DataFusionError::Internal(format!(
                                     "negative operator can be only applied to integer and float operands, got: {}",
-                                n))
+                                    n))
                             })?)),
                     },
                     // not a literal, apply negative operator on expression
@@ -1511,7 +1540,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             } else {
                                 Ok(window_frame)
                             }
-
                         })
                         .transpose()?;
                     let fun = window_functions::WindowFunction::from_str(&name)?;
@@ -1540,7 +1568,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                 fun: window_functions::WindowFunction::BuiltInWindowFunction(
                                     window_fun,
                                 ),
-                                args:self.function_args_to_expr(function, schema)?,
+                                args: self.function_args_to_expr(function, schema)?,
                                 partition_by,
                                 order_by,
                                 window_frame,
@@ -1685,7 +1713,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return Err(DataFusionError::SQL(ParserError(format!(
                         "Unsupported Interval Expression with value {:?}",
                         value
-                    ))))
+                    ))));
                 }
             };
 
@@ -2005,11 +2033,13 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use functions::ScalarFunctionImplementation;
+
     use crate::datasource::empty::EmptyTable;
     use crate::physical_plan::functions::Volatility;
     use crate::{logical_plan::create_udf, sql::parser::DFParser};
-    use functions::ScalarFunctionImplementation;
+
+    use super::*;
 
     #[test]
     fn select_no_relation() {
@@ -2786,6 +2816,7 @@ mod tests {
              \n    TableScan: person projection=None",
         )
     }
+
     #[test]
     fn select_simple_aggregate_with_groupby_non_column_expression_unselected() {
         quick_test(
@@ -2957,6 +2988,36 @@ mod tests {
             \n  Filter: #aggregate_test_100.c3 > Float64(0.1) AND #aggregate_test_100.c4 > Int64(0)\
             \n    TableScan: aggregate_test_100 projection=None";
         quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_order_by_index() {
+        let sql = "SELECT id FROM person ORDER BY 1";
+        let expected = "Sort: #person.id ASC NULLS LAST\
+                        \n  Projection: #person.id\
+                        \n    TableScan: person projection=None";
+
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_order_by_index_of_0() {
+        let sql = "SELECT id FROM person ORDER BY 0";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert_eq!(
+            "Plan(\"Order by index starts at 1 for column indexes\")",
+            format!("{:?}", err)
+        );
+    }
+
+    #[test]
+    fn select_order_by_index_oob() {
+        let sql = "SELECT id FROM person ORDER BY 2";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert_eq!(
+            "Plan(\"Order by column out of bounds, specified: 2, max: 1\")",
+            format!("{:?}", err)
+        );
     }
 
     #[test]

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1038,9 +1038,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     .map_err(|err| DataFusionError::Plan(err.to_string()))?;
 
                 if field_index == 0 {
-                    return Err(DataFusionError::Plan(format!(
-                        "Order by index starts at 1 for column indexes"
-                    )));
+                    return Err(DataFusionError::Plan(
+                        "Order by index starts at 1 for column indexes".to_string(),
+                    ));
                 } else if schema.fields().len() < field_index {
                     return Err(DataFusionError::Plan(format!(
                         "Order by column out of bounds, specified: {}, max: {}",

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -3001,6 +3001,16 @@ mod tests {
     }
 
     #[test]
+    fn select_order_by_multiple_index() {
+        let sql = "SELECT id, state, age FROM person ORDER BY 1, 3";
+        let expected = "Sort: #person.id ASC NULLS LAST, #person.age ASC NULLS LAST\
+                        \n  Projection: #person.id, #person.state, #person.age\
+                        \n    TableScan: person projection=None";
+
+        quick_test(sql, expected);
+    }
+
+    #[test]
     fn select_order_by_index_of_0() {
         let sql = "SELECT id FROM person ORDER BY 0";
         let err = logical_plan(sql).expect_err("query should have failed");


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1414 

 # Rationale for this change
You couldn't do this before, but now you can.

# What changes are included in this PR?

You can now order by the index of columns in a select statement. Sorry about the small formatting change, `cargo fmt` took over a bit there.

# Are there any user-facing changes?
New functionality for ordering by index

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
