### PR TITLE
Fix new clippy lints introduced in Rust 1.58

### DIFF
--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -83,9 +83,7 @@ impl Executor {
             job_id,
             stage_id,
             part,
-            DisplayableExecutionPlan::with_metrics(&exec)
-                .indent()
-                .to_string()
+            DisplayableExecutionPlan::with_metrics(&exec).indent()
         );
 
         Ok(partitions)

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -293,7 +293,7 @@ mod test {
             .plan_query_stages(&job_uuid.to_string(), plan)
             .await?;
         for stage in &stages {
-            println!("{}", displayable(stage.as_ref()).indent().to_string());
+            println!("{}", displayable(stage.as_ref()).indent());
         }
 
         /* Expected result:
@@ -407,7 +407,7 @@ order by
             .plan_query_stages(&job_uuid.to_string(), plan)
             .await?;
         for stage in &stages {
-            println!("{}", displayable(stage.as_ref()).indent().to_string());
+            println!("{}", displayable(stage.as_ref()).indent());
         }
 
         /* Expected result:

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -546,7 +546,7 @@ async fn execute_query(
     if debug {
         println!(
             "=== Physical plan ===\n{}\n",
-            displayable(physical_plan.as_ref()).indent().to_string()
+            displayable(physical_plan.as_ref()).indent()
         );
     }
     let runtime = ctx.state.lock().unwrap().runtime_env.clone();
@@ -554,9 +554,7 @@ async fn execute_query(
     if debug {
         println!(
             "=== Physical plan with metrics ===\n{}\n",
-            DisplayableExecutionPlan::with_metrics(physical_plan.as_ref())
-                .indent()
-                .to_string()
+            DisplayableExecutionPlan::with_metrics(physical_plan.as_ref()).indent()
         );
         pretty::print_batches(&result)?;
     }

--- a/datafusion/src/physical_plan/expressions/rank.rs
+++ b/datafusion/src/physical_plan/expressions/rank.rs
@@ -38,6 +38,7 @@ pub struct Rank {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum RankType {
     Rank,
     DenseRank,

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1627,7 +1627,7 @@ mod tests {
             Err(e) => assert!(
                 e.to_string().contains(expected_error),
                 "Error '{}' did not contain expected error '{}'",
-                e.to_string(),
+                e,
                 expected_error
             ),
         }
@@ -1674,7 +1674,7 @@ mod tests {
             Err(e) => assert!(
                 e.to_string().contains(expected_error),
                 "Error '{}' did not contain expected error '{}'",
-                e.to_string(),
+                e,
                 expected_error
             ),
         }
@@ -1733,7 +1733,7 @@ mod tests {
             Err(e) => assert!(
                 e.to_string().contains(expected_error),
                 "Error '{}' did not contain expected error '{}'",
-                e.to_string(),
+                e,
                 expected_error
             ),
         }

--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -1739,7 +1739,7 @@ impl fmt::Display for ScalarValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ScalarValue::Decimal128(v, p, s) => {
-                write!(f, "{}", format!("{:?},{:?},{:?}", v, p, s))?;
+                write!(f, "{:?},{:?},{:?}", v, p, s)?;
             }
             ScalarValue::Boolean(e) => format_option!(f, e)?,
             ScalarValue::Float32(e) => format_option!(f, e)?,

--- a/datafusion/src/test/variable.rs
+++ b/datafusion/src/test/variable.rs
@@ -35,7 +35,7 @@ impl SystemVar {
 impl VarProvider for SystemVar {
     /// get system variable value
     fn get_value(&self, var_names: Vec<String>) -> Result<ScalarValue> {
-        let s = format!("{}-{}", "system-var".to_string(), var_names.concat());
+        let s = format!("system-var-{}", var_names.concat());
         Ok(ScalarValue::Utf8(Some(s)))
     }
 }
@@ -54,7 +54,7 @@ impl UserDefinedVar {
 impl VarProvider for UserDefinedVar {
     /// Get user defined variable value
     fn get_value(&self, var_names: Vec<String>) -> Result<ScalarValue> {
-        let s = format!("{}-{}", "user-defined-var".to_string(), var_names.concat());
+        let s = format!("user-defined-var-{}", var_names.concat());
         Ok(ScalarValue::Utf8(Some(s)))
     }
 }


### PR DESCRIPTION
Its that time of month! Rust 1.58 has been released and with it some new clippy lints.

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13

This PR updates DataFusion so it passes the new more stringent clippy.

Overall I would say it is a nice improvement
