### PR TITLE
Add support for PartitionBy functionality

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -329,12 +329,20 @@ message RepartitionNode {
   oneof partition_method {
     uint64 round_robin = 2;
     HashRepartition hash = 3;
+    PartitionByRepartition partition_by = 4;
   }
 }
 
 message HashRepartition {
   repeated LogicalExprNode hash_expr = 1;
   uint64 partition_count = 2;
+}
+
+message PartitionByRepartition {
+  repeated LogicalExprNode hash_expr = 1;
+  oneof optional_partition_count {
+    uint64 partition_count = 2;
+  }
 }
 
 message EmptyRelationNode {
@@ -752,12 +760,20 @@ message PhysicalHashRepartition {
   uint64 partition_count = 2;
 }
 
-message RepartitionExecNode{
+message PhysicalPartitionByRepartition {
+  repeated PhysicalExprNode hash_expr = 1;
+  oneof optional_partition_count {
+    uint64 partition_count = 2;
+  }
+}
+
+message RepartitionExecNode {
   PhysicalPlanNode input = 1;
   oneof partition_method {
     uint64 round_robin = 2;
     PhysicalHashRepartition hash = 3;
-    uint64 unknown = 4;
+    PhysicalPartitionByRepartition partition_by = 4;
+    uint64 unknown = 5;
   }
 }
 

--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -246,6 +246,20 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                             .collect::<Result<Vec<_>, _>>()?,
                         partition_count as usize,
                     ),
+                    PartitionMethod::PartitionBy(protobuf::PartitionByRepartition {
+                        hash_expr: pb_hash_expr,
+                        optional_partition_count,
+                    }) => Partitioning::PartitionBy(
+                        pb_hash_expr
+                            .iter()
+                            .map(|pb_expr| pb_expr.try_into())
+                            .collect::<Result<Vec<_>, _>>()?,
+                        optional_partition_count.as_ref().map(|o| match o {
+                            protobuf::partition_by_repartition::OptionalPartitionCount::PartitionCount(cnt) => {
+                                *cnt as usize
+                            }
+                        }),
+                    ),
                     PartitionMethod::RoundRobin(batch_size) => {
                         Partitioning::RoundRobinBatch(batch_size as usize)
                     }

--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -925,6 +925,16 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                             partition_count: *partition_count as u64,
                         })
                     }
+                    Partitioning::PartitionBy(exprs, optional_partition_count) => {
+                        PartitionMethod::PartitionBy(protobuf::PartitionByRepartition {
+                            hash_expr: exprs
+                                .iter()
+                                .map(|expr| expr.try_into())
+                                .collect::<Result<Vec<_>, BallistaError>>()?,
+                            optional_partition_count: optional_partition_count.clone()
+                                .map(|o| protobuf::partition_by_repartition::OptionalPartitionCount::PartitionCount(o as u64)),
+                        })
+                    }
                     Partitioning::RoundRobinBatch(batch_size) => {
                         PartitionMethod::RoundRobin(*batch_size as u64)
                     }

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -313,6 +313,16 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                         partition_count: *partition_count as u64,
                     })
                 }
+                Partitioning::PartitionBy(exprs, optional_partition_count) => {
+                    PartitionMethod::PartitionBy(protobuf::PhysicalPartitionByRepartition {
+                        hash_expr: exprs
+                            .iter()
+                            .map(|expr| expr.clone().try_into())
+                            .collect::<Result<Vec<_>, BallistaError>>()?,
+                        optional_partition_count: optional_partition_count.clone()
+                            .map(|o| protobuf::physical_partition_by_repartition::OptionalPartitionCount::PartitionCount(o as u64)),
+                    })
+                }
                 Partitioning::RoundRobinBatch(partition_count) => {
                     PartitionMethod::RoundRobin(*partition_count as u64)
                 }

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -173,6 +173,12 @@ pub fn from_plan(
                 partitioning_scheme: Partitioning::Hash(expr.to_owned(), *n),
                 input: Arc::new(inputs[0].clone()),
             })),
+            Partitioning::PartitionBy(_, n) => {
+                Ok(LogicalPlan::Repartition(Repartition {
+                    partitioning_scheme: Partitioning::PartitionBy(expr.to_owned(), *n),
+                    input: Arc::new(inputs[0].clone()),
+                }))
+            }
         },
         LogicalPlan::Window(Window {
             window_expr,

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -70,6 +70,7 @@ fn optimize_partitions(
         // we don't want to introduce partitioning after hash partitioning
         // as the plan will likely depend on this
         Hash(_, _) => false,
+        PartitionBy(_, _) => false,
     };
 
     // TODO: EmptyExec causes failures with RepartitionExec

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -673,6 +673,20 @@ impl DefaultPhysicalPlanner {
                                 .collect::<Result<Vec<_>>>()?;
                             Partitioning::Hash(runtime_expr, *n)
                         }
+                        LogicalPartitioning::PartitionBy(expr, n) => {
+                            let runtime_expr = expr
+                                .iter()
+                                .map(|e| {
+                                    self.create_physical_expr(
+                                        e,
+                                        input_dfschema,
+                                        &input_schema,
+                                        ctx_state,
+                                    )
+                                })
+                                .collect::<Result<Vec<_>>>()?;
+                            Partitioning::PartitionBy(runtime_expr, *n)
+                        }
                     };
                     Ok(Arc::new(RepartitionExec::try_new(
                         physical_input,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1404.

 # Rationale for this change

DataFusion lacks support for partition by operation. 

The most used example is" given a dataset, we need to write it down on the storage as a partitioned set of files (ie: Parquet dataset partitioned by year/month/day, etc). We need to write it as paths like this:

```
/dataset/day=2021-12-28/fuel=Gas/
/dataset/day=2021-12-28/fuel=Diesel/
/dataset/day=2021-12-27/fuel=Electric/
...
```

The pattern above is not supported and the `collect_partitioned` method returns data only hash partitioned.

# What changes are included in this PR?

This PR adds a new partitioning method: `Partitioning::PartitionBy`. 

It has two parameters:
- the expression by which the partitioning will take place
- an optional value to specify the number of partition to output:
  - the best would be to know the exact number of distinct values by which the data will be partitioned, fact that will be beneficial in terms of performance
  - if it Is bigger than the  exact number of distinct values for partitioning it will return the number of partitions found in the data
  - if is smaller it will return the first n number of partitions dropping the other
  - if not specified, it will start from `i16::MAX`

# Are there any user-facing changes?

There is a new partitioning option available as  part of the API.

