### PR TITLE
Handle merging of evolved schemas in ParquetExec

### DIFF
--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -88,9 +88,6 @@ impl FileFormat for ParquetFormat {
     }
 
     async fn infer_schema(&self, readers: ObjectReaderStream) -> Result<SchemaRef> {
-        // We currently get the schema information from the first file rather than do
-        // schema merging and this is a limitation.
-        // See https://issues.apache.org/jira/browse/ARROW-11017
         let merged_schema = readers
             .try_fold(Schema::empty(), |acc, reader| async {
                 let next_schema = fetch_schema(reader);
@@ -98,11 +95,6 @@ impl FileFormat for ParquetFormat {
                     .map_err(|e| DataFusionError::ArrowError(e))
             })
             .await?;
-        // let first_file = readers
-        //     .next()
-        //     .await
-        //     .ok_or_else(|| DataFusionError::Plan("No data file found".to_owned()))??;
-        // let schema = fetch_schema(first_file)?;
         Ok(Arc::new(merged_schema))
     }
 

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -366,7 +366,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::datasource::listing::ListingOptions;
+    
     use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use arrow::array::{
         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -375,20 +375,6 @@ mod tests {
     use futures::StreamExt;
 
     #[tokio::test]
-    async fn test_merge_schema() -> Result<()> {
-        let testdata = crate::test_util::parquet_test_data();
-        let filename = format!("{}/{}", testdata, "schema_evolution");
-        let opt = ListingOptions::new(Arc::new(ParquetFormat::default()));
-        let schema = opt
-            .infer_schema(Arc::new(LocalFileSystem {}), &filename)
-            .await?;
-
-        assert_eq!(schema.fields().len(), 5);
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn read_small_batches() -> Result<()> {
         let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::new().with_batch_size(2))?);
         let projection = None;

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -366,7 +366,7 @@ mod tests {
     };
 
     use super::*;
-    
+
     use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use arrow::array::{
         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -92,7 +92,7 @@ impl FileFormat for ParquetFormat {
             .try_fold(Schema::empty(), |acc, reader| async {
                 let next_schema = fetch_schema(reader);
                 Schema::try_merge([acc, next_schema?])
-                    .map_err(|e| DataFusionError::ArrowError(e))
+                    .map_err(DataFusionError::ArrowError)
             })
             .await?;
         Ok(Arc::new(merged_schema))

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -44,7 +44,7 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
-use log::{debug, error};
+use log::{debug, info};
 use parquet::file::{
     metadata::RowGroupMetaData,
     reader::{FileReader, SerializedFileReader},
@@ -62,7 +62,7 @@ use tokio::{
 
 use crate::execution::runtime_env::RuntimeEnv;
 use async_trait::async_trait;
-use parquet::errors::ParquetError;
+
 
 use super::PartitionColumnProjector;
 
@@ -530,6 +530,7 @@ mod tests {
     };
 
     use super::*;
+    use arrow::array::{Float32Array};
     use arrow::{
         array::{Int64Array, Int8Array, StringArray},
         datatypes::{DataType, Field},
@@ -789,8 +790,11 @@ mod tests {
 
         let c3: ArrayRef = Arc::new(Int8Array::from(vec![Some(10), Some(20), None]));
 
-        let c4: ArrayRef =
-            Arc::new(StringArray::from(vec![Some("baz"), Some("boo"), None]));
+        let c4: ArrayRef = Arc::new(Float32Array::from(vec![
+            Some(1.0 as f32),
+            Some(2.0 as f32),
+            None,
+        ]));
 
         // batch1: c1(string), c2(int64), c3(int8)
         let batch1 = create_batch(vec![
@@ -812,7 +816,8 @@ mod tests {
         let read =
             round_trip_to_parquet(vec![batch1, batch2], None, Some(Arc::new(schema)))
                 .await;
-        // expect on the first batch to be read
+
+        // expect only the first batch to be read
         let expected = vec![
             "+-----+----+----+",
             "| c1  | c2 | c3 |",

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -404,8 +404,8 @@ fn map_projections(
                 mapped.push(mapped_idx)
             } else {
                 let msg = format!("Failed to map column projection for field {}. Incompatible data types {:?} and {:?}", field.name(), file_schema.field(mapped_idx).data_type(), field.data_type());
-                error!("{}", msg);
-                return Err(DataFusionError::ParquetError(ParquetError::General(msg)));
+                info!("{}", msg);
+                return Err(DataFusionError::Execution(msg));
             }
         }
     }

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -401,11 +401,9 @@ fn map_projections(
         let mut mapped: Vec<usize> = vec![];
         for idx in projections {
             let field = merged_schema.field(*idx);
-            if let Ok(file_field) = file_schema.field_with_name(field.name().as_str()) {
-                if file_field.data_type() == field.data_type() {
-                    if let Ok(mapped_idx) = file_schema.index_of(field.name().as_str()) {
-                        mapped.push(mapped_idx)
-                    }
+            if let Ok(mapped_idx) = file_schema.index_of(field.name().as_str()) {
+                if file_schema.field(mapped_idx).data_type() == field.data_type() {
+                    mapped.push(mapped_idx)
                 }
             }
         }

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -63,7 +63,6 @@ use tokio::{
 use crate::execution::runtime_env::RuntimeEnv;
 use async_trait::async_trait;
 
-
 use super::PartitionColumnProjector;
 
 /// Execution plan for scanning one or more Parquet partitions
@@ -530,7 +529,7 @@ mod tests {
     };
 
     use super::*;
-    use arrow::array::{Float32Array};
+    use arrow::array::Float32Array;
     use arrow::{
         array::{Int64Array, Int8Array, StringArray},
         datatypes::{DataType, Field},

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -789,11 +789,8 @@ mod tests {
 
         let c3: ArrayRef = Arc::new(Int8Array::from(vec![Some(10), Some(20), None]));
 
-        let c4: ArrayRef = Arc::new(Float32Array::from(vec![
-            Some(1.0 as f32),
-            Some(2.0 as f32),
-            None,
-        ]));
+        let c4: ArrayRef =
+            Arc::new(Float32Array::from(vec![Some(1.0_f32), Some(2.0_f32), None]));
 
         // batch1: c1(string), c2(int64), c3(int8)
         let batch1 = create_batch(vec![


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #132

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, it is assumed that all parquet files in a listing scan will have the same schema. This will allow support for schema evolution in the underlying storage layer by merging parquet schemas on read. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

There are three parts:
1. Modify `ParquetFormat` to merge schemas for all listed parquet files using the underlying `Schema::try_merge` method in `arrow-rs`
2. When reading individual parquet files, map projected column indexes from the merged schema to the file schema. 
3. "Backfill" any missing columns from the merged schema with null-valued columns.   

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Scans that contain heterogenous schemas will attempt to merge the schemas. If that error was expected then the observed behavior will be different. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
