### PR TITLE
Support identifiers with `.` in them

### DIFF
--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1062,10 +1062,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
 
                 let field = schema.field(field_index - 1);
-                Expr::Column(Column {
-                    relation: field.qualifier().cloned(),
-                    name: field.name().clone(),
-                })
+                Expr::Column(field.qualified_column())
             }
             e => self.sql_expr_to_logical_expr(e, schema)?,
         };

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1062,8 +1062,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
 
                 let field = schema.field(field_index - 1);
-                let col_ident = SQLExpr::Identifier(Ident::new(field.qualified_name()));
-                self.sql_expr_to_logical_expr(&col_ident, schema)?
+                Expr::Column(Column {
+                    relation: field.qualifier().cloned(),
+                    name: field.name().clone(),
+                })
             }
             e => self.sql_expr_to_logical_expr(e, schema)?,
         };
@@ -1323,9 +1325,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     let var_names = vec![id.value.clone()];
                     Ok(Expr::ScalarVariable(var_names))
                 } else {
-                    // create a column expression based on raw user input, this column will be
-                    // normalized with qualifer later by the SQL planner.
-                    Ok(col(&id.value))
+                    // Don't use `col()` here because it will try to
+                    // interpret names with '.' as if they were
+                    // compound indenfiers, but this is not a compound
+                    // identifier. (e.g. it is "foo.bar" not foo.bar)
+                    Ok(Expr::Column(Column {
+                        relation: None,
+                        name: id.value.clone(),
+                    }))
                 }
             }
 

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -5446,7 +5446,7 @@ async fn qualified_table_references_and_fields() -> Result<()> {
     ctx.register_table("test", Arc::new(table))?;
 
     // referring to the unquoted column is an error
-    let sql = format!(r#"SELECT f1.c1 from test"#);
+    let sql = r#"SELECT f1.c1 from test"#;
     let error = ctx.create_logical_plan(&sql).unwrap_err();
     assert_contains!(
         error.to_string(),
@@ -5454,7 +5454,7 @@ async fn qualified_table_references_and_fields() -> Result<()> {
     );
 
     // however, enclosing it in double quotes is ok
-    let sql = format!(r#"SELECT "f.c1" from test"#);
+    let sql = r#"SELECT "f.c1" from test"#;
     let actual = execute_to_batches(&mut ctx, &sql).await;
     let expected = vec![
         "+--------+",
@@ -5467,12 +5467,12 @@ async fn qualified_table_references_and_fields() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
     // Works fully qualified too
-    let sql = format!(r#"SELECT test."f.c1" from test"#);
+    let sql = r#"SELECT test."f.c1" from test"#;
     let actual = execute_to_batches(&mut ctx, &sql).await;
     assert_batches_eq!(expected, &actual);
 
     // check that duplicated table name and column name are ok
-    let sql = format!(r#"SELECT "test.c2" as expr1, test."test.c2" as expr2 from test"#);
+    let sql = r#"SELECT "test.c2" as expr1, test."test.c2" as expr2 from test"#;
     let actual = execute_to_batches(&mut ctx, &sql).await;
     let expected = vec![
         "+-------+-------+",

--- a/datafusion/tests/sql.rs
+++ b/datafusion/tests/sql.rs
@@ -5447,7 +5447,7 @@ async fn qualified_table_references_and_fields() -> Result<()> {
 
     // referring to the unquoted column is an error
     let sql = r#"SELECT f1.c1 from test"#;
-    let error = ctx.create_logical_plan(&sql).unwrap_err();
+    let error = ctx.create_logical_plan(sql).unwrap_err();
     assert_contains!(
         error.to_string(),
         "No field named 'f1.c1'. Valid fields are 'test.f.c1', 'test.test.c2'"
@@ -5455,7 +5455,7 @@ async fn qualified_table_references_and_fields() -> Result<()> {
 
     // however, enclosing it in double quotes is ok
     let sql = r#"SELECT "f.c1" from test"#;
-    let actual = execute_to_batches(&mut ctx, &sql).await;
+    let actual = execute_to_batches(&mut ctx, sql).await;
     let expected = vec![
         "+--------+",
         "| f.c1   |",
@@ -5468,12 +5468,12 @@ async fn qualified_table_references_and_fields() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     // Works fully qualified too
     let sql = r#"SELECT test."f.c1" from test"#;
-    let actual = execute_to_batches(&mut ctx, &sql).await;
+    let actual = execute_to_batches(&mut ctx, sql).await;
     assert_batches_eq!(expected, &actual);
 
     // check that duplicated table name and column name are ok
     let sql = r#"SELECT "test.c2" as expr1, test."test.c2" as expr2 from test"#;
-    let actual = execute_to_batches(&mut ctx, &sql).await;
+    let actual = execute_to_batches(&mut ctx, sql).await;
     let expected = vec![
         "+-------+-------+",
         "| expr1 | expr2 |",


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-datafusion/issues/1432

 # Rationale for this change
Field names containing period such as `f.c1` cannot be named in SQL query


# What changes are included in this PR?
1. Directly construct `Expr::Column` references rather than trying to parse a string using `col()` when converting SQL

# Are there any user-facing changes?
columns with periods can now be used
