### PR TITLE
feat: Support complex interval via IntervalMonthDayNano

### DIFF
--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1818,16 +1818,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // Interval is tricky thing
         // 1 day is not 24 hours because timezones, 1 year != 365/364! 30 days != 1 month
         // The true way to store and calculate intervals is to store it as it defined
-        // Due the fact that Arrow supports only two types YearMonth (month) and DayTime (day, time)
-        // It's not possible to store complex intervals
-        // It's possible to do select (NOW() + INTERVAL '1 year') + INTERVAL '1 day'; as workaround
+        // It's why we there are 3 different interval types in Arrow
         if result_month != 0 && (result_days != 0 || result_millis != 0) {
-            return Err(DataFusionError::NotImplemented(format!(
-                "DF does not support intervals that have both a Year/Month part as well as Days/Hours/Mins/Seconds: {:?}. Hint: try breaking the interval into two parts, one with Year/Month and the other with Days/Hours/Mins/Seconds - e.g. (NOW() + INTERVAL '1 year') + INTERVAL '1 day'",
-                value
-            )));
+            let result: i128 = ((result_month as i128) << 96)
+                | ((result_days as i128) << 64)
+                // IntervalMonthDayNano uses nanos, but IntervalDayTime uses milles
+                | ((result_millis * 1_000_000_i64) as i128);
+
+            return Ok(Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(
+                result,
+            ))));
         }
 
+        // Month interval
         if result_month != 0 {
             return Ok(Expr::Literal(ScalarValue::IntervalYearMonth(Some(
                 result_month as i32,
@@ -2762,16 +2765,6 @@ mod tests {
             r#"NotImplemented("Interval field value out of range: \"100000000000000000 day\"")"#,
             format!("{:?}", err)
         );
-    }
-
-    #[test]
-    fn select_unsupported_complex_interval() {
-        let sql = "SELECT INTERVAL '1 year 1 day'";
-        let err = logical_plan(sql).expect_err("query should have failed");
-        assert!(matches!(
-            err,
-            DataFusionError::NotImplemented(msg) if msg == "DF does not support intervals that have both a Year/Month part as well as Days/Hours/Mins/Seconds: \"1 year 1 day\". Hint: try breaking the interval into two parts, one with Year/Month and the other with Days/Hours/Mins/Seconds - e.g. (NOW() + INTERVAL '1 year') + INTERVAL '1 day'",
-        ));
     }
 
     #[test]

--- a/datafusion/tests/sql/expr.rs
+++ b/datafusion/tests/sql/expr.rs
@@ -367,6 +367,7 @@ async fn test_crypto_expressions() -> Result<()> {
 
 #[tokio::test]
 async fn test_interval_expressions() -> Result<()> {
+    // day nano intervals
     test_expression!(
         "interval '1'",
         "0 years 0 mons 0 days 0 hours 0 mins 1.00 secs"
@@ -456,6 +457,7 @@ async fn test_interval_expressions() -> Result<()> {
         "interval '5 day 4 hours 3 minutes 2 seconds 100 milliseconds'",
         "0 years 0 mons 5 days 4 hours 3 mins 2.100 secs"
     );
+    // month intervals
     test_expression!(
         "interval '0.5 month'",
         "0 years 0 mons 15 days 0 hours 0 mins 0.00 secs"
@@ -496,6 +498,24 @@ async fn test_interval_expressions() -> Result<()> {
         "interval '2' year",
         "2 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
     );
+    // complex
+    test_expression!(
+        "interval '1 year 1 day'",
+        "0 years 12 mons 1 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 year 1 day 1 hour'",
+        "0 years 12 mons 1 days 1 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 year 1 day 1 hour 1 minute'",
+        "0 years 12 mons 1 days 1 hours 1 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 year 1 day 1 hour 1 minute 1 second'",
+        "0 years 12 mons 1 days 1 hours 1 mins 1.00 secs"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1017.

 # Rationale for this change

DF didn't support complex intervals, because it was not possible before Arrow introduced MonthDayNano type for IntervalType

# What changes are included in this PR?

Support for planning complex intervals from SQL, for example:

```
SELECT INTERVAL '1 year 1 day 1 hour 1 minute 1 second'
```

# Are there any user-facing changes?

No breaking changes.