### PR TITLE
Pass local address host so we do not get mismatch between IPv4 and IP…

### DIFF
--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use ballista_core::{
     error::Result,
+    serde::protobuf::executor_registration::OptionalHost,
     serde::protobuf::{scheduler_grpc_client::SchedulerGrpcClient, ExecutorRegistration},
     BALLISTA_VERSION,
 };
@@ -46,8 +47,9 @@ pub async fn new_standalone_executor(
 
     let server = FlightServiceServer::new(service);
     // Let the OS assign a random, free port
-    let listener = TcpListener::bind("localhost:0").await?;
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
+    let host = addr.ip().to_string();
     info!(
         "Ballista v{} Rust Executor listening on {:?}",
         BALLISTA_VERSION, addr
@@ -59,7 +61,7 @@ pub async fn new_standalone_executor(
     );
     let executor_meta = ExecutorRegistration {
         id: Uuid::new_v4().to_string(), // assign this executor a unique ID
-        optional_host: None,
+        optional_host: Some(OptionalHost::Host(host)),
         port: addr.port() as u32,
     };
     tokio::spawn(execution_loop::poll_loop(

--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -47,9 +47,8 @@ pub async fn new_standalone_executor(
 
     let server = FlightServiceServer::new(service);
     // Let the OS assign a random, free port
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let listener = TcpListener::bind("localhost:0").await?;
     let addr = listener.local_addr()?;
-    let host = addr.ip().to_string();
     info!(
         "Ballista v{} Rust Executor listening on {:?}",
         BALLISTA_VERSION, addr
@@ -61,7 +60,7 @@ pub async fn new_standalone_executor(
     );
     let executor_meta = ExecutorRegistration {
         id: Uuid::new_v4().to_string(), // assign this executor a unique ID
-        optional_host: Some(OptionalHost::Host(host)),
+        optional_host: Some(OptionalHost::Host("localhost".to_string())),
         port: addr.port() as u32,
     };
     tokio::spawn(execution_loop::poll_loop(


### PR DESCRIPTION
…v6 addresses

# Which issue does this PR close?

Fixes #1020 

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

Closes #1020 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently when using Ballista standalone, the standalone executor does not send its local IP when registering metadata with the scheduler. The scheduler will default to the IPv4 caller address even though the executor is listening on the IPv6 loopback address (on some platforms). This will cause clients to fail to fetch partitions when they try and call the flight service on the IPv4 socket instead of the IPv6 socket. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Standalone executor should explicitly return it's local IP address when registering metadata

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

I don't think so.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

I don't think so.
