### PR TITLE
Fixes for working with functions in dataframes, additional documentation

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1624,8 +1624,6 @@ unary_scalar_expr!(Ln, ln);
 scalar_expr!(Ascii, ascii, string);
 scalar_expr!(BitLength, bit_length, string);
 nary_scalar_expr!(Btrim, btrim);
-// scalar_expr!(Btrim, btrim, string);
-// scalar_expr!(Btrim, btrim_chars, string, characters);
 scalar_expr!(CharacterLength, character_length, string);
 scalar_expr!(CharacterLength, length, string);
 scalar_expr!(Chr, chr, string);

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1564,7 +1564,7 @@ pub fn approx_distinct(expr: Expr) -> Expr {
 /// Create an convenience function representing a unary scalar function
 macro_rules! unary_scalar_expr {
     ($ENUM:ident, $FUNC:ident) => {
-        #[doc = "this scalar function is not documented yet"]
+        #[doc = concat!("Unary scalar function definition for ", stringify!($FUNC) ) ]
         pub fn $FUNC(e: Expr) -> Expr {
             Expr::ScalarFunction {
                 fun: functions::BuiltinScalarFunction::$ENUM,
@@ -1574,17 +1574,28 @@ macro_rules! unary_scalar_expr {
     };
 }
 
-/// Create an convenience function representing a binary scalar function
-macro_rules! binary_scalar_expr {
-    ($ENUM:ident, $FUNC:ident) => {
-        #[doc = "this scalar function is not documented yet"]
-        pub fn $FUNC(arg1: Expr, arg2: Expr) -> Expr {
+macro_rules! scalar_expr {
+    ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
+        #[doc = concat!("Scalar function definition for ", stringify!($FUNC) ) ]
+        pub fn $FUNC($($arg: Expr),*) -> Expr {            
             Expr::ScalarFunction {
                 fun: functions::BuiltinScalarFunction::$ENUM,
-                args: vec![arg1, arg2],
+                args: vec![$($arg),*],
             }
         }
-    };
+    };  
+}
+
+macro_rules! nary_scalar_expr {
+    ($ENUM:ident, $FUNC:ident) => {
+        #[doc = concat!("Scalar function definition for ", stringify!($FUNC) ) ]
+        pub fn $FUNC(args: Vec<Expr>) -> Expr {            
+            Expr::ScalarFunction {
+                fun: functions::BuiltinScalarFunction::$ENUM,
+                args: args,
+            }
+        }
+    };  
 }
 
 // generate methods for creating the supported unary/binary expressions
@@ -1610,44 +1621,46 @@ unary_scalar_expr!(Log10, log10);
 unary_scalar_expr!(Ln, ln);
 
 // string functions
-unary_scalar_expr!(Ascii, ascii);
-unary_scalar_expr!(BitLength, bit_length);
-unary_scalar_expr!(Btrim, btrim);
-unary_scalar_expr!(CharacterLength, character_length);
-unary_scalar_expr!(CharacterLength, length);
-unary_scalar_expr!(Chr, chr);
-unary_scalar_expr!(InitCap, initcap);
-unary_scalar_expr!(Left, left);
-unary_scalar_expr!(Lower, lower);
-unary_scalar_expr!(Lpad, lpad);
-unary_scalar_expr!(Ltrim, ltrim);
-unary_scalar_expr!(MD5, md5);
-unary_scalar_expr!(OctetLength, octet_length);
-unary_scalar_expr!(RegexpMatch, regexp_match);
-unary_scalar_expr!(RegexpReplace, regexp_replace);
-unary_scalar_expr!(Replace, replace);
-unary_scalar_expr!(Repeat, repeat);
-unary_scalar_expr!(Reverse, reverse);
-unary_scalar_expr!(Right, right);
-unary_scalar_expr!(Rpad, rpad);
-unary_scalar_expr!(Rtrim, rtrim);
-unary_scalar_expr!(SHA224, sha224);
-unary_scalar_expr!(SHA256, sha256);
-unary_scalar_expr!(SHA384, sha384);
-unary_scalar_expr!(SHA512, sha512);
-unary_scalar_expr!(SplitPart, split_part);
-unary_scalar_expr!(StartsWith, starts_with);
-unary_scalar_expr!(Strpos, strpos);
-unary_scalar_expr!(Substr, substr);
-unary_scalar_expr!(ToHex, to_hex);
-unary_scalar_expr!(Translate, translate);
-unary_scalar_expr!(Trim, trim);
-unary_scalar_expr!(Upper, upper);
+scalar_expr!(Ascii, ascii, string);
+scalar_expr!(BitLength, bit_length, string);
+nary_scalar_expr!(Btrim, btrim);
+// scalar_expr!(Btrim, btrim, string);
+// scalar_expr!(Btrim, btrim_chars, string, characters);
+scalar_expr!(CharacterLength, character_length, string);
+scalar_expr!(CharacterLength, length, string);
+scalar_expr!(Chr, chr, string);
+scalar_expr!(Digest, digest, string, algorithm);
+scalar_expr!(InitCap, initcap, string);
+scalar_expr!(Left, left, string, count);
+scalar_expr!(Lower, lower, string);
+nary_scalar_expr!(Lpad, lpad);
+scalar_expr!(Ltrim, ltrim, string);
+scalar_expr!(MD5, md5, string);
+scalar_expr!(OctetLength, octet_length, string);
+nary_scalar_expr!(RegexpMatch, regexp_match);
+nary_scalar_expr!(RegexpReplace, regexp_replace);
+scalar_expr!(Replace, replace, string, from, to);
+scalar_expr!(Repeat, repeat, string, count);
+scalar_expr!(Reverse, reverse, string);
+scalar_expr!(Right, right, string, count);
+nary_scalar_expr!(Rpad, rpad);
+scalar_expr!(Rtrim, rtrim, string);
+scalar_expr!(SHA224, sha224, string);
+scalar_expr!(SHA256, sha256, string);
+scalar_expr!(SHA384, sha384, string);
+scalar_expr!(SHA512, sha512, string);
+scalar_expr!(SplitPart, split_part, expr, delimiter, index);
+scalar_expr!(StartsWith, starts_with, string, characters);
+scalar_expr!(Strpos, strpos, string, substring);
+scalar_expr!(Substr, substr, string, position);
+scalar_expr!(ToHex, to_hex, string);
+scalar_expr!(Translate, translate, string, from, to);
+scalar_expr!(Trim, trim, string);
+scalar_expr!(Upper, upper, string);
 
 // date functions
-binary_scalar_expr!(DatePart, date_part);
-binary_scalar_expr!(DateTrunc, date_trunc);
-binary_scalar_expr!(Digest, digest);
+scalar_expr!(DatePart, date_part, part, date);
+scalar_expr!(DateTrunc, date_trunc, part, date);
 
 /// returns an array of fixed size with each argument on it.
 pub fn array(args: Vec<Expr>) -> Expr {
@@ -2217,6 +2230,44 @@ mod tests {
         }};
     }
 
+    macro_rules! test_scalar_expr {
+        ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
+            let expected = vec![$(stringify!($arg)),*];            
+            let result = $FUNC(
+                $(
+                    col(stringify!($arg.to_string()))
+                ),*    
+            );
+            if let Expr::ScalarFunction { fun, args } = result {
+                let name = functions::BuiltinScalarFunction::$ENUM;
+                assert_eq!(name, fun);
+                assert_eq!(expected.len(), args.len());
+            } else {
+                assert!(false, "unexpected");
+            }               
+        };  
+    }    
+
+    macro_rules! test_nary_scalar_expr {
+        ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
+            let expected = vec![$(stringify!($arg)),*]; 
+            let result = $FUNC(
+                vec![
+                    $(
+                        col(stringify!($arg.to_string()))
+                    ),*    
+                ]
+            );
+            if let Expr::ScalarFunction { fun, args } = result {
+                let name = functions::BuiltinScalarFunction::$ENUM;
+                assert_eq!(name, fun);
+                assert_eq!(expected.len(), args.len());
+            } else {
+                assert!(false, "unexpected");
+            }               
+        };  
+    }    
+
     #[test]
     fn digest_function_definitions() {
         if let Expr::ScalarFunction { fun, args } = digest(col("tableA.a"), lit("md5")) {
@@ -2248,39 +2299,49 @@ mod tests {
         test_unary_scalar_expr!(Log2, log2);
         test_unary_scalar_expr!(Log10, log10);
         test_unary_scalar_expr!(Ln, ln);
-        test_unary_scalar_expr!(Ascii, ascii);
-        test_unary_scalar_expr!(BitLength, bit_length);
-        test_unary_scalar_expr!(Btrim, btrim);
-        test_unary_scalar_expr!(CharacterLength, character_length);
-        test_unary_scalar_expr!(CharacterLength, length);
-        test_unary_scalar_expr!(Chr, chr);
-        test_unary_scalar_expr!(InitCap, initcap);
-        test_unary_scalar_expr!(Left, left);
-        test_unary_scalar_expr!(Lower, lower);
-        test_unary_scalar_expr!(Lpad, lpad);
-        test_unary_scalar_expr!(Ltrim, ltrim);
-        test_unary_scalar_expr!(MD5, md5);
-        test_unary_scalar_expr!(OctetLength, octet_length);
-        test_unary_scalar_expr!(RegexpMatch, regexp_match);
-        test_unary_scalar_expr!(RegexpReplace, regexp_replace);
-        test_unary_scalar_expr!(Replace, replace);
-        test_unary_scalar_expr!(Repeat, repeat);
-        test_unary_scalar_expr!(Reverse, reverse);
-        test_unary_scalar_expr!(Right, right);
-        test_unary_scalar_expr!(Rpad, rpad);
-        test_unary_scalar_expr!(Rtrim, rtrim);
-        test_unary_scalar_expr!(SHA224, sha224);
-        test_unary_scalar_expr!(SHA256, sha256);
-        test_unary_scalar_expr!(SHA384, sha384);
-        test_unary_scalar_expr!(SHA512, sha512);
-        test_unary_scalar_expr!(SplitPart, split_part);
-        test_unary_scalar_expr!(StartsWith, starts_with);
-        test_unary_scalar_expr!(Strpos, strpos);
-        test_unary_scalar_expr!(Substr, substr);
-        test_unary_scalar_expr!(ToHex, to_hex);
-        test_unary_scalar_expr!(Translate, translate);
-        test_unary_scalar_expr!(Trim, trim);
-        test_unary_scalar_expr!(Upper, upper);
+
+        test_scalar_expr!(Ascii, ascii, input);
+        test_scalar_expr!(BitLength, bit_length, string);
+        test_nary_scalar_expr!(Btrim, btrim, string);
+        test_nary_scalar_expr!(Btrim, btrim, string, characters);
+        test_scalar_expr!(CharacterLength, character_length, string);
+        test_scalar_expr!(CharacterLength, length, string);
+        test_scalar_expr!(Chr, chr, string);
+        test_scalar_expr!(Digest, digest, string, algorithm);
+        test_scalar_expr!(InitCap, initcap, string);
+        test_scalar_expr!(Left, left, string, count);
+        test_scalar_expr!(Lower, lower, string);
+        test_nary_scalar_expr!(Lpad, lpad, string, count);
+        test_nary_scalar_expr!(Lpad, lpad, string, count, characters);
+        test_scalar_expr!(Ltrim, ltrim, string);
+        test_scalar_expr!(MD5, md5, string);
+        test_scalar_expr!(OctetLength, octet_length, string);
+        test_nary_scalar_expr!(RegexpMatch, regexp_match, string, pattern);
+        test_nary_scalar_expr!(RegexpMatch, regexp_match, string, pattern, flags);
+        test_nary_scalar_expr!(RegexpReplace, regexp_replace, string, pattern, replacement);
+        test_nary_scalar_expr!(RegexpReplace, regexp_replace, string, pattern, replacement, flags);
+        test_scalar_expr!(Replace, replace, string, from, to);
+        test_scalar_expr!(Repeat, repeat, string, count);
+        test_scalar_expr!(Reverse, reverse, string);
+        test_scalar_expr!(Right, right, string, count);
+        test_nary_scalar_expr!(Rpad, rpad, string, count);
+        test_nary_scalar_expr!(Rpad, rpad, string, count, characters);
+        test_scalar_expr!(Rtrim, rtrim, string);
+        test_scalar_expr!(SHA224, sha224, string);
+        test_scalar_expr!(SHA256, sha256, string);
+        test_scalar_expr!(SHA384, sha384, string);
+        test_scalar_expr!(SHA512, sha512, string);
+        test_scalar_expr!(SplitPart, split_part, expr, delimiter, index);
+        test_scalar_expr!(StartsWith, starts_with, string, characters);
+        test_scalar_expr!(Strpos, strpos, string, substring);
+        test_scalar_expr!(Substr, substr, string, position);
+        test_scalar_expr!(ToHex, to_hex, string);
+        test_scalar_expr!(Translate, translate, string, from, to);
+        test_scalar_expr!(Trim, trim, string);
+        test_scalar_expr!(Upper, upper, string);
+
+        test_scalar_expr!(DatePart, date_part, part, date);
+        test_scalar_expr!(DateTrunc, date_trunc, part, date);
     }
 
     #[test]

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -2263,7 +2263,7 @@ mod tests {
                 assert_eq!(name, fun);
                 assert_eq!(expected.len(), args.len());
             } else {
-                assert!(false, "unexpected");
+                assert!(false, "unexpected: {:?}", result);
             }               
         };  
     }    

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -2243,7 +2243,7 @@ mod tests {
                 assert_eq!(name, fun);
                 assert_eq!(expected.len(), args.len());
             } else {
-                assert!(false, "unexpected");
+                assert!(false, "unexpected: {:?}", result);
             }               
         };  
     }    

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1592,10 +1592,10 @@ macro_rules! nary_scalar_expr {
         pub fn $FUNC(args: Vec<Expr>) -> Expr {            
             Expr::ScalarFunction {
                 fun: functions::BuiltinScalarFunction::$ENUM,
-                args: args,
+                args,
             }
         }
-    };  
+    };    
 }
 
 // generate methods for creating the supported unary/binary expressions

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -1577,25 +1577,25 @@ macro_rules! unary_scalar_expr {
 macro_rules! scalar_expr {
     ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
         #[doc = concat!("Scalar function definition for ", stringify!($FUNC) ) ]
-        pub fn $FUNC($($arg: Expr),*) -> Expr {            
+        pub fn $FUNC($($arg: Expr),*) -> Expr {
             Expr::ScalarFunction {
                 fun: functions::BuiltinScalarFunction::$ENUM,
                 args: vec![$($arg),*],
             }
         }
-    };  
+    };
 }
 
 macro_rules! nary_scalar_expr {
     ($ENUM:ident, $FUNC:ident) => {
         #[doc = concat!("Scalar function definition for ", stringify!($FUNC) ) ]
-        pub fn $FUNC(args: Vec<Expr>) -> Expr {            
+        pub fn $FUNC(args: Vec<Expr>) -> Expr {
             Expr::ScalarFunction {
                 fun: functions::BuiltinScalarFunction::$ENUM,
                 args,
             }
         }
-    };    
+    };
 }
 
 // generate methods for creating the supported unary/binary expressions
@@ -2230,11 +2230,11 @@ mod tests {
 
     macro_rules! test_scalar_expr {
         ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
-            let expected = vec![$(stringify!($arg)),*];            
+            let expected = vec![$(stringify!($arg)),*];
             let result = $FUNC(
                 $(
                     col(stringify!($arg.to_string()))
-                ),*    
+                ),*
             );
             if let Expr::ScalarFunction { fun, args } = result {
                 let name = functions::BuiltinScalarFunction::$ENUM;
@@ -2242,18 +2242,18 @@ mod tests {
                 assert_eq!(expected.len(), args.len());
             } else {
                 assert!(false, "unexpected: {:?}", result);
-            }               
-        };  
-    }    
+            }
+        };
+    }
 
     macro_rules! test_nary_scalar_expr {
         ($ENUM:ident, $FUNC:ident, $($arg:ident),*) => {
-            let expected = vec![$(stringify!($arg)),*]; 
+            let expected = vec![$(stringify!($arg)),*];
             let result = $FUNC(
                 vec![
                     $(
                         col(stringify!($arg.to_string()))
-                    ),*    
+                    ),*
                 ]
             );
             if let Expr::ScalarFunction { fun, args } = result {
@@ -2262,9 +2262,9 @@ mod tests {
                 assert_eq!(expected.len(), args.len());
             } else {
                 assert!(false, "unexpected: {:?}", result);
-            }               
-        };  
-    }    
+            }
+        };
+    }
 
     #[test]
     fn digest_function_definitions() {
@@ -2316,8 +2316,21 @@ mod tests {
         test_scalar_expr!(OctetLength, octet_length, string);
         test_nary_scalar_expr!(RegexpMatch, regexp_match, string, pattern);
         test_nary_scalar_expr!(RegexpMatch, regexp_match, string, pattern, flags);
-        test_nary_scalar_expr!(RegexpReplace, regexp_replace, string, pattern, replacement);
-        test_nary_scalar_expr!(RegexpReplace, regexp_replace, string, pattern, replacement, flags);
+        test_nary_scalar_expr!(
+            RegexpReplace,
+            regexp_replace,
+            string,
+            pattern,
+            replacement
+        );
+        test_nary_scalar_expr!(
+            RegexpReplace,
+            regexp_replace,
+            string,
+            pattern,
+            replacement,
+            flags
+        );
         test_scalar_expr!(Replace, replace, string, from, to);
         test_scalar_expr!(Repeat, repeat, string, count);
         test_scalar_expr!(Reverse, reverse, string);

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -2575,6 +2575,19 @@ mod tests {
             Int32,
             Int32Array
         );
+        // #[cfg(feature = "regex_expressions")]
+        // test_function!(
+        //     RegexpMatch,
+        //     &[
+        //         lit(ScalarValue::Utf8(Some("abc".to_string()))),
+        //         lit(ScalarValue::Utf8(Some("a..".to_string()))),
+        //         lit(ScalarValue::Utf8(Some("g".to_string()))),
+        //     ],
+        //     Ok(Some("abc")),
+        //     &str,
+        //     Utf8,
+        //     StringArray
+        // );        
         #[cfg(feature = "regex_expressions")]
         test_function!(
             RegexpReplace,

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -2574,20 +2574,7 @@ mod tests {
             i32,
             Int32,
             Int32Array
-        );
-        // #[cfg(feature = "regex_expressions")]
-        // test_function!(
-        //     RegexpMatch,
-        //     &[
-        //         lit(ScalarValue::Utf8(Some("abc".to_string()))),
-        //         lit(ScalarValue::Utf8(Some("a..".to_string()))),
-        //         lit(ScalarValue::Utf8(Some("g".to_string()))),
-        //     ],
-        //     Ok(Some("abc")),
-        //     &str,
-        //     Utf8,
-        //     StringArray
-        // );        
+        );   
         #[cfg(feature = "regex_expressions")]
         test_function!(
             RegexpReplace,

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -2574,7 +2574,7 @@ mod tests {
             i32,
             Int32,
             Int32Array
-        );   
+        );
         #[cfg(feature = "regex_expressions")]
         test_function!(
             RegexpReplace,

--- a/datafusion/src/prelude.rs
+++ b/datafusion/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::execution::options::{CsvReadOptions, NdJsonReadOptions};
 pub use crate::logical_plan::{
     array, ascii, avg, bit_length, btrim, character_length, chr, col, concat, concat_ws,
     count, create_udf, date_part, date_trunc, digest, in_list, initcap, left, length,
-    lit, lower, lpad, ltrim, max, md5, min, now, octet_length, random, regexp_replace,
+    lit, lower, lpad, ltrim, max, md5, min, now, octet_length, random, regexp_match, regexp_replace,
     repeat, replace, reverse, right, rpad, rtrim, sha224, sha256, sha384, sha512,
     split_part, starts_with, strpos, substr, sum, to_hex, translate, trim, upper, Column,
     JoinType, Partitioning,

--- a/datafusion/src/prelude.rs
+++ b/datafusion/src/prelude.rs
@@ -32,8 +32,8 @@ pub use crate::execution::options::{CsvReadOptions, NdJsonReadOptions};
 pub use crate::logical_plan::{
     array, ascii, avg, bit_length, btrim, character_length, chr, col, concat, concat_ws,
     count, create_udf, date_part, date_trunc, digest, in_list, initcap, left, length,
-    lit, lower, lpad, ltrim, max, md5, min, now, octet_length, random, regexp_match, regexp_replace,
-    repeat, replace, reverse, right, rpad, rtrim, sha224, sha256, sha384, sha512,
-    split_part, starts_with, strpos, substr, sum, to_hex, translate, trim, upper, Column,
-    JoinType, Partitioning,
+    lit, lower, lpad, ltrim, max, md5, min, now, octet_length, random, regexp_match,
+    regexp_replace, repeat, replace, reverse, right, rpad, rtrim, sha224, sha256, sha384,
+    sha512, split_part, starts_with, strpos, substr, sum, to_hex, translate, trim, upper,
+    Column, JoinType, Partitioning,
 };

--- a/datafusion/tests/dataframe_functions.rs
+++ b/datafusion/tests/dataframe_functions.rs
@@ -67,7 +67,6 @@ fn create_test_table() -> Result<Arc<dyn DataFrame>> {
 /// Excutes an expression on the test dataframe as a select.
 /// Compares formatted output of a record batch with an expected
 /// vector of strings, using the assert_batch_eq! macro
-///
 macro_rules! assert_fn_batches {
     ($EXPR:expr, $EXPECTED: expr) => {
         assert_fn_batches!($EXPR, $EXPECTED, 10)
@@ -80,10 +79,6 @@ macro_rules! assert_fn_batches {
         assert_batches_eq!($EXPECTED, &batches);  
     };
 } 
-
-fn assert_record_count(batches: &Vec<RecordBatch>, count: usize) {
-    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), count);
-}
 
 #[tokio::test]
 async fn test_fn_ascii() -> Result<()> {

--- a/datafusion/tests/dataframe_functions.rs
+++ b/datafusion/tests/dataframe_functions.rs
@@ -35,8 +35,6 @@ use datafusion::execution::context::ExecutionContext;
 
 use datafusion::assert_batches_eq;
 
-
-
 fn create_test_table() -> Result<Arc<dyn DataFrame>> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("a", DataType::Utf8, false),
@@ -47,9 +45,12 @@ fn create_test_table() -> Result<Arc<dyn DataFrame>> {
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
-            Arc::new(StringArray::from(
-                vec!["abcDEF", "abc123", "CBAdef", "123AbcDef"]
-            )),
+            Arc::new(StringArray::from(vec![
+                "abcDEF",
+                "abc123",
+                "CBAdef",
+                "123AbcDef",
+            ])),
             Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
         ],
     )?;
@@ -63,7 +64,6 @@ fn create_test_table() -> Result<Arc<dyn DataFrame>> {
     ctx.table("test")
 }
 
-
 /// Excutes an expression on the test dataframe as a select.
 /// Compares formatted output of a record batch with an expected
 /// vector of strings, using the assert_batch_eq! macro
@@ -73,16 +73,15 @@ macro_rules! assert_fn_batches {
     };
     ($EXPR:expr, $EXPECTED: expr, $LIMIT: expr) => {
         let df = create_test_table()?;
-        let df = df.select( vec![$EXPR])?.limit($LIMIT)?;
+        let df = df.select(vec![$EXPR])?.limit($LIMIT)?;
         let batches = df.collect().await?;
 
-        assert_batches_eq!($EXPECTED, &batches);  
+        assert_batches_eq!($EXPECTED, &batches);
     };
-} 
+}
 
 #[tokio::test]
 async fn test_fn_ascii() -> Result<()> {
-
     let expr = ascii(col("a"));
 
     let expected = vec![
@@ -92,7 +91,7 @@ async fn test_fn_ascii() -> Result<()> {
         "| 97            |",
         "+---------------+",
     ];
-    
+
     assert_fn_batches!(expr, expected, 1);
 
     Ok(())
@@ -100,9 +99,8 @@ async fn test_fn_ascii() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_bit_length() -> Result<()> {
-
     let expr = bit_length(col("a"));
-    
+
     let expected = vec![
         "+-------------------+",
         "| bitlength(test.a) |",
@@ -120,7 +118,6 @@ async fn test_fn_bit_length() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_btrim() -> Result<()> {
-
     let expr = btrim(vec![lit("      a b c             ")]);
 
     let expected = vec![
@@ -150,7 +147,7 @@ async fn test_fn_btrim_with_chars() -> Result<()> {
         "| 123AbcDef                |",
         "+--------------------------+",
     ];
-    
+
     assert_fn_batches!(expr, expected);
 
     Ok(())
@@ -178,7 +175,7 @@ async fn test_fn_character_length() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_chr() -> Result<()> {
-    let expr = chr(lit(128175) );
+    let expr = chr(lit(128175));
 
     let expected = vec![
         "+--------------------+",
@@ -195,7 +192,7 @@ async fn test_fn_chr() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_initcap() -> Result<()> {
-    let expr = initcap(col("a") );
+    let expr = initcap(col("a"));
 
     let expected = vec![
         "+-----------------+",
@@ -215,7 +212,7 @@ async fn test_fn_initcap() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_left() -> Result<()> {
-    let expr = left(col("a"), lit(3) );
+    let expr = left(col("a"), lit(3));
 
     let expected = vec![
         "+-----------------------+",
@@ -225,7 +222,7 @@ async fn test_fn_left() -> Result<()> {
         "| abc                   |",
         "| CBA                   |",
         "| 123                   |",
-        "+-----------------------+",            
+        "+-----------------------+",
     ];
 
     assert_fn_batches!(expr, expected);
@@ -235,7 +232,7 @@ async fn test_fn_left() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_lower() -> Result<()> {
-    let expr = lower(col("a") );
+    let expr = lower(col("a"));
 
     let expected = vec![
         "+---------------+",
@@ -255,7 +252,7 @@ async fn test_fn_lower() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_lpad() -> Result<()> {
-    let expr = lpad(vec![col("a"), lit(10)] );
+    let expr = lpad(vec![col("a"), lit(10)]);
 
     let expected = vec![
         "+------------------------+",
@@ -275,7 +272,7 @@ async fn test_fn_lpad() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_lpad_with_string() -> Result<()> {
-    let expr = lpad(vec![col("a"), lit(10), lit("*")] );
+    let expr = lpad(vec![col("a"), lit(10), lit("*")]);
 
     let expected = vec![
         "+----------------------------------+",
@@ -332,7 +329,7 @@ async fn test_fn_ltrim_with_columns() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_md5() -> Result<()> {
-    let expr = md5( col("a") );
+    let expr = md5(col("a"));
 
     let expected = vec![
         "+----------------------------------+",
@@ -355,7 +352,7 @@ async fn test_fn_md5() -> Result<()> {
 //       g flag doesn't compile
 #[tokio::test]
 async fn test_fn_regexp_match() -> Result<()> {
-    let expr = regexp_match( vec![col("a"), lit("[a-z]")]);
+    let expr = regexp_match(vec![col("a"), lit("[a-z]")]);
     // The below will fail
     // let expr = regexp_match( vec![col("a"), lit("[a-z]"), lit("g")]);
 
@@ -373,11 +370,11 @@ async fn test_fn_regexp_match() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}    
+}
 
 #[tokio::test]
 async fn test_fn_regexp_replace() -> Result<()> {
-    let expr = regexp_replace( vec![col("a"), lit("[a-z]"), lit("x"), lit("g")]);
+    let expr = regexp_replace(vec![col("a"), lit("[a-z]"), lit("x"), lit("g")]);
 
     let expected = vec![
         "+---------------------------------------------------------+",
@@ -393,8 +390,8 @@ async fn test_fn_regexp_replace() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}    
-    
+}
+
 #[tokio::test]
 async fn test_fn_replace() -> Result<()> {
     let expr = replace(col("a"), lit("abc"), lit("x"));
@@ -417,7 +414,7 @@ async fn test_fn_replace() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_repeat() -> Result<()> {
-    let expr = repeat( col("a"), lit(2));
+    let expr = repeat(col("a"), lit(2));
 
     let expected = vec![
         "+-------------------------+",
@@ -433,13 +430,11 @@ async fn test_fn_repeat() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}    
-
-
+}
 
 #[tokio::test]
 async fn test_fn_reverse() -> Result<()> {
-    let expr = reverse( col("a"));
+    let expr = reverse(col("a"));
 
     let expected = vec![
         "+-----------------+",
@@ -455,11 +450,11 @@ async fn test_fn_reverse() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}    
+}
 
 #[tokio::test]
 async fn test_fn_right() -> Result<()> {
-    let expr = right( col("a"), lit(3));
+    let expr = right(col("a"), lit(3));
 
     let expected = vec![
         "+------------------------+",
@@ -475,11 +470,11 @@ async fn test_fn_right() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}    
+}
 
 #[tokio::test]
 async fn test_fn_rpad() -> Result<()> {
-    let expr = rpad( vec![col("a"), lit(11)]);
+    let expr = rpad(vec![col("a"), lit(11)]);
 
     let expected = vec![
         "+------------------------+",
@@ -495,11 +490,11 @@ async fn test_fn_rpad() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}        
+}
 
 #[tokio::test]
 async fn test_fn_rpad_with_characters() -> Result<()> {
-    let expr = rpad( vec![col("a"), lit(11), lit("x")]);
+    let expr = rpad(vec![col("a"), lit(11), lit("x")]);
 
     let expected = vec![
         "+----------------------------------+",
@@ -515,11 +510,11 @@ async fn test_fn_rpad_with_characters() -> Result<()> {
     assert_fn_batches!(expr, expected);
 
     Ok(())
-}         
+}
 
 #[tokio::test]
 async fn test_fn_sha224() -> Result<()> {
-    let expr = sha224( col("a") );
+    let expr = sha224(col("a"));
 
     let expected = vec![
         "+----------------------------------------------------------+",
@@ -537,10 +532,8 @@ async fn test_fn_sha224() -> Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn test_fn_split_part() -> Result<()> {
-
     let expr = split_part(col("a"), lit("b"), lit(1));
 
     let expected = vec![
@@ -560,7 +553,6 @@ async fn test_fn_split_part() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_starts_with() -> Result<()> {
-
     let expr = starts_with(col("a"), lit("abc"));
 
     let expected = vec![
@@ -581,7 +573,6 @@ async fn test_fn_starts_with() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_strpos() -> Result<()> {
-
     let expr = strpos(col("a"), lit("f"));
 
     let expected = vec![
@@ -601,7 +592,6 @@ async fn test_fn_strpos() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_substr() -> Result<()> {
-
     let expr = substr(col("a"), lit(2));
 
     let expected = vec![
@@ -612,7 +602,7 @@ async fn test_fn_substr() -> Result<()> {
         "| bc123                   |",
         "| BAdef                   |",
         "| 23AbcDef                |",
-        "+-------------------------+",            
+        "+-------------------------+",
     ];
     assert_fn_batches!(expr, expected);
 
@@ -621,7 +611,6 @@ async fn test_fn_substr() -> Result<()> {
 
 #[tokio::test]
 async fn test_fn_to_hex() -> Result<()> {
-
     let expr = to_hex(col("b"));
 
     let expected = vec![
@@ -632,17 +621,15 @@ async fn test_fn_to_hex() -> Result<()> {
         "| a             |",
         "| a             |",
         "| 64            |",
-        "+---------------+",       
+        "+---------------+",
     ];
     assert_fn_batches!(expr, expected);
 
     Ok(())
 }
 
-
 #[tokio::test]
 async fn test_fn_translate() -> Result<()> {
-
     let expr = translate(col("a"), lit("bc"), lit("xx"));
 
     let expected = vec![
@@ -653,17 +640,15 @@ async fn test_fn_translate() -> Result<()> {
         "| axx123                                  |",
         "| CBAdef                                  |",
         "| 123AxxDef                               |",
-        "+-----------------------------------------+",           
+        "+-----------------------------------------+",
     ];
     assert_fn_batches!(expr, expected);
 
     Ok(())
 }
 
-
 #[tokio::test]
 async fn test_fn_upper() -> Result<()> {
-
     let expr = upper(col("a"));
 
     let expected = vec![
@@ -674,10 +659,9 @@ async fn test_fn_upper() -> Result<()> {
         "| ABC123        |",
         "| CBADEF        |",
         "| 123ABCDEF     |",
-        "+---------------+",       
+        "+---------------+",
     ];
     assert_fn_batches!(expr, expected);
 
     Ok(())
 }
-

--- a/datafusion/tests/dataframe_functions.rs
+++ b/datafusion/tests/dataframe_functions.rs
@@ -1,0 +1,688 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::{
+    array::{Int32Array, StringArray},
+    record_batch::RecordBatch,
+};
+
+use datafusion::dataframe::DataFrame;
+use datafusion::datasource::MemTable;
+
+use datafusion::error::Result;
+
+// use datafusion::logical_plan::Expr;
+use datafusion::prelude::*;
+
+use datafusion::execution::context::ExecutionContext;
+
+use datafusion::assert_batches_eq;
+
+
+
+fn create_test_table() -> Result<Arc<dyn DataFrame>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Utf8, false),
+        Field::new("b", DataType::Int32, false),
+    ]));
+
+    // define data.
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(
+                vec!["abcDEF", "abc123", "CBAdef", "123AbcDef"]
+            )),
+            Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
+        ],
+    )?;
+
+    let mut ctx = ExecutionContext::new();
+
+    let table = MemTable::try_new(schema, vec![vec![batch]])?;
+
+    ctx.register_table("test", Arc::new(table))?;
+
+    ctx.table("test")
+}
+
+
+/// Excutes an expression on the test dataframe as a select.
+/// Compares formatted output of a record batch with an expected
+/// vector of strings, using the assert_batch_eq! macro
+///
+macro_rules! assert_fn_batches {
+    ($EXPR:expr, $EXPECTED: expr) => {
+        assert_fn_batches!($EXPR, $EXPECTED, 10)
+    };
+    ($EXPR:expr, $EXPECTED: expr, $LIMIT: expr) => {
+        let df = create_test_table()?;
+        let df = df.select( vec![$EXPR])?.limit($LIMIT)?;
+        let batches = df.collect().await?;
+
+        assert_batches_eq!($EXPECTED, &batches);  
+    };
+} 
+
+fn assert_record_count(batches: &Vec<RecordBatch>, count: usize) {
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), count);
+}
+
+#[tokio::test]
+async fn test_fn_ascii() -> Result<()> {
+
+    let expr = ascii(col("a"));
+
+    let expected = vec![
+        "+---------------+",
+        "| ascii(test.a) |",
+        "+---------------+",
+        "| 97            |",
+        "+---------------+",
+    ];
+    
+    assert_fn_batches!(expr, expected, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_bit_length() -> Result<()> {
+
+    let expr = bit_length(col("a"));
+    
+    let expected = vec![
+        "+-------------------+",
+        "| bitlength(test.a) |",
+        "+-------------------+",
+        "| 48                |",
+        "| 48                |",
+        "| 48                |",
+        "| 72                |",
+        "+-------------------+",
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_btrim() -> Result<()> {
+
+    let expr = btrim(vec![lit("      a b c             ")]);
+
+    let expected = vec![
+        "+-----------------------------------------+",
+        "| btrim(Utf8(\"      a b c             \")) |",
+        "+-----------------------------------------+",
+        "| a b c                                   |",
+        "+-----------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_btrim_with_chars() -> Result<()> {
+    let expr = btrim(vec![col("a"), lit("ab")]);
+
+    let expected = vec![
+        "+--------------------------+",
+        "| btrim(test.a,Utf8(\"ab\")) |",
+        "+--------------------------+",
+        "| cDEF                     |",
+        "| c123                     |",
+        "| CBAdef                   |",
+        "| 123AbcDef                |",
+        "+--------------------------+",
+    ];
+    
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_character_length() -> Result<()> {
+    let expr = character_length(col("a"));
+
+    let expected = vec![
+        "+-------------------------+",
+        "| characterlength(test.a) |",
+        "+-------------------------+",
+        "| 6                       |",
+        "| 6                       |",
+        "| 6                       |",
+        "| 9                       |",
+        "+-------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_chr() -> Result<()> {
+    let expr = chr(lit(128175) );
+
+    let expected = vec![
+        "+--------------------+",
+        "| chr(Int32(128175)) |",
+        "+--------------------+",
+        "| 💯                 |",
+        "+--------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_initcap() -> Result<()> {
+    let expr = initcap(col("a") );
+
+    let expected = vec![
+        "+-----------------+",
+        "| initcap(test.a) |",
+        "+-----------------+",
+        "| Abcdef          |",
+        "| Abc123          |",
+        "| Cbadef          |",
+        "| 123abcdef       |",
+        "+-----------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_left() -> Result<()> {
+    let expr = left(col("a"), lit(3) );
+
+    let expected = vec![
+        "+-----------------------+",
+        "| left(test.a,Int32(3)) |",
+        "+-----------------------+",
+        "| abc                   |",
+        "| abc                   |",
+        "| CBA                   |",
+        "| 123                   |",
+        "+-----------------------+",            
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_lower() -> Result<()> {
+    let expr = lower(col("a") );
+
+    let expected = vec![
+        "+---------------+",
+        "| lower(test.a) |",
+        "+---------------+",
+        "| abcdef        |",
+        "| abc123        |",
+        "| cbadef        |",
+        "| 123abcdef     |",
+        "+---------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_lpad() -> Result<()> {
+    let expr = lpad(vec![col("a"), lit(10)] );
+
+    let expected = vec![
+        "+------------------------+",
+        "| lpad(test.a,Int32(10)) |",
+        "+------------------------+",
+        "|     abcDEF             |",
+        "|     abc123             |",
+        "|     CBAdef             |",
+        "|  123AbcDef             |",
+        "+------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_lpad_with_string() -> Result<()> {
+    let expr = lpad(vec![col("a"), lit(10), lit("*")] );
+
+    let expected = vec![
+        "+----------------------------------+",
+        "| lpad(test.a,Int32(10),Utf8(\"*\")) |",
+        "+----------------------------------+",
+        "| ****abcDEF                       |",
+        "| ****abc123                       |",
+        "| ****CBAdef                       |",
+        "| *123AbcDef                       |",
+        "+----------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_ltrim() -> Result<()> {
+    let expr = ltrim(lit("      a b c             "));
+
+    let expected = vec![
+        "+-----------------------------------------+",
+        "| ltrim(Utf8(\"      a b c             \")) |",
+        "+-----------------------------------------+",
+        "| a b c                                   |",
+        "+-----------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_ltrim_with_columns() -> Result<()> {
+    let expr = ltrim(col("a"));
+
+    let expected = vec![
+        "+---------------+",
+        "| ltrim(test.a) |",
+        "+---------------+",
+        "| abcDEF        |",
+        "| abc123        |",
+        "| CBAdef        |",
+        "| 123AbcDef     |",
+        "+---------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_md5() -> Result<()> {
+    let expr = md5( col("a") );
+
+    let expected = vec![
+        "+----------------------------------+",
+        "| md5(test.a)                      |",
+        "+----------------------------------+",
+        "| ea2de8bd80f3a1f52c754214fc9b0ed1 |",
+        "| e99a18c428cb38d5f260853678922e03 |",
+        "| 11ed4a6e9985df40913eead67f022e27 |",
+        "| 8f5e60e523c9253e623ae38bb58c399a |",
+        "+----------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+// TODO: tobyhede - Issue #1429
+//       https://github.com/apache/arrow-datafusion/issues/1429
+//       g flag doesn't compile
+#[tokio::test]
+async fn test_fn_regexp_match() -> Result<()> {
+    let expr = regexp_match( vec![col("a"), lit("[a-z]")]);
+    // The below will fail
+    // let expr = regexp_match( vec![col("a"), lit("[a-z]"), lit("g")]);
+
+    let expected = vec![
+        "+-----------------------------------+",
+        "| regexpmatch(test.a,Utf8(\"[a-z]\")) |",
+        "+-----------------------------------+",
+        "| []                                |",
+        "| []                                |",
+        "| []                                |",
+        "| []                                |",
+        "+-----------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}    
+
+#[tokio::test]
+async fn test_fn_regexp_replace() -> Result<()> {
+    let expr = regexp_replace( vec![col("a"), lit("[a-z]"), lit("x"), lit("g")]);
+
+    let expected = vec![
+        "+---------------------------------------------------------+",
+        "| regexpreplace(test.a,Utf8(\"[a-z]\"),Utf8(\"x\"),Utf8(\"g\")) |",
+        "+---------------------------------------------------------+",
+        "| xxxDEF                                                  |",
+        "| xxx123                                                  |",
+        "| CBAxxx                                                  |",
+        "| 123AxxDxx                                               |",
+        "+---------------------------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}    
+    
+#[tokio::test]
+async fn test_fn_replace() -> Result<()> {
+    let expr = replace(col("a"), lit("abc"), lit("x"));
+
+    let expected = vec![
+        "+---------------------------------------+",
+        "| replace(test.a,Utf8(\"abc\"),Utf8(\"x\")) |",
+        "+---------------------------------------+",
+        "| xDEF                                  |",
+        "| x123                                  |",
+        "| CBAdef                                |",
+        "| 123AbcDef                             |",
+        "+---------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_repeat() -> Result<()> {
+    let expr = repeat( col("a"), lit(2));
+
+    let expected = vec![
+        "+-------------------------+",
+        "| repeat(test.a,Int32(2)) |",
+        "+-------------------------+",
+        "| abcDEFabcDEF            |",
+        "| abc123abc123            |",
+        "| CBAdefCBAdef            |",
+        "| 123AbcDef123AbcDef      |",
+        "+-------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}    
+
+
+
+#[tokio::test]
+async fn test_fn_reverse() -> Result<()> {
+    let expr = reverse( col("a"));
+
+    let expected = vec![
+        "+-----------------+",
+        "| reverse(test.a) |",
+        "+-----------------+",
+        "| FEDcba          |",
+        "| 321cba          |",
+        "| fedABC          |",
+        "| feDcbA321       |",
+        "+-----------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}    
+
+#[tokio::test]
+async fn test_fn_right() -> Result<()> {
+    let expr = right( col("a"), lit(3));
+
+    let expected = vec![
+        "+------------------------+",
+        "| right(test.a,Int32(3)) |",
+        "+------------------------+",
+        "| DEF                    |",
+        "| 123                    |",
+        "| def                    |",
+        "| Def                    |",
+        "+------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}    
+
+#[tokio::test]
+async fn test_fn_rpad() -> Result<()> {
+    let expr = rpad( vec![col("a"), lit(11)]);
+
+    let expected = vec![
+        "+------------------------+",
+        "| rpad(test.a,Int32(11)) |",
+        "+------------------------+",
+        "| abcDEF                 |",
+        "| abc123                 |",
+        "| CBAdef                 |",
+        "| 123AbcDef              |",
+        "+------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}        
+
+#[tokio::test]
+async fn test_fn_rpad_with_characters() -> Result<()> {
+    let expr = rpad( vec![col("a"), lit(11), lit("x")]);
+
+    let expected = vec![
+        "+----------------------------------+",
+        "| rpad(test.a,Int32(11),Utf8(\"x\")) |",
+        "+----------------------------------+",
+        "| abcDEFxxxxx                      |",
+        "| abc123xxxxx                      |",
+        "| CBAdefxxxxx                      |",
+        "| 123AbcDefxx                      |",
+        "+----------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}         
+
+#[tokio::test]
+async fn test_fn_sha224() -> Result<()> {
+    let expr = sha224( col("a") );
+
+    let expected = vec![
+        "+----------------------------------------------------------+",
+        "| sha224(test.a)                                           |",
+        "+----------------------------------------------------------+",
+        "| 8b9ef961d2b19cfe7ee2a8452e3adeea98c7b22954b4073976bf80ee |",
+        "| 5c69bb695cc29b93d655e1a4bb5656cda624080d686f74477ea09349 |",
+        "| b3b3783b7470594e7ddb845eca0aec5270746dd6d0bc309bb948ceab |",
+        "| fc8a30d59386d78053328440c6670c3b583404a905cbe9bbd491a517 |",
+        "+----------------------------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn test_fn_split_part() -> Result<()> {
+
+    let expr = split_part(col("a"), lit("b"), lit(1));
+
+    let expected = vec![
+        "+--------------------------------------+",
+        "| splitpart(test.a,Utf8(\"b\"),Int32(1)) |",
+        "+--------------------------------------+",
+        "| a                                    |",
+        "| a                                    |",
+        "| CBAdef                               |",
+        "| 123A                                 |",
+        "+--------------------------------------+",
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_starts_with() -> Result<()> {
+
+    let expr = starts_with(col("a"), lit("abc"));
+
+    let expected = vec![
+        "+--------------------------------+",
+        "| startswith(test.a,Utf8(\"abc\")) |",
+        "+--------------------------------+",
+        "| true                           |",
+        "| true                           |",
+        "| false                          |",
+        "| false                          |",
+        "+--------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_strpos() -> Result<()> {
+
+    let expr = strpos(col("a"), lit("f"));
+
+    let expected = vec![
+        "+--------------------------+",
+        "| strpos(test.a,Utf8(\"f\")) |",
+        "+--------------------------+",
+        "| 0                        |",
+        "| 0                        |",
+        "| 6                        |",
+        "| 9                        |",
+        "+--------------------------+",
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_substr() -> Result<()> {
+
+    let expr = substr(col("a"), lit(2));
+
+    let expected = vec![
+        "+-------------------------+",
+        "| substr(test.a,Int32(2)) |",
+        "+-------------------------+",
+        "| bcDEF                   |",
+        "| bc123                   |",
+        "| BAdef                   |",
+        "| 23AbcDef                |",
+        "+-------------------------+",            
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_to_hex() -> Result<()> {
+
+    let expr = to_hex(col("b"));
+
+    let expected = vec![
+        "+---------------+",
+        "| tohex(test.b) |",
+        "+---------------+",
+        "| 1             |",
+        "| a             |",
+        "| a             |",
+        "| 64            |",
+        "+---------------+",       
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn test_fn_translate() -> Result<()> {
+
+    let expr = translate(col("a"), lit("bc"), lit("xx"));
+
+    let expected = vec![
+        "+-----------------------------------------+",
+        "| translate(test.a,Utf8(\"bc\"),Utf8(\"xx\")) |",
+        "+-----------------------------------------+",
+        "| axxDEF                                  |",
+        "| axx123                                  |",
+        "| CBAdef                                  |",
+        "| 123AxxDef                               |",
+        "+-----------------------------------------+",           
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn test_fn_upper() -> Result<()> {
+
+    let expr = upper(col("a"));
+
+    let expected = vec![
+        "+---------------+",
+        "| upper(test.a) |",
+        "+---------------+",
+        "| ABCDEF        |",
+        "| ABC123        |",
+        "| CBADEF        |",
+        "| 123ABCDEF     |",
+        "+---------------+",       
+    ];
+    assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+


### PR DESCRIPTION
### Which issue does this PR close?
Closes #1364 Closes #1173 

Several of the built-in function definitions are not setup correctly and the functions cannot actually be used at all.

Adds a test suite for using most of the functions with a dataframe.

In order to try and catch errors like this in future, as well as provide some extra documentation of intent, I've changed the helper macros to explicitly accept arguments rather than use a fixed arity. 

I've played with a couple of options for functions that have a mixed arity. 

btrim, as an example has two forms:

```
btrim(string); // defaults to trim whitespace from string
btrim(string, characters); // trims the supplied characters from string
```

At the moment, functions with varied arity expect a Vec<Expr>
```
btrim(vec![col("a"), lit("ab")]);
```

Alternative I played with was using two different definitions:
```
btrim(string);
btrim_chars(string, characters);
``` 

We could also make these functions macros. Doing that would mean that some functions would be functions, some macros. Felt a bit strange.