### PR TITLE
Clarify communication on bi-weekly sync

### DIFF
--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -52,13 +52,14 @@ server ([invite link](https://discord.gg/Qw5gKqHxUM)) in case you are not able
 to join the Slack workspace. If you need an invite to the Slack workspace, you
 can also ask for one in our Discord server.
 
-### Sync up Zoom calls
+### Sync up video calls
 
-We have biweekly sync calls every other Thursdays at 04:00 UTC and 16:00 UTC
-(starting September 30, 2021) which are held if there are agenda items to discuss
+We have biweekly sync calls every other Thursdays at both 04:00 UTC
+and 16:00 UTC (starting September 30, 2021) depending on if there are
+items on the agenda to discuss and someone being willing to host.
 
 Please see the [agenda](https://docs.google.com/document/d/1atCVnoff5SR4eM4Lwf2M1BBJTY6g3_HUNR6qswYJW_U/edit)
-to learn about what others plan to discuss and topics for future discussion.
+for the video call link, add topics and to see what others plan to discuss.
 
 The goals of these calls are:
 

--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -54,11 +54,11 @@ can also ask for one in our Discord server.
 
 ### Sync up Zoom calls
 
-We have biweekly sync calls every other Thursdays at 16:00 UTC
-(starting September 30, 2021) on Zoom [Meeting Link](https://influxdata.zoom.us/j/94666921249)
+We have biweekly sync calls every other Thursdays at 04:00 UTC and 16:00 UTC
+(starting September 30, 2021) which are held if there are agenda items to discuss
 
-The[agenda](https://docs.google.com/document/d/1atCVnoff5SR4eM4Lwf2M1BBJTY6g3_HUNR6qswYJW_U/edit)
-is available if you would like to add a topic for discussion or see what is planned.
+Please see the [agenda](https://docs.google.com/document/d/1atCVnoff5SR4eM4Lwf2M1BBJTY6g3_HUNR6qswYJW_U/edit)
+to learn about what others plan to discuss and topics for future discussion.
 
 The goals of these calls are:
 


### PR DESCRIPTION
There was a bit of an issue with the zoom link today for the sync call -- by updating the shared agenda it was disseminated, but I want to make that easier to do in the future, with less confusion

Thus, remove the explicit zoom link and instead leave it in the agenda item