### PR TITLE
Use NamedTempFile rather than `String` in DiskManager

### DIFF
--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -265,11 +265,10 @@ impl ShuffleWriterExec {
                                 std::fs::create_dir_all(&path)?;
 
                                 path.push(format!("data-{}.arrow", input_partition));
-                                let path = path.to_str().unwrap();
-                                info!("Writing results to {}", path);
+                                info!("Writing results to {:?}", path);
 
                                 let mut writer =
-                                    IPCWriter::new(path, stream.schema().as_ref())?;
+                                    IPCWriter::new(&path, stream.schema().as_ref())?;
 
                                 writer.write(&output_batch)?;
                                 writers[output_partition] = Some(writer);
@@ -287,7 +286,7 @@ impl ShuffleWriterExec {
                         Some(w) => {
                             w.finish()?;
                             info!(
-                                "Finished writing shuffle partition {} at {}. Batches: {}. Rows: {}. Bytes: {}.",
+                                "Finished writing shuffle partition {} at {:?}. Batches: {}. Rows: {}. Bytes: {}.",
                                 i,
                                 w.path(),
                                 w.num_batches,
@@ -297,7 +296,7 @@ impl ShuffleWriterExec {
 
                             part_locs.push(ShuffleWritePartition {
                                 partition_id: i as u64,
-                                path: w.path().to_owned(),
+                                path: w.path().to_string_lossy().to_string(),
                                 num_batches: w.num_batches,
                                 num_rows: w.num_rows,
                                 num_bytes: w.num_bytes,

--- a/datafusion/src/physical_plan/common.rs
+++ b/datafusion/src/physical_plan/common.rs
@@ -33,6 +33,7 @@ use futures::{Future, SinkExt, Stream, StreamExt, TryStreamExt};
 use pin_project_lite::pin_project;
 use std::fs;
 use std::fs::{metadata, File};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::task::JoinHandle;
@@ -387,7 +388,7 @@ mod tests {
 /// Write in Arrow IPC format.
 pub struct IPCWriter {
     /// path
-    pub path: String,
+    pub path: PathBuf,
     /// Inner writer
     pub writer: FileWriter<File>,
     /// bathes written
@@ -400,10 +401,10 @@ pub struct IPCWriter {
 
 impl IPCWriter {
     /// Create new writer
-    pub fn new(path: &str, schema: &Schema) -> Result<Self> {
+    pub fn new(path: &Path, schema: &Schema) -> Result<Self> {
         let file = File::create(path).map_err(|e| {
             DataFusionError::Execution(format!(
-                "Failed to create partition file at {}: {:?}",
+                "Failed to create partition file at {:?}: {:?}",
                 path, e
             ))
         })?;
@@ -411,7 +412,7 @@ impl IPCWriter {
             num_batches: 0,
             num_rows: 0,
             num_bytes: 0,
-            path: path.to_owned(),
+            path: path.into(),
             writer: FileWriter::try_new(file, schema)?,
         })
     }
@@ -432,7 +433,7 @@ impl IPCWriter {
     }
 
     /// Path write to
-    pub fn path(&self) -> &str {
+    pub fn path(&self) -> &Path {
         &self.path
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1679

 # Rationale for this change
1. Using `String` for temporary files leaves the files around longer than necessary, and would cause trouble with a long lived DiskManager across plans.
2. Using the existing `tempfile` crate in rust is likely to work better across operating systems than DataFusion specific tempfile creation logic

# What changes are included in this PR?
1. `DiskManager` passes out `NamedTempFile`s rather than `String` (when these are dropped they also clean up the temp file immediately)
2. Update users to use NamedTempFiles

# Are there any user-facing changes?
No
