### PR TITLE
All building execution context from another execution context's state

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -147,6 +147,7 @@ impl ExecutionContext {
         Self::with_config(ExecutionConfig::new())
     }
 
+    /// Create a new execution context from an existing state context
     pub fn with_context(state: Arc<Mutex<ExecutionContextState>>) -> Self {
         Self { state }
     }
@@ -189,6 +190,7 @@ impl ExecutionContext {
         }
     }
 
+    /// Return the current state context
     pub fn get_state(&self) -> Arc<Mutex<ExecutionContextState>> {
         self.state.clone()
     }

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -147,6 +147,10 @@ impl ExecutionContext {
         Self::with_config(ExecutionConfig::new())
     }
 
+    pub fn with_context(state: Arc<Mutex<ExecutionContextState>>) -> Self {
+        Self { state }
+    }
+
     /// Creates a new execution context using the provided configuration.
     pub fn with_config(config: ExecutionConfig) -> Self {
         let catalog_list = Arc::new(MemoryCatalogList::new()) as Arc<dyn CatalogList>;
@@ -183,6 +187,10 @@ impl ExecutionContext {
                 object_store_registry: Arc::new(ObjectStoreRegistry::new()),
             })),
         }
+    }
+
+    pub fn get_state(&self) -> Arc<Mutex<ExecutionContextState>> {
+        self.state.clone()
     }
 
     /// Creates a dataframe that will execute a SQL query.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1439 

# Rationale for this change
See issue, but this allows a way to carry over current state to newly created execution contextes 

# What changes are included in this PR?
Changes to carry over execution conext

# Are there any user-facing changes?
Not really

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
