### PR TITLE
Fix SortExec discards field metadata on the output schema

### DIFF
--- a/datafusion/src/physical_plan/sort.rs
+++ b/datafusion/src/physical_plan/sort.rs
@@ -29,7 +29,7 @@ use crate::physical_plan::{
 };
 pub use arrow::compute::SortOptions;
 use arrow::compute::{lexsort_to_indices, take, SortColumn, TakeOptions};
-use arrow::datatypes::{Field, Schema, SchemaRef};
+use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use arrow::{array::ArrayRef, error::ArrowError};
@@ -201,15 +201,6 @@ fn sort_batch(
         None,
     )?;
 
-    let schema = Arc::new(Schema::new(
-        schema
-            .fields()
-            .iter()
-            .zip(batch.columns().iter().map(|col| col.data_type()))
-            .map(|(field, ty)| Field::new(field.name(), ty.clone(), field.is_nullable()))
-            .collect::<Vec<_>>(),
-    ));
-
     // reorder all rows based on sorted indices
     RecordBatch::try_new(
         schema,
@@ -318,6 +309,8 @@ impl RecordBatchStream for SortStream {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
     use super::*;
     use crate::datasource::object_store::local::LocalFileSystem;
     use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
@@ -394,6 +387,57 @@ mod tests {
         let c7 = as_primitive_array::<UInt8Type>(&columns[6]);
         assert_eq!(c7.value(0), 15);
         assert_eq!(c7.value(c7.len() - 1), 254,);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sort_metadata() -> Result<()> {
+        let field_metadata: BTreeMap<String, String> =
+            vec![("foo".to_string(), "bar".to_string())]
+                .into_iter()
+                .collect();
+        let schema_metadata: HashMap<String, String> =
+            vec![("baz".to_string(), "barf".to_string())]
+                .into_iter()
+                .collect();
+
+        let mut field = Field::new("field_name", DataType::UInt64, true);
+        field.set_metadata(Some(field_metadata.clone()));
+        let schema = Schema::new_with_metadata(vec![field], schema_metadata.clone());
+        let schema = Arc::new(schema);
+
+        let data: ArrayRef =
+            Arc::new(vec![3, 2, 1].into_iter().map(Some).collect::<UInt64Array>());
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![data]).unwrap();
+        let input =
+            Arc::new(MemoryExec::try_new(&[vec![batch]], schema.clone(), None).unwrap());
+
+        let sort_exec = Arc::new(SortExec::try_new(
+            vec![PhysicalSortExpr {
+                expr: col("field_name", &schema)?,
+                options: SortOptions::default(),
+            }],
+            input,
+        )?);
+
+        let result: Vec<RecordBatch> = collect(sort_exec).await?;
+
+        let expected_data: ArrayRef =
+            Arc::new(vec![1, 2, 3].into_iter().map(Some).collect::<UInt64Array>());
+        let expected_batch =
+            RecordBatch::try_new(schema.clone(), vec![expected_data]).unwrap();
+
+        // Data is correct
+        assert_eq!(&vec![expected_batch], &result);
+
+        // explicitlty ensure the metadata is present
+        assert_eq!(
+            result[0].schema().fields()[0].metadata(),
+            &Some(field_metadata)
+        );
+        assert_eq!(result[0].schema().metadata(), &schema_metadata);
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1476 

 # Rationale for this change

This is a regression introduced in https://github.com/apache/arrow-datafusion/pull/1455

The following code in Sort skips the field level metadata when when it constructs the output batch.

```rust
    let schema = Arc::new(Schema::new(
        schema
            .fields()
            .iter()
            .zip(batch.columns().iter().map(|col| col.data_type()))
            .map(|(field, ty)| Field::new(field.name(), ty.clone(), field.is_nullable()))
            .collect::<Vec<_>>(),
    ));
```

Thus the output schema is not correct. 

It also seems to be unnecessary (at least all the tests pass without it, so maybe @maxburke  can comment on what problem it was solving). 

@hntd187 has also added some functions working with https://github.com/apache/arrow-rs/pull/1033 PR to add some additional functions for creating fields and I will work on this as well

# What changes are included in this PR?
1. Remove offending code
2. add a test

# Are there any user-facing changes?
Bug fix
