### PR TITLE
Fix the duplicate short options in tpch

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -90,7 +90,7 @@ struct BallistaBenchmarkOpt {
     // #[structopt(short = "m", long = "mem-table")]
     // mem_table: bool,
     /// Number of partitions to process in parallel
-    #[structopt(short = "p", long = "partitions", default_value = "2")]
+    #[structopt(short = "n", long = "partitions", default_value = "2")]
     partitions: usize,
 
     /// Ballista executor host
@@ -117,7 +117,7 @@ struct DataFusionBenchmarkOpt {
     iterations: usize,
 
     /// Number of partitions to process in parallel
-    #[structopt(short = "p", long = "partitions", default_value = "2")]
+    #[structopt(short = "n", long = "partitions", default_value = "2")]
     partitions: usize,
 
     /// Batch size when reading CSV or Parquet files
@@ -156,7 +156,7 @@ struct ConvertOpt {
     compression: String,
 
     /// Number of partitions to produce
-    #[structopt(short = "p", long = "partitions", default_value = "1")]
+    #[structopt(short = "n", long = "partitions", default_value = "1")]
     partitions: usize,
 
     /// Batch size when reading CSV or Parquet files


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1409 .

 # Rationale for this change

The crash of command `cargo run --bin  tpch` is caused by the duplicate short names of option `path` and `partitions`.
It seems that the short name of `partitions` is updated from `n` to `p` in the [PR-706](https://github.com/apache/arrow-datafusion/commit/405171cd6a8ac65f5f9532f0c8138c11df6cb9d2#diff-7b244e2b92899e92774d072a5c26b1e5daafec998316050726b3344c667b1aa0).
There is an associating [issue-500](https://github.com/TeXitoi/structopt/issues/500) of `structopt`.

# What changes are included in this PR?

Reverts the short name of `partitions` from `p` to `n`. 

# Are there any user-facing changes?

Seems no.