### PR TITLE
(minor) Reduce memory manager and disk manager logs from `info!` to `debug!`

### DIFF
--- a/datafusion/src/execution/disk_manager.rs
+++ b/datafusion/src/execution/disk_manager.rs
@@ -19,7 +19,7 @@
 //! hashed among the directories listed in RuntimeConfig::local_dirs.
 
 use crate::error::{DataFusionError, Result};
-use log::{debug, info};
+use log::debug;
 use rand::{thread_rng, Rng};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -88,7 +88,7 @@ impl DiskManager {
             }
             DiskManagerConfig::NewSpecified(conf_dirs) => {
                 let local_dirs = create_local_dirs(conf_dirs)?;
-                info!(
+                debug!(
                     "Created local dirs {:?} as DataFusion working directory",
                     local_dirs
                 );

--- a/datafusion/src/execution/memory_manager.rs
+++ b/datafusion/src/execution/memory_manager.rs
@@ -20,7 +20,7 @@
 use crate::error::{DataFusionError, Result};
 use async_trait::async_trait;
 use hashbrown::HashMap;
-use log::info;
+use log::debug;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -169,7 +169,7 @@ pub trait MemoryConsumer: Send + Sync {
     /// reached for this consumer.
     async fn try_grow(&self, required: usize) -> Result<()> {
         let current = self.mem_used();
-        info!(
+        debug!(
             "trying to acquire {} whiling holding {} from consumer {}",
             human_readable_size(required),
             human_readable_size(current),
@@ -181,7 +181,7 @@ pub trait MemoryConsumer: Send + Sync {
             .can_grow_directly(required, current)
             .await;
         if !can_grow_directly {
-            info!(
+            debug!(
                 "Failed to grow memory of {} directly from consumer {}, spilling first ...",
                 human_readable_size(required),
                 self.id()
@@ -261,7 +261,7 @@ impl MemoryManager {
         match config {
             MemoryManagerConfig::Existing(manager) => manager,
             MemoryManagerConfig::New { .. } => {
-                info!(
+                debug!(
                     "Creating memory manager with initial size {}",
                     human_readable_size(pool_size)
                 );

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -44,7 +44,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use futures::StreamExt;
-use log::{error, debug};
+use log::{debug, error};
 use std::any::Any;
 use std::fmt;
 use std::fmt::{Debug, Formatter};

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -44,7 +44,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use futures::StreamExt;
-use log::{error, info};
+use log::{error, debug};
 use std::any::Any;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -207,7 +207,7 @@ impl MemoryConsumer for ExternalSorter {
     }
 
     async fn spill(&self) -> Result<usize> {
-        info!(
+        debug!(
             "{}[{}] spilling sort data of {} to disk while inserting ({} time(s) so far)",
             self.name(),
             self.id(),
@@ -331,7 +331,7 @@ fn write_sorted(
         writer.write(&batch?)?;
     }
     writer.finish()?;
-    info!(
+    debug!(
         "Spilled {} batches of total {} rows to disk, memory released {}",
         writer.num_batches, writer.num_rows, writer.num_bytes
     );


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change
Generally `info!` logs are enabled in production whereas `debug!` are used locally while debugging. I think the messages in the memory manager and disk manager better match the usecase for `debug`

# What changes are included in this PR?
Change some `info!` messages to `debug!`

# Are there any user-facing changes?
Less verbose logging at the `info` level

cc @yjshen 