### PR TITLE
Fix bug in projection: "column types must match schema types, expected XXX but found YYY"

### DIFF
--- a/datafusion/src/physical_plan/projection.rs
+++ b/datafusion/src/physical_plan/projection.rs
@@ -70,7 +70,7 @@ impl ProjectionExec {
                     e.data_type(&input_schema)?,
                     e.nullable(&input_schema)?,
                 );
-                field.set_metadata(get_field_metadata(&e, &input_schema));
+                field.set_metadata(get_field_metadata(e, &input_schema));
 
                 Ok(field)
             })

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -892,6 +892,29 @@ async fn projection_same_fields() -> Result<()> {
 }
 
 #[tokio::test]
+async fn projection_type_alias() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_simple_csv(&mut ctx).await?;
+
+    // Query that aliases one column to the name of a different column
+    // that also has a different type (c1 == float32, c3 == boolean)
+    let sql = "SELECT c1 as c3 FROM aggregate_simple ORDER BY c3 LIMIT 2";
+    let actual = execute_to_batches(&mut ctx, sql).await;
+
+    let expected = vec![
+        "+---------+",
+        "| c3      |",
+        "+---------+",
+        "| 0.00001 |",
+        "| 0.00002 |",
+        "+---------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn csv_query_group_by_float64() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-datafusion/issues/1447

 # Rationale for this change
There was a bug introduced in  https://github.com/apache/arrow-datafusion/pull/1378

# What changes are included in this PR?
Do not copy the field from the input schema, but explicitly copy the metadata

# Are there any user-facing changes?
Queries that should work will once again do so


cc @hntd187 