### PR TITLE
Mark ARRAY_AGG(DISTINCT ...) not implemented

### DIFF
--- a/datafusion/src/physical_plan/aggregates.rs
+++ b/datafusion/src/physical_plan/aggregates.rs
@@ -187,11 +187,16 @@ pub fn create_aggregate_expr(
                 coerced_exprs_types[0].clone(),
             ))
         }
-        (AggregateFunction::ArrayAgg, _) => Arc::new(expressions::ArrayAgg::new(
+        (AggregateFunction::ArrayAgg, false) => Arc::new(expressions::ArrayAgg::new(
             coerced_phy_exprs[0].clone(),
             name,
             coerced_exprs_types[0].clone(),
         )),
+        (AggregateFunction::ArrayAgg, true) => {
+            return Err(DataFusionError::NotImplemented(
+                "ARRAY_AGG(DISTINCT) aggregations are not available".to_string(),
+            ));
+        }
         (AggregateFunction::Min, _) => Arc::new(expressions::Min::new(
             coerced_phy_exprs[0].clone(),
             name,
@@ -265,7 +270,9 @@ pub fn signature(fun: &AggregateFunction) -> Signature {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::DataFusionError::NotImplemented;
     use crate::error::Result;
+    use crate::physical_plan::distinct_expressions::DistinctCount;
     use crate::physical_plan::expressions::{
         ApproxDistinct, ArrayAgg, Avg, Count, Max, Min, Sum,
     };
@@ -332,6 +339,51 @@ mod tests {
                             result_agg_phy_exprs.field().unwrap()
                         );
                     }
+                    _ => {}
+                };
+
+                let result_distinct = create_aggregate_expr(
+                    &fun,
+                    true,
+                    &input_phy_exprs[0..1],
+                    &input_schema,
+                    "c1",
+                );
+                match fun {
+                    AggregateFunction::Count => {
+                        let result_agg_phy_exprs_distinct = result_distinct?;
+                        assert!(result_agg_phy_exprs_distinct
+                            .as_any()
+                            .is::<DistinctCount>());
+                        assert_eq!("c1", result_agg_phy_exprs_distinct.name());
+                        assert_eq!(
+                            Field::new("c1", DataType::UInt64, true),
+                            result_agg_phy_exprs_distinct.field().unwrap()
+                        );
+                    }
+                    AggregateFunction::ApproxDistinct => {
+                        let result_agg_phy_exprs_distinct = result_distinct?;
+                        assert!(result_agg_phy_exprs_distinct
+                            .as_any()
+                            .is::<ApproxDistinct>());
+                        assert_eq!("c1", result_agg_phy_exprs_distinct.name());
+                        assert_eq!(
+                            Field::new("c1", DataType::UInt64, false),
+                            result_agg_phy_exprs_distinct.field().unwrap()
+                        );
+                    }
+                    AggregateFunction::ArrayAgg => match result_distinct {
+                        Err(NotImplemented(s)) => {
+                            assert_eq!(
+                                s,
+                                "ARRAY_AGG(DISTINCT) aggregations are not available"
+                                    .to_string()
+                            );
+                        }
+                        _ => {
+                            unreachable!()
+                        }
+                    },
                     _ => {}
                 };
             }


### PR DESCRIPTION
# Which issue does this PR close?
This is the last change required to close https://github.com/apache/arrow-datafusion/issues/1512

 # Rationale for this change
Right now `array_agg(distinct ...)` doesn't work. The physical plan construction logic uses the non-distinct `array_agg` whether or not distinct was specified. Interestingly enough it still works correctly under certain conditions, due to the `SingleDistinctToGroupBy` optimizer rule. 

As an example, consider the following queries:
```sql
--- Works, since logical plan is rewritten with a subquery and non-distinct agg. Will return:
--- +------------------------------------------+
--- | ARRAYAGG(DISTINCT aggregate_test_100.c2) |
--- +------------------------------------------+
--- | [2, 3, 5, 1, 4]                          |
--- +------------------------------------------+
SELECT array_agg(DISTINCT c2) FROM aggregate_test_100;

--- Returns incorrect results, since SingleDistinctToGroupBy optimizer rule does not apply:
--- +--------------------------------------------------------------------------+
--- | ARRAYAGG(DISTINCT aggregate_test_100.c2)      | COUNT(DISTINCT UInt8(1)) |
--- +--------------------------------------------------------------------------+
--- | [2, 5, 1, 1, 5, 4, 3, 3, 1, 4, 1, 4, 3, ...]  | 1                        |
--- +--------------------------------------------------------------------------+
SELECT array_agg(DISTINCT c2), count(distinct 1) FROM aggregate_test_100;
```

After this change distinct array agg will throw an error when `SingleDistinctToGroupBy` does not apply.

I'm planning on working on actually implementing distinct array_agg after this, but figured this was worth fixing for now.
# What changes are included in this PR?
This marks the aggregation not implemented, and adds a block for testing count/approx distinct/array agg with `distinct = true`.
