### PR TITLE
Add `DataFusionError` -> `ArrowError` conversion

### DIFF
--- a/datafusion/src/error.rs
+++ b/datafusion/src/error.rs
@@ -176,22 +176,20 @@ mod test {
     #[test]
     fn arrow_error_to_datafusion() {
         let res = return_arrow_error().unwrap_err();
-        assert_eq!(res.to_string(), "DD");
+        assert_eq!(res.to_string(), "External error: Error during planning: foo");
     }
 
     #[test]
     fn datafusion_error_to_arrow() {
         let res = return_datafusion_error().unwrap_err();
-        assert_eq!(res.to_string(), "DD");
+        assert_eq!(res.to_string(), "Arrow error: Schema error: bar");
     }
-
-
 
     /// Model what happens when implementing SendableRecrordBatchStream:
     /// DataFusion code needs to return an ArrowError
     fn return_arrow_error() -> arrow::error::Result<()> {
         // Expect the '?' to work
-        let _foo = Err(DataFusionError::Internal("foo".to_string()))?;
+        let _foo = Err(DataFusionError::Plan("foo".to_string()))?;
         Ok(())
     }
 

--- a/datafusion/src/error.rs
+++ b/datafusion/src/error.rs
@@ -170,13 +170,16 @@ impl error::Error for DataFusionError {}
 
 #[cfg(test)]
 mod test {
-    use arrow::error::ArrowError;
     use crate::error::DataFusionError;
+    use arrow::error::ArrowError;
 
     #[test]
     fn arrow_error_to_datafusion() {
         let res = return_arrow_error().unwrap_err();
-        assert_eq!(res.to_string(), "External error: Error during planning: foo");
+        assert_eq!(
+            res.to_string(),
+            "External error: Error during planning: foo"
+        );
     }
 
     #[test]
@@ -187,15 +190,16 @@ mod test {
 
     /// Model what happens when implementing SendableRecrordBatchStream:
     /// DataFusion code needs to return an ArrowError
+    #[allow(clippy::try_err)]
     fn return_arrow_error() -> arrow::error::Result<()> {
         // Expect the '?' to work
         let _foo = Err(DataFusionError::Plan("foo".to_string()))?;
         Ok(())
     }
 
-
     /// Model what happens when using arrow kernels in DataFusion
     /// code: need to turn an ArrowError into a DataFusionError
+    #[allow(clippy::try_err)]
     fn return_datafusion_error() -> crate::error::Result<()> {
         // Expect the '?' to work
         let _bar = Err(ArrowError::SchemaError("bar".to_string()))?;

--- a/datafusion/src/error.rs
+++ b/datafusion/src/error.rs
@@ -93,6 +93,16 @@ impl From<ArrowError> for DataFusionError {
     }
 }
 
+impl From<DataFusionError> for ArrowError {
+    fn from(e: DataFusionError) -> Self {
+        match e {
+            DataFusionError::ArrowError(e) => e,
+            DataFusionError::External(e) => ArrowError::ExternalError(e),
+            other => ArrowError::ExternalError(Box::new(other)),
+        }
+    }
+}
+
 impl From<ParquetError> for DataFusionError {
     fn from(e: ParquetError) -> Self {
         DataFusionError::ParquetError(e)


### PR DESCRIPTION
# Which issue does this PR close?

Resolves: https://github.com/apache/arrow-datafusion/issues/1642


 # Rationale for this change
Please see https://github.com/apache/arrow-datafusion/issues/1642


# What changes are included in this PR?
1. Add `impl From<DataFusionError> for ArrowError`
2. Tests

# Are there any user-facing changes?
Possible to use `?` now