### PR TITLE
Remove non idiomatic `DataFusionError::into_arrow_external_error` in favor of From conversion

### DIFF
--- a/datafusion/src/error.rs
+++ b/datafusion/src/error.rs
@@ -72,15 +72,6 @@ pub enum DataFusionError {
     External(GenericError),
 }
 
-impl DataFusionError {
-    /// Wraps this [DataFusionError] as an [arrow::error::ArrowError].
-    ///
-    /// TODO this can be removed in favor if the conversion below
-    pub fn into_arrow_external_error(self) -> ArrowError {
-        ArrowError::from_external_error(Box::new(self))
-    }
-}
-
 impl From<io::Error> for DataFusionError {
     fn from(e: io::Error) -> Self {
         DataFusionError::IoError(e)

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -331,8 +331,7 @@ fn build_batch(
             let scalar = ScalarValue::try_from_array(arr, left_index)?;
             Ok(scalar.to_array_of_size(batch.num_rows()))
         })
-        .collect::<Result<Vec<_>>>()
-        .map_err(|x| x.into_arrow_external_error())?;
+        .collect::<Result<Vec<_>>>()?;
 
     RecordBatch::try_new(
         Arc::new(schema.clone()),

--- a/datafusion/src/physical_plan/filter.rs
+++ b/datafusion/src/physical_plan/filter.rs
@@ -176,7 +176,7 @@ fn batch_filter(
     predicate
         .evaluate(batch)
         .map(|v| v.into_array(batch.num_rows()))
-        .map_err(DataFusionError::into_arrow_external_error)
+        .map_err(DataFusionError::into)
         .and_then(|array| {
             array
                 .as_any()
@@ -185,7 +185,7 @@ fn batch_filter(
                     DataFusionError::Internal(
                         "Filter predicate evaluated to non-boolean value".to_string(),
                     )
-                    .into_arrow_external_error()
+                    .into()
                 })
                 // apply filter array to record batch
                 .and_then(|filter_array| filter_record_batch(batch, filter_array))

--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -416,7 +416,7 @@ impl RepartitionExec {
             Err(e) => {
                 for (_, tx) in txs {
                     let err = DataFusionError::Execution(format!("Join Error: {}", e));
-                    let err = Err(err.into_arrow_external_error());
+                    let err = Err(err.into());
                     tx.send(Some(err)).ok();
                 }
             }
@@ -425,7 +425,7 @@ impl RepartitionExec {
                 for (_, tx) in txs {
                     // wrap it because need to send error to all output partitions
                     let err = DataFusionError::Execution(e.to_string());
-                    let err = Err(err.into_arrow_external_error());
+                    let err = Err(err.into());
                     tx.send(Some(err)).ok();
                 }
             }

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -634,8 +634,7 @@ fn sort_batch(
         &expr
             .iter()
             .map(|e| e.evaluate_to_sort_column(&batch))
-            .collect::<Result<Vec<SortColumn>>>()
-            .map_err(DataFusionError::into_arrow_external_error)?,
+            .collect::<Result<Vec<SortColumn>>>()?,
         None,
     )?;
 

--- a/datafusion/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/src/physical_plan/windows/window_agg_exec.rs
@@ -273,9 +273,7 @@ impl WindowAggStream {
         elapsed_compute: crate::physical_plan::metrics::Time,
     ) -> ArrowResult<RecordBatch> {
         let input_schema = input.schema();
-        let batches = common::collect(input)
-            .await
-            .map_err(DataFusionError::into_arrow_external_error)?;
+        let batches = common::collect(input).await?;
 
         // record compute time on drop
         let _timer = elapsed_compute.timer();
@@ -283,8 +281,7 @@ impl WindowAggStream {
         let batch = common::combine_batches(&batches, input_schema.clone())?;
         if let Some(batch) = batch {
             // calculate window cols
-            let mut columns = compute_window_aggregates(window_expr, &batch)
-                .map_err(DataFusionError::into_arrow_external_error)?;
+            let mut columns = compute_window_aggregates(window_expr, &batch)?;
             // combine with the original cols
             // note the setup of window aggregates is that they newly calculated window
             // expressions are always prepended to the columns


### PR DESCRIPTION
~Builds on https://github.com/apache/arrow-datafusion/pull/1643, so draft until that is merged~

# Which issue does this PR close?
closes https://github.com/apache/arrow-datafusion/issues/1644

 # Rationale for this change
The way to convert `DataFusionError` into an `ArrowError` is confusing for Rust programmers coming to the DataFusion codebase and makes our codebase a bit of a mess
```
DataFusionError::into_arrow_external_error
```
They typically expect a `impl From<..>` conversion trait

# What changes are included in this PR?
1. remove `DataFusionError::into_arrow_external_error`
2. Update code to use `From` impl instead

# Are there any user-facing changes?
Nicer error handling, but removal of `into_arrow_external_error`

