### PR TITLE
Revert "Workaround build failure: Pin quote to 1.0.10 (#1499)"

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -43,9 +43,6 @@ tonic = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = { version = "0.4", default-features = false }
 
-# workaround for https://github.com/apache/arrow-datafusion/issues/1498
-# should be able to remove when we update arrow-flight
-quote = "=1.0.10"
 arrow-flight = { version = "6.4.0"  }
 
 datafusion = { path = "../../../datafusion", version = "6.0.0" }


### PR DESCRIPTION
This reverts commit 8d20f1487557e5df63d44b1390782200b1867497.

Removes workaround added in https://github.com/apache/arrow-datafusion/pull/1499 

This can be merged when the issue described in https://github.com/apache/arrow-datafusion/issues/1498 is fixed (either by an upgrade in upstream `arrow-flight` or by @dtolnay yanking `quote 1.0.11` from crates.io