### PR TITLE
Add a new metric type: `Gauge` + `CurrentMemoryUsage` to metrics

### DIFF
--- a/datafusion/src/physical_plan/metrics/aggregated.rs
+++ b/datafusion/src/physical_plan/metrics/aggregated.rs
@@ -35,9 +35,15 @@ pub struct AggregatedMetricsSet {
     final_: Arc<std::sync::Mutex<Vec<ExecutionPlanMetricsSet>>>,
 }
 
+impl Default for AggregatedMetricsSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AggregatedMetricsSet {
     /// Create a new aggregated set
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             intermediate: Arc::new(std::sync::Mutex::new(vec![])),
             final_: Arc::new(std::sync::Mutex::new(vec![])),
@@ -45,7 +51,7 @@ impl AggregatedMetricsSet {
     }
 
     /// create a new intermediate baseline
-    pub(crate) fn new_intermediate_baseline(&self, partition: usize) -> BaselineMetrics {
+    pub fn new_intermediate_baseline(&self, partition: usize) -> BaselineMetrics {
         let ms = ExecutionPlanMetricsSet::new();
         let result = BaselineMetrics::new(&ms, partition);
         self.intermediate.lock().unwrap().push(ms);
@@ -53,7 +59,7 @@ impl AggregatedMetricsSet {
     }
 
     /// create a new final baseline
-    pub(crate) fn new_final_baseline(&self, partition: usize) -> BaselineMetrics {
+    pub fn new_final_baseline(&self, partition: usize) -> BaselineMetrics {
         let ms = ExecutionPlanMetricsSet::new();
         let result = BaselineMetrics::new(&ms, partition);
         self.final_.lock().unwrap().push(ms);
@@ -137,7 +143,7 @@ impl AggregatedMetricsSet {
     }
 
     /// Aggregate all metrics into a one
-    pub(crate) fn aggregate_all(&self) -> MetricsSet {
+    pub fn aggregate_all(&self) -> MetricsSet {
         let metrics = ExecutionPlanMetricsSet::new();
         let baseline = BaselineMetrics::new(&metrics, 0);
         self.merge_compute_time(baseline.elapsed_compute());

--- a/datafusion/src/physical_plan/metrics/baseline.rs
+++ b/datafusion/src/physical_plan/metrics/baseline.rs
@@ -21,7 +21,7 @@ use std::task::Poll;
 
 use arrow::{error::ArrowError, record_batch::RecordBatch};
 
-use super::{Count, ExecutionPlanMetricsSet, MetricBuilder, Time, Timestamp};
+use super::{Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, Time, Timestamp};
 
 /// Helper for creating and tracking common "baseline" metrics for
 /// each operator
@@ -56,6 +56,9 @@ pub struct BaselineMetrics {
     /// total spilled bytes during the execution of the operator
     spilled_bytes: Count,
 
+    /// current memory usage for the operator
+    mem_used: Gauge,
+
     /// output rows: the total output rows
     output_rows: Count,
 }
@@ -71,6 +74,7 @@ impl BaselineMetrics {
             elapsed_compute: MetricBuilder::new(metrics).elapsed_compute(partition),
             spill_count: MetricBuilder::new(metrics).spill_count(partition),
             spilled_bytes: MetricBuilder::new(metrics).spilled_bytes(partition),
+            mem_used: MetricBuilder::new(metrics).mem_used(partition),
             output_rows: MetricBuilder::new(metrics).output_rows(partition),
         }
     }
@@ -88,6 +92,11 @@ impl BaselineMetrics {
     /// return the metric for the total spilled bytes during execution
     pub fn spilled_bytes(&self) -> &Count {
         &self.spilled_bytes
+    }
+
+    /// return the metric for current memory usage
+    pub fn mem_used(&self) -> &Gauge {
+        &self.mem_used
     }
 
     /// Record a spill of `spilled_bytes` size.

--- a/datafusion/src/physical_plan/metrics/builder.rs
+++ b/datafusion/src/physical_plan/metrics/builder.rs
@@ -20,7 +20,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use super::{
-    Count, ExecutionPlanMetricsSet, Label, Metric, MetricValue, Time, Timestamp,
+    Count, ExecutionPlanMetricsSet, Gauge, Label, Metric, MetricValue, Time, Timestamp,
 };
 
 /// Structure for constructing metrics, counters, timers, etc.
@@ -123,6 +123,14 @@ impl<'a> MetricBuilder<'a> {
         count
     }
 
+    /// Consume self and create a new gauge for reporting current memory usage
+    pub fn mem_used(self, partition: usize) -> Gauge {
+        let gauge = Gauge::new();
+        self.with_partition(partition)
+            .build(MetricValue::CurrentMemoryUsage(gauge.clone()));
+        gauge
+    }
+
     /// Consumes self and creates a new [`Count`] for recording some
     /// arbitrary metric of an operator.
     pub fn counter(
@@ -131,6 +139,16 @@ impl<'a> MetricBuilder<'a> {
         partition: usize,
     ) -> Count {
         self.with_partition(partition).global_counter(counter_name)
+    }
+
+    /// Consumes self and creates a new [`Gauge`] for reporting some
+    /// arbitrary metric of an operator.
+    pub fn gauge(
+        self,
+        gauge_name: impl Into<Cow<'static, str>>,
+        partition: usize,
+    ) -> Gauge {
+        self.with_partition(partition).global_gauge(gauge_name)
     }
 
     /// Consumes self and creates a new [`Count`] for recording a
@@ -142,6 +160,17 @@ impl<'a> MetricBuilder<'a> {
             count: count.clone(),
         });
         count
+    }
+
+    /// Consumes self and creates a new [`Gauge`] for reporting a
+    /// metric of an overall operator (not per partition)
+    pub fn global_gauge(self, gauge_name: impl Into<Cow<'static, str>>) -> Gauge {
+        let gauge = Gauge::new();
+        self.build(MetricValue::Gauge {
+            name: gauge_name.into(),
+            gauge: gauge.clone(),
+        });
+        gauge
     }
 
     /// Consume self and create a new Timer for recording the elapsed

--- a/datafusion/src/physical_plan/metrics/mod.rs
+++ b/datafusion/src/physical_plan/metrics/mod.rs
@@ -34,7 +34,7 @@ use hashbrown::HashMap;
 pub use aggregated::AggregatedMetricsSet;
 pub use baseline::{BaselineMetrics, RecordOutput};
 pub use builder::MetricBuilder;
-pub use value::{Count, MetricValue, ScopedTimerGuard, Time, Timestamp};
+pub use value::{Count, Gauge, MetricValue, ScopedTimerGuard, Time, Timestamp};
 
 /// Something that tracks a value of interest (metric) of a DataFusion
 /// [`ExecutionPlan`] execution.

--- a/datafusion/src/physical_plan/metrics/value.rs
+++ b/datafusion/src/physical_plan/metrics/value.rs
@@ -83,7 +83,7 @@ impl Count {
 /// Note `clone`ing gauge update the same underlying metrics
 #[derive(Debug, Clone)]
 pub struct Gauge {
-    /// value of the metric counter
+    /// value of the metric gauge
     value: std::sync::Arc<AtomicUsize>,
 }
 

--- a/datafusion/src/physical_plan/metrics/value.rs
+++ b/datafusion/src/physical_plan/metrics/value.rs
@@ -77,6 +77,62 @@ impl Count {
     }
 }
 
+/// A gauge is the simplest metrics type. It just returns a value.
+/// For example, you can easily expose current memory consumption with a gauge.
+///
+/// Note `clone`ing gauge update the same underlying metrics
+#[derive(Debug, Clone)]
+pub struct Gauge {
+    /// value of the metric counter
+    value: std::sync::Arc<AtomicUsize>,
+}
+
+impl PartialEq for Gauge {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().eq(&other.value())
+    }
+}
+
+impl Display for Gauge {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.value())
+    }
+}
+
+impl Default for Gauge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Gauge {
+    /// create a new gauge
+    pub fn new() -> Self {
+        Self {
+            value: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Add `n` to the metric's value
+    pub fn add(&self, n: usize) {
+        // relaxed ordering for operations on `value` poses no issues
+        // we're purely using atomic ops with no associated memory ops
+        self.value.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Set the metric's value to `n` and return the previous value
+    pub fn set(&self, n: usize) -> usize {
+        // relaxed ordering for operations on `value` poses no issues
+        // we're purely using atomic ops with no associated memory ops
+        self.value.swap(n, Ordering::Relaxed)
+    }
+
+    /// Get the current value
+    pub fn value(&self) -> usize {
+        self.value.load(Ordering::Relaxed)
+    }
+}
+
 /// Measure a potentially non contiguous duration of time
 #[derive(Debug, Clone)]
 pub struct Time {
@@ -287,12 +343,21 @@ pub enum MetricValue {
     SpillCount(Count),
     /// Total size of spilled bytes produced: "spilled_bytes" metric
     SpilledBytes(Count),
+    /// Current memory used
+    CurrentMemoryUsage(Gauge),
     /// Operator defined count.
     Count {
         /// The provided name of this metric
         name: Cow<'static, str>,
         /// The value of the metric
         count: Count,
+    },
+    /// Operator defined gauge.
+    Gauge {
+        /// The provided name of this metric
+        name: Cow<'static, str>,
+        /// The value of the metric
+        gauge: Gauge,
     },
     /// Operator defined time
     Time {
@@ -314,8 +379,10 @@ impl MetricValue {
             Self::OutputRows(_) => "output_rows",
             Self::SpillCount(_) => "spill_count",
             Self::SpilledBytes(_) => "spilled_bytes",
+            Self::CurrentMemoryUsage(_) => "mem_used",
             Self::ElapsedCompute(_) => "elapsed_compute",
             Self::Count { name, .. } => name.borrow(),
+            Self::Gauge { name, .. } => name.borrow(),
             Self::Time { name, .. } => name.borrow(),
             Self::StartTimestamp(_) => "start_timestamp",
             Self::EndTimestamp(_) => "end_timestamp",
@@ -328,8 +395,10 @@ impl MetricValue {
             Self::OutputRows(count) => count.value(),
             Self::SpillCount(count) => count.value(),
             Self::SpilledBytes(bytes) => bytes.value(),
+            Self::CurrentMemoryUsage(used) => used.value(),
             Self::ElapsedCompute(time) => time.value(),
             Self::Count { count, .. } => count.value(),
+            Self::Gauge { gauge, .. } => gauge.value(),
             Self::Time { time, .. } => time.value(),
             Self::StartTimestamp(timestamp) => timestamp
                 .value()
@@ -349,10 +418,15 @@ impl MetricValue {
             Self::OutputRows(_) => Self::OutputRows(Count::new()),
             Self::SpillCount(_) => Self::SpillCount(Count::new()),
             Self::SpilledBytes(_) => Self::SpilledBytes(Count::new()),
+            Self::CurrentMemoryUsage(_) => Self::CurrentMemoryUsage(Gauge::new()),
             Self::ElapsedCompute(_) => Self::ElapsedCompute(Time::new()),
             Self::Count { name, .. } => Self::Count {
                 name: name.clone(),
                 count: Count::new(),
+            },
+            Self::Gauge { name, .. } => Self::Gauge {
+                name: name.clone(),
+                gauge: Gauge::new(),
             },
             Self::Time { name, .. } => Self::Time {
                 name: name.clone(),
@@ -383,6 +457,13 @@ impl MetricValue {
                     count: other_count, ..
                 },
             ) => count.add(other_count.value()),
+            (Self::CurrentMemoryUsage(gauge), Self::CurrentMemoryUsage(other_gauge))
+            | (
+                Self::Gauge { gauge, .. },
+                Self::Gauge {
+                    gauge: other_gauge, ..
+                },
+            ) => gauge.add(other_gauge.value()),
             (Self::ElapsedCompute(time), Self::ElapsedCompute(other_time))
             | (
                 Self::Time { time, .. },
@@ -415,10 +496,12 @@ impl MetricValue {
             Self::ElapsedCompute(_) => 1, // show second
             Self::SpillCount(_) => 2,
             Self::SpilledBytes(_) => 3,
-            Self::Count { .. } => 4,
-            Self::Time { .. } => 5,
-            Self::StartTimestamp(_) => 6, // show timestamps last
-            Self::EndTimestamp(_) => 7,
+            Self::CurrentMemoryUsage(_) => 4,
+            Self::Count { .. } => 5,
+            Self::Gauge { .. } => 6,
+            Self::Time { .. } => 7,
+            Self::StartTimestamp(_) => 8, // show timestamps last
+            Self::EndTimestamp(_) => 9,
         }
     }
 
@@ -437,6 +520,9 @@ impl std::fmt::Display for MetricValue {
             | Self::SpilledBytes(count)
             | Self::Count { count, .. } => {
                 write!(f, "{}", count)
+            }
+            Self::CurrentMemoryUsage(gauge) | Self::Gauge { gauge, .. } => {
+                write!(f, "{}", gauge)
             }
             Self::ElapsedCompute(time) | Self::Time { time, .. } => {
                 // distinguish between no time recorded and very small

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -52,8 +52,8 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::mpsc::{Receiver, Sender};
 use tempfile::NamedTempFile;
+use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task;
 
 /// Sort arbitrary size of data to get a total order (may spill several times during sorting based on free memory available).
@@ -232,7 +232,8 @@ impl MemoryConsumer for ExternalSorter {
             baseline_metrics,
         );
 
-        spill_partial_sorted_stream(&mut stream?, spillfile.path(), self.schema.clone()).await?;
+        spill_partial_sorted_stream(&mut stream?, spillfile.path(), self.schema.clone())
+            .await?;
         let mut spills = self.spills.lock().await;
         let used = self.inner_metrics.mem_used().set(0);
         self.inner_metrics.record_spill(used);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

A gauge metric is useful for reporting purposes by returning a value each time, and a gauge suits well for memory consumption reports.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. a new kind of metric: `Gauge`
2. add `CurrentMemoryUsage` to `BaselineMetrics`
3. use `gauge` in sort for memory tracking.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
