### PR TITLE
docs: Add link to VegaFusion as a project that uses DataFusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Here are some of the projects known to use DataFusion:
 - [ROAPI](https://github.com/roapi/roapi)
 - [Tensorbase](https://github.com/tensorbase/tensorbase)
 - [Squirtle](https://github.com/DSLAM-UMD/Squirtle)
+- [VegaFusion](https://vegafusion.io/) Server-side acceleration for the [Vega](https://vega.github.io/) visualization grammar
 
 (if you know of another project, please submit a PR to add a link!)
 


### PR DESCRIPTION
Hi, I'd like to add my open source project, [VegaFusion](https://vegafusion.io/), to the list of projects that are known to use DataFusion.

This project uses DataFusion to accelerate visualizations defined using the [Vega](https://vega.github.io/) visualization grammar.

As an aside: The flexibility of DataFusion has made it a wonderful fit for this project!