### PR TITLE
Workaround build failure: Pin quote to 1.0.10

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -43,6 +43,9 @@ tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = { version = "0.4", default-features = false }
 
+# workaround for https://github.com/apache/arrow-datafusion/issues/1498
+# should be able to remove when we update arrow-flight
+quote = "=1.0.10"
 arrow-flight = { version = "6.4.0"  }
 
 datafusion = { path = "../../../datafusion", version = "6.0.0" }


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/1498


 # Rationale for this change
Seems like quote needs a newer version of `proc-macro2` but that crate is held back by arrow-flight. 

# What changes are included in this PR?
Work around by pinning `quote` crate to an earlier version

# Are there any user-facing changes?
deps will hold back `quote`
