### PR TITLE
[Minor] Fix `send_time` metric for hash-repartition

### DIFF
--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -364,7 +364,7 @@ impl RepartitionExec {
                             RecordBatch::try_new(input_batch.schema(), columns);
                         timer.done();
 
-                        let timer = r_metrics.repart_time.timer();
+                        let timer = r_metrics.send_time.timer();
                         // if there is still a receiver, send to it
                         if let Some(tx) = txs.get_mut(&num_output_partition) {
                             if tx.send(Some(output_batch)).is_err() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

n/a.


 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Improves/fixes output of hash repartition metric.

Before:

```
send_time{inputPartition=0}=NOT RECORDED
```

After:

```
send_time{inputPartition=0}=210.326µs,
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
