### PR TITLE
Ship Cargo.lock in the source distribution

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Build Python package
         run: maturin build --release --no-sdist --strip
 
+      - name: Check that the lock file is up to date
+        run: git diff --exit-code Cargo.lock
+
       - name: List Windows wheels
         if: matrix.os == 'windows-latest'
         run: dir target\wheels\
@@ -111,6 +114,10 @@ jobs:
             --workdir /io/python \
             konstin2/maturin:v0.11.2 \
             build --release --manylinux 2010
+
+      - name: Check that the lock file is up to date
+        run: git diff --exit-code Cargo.lock
+
       - name: Archive wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -53,6 +53,8 @@ jobs:
           black --line-length 79 --diff --check python
       - name: Run tests
         run: |
+          set -euo pipefail
+
           source venv/bin/activate
           cd python
           maturin develop

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -56,6 +56,7 @@ jobs:
           source venv/bin/activate
           cd python
           maturin develop
+          git diff --exit-code Cargo.lock
           RUST_BACKTRACE=1 pytest -v .
         env:
           CARGO_HOME: "/home/runner/.cargo"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "arrow"
-version = "6.0.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337e668497751234149fd607f5cb41a6ae7b286b6329589126fe67f0ac55d637"
+checksum = "216c6846a292bdd93c2b93c1baab58c32ff50e2ab5e8d50db333ab518535dd8b"
 dependencies = [
  "bitflags",
  "chrono",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e95a3e867422fd8d04049041f5671f94d53c32a9dcd82e2be268714942f3f3"
+checksum = "c42350b81f044f576ff88ac750419f914abb46a03831bb1747134344ee7a4e64"
 dependencies = [
  "strum",
  "strum_macros",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "5.1.0"
+version = "6.0.0"
 dependencies = [
  "ahash",
  "arrow",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "datafusion",
  "pyo3",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "6.0.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d263b9b59ba260518de9e57bd65931c3f765fea0fabacfe84f40d6fde38e841a"
+checksum = "788d9953f4cfbe9db1beff7bebd54299d105e34680d78b82b1ddc85d432cac9d"
 dependencies = [
  "arrow",
  "base64",
@@ -1213,9 +1213,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "sqlparser"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760e624412a15d5838ae04fad01037beeff1047781431d74360cddd6b3c1c784"
+checksum = "b9907f54bd0f7b6ce72c2be1e570a614819ee08e3deb66d90480df341d8a12a8"
 dependencies = [
  "log",
 ]
@@ -1228,15 +1228,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -53,3 +53,6 @@ repository = "https://github.com/apache/arrow-datafusion"
 
 [tool.isort]
 profile = "black"
+
+[tool.maturin]
+sdist-include = ["Cargo.lock"]


### PR DESCRIPTION
# Which issue does this PR close?

It doesn't close an issue as far as I know.

# Rationale for this change

Build systems like `nix` need `Cargo.lock` to build reproducible Rust packages.

The `Cargo.lock` file is necessary to generate a hash for a crate's dependencies.

Without the 

# What changes are included in this PR?

- Updates to `Cargo.lock` resulting from running `maturin build`
- Required changes to `pyproject.toml` to ship the `Cargo.lock` in the source distribution

# Are there any user-facing changes?

No API changes.

Does user-facing mean only API changes?
