### PR TITLE
Fix duplicated 'cargo run --example parquet_sql'

### DIFF
--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -197,13 +197,11 @@
 //!
 //! cargo run --example csv_sql
 //!
-//! cargo run --example parquet_sql
+//! PARQUET_TEST_DATA=./parquet-testing/data cargo run --example parquet_sql
 //!
 //! cargo run --example dataframe
 //!
 //! cargo run --example dataframe_in_memory
-//!
-//! cargo run --example parquet_sql
 //!
 //! cargo run --example simple_udaf
 //!


### PR DESCRIPTION
Just a small doc fix - removed duplicate and added necessary env variable.