### PR TITLE
Add factorial function

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -77,6 +77,7 @@ rand = "0.8"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 num-traits = { version = "0.2", optional = true }
 pyo3 = { version = "0.14", optional = true }
+statrs = "0.15"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -189,6 +189,8 @@ pub enum BuiltinScalarFunction {
     Digest,
     /// exp
     Exp,
+    /// Factorial
+    Factorial,
     /// floor
     Floor,
     /// ln, Natural logarithm
@@ -328,6 +330,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Log => Volatility::Immutable,
             BuiltinScalarFunction::Log10 => Volatility::Immutable,
             BuiltinScalarFunction::Log2 => Volatility::Immutable,
+            BuiltinScalarFunction::Factorial => Volatility::Immutable,
             BuiltinScalarFunction::Round => Volatility::Immutable,
             BuiltinScalarFunction::Signum => Volatility::Immutable,
             BuiltinScalarFunction::Sin => Volatility::Immutable,
@@ -406,6 +409,7 @@ impl FromStr for BuiltinScalarFunction {
             "ceil" => BuiltinScalarFunction::Ceil,
             "cos" => BuiltinScalarFunction::Cos,
             "exp" => BuiltinScalarFunction::Exp,
+            "factorial" => BuiltinScalarFunction::Factorial,
             "floor" => BuiltinScalarFunction::Floor,
             "ln" => BuiltinScalarFunction::Ln,
             "log" => BuiltinScalarFunction::Log,
@@ -546,6 +550,7 @@ pub fn return_type(
         BuiltinScalarFunction::Lpad => utf8_to_str_type(&input_expr_types[0], "lpad"),
         BuiltinScalarFunction::Ltrim => utf8_to_str_type(&input_expr_types[0], "ltrim"),
         BuiltinScalarFunction::MD5 => utf8_to_str_type(&input_expr_types[0], "md5"),
+        BuiltinScalarFunction::Factorial => Ok(DataType::Float64),
         BuiltinScalarFunction::NullIf => {
             // NULLIF has two args and they might get coerced, get a preview of this
             let coerced_types = data_types(input_expr_types, &signature(fun));
@@ -734,6 +739,7 @@ pub fn create_physical_fun(
         BuiltinScalarFunction::Ceil => Arc::new(math_expressions::ceil),
         BuiltinScalarFunction::Cos => Arc::new(math_expressions::cos),
         BuiltinScalarFunction::Exp => Arc::new(math_expressions::exp),
+        BuiltinScalarFunction::Factorial => Arc::new(math_expressions::factorial),
         BuiltinScalarFunction::Floor => Arc::new(math_expressions::floor),
         BuiltinScalarFunction::Log => Arc::new(math_expressions::log10),
         BuiltinScalarFunction::Ln => Arc::new(math_expressions::ln),

--- a/datafusion/src/physical_plan/math_expressions.rs
+++ b/datafusion/src/physical_plan/math_expressions.rs
@@ -118,15 +118,13 @@ pub fn factorial(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                     Ok(ColumnarValue::Array(arc1))
                 }
                 _ => Err(DataFusionError::Internal(
-                    format!("Invalid data type for ",),
+                    "Invalid data type for factorial function".to_string(),
                 )),
             }
         }
-        _ => {
-            return Err(DataFusionError::Internal(
-                "Expect factorial function to take some params".to_string(),
-            ))
-        }
+        _ => Err(DataFusionError::Internal(
+            "Expect factorial function to take some params".to_string(),
+        )),
     }
 }
 

--- a/datafusion/tests/sql/functions.rs
+++ b/datafusion/tests/sql/functions.rs
@@ -26,7 +26,9 @@ async fn factorial() -> Result<()> {
         vec![Arc::new(Float64Array::from(vec![
             Some(4.0),
             Some(0.0),
-            Some(5.0),
+            Some(1.5),
+            Some(-1.0),
+            Some(10000000000.0),
         ]))],
     )?;
     let table = MemTable::try_new(schema, vec![vec![data]])?;
@@ -41,7 +43,9 @@ async fn factorial() -> Result<()> {
         "+--------------------+",
         "| 24                 |",
         "| 1                  |",
-        "| 120                |",
+        "| 1                  |",
+        "| 1                  |",
+        "| inf                |",
         "+--------------------+",
     ];
     assert_batches_eq!(expected, &actual);

--- a/datafusion/tests/sql/functions.rs
+++ b/datafusion/tests/sql/functions.rs
@@ -19,10 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn factorial() -> Result<()> {
-    let schema = Arc::new(
-        Schema::new(vec![
-            Field::new("c1", DataType::Float64, true)]
-        ));
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Float64, true)]));
 
     let data = RecordBatch::try_new(
         schema.clone(),


### PR DESCRIPTION
# Which issue does this PR close?
Adds the SQL factorial function as defined in https://www.postgresql.org/docs/14/functions-math.html 

 # Rationale for this change
To have additional math functions and have feature parity with postgres

# What changes are included in this PR?
Added a new sql function called `factorial` which computes the factorial of a given number and also added tests to verify how it works.

# Are there any user-facing changes?
There are no API changes
