### PR TITLE
Add `MemTrackingMetrics` to ease memory tracking for non-limited memory consumers

### DIFF
--- a/datafusion/src/execution/memory_manager.rs
+++ b/datafusion/src/execution/memory_manager.rs
@@ -532,7 +532,7 @@ mod tests {
         runtime.drop_consumer(tracker1.id(), tracker1.mem_used);
         assert_eq!(runtime.memory_manager.get_tracker_total(), 20);
 
-        // MemTrackingMetrics as an easy way to tracking memory
+        // MemTrackingMetrics as an easy way to track memory
         let ms = ExecutionPlanMetricsSet::new();
         let tracking_metric = MemTrackingMetrics::new_with_rt(&ms, 0, runtime.clone());
         tracking_metric.init_mem_used(15);

--- a/datafusion/src/execution/memory_manager.rs
+++ b/datafusion/src/execution/memory_manager.rs
@@ -281,6 +281,10 @@ impl MemoryManager {
         *self.trackers_total.lock().unwrap()
     }
 
+    pub(crate) fn grow_tracker_total(&self, size: usize) {
+        *self.trackers_total.lock().unwrap() += size;
+    }
+
     fn get_requester_total(&self) -> usize {
         *self.requesters_total.lock().unwrap()
     }

--- a/datafusion/src/execution/memory_manager.rs
+++ b/datafusion/src/execution/memory_manager.rs
@@ -295,7 +295,7 @@ impl MemoryManager {
         *self.requesters_total.lock().unwrap()
     }
 
-    /// Register a new memory requester for memory usage tracking
+    /// Register a new memory requester
     pub(crate) fn register_requester(&self, requester_id: &MemoryConsumerId) {
         self.requesters.lock().unwrap().insert(requester_id.clone());
     }
@@ -349,7 +349,7 @@ impl MemoryManager {
         self.cv.notify_all()
     }
 
-    /// Drop a memory consumer from memory usage tracking
+    /// Drop a memory consumer and reclaim the memory
     pub(crate) fn drop_consumer(&self, id: &MemoryConsumerId, mem_used: usize) {
         // find in requesters first
         {

--- a/datafusion/src/execution/runtime_env.rs
+++ b/datafusion/src/execution/runtime_env.rs
@@ -22,9 +22,7 @@ use crate::{
     error::Result,
     execution::{
         disk_manager::{DiskManager, DiskManagerConfig},
-        memory_manager::{
-            MemoryConsumer, MemoryConsumerId, MemoryManager, MemoryManagerConfig,
-        },
+        memory_manager::{MemoryConsumerId, MemoryManager, MemoryManagerConfig},
     },
 };
 
@@ -71,13 +69,13 @@ impl RuntimeEnv {
     }
 
     /// Register the consumer to get it tracked
-    pub fn register_consumer(&self, memory_consumer: &Arc<dyn MemoryConsumer>) {
-        self.memory_manager.register_consumer(memory_consumer);
+    pub fn register_requester(&self, id: &MemoryConsumerId) {
+        self.memory_manager.register_requester(id);
     }
 
-    /// Drop the consumer from get tracked
-    pub fn drop_consumer(&self, id: &MemoryConsumerId) {
-        self.memory_manager.drop_consumer(id)
+    /// Drop the consumer from get tracked, reclaim memory
+    pub fn drop_consumer(&self, id: &MemoryConsumerId, mem_used: usize) {
+        self.memory_manager.drop_consumer(id, mem_used)
     }
 }
 

--- a/datafusion/src/execution/runtime_env.rs
+++ b/datafusion/src/execution/runtime_env.rs
@@ -77,6 +77,16 @@ impl RuntimeEnv {
     pub fn drop_consumer(&self, id: &MemoryConsumerId, mem_used: usize) {
         self.memory_manager.drop_consumer(id, mem_used)
     }
+
+    /// Grow tracker memory usage during execution
+    pub fn grow_tracker_usage(&self, delta: usize) {
+        self.memory_manager.grow_tracker_usage(delta)
+    }
+
+    /// Shrink tracker memory usage
+    pub fn shrink_tracker_usage(&self, delta: usize) {
+        self.memory_manager.shrink_tracker_usage(delta)
+    }
 }
 
 impl Default for RuntimeEnv {

--- a/datafusion/src/execution/runtime_env.rs
+++ b/datafusion/src/execution/runtime_env.rs
@@ -78,12 +78,12 @@ impl RuntimeEnv {
         self.memory_manager.drop_consumer(id, mem_used)
     }
 
-    /// Grow tracker memory usage during execution
+    /// Grow tracker memory of `delta`
     pub fn grow_tracker_usage(&self, delta: usize) {
         self.memory_manager.grow_tracker_usage(delta)
     }
 
-    /// Shrink tracker memory usage
+    /// Shrink tracker memory of `delta`
     pub fn shrink_tracker_usage(&self, delta: usize) {
         self.memory_manager.shrink_tracker_usage(delta)
     }

--- a/datafusion/src/physical_plan/explain.rs
+++ b/datafusion/src/physical_plan/explain.rs
@@ -32,7 +32,7 @@ use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatc
 
 use super::SendableRecordBatchStream;
 use crate::execution::runtime_env::RuntimeEnv;
-use crate::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet};
+use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 use async_trait::async_trait;
 
 /// Explain execution plan operator. This operator contains the string
@@ -148,12 +148,12 @@ impl ExecutionPlan for ExplainExec {
         )?;
 
         let metrics = ExecutionPlanMetricsSet::new();
-        let baseline_metrics = BaselineMetrics::new(&metrics, partition);
+        let tracking_metrics = MemTrackingMetrics::new(&metrics, partition);
 
         Ok(Box::pin(SizedRecordBatchStream::new(
             self.schema.clone(),
             vec![Arc::new(record_batch)],
-            baseline_metrics,
+            tracking_metrics,
         )))
     }
 

--- a/datafusion/src/physical_plan/metrics/baseline.rs
+++ b/datafusion/src/physical_plan/metrics/baseline.rs
@@ -113,7 +113,7 @@ impl BaselineMetrics {
     /// Records the fact that this operator's execution is complete
     /// (recording the `end_time` metric).
     ///
-    /// Note care should be taken to call `done()` maually if
+    /// Note care should be taken to call `done()` manually if
     /// `BaselineMetrics` is not `drop`ped immediately upon operator
     /// completion, as async streams may not be dropped immediately
     /// depending on the consumer.
@@ -127,6 +127,13 @@ impl BaselineMetrics {
     /// batch output for other thing
     pub fn record_output(&self, num_rows: usize) {
         self.output_rows.add(num_rows);
+    }
+
+    /// If not previously recorded `done()`, record
+    pub fn try_done(&self) {
+        if self.end_time.value().is_none() {
+            self.end_time.record()
+        }
     }
 
     /// Process a poll result of a stream producing output for an
@@ -151,10 +158,7 @@ impl BaselineMetrics {
 
 impl Drop for BaselineMetrics {
     fn drop(&mut self) {
-        // if not previously recorded, record
-        if self.end_time.value().is_none() {
-            self.end_time.record()
-        }
+        self.try_done()
     }
 }
 

--- a/datafusion/src/physical_plan/metrics/composite.rs
+++ b/datafusion/src/physical_plan/metrics/composite.rs
@@ -17,6 +17,8 @@
 
 //! Metrics common for complex operators with multiple steps.
 
+use crate::execution::runtime_env::RuntimeEnv;
+use crate::physical_plan::metrics::tracker::MemTrackingMetrics;
 use crate::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricValue, MetricsSet, Time,
     Timestamp,
@@ -61,6 +63,24 @@ impl CompositeMetricsSet {
     /// create a new final baseline
     pub fn new_final_baseline(&self, partition: usize) -> BaselineMetrics {
         BaselineMetrics::new(&self.final_, partition)
+    }
+
+    /// create a new intermediate memory tracking metrics
+    pub fn new_intermediate_tracking(
+        &self,
+        partition: usize,
+        runtime: Arc<RuntimeEnv>,
+    ) -> MemTrackingMetrics {
+        MemTrackingMetrics::new_with_rt(&self.mid, partition, runtime)
+    }
+
+    /// create a new final memory tracking metrics
+    pub fn new_final_tracking(
+        &self,
+        partition: usize,
+        runtime: Arc<RuntimeEnv>,
+    ) -> MemTrackingMetrics {
+        MemTrackingMetrics::new_with_rt(&self.final_, partition, runtime)
     }
 
     fn merge_compute_time(&self, dest: &Time) {

--- a/datafusion/src/physical_plan/metrics/mod.rs
+++ b/datafusion/src/physical_plan/metrics/mod.rs
@@ -31,7 +31,7 @@ use std::{
 use hashbrown::HashMap;
 
 // public exports
-pub use aggregated::AggregatedMetricsSet;
+pub use aggregated::CompositeMetricsSet;
 pub use baseline::{BaselineMetrics, RecordOutput};
 pub use builder::MetricBuilder;
 pub use value::{Count, Gauge, MetricValue, ScopedTimerGuard, Time, Timestamp};

--- a/datafusion/src/physical_plan/metrics/mod.rs
+++ b/datafusion/src/physical_plan/metrics/mod.rs
@@ -17,9 +17,10 @@
 
 //! Metrics for recording information about execution
 
-mod aggregated;
 mod baseline;
 mod builder;
+mod composite;
+mod tracker;
 mod value;
 
 use std::{
@@ -31,9 +32,10 @@ use std::{
 use hashbrown::HashMap;
 
 // public exports
-pub use aggregated::CompositeMetricsSet;
 pub use baseline::{BaselineMetrics, RecordOutput};
 pub use builder::MetricBuilder;
+pub use composite::CompositeMetricsSet;
+pub use tracker::MemTrackingMetrics;
 pub use value::{Count, Gauge, MetricValue, ScopedTimerGuard, Time, Timestamp};
 
 /// Something that tracks a value of interest (metric) of a DataFusion

--- a/datafusion/src/physical_plan/metrics/tracker.rs
+++ b/datafusion/src/physical_plan/metrics/tracker.rs
@@ -80,7 +80,7 @@ impl MemTrackingMetrics {
     pub fn init_mem_used(&self, size: usize) {
         self.metrics.mem_used().set(size);
         if let Some(rt) = self.runtime.as_ref() {
-            rt.memory_manager.grow_tracker_total(size);
+            rt.memory_manager.grow_tracker_usage(size);
         }
     }
 

--- a/datafusion/src/physical_plan/metrics/tracker.rs
+++ b/datafusion/src/physical_plan/metrics/tracker.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Metrics with memory usage tracking capability
+
+use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::MemoryConsumerId;
+use crate::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, Time,
+};
+use std::sync::Arc;
+use std::task::Poll;
+
+use arrow::{error::ArrowError, record_batch::RecordBatch};
+
+/// Simplified version of tracking memory consumer,
+/// see also: [`Tracking`](crate::execution::memory_manager::ConsumerType::Tracking)
+///
+/// You could use this to replace [BaselineMetrics], report the memory,
+/// and get the memory usage bookkeeping in the memory manager easily.
+#[derive(Debug)]
+pub struct MemTrackingMetrics {
+    id: MemoryConsumerId,
+    runtime: Option<Arc<RuntimeEnv>>,
+    metrics: BaselineMetrics,
+}
+
+/// Delegates most of the metrics functionalities to the inner BaselineMetrics,
+/// intercept memory metrics functionalities and do memory manager bookkeeping.
+impl MemTrackingMetrics {
+    /// Create metrics similar to [BaselineMetrics]
+    pub fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        let id = MemoryConsumerId::new(partition);
+        Self {
+            id,
+            runtime: None,
+            metrics: BaselineMetrics::new(metrics, partition),
+        }
+    }
+
+    /// Create memory tracking metrics with reference to runtime
+    pub fn new_with_rt(
+        metrics: &ExecutionPlanMetricsSet,
+        partition: usize,
+        runtime: Arc<RuntimeEnv>,
+    ) -> Self {
+        let id = MemoryConsumerId::new(partition);
+        Self {
+            id,
+            runtime: Some(runtime),
+            metrics: BaselineMetrics::new(metrics, partition),
+        }
+    }
+
+    /// return the metric for cpu time spend in this operator
+    pub fn elapsed_compute(&self) -> &Time {
+        self.metrics.elapsed_compute()
+    }
+
+    /// return the size for current memory usage
+    pub fn mem_used(&self) -> usize {
+        self.metrics.mem_used().value()
+    }
+
+    /// setup initial memory usage and register it with memory manager
+    pub fn init_mem_used(&self, size: usize) {
+        self.metrics.mem_used().set(size);
+        self.runtime.as_ref()
+            .map(|rt| rt.memory_manager.grow_tracker_total(size));
+    }
+
+    /// return the metric for the total number of output rows produced
+    pub fn output_rows(&self) -> &Count {
+        self.metrics.output_rows()
+    }
+
+    /// Records the fact that this operator's execution is complete
+    /// (recording the `end_time` metric).
+    ///
+    /// Note care should be taken to call `done()` manually if
+    /// `MemTrackingMetrics` is not `drop`ped immediately upon operator
+    /// completion, as async streams may not be dropped immediately
+    /// depending on the consumer.
+    pub fn done(&self) {
+        self.metrics.done()
+    }
+
+    /// Record that some number of rows have been produced as output
+    ///
+    /// See the [`RecordOutput`] for conveniently recording record
+    /// batch output for other thing
+    pub fn record_output(&self, num_rows: usize) {
+        self.metrics.record_output(num_rows)
+    }
+
+    /// Process a poll result of a stream producing output for an
+    /// operator, recording the output rows and stream done time and
+    /// returning the same poll result
+    pub fn record_poll(
+        &self,
+        poll: Poll<Option<Result<RecordBatch, ArrowError>>>,
+    ) -> Poll<Option<Result<RecordBatch, ArrowError>>> {
+        self.metrics.record_poll(poll)
+    }
+}
+
+impl Drop for MemTrackingMetrics {
+    fn drop(&mut self) {
+        self.metrics.try_done();
+        if self.mem_used() != 0 {
+            self.runtime.as_ref()
+                .map(|rt| rt.drop_consumer(&self.id, self.mem_used()));
+        }
+    }
+}

--- a/datafusion/src/physical_plan/sorts/mod.rs
+++ b/datafusion/src/physical_plan/sorts/mod.rs
@@ -248,15 +248,6 @@ enum StreamWrapper {
     Stream(Option<SortedStream>),
 }
 
-impl StreamWrapper {
-    fn mem_used(&self) -> usize {
-        match &self {
-            StreamWrapper::Stream(Some(s)) => s.mem_used,
-            _ => 0,
-        }
-    }
-}
-
 impl Stream for StreamWrapper {
     type Item = ArrowResult<RecordBatch>;
 

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -26,7 +26,9 @@ use crate::execution::memory_manager::{
 use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::common::{batch_byte_size, IPCWriter, SizedRecordBatchStream};
 use crate::physical_plan::expressions::PhysicalSortExpr;
-use crate::physical_plan::metrics::{BaselineMetrics, CompositeMetricsSet, MetricsSet};
+use crate::physical_plan::metrics::{
+    BaselineMetrics, CompositeMetricsSet, MemTrackingMetrics, MetricsSet,
+};
 use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeStream;
 use crate::physical_plan::sorts::SortedStream;
 use crate::physical_plan::stream::RecordBatchReceiverStream;
@@ -73,8 +75,8 @@ struct ExternalSorter {
     /// Sort expressions
     expr: Vec<PhysicalSortExpr>,
     runtime: Arc<RuntimeEnv>,
-    metrics: CompositeMetricsSet,
-    inner_metrics: BaselineMetrics,
+    metrics_set: CompositeMetricsSet,
+    metrics: BaselineMetrics,
 }
 
 impl ExternalSorter {
@@ -82,10 +84,10 @@ impl ExternalSorter {
         partition_id: usize,
         schema: SchemaRef,
         expr: Vec<PhysicalSortExpr>,
-        metrics: CompositeMetricsSet,
+        metrics_set: CompositeMetricsSet,
         runtime: Arc<RuntimeEnv>,
     ) -> Self {
-        let inner_metrics = metrics.new_intermediate_baseline(partition_id);
+        let metrics = metrics_set.new_intermediate_baseline(partition_id);
         Self {
             id: MemoryConsumerId::new(partition_id),
             schema,
@@ -93,8 +95,8 @@ impl ExternalSorter {
             spills: Mutex::new(vec![]),
             expr,
             runtime,
+            metrics_set,
             metrics,
-            inner_metrics,
         }
     }
 
@@ -102,7 +104,7 @@ impl ExternalSorter {
         if input.num_rows() > 0 {
             let size = batch_byte_size(&input);
             self.try_grow(size).await?;
-            self.inner_metrics.mem_used().add(size);
+            self.metrics.mem_used().add(size);
             let mut in_mem_batches = self.in_mem_batches.lock().await;
             in_mem_batches.push(input);
         }
@@ -120,16 +122,18 @@ impl ExternalSorter {
         let mut in_mem_batches = self.in_mem_batches.lock().await;
 
         if self.spilled_before().await {
-            let baseline_metrics = self.metrics.new_intermediate_baseline(partition);
+            let tracking_metrics = self
+                .metrics_set
+                .new_intermediate_tracking(partition, self.runtime.clone());
             let mut streams: Vec<SortedStream> = vec![];
             if in_mem_batches.len() > 0 {
                 let in_mem_stream = in_mem_partial_sort(
                     &mut *in_mem_batches,
                     self.schema.clone(),
                     &self.expr,
-                    baseline_metrics,
+                    tracking_metrics,
                 )?;
-                let prev_used = self.inner_metrics.mem_used().set(0);
+                let prev_used = self.metrics.mem_used().set(0);
                 streams.push(SortedStream::new(in_mem_stream, prev_used));
             }
 
@@ -139,7 +143,7 @@ impl ExternalSorter {
                 let stream = read_spill_as_stream(spill, self.schema.clone())?;
                 streams.push(SortedStream::new(stream, 0));
             }
-            let baseline_metrics = self.metrics.new_final_baseline(partition);
+            let baseline_metrics = self.metrics_set.new_final_baseline(partition);
             Ok(Box::pin(SortPreservingMergeStream::new_from_streams(
                 streams,
                 self.schema.clone(),
@@ -149,15 +153,16 @@ impl ExternalSorter {
                 self.runtime.clone(),
             )))
         } else if in_mem_batches.len() > 0 {
-            let baseline_metrics = self.metrics.new_final_baseline(partition);
+            let tracking_metrics = self
+                .metrics_set
+                .new_final_tracking(partition, self.runtime.clone());
             let result = in_mem_partial_sort(
                 &mut *in_mem_batches,
                 self.schema.clone(),
                 &self.expr,
-                baseline_metrics,
+                tracking_metrics,
             );
-            self.inner_metrics.mem_used().set(0);
-            // TODO: the result size is not tracked
+            self.metrics.mem_used().set(0);
             result
         } else {
             Ok(Box::pin(EmptyRecordBatchStream::new(self.schema.clone())))
@@ -165,15 +170,15 @@ impl ExternalSorter {
     }
 
     fn used(&self) -> usize {
-        self.inner_metrics.mem_used().value()
+        self.metrics.mem_used().value()
     }
 
     fn spilled_bytes(&self) -> usize {
-        self.inner_metrics.spilled_bytes().value()
+        self.metrics.spilled_bytes().value()
     }
 
     fn spill_count(&self) -> usize {
-        self.inner_metrics.spill_count().value()
+        self.metrics.spill_count().value()
     }
 }
 
@@ -228,27 +233,29 @@ impl MemoryConsumer for ExternalSorter {
             return Ok(0);
         }
 
-        let baseline_metrics = self.metrics.new_intermediate_baseline(partition);
+        let tracking_metrics = self
+            .metrics_set
+            .new_intermediate_tracking(partition, self.runtime.clone());
 
         let spillfile = self.runtime.disk_manager.create_tmp_file()?;
         let stream = in_mem_partial_sort(
             &mut *in_mem_batches,
             self.schema.clone(),
             &*self.expr,
-            baseline_metrics,
+            tracking_metrics,
         );
 
         spill_partial_sorted_stream(&mut stream?, spillfile.path(), self.schema.clone())
             .await?;
         let mut spills = self.spills.lock().await;
-        let used = self.inner_metrics.mem_used().set(0);
-        self.inner_metrics.record_spill(used);
+        let used = self.metrics.mem_used().set(0);
+        self.metrics.record_spill(used);
         spills.push(spillfile);
         Ok(used)
     }
 
     fn mem_used(&self) -> usize {
-        self.inner_metrics.mem_used().value()
+        self.metrics.mem_used().value()
     }
 }
 
@@ -257,14 +264,14 @@ fn in_mem_partial_sort(
     buffered_batches: &mut Vec<RecordBatch>,
     schema: SchemaRef,
     expressions: &[PhysicalSortExpr],
-    baseline_metrics: BaselineMetrics,
+    tracking_metrics: MemTrackingMetrics,
 ) -> Result<SendableRecordBatchStream> {
     assert_ne!(buffered_batches.len(), 0);
 
     let result = {
         // NB timer records time taken on drop, so there are no
         // calls to `timer.done()` below.
-        let _timer = baseline_metrics.elapsed_compute().timer();
+        let _timer = tracking_metrics.elapsed_compute().timer();
 
         let pre_sort = if buffered_batches.len() == 1 {
             buffered_batches.pop()
@@ -282,7 +289,7 @@ fn in_mem_partial_sort(
     Ok(Box::pin(SizedRecordBatchStream::new(
         schema,
         vec![Arc::new(result.unwrap())],
-        baseline_metrics,
+        tracking_metrics,
     )))
 }
 
@@ -363,7 +370,7 @@ pub struct SortExec {
     /// Sort expressions
     expr: Vec<PhysicalSortExpr>,
     /// Containing all metrics set created during sort
-    all_metrics: CompositeMetricsSet,
+    metrics_set: CompositeMetricsSet,
     /// Preserve partitions of input plan
     preserve_partitioning: bool,
 }
@@ -387,7 +394,7 @@ impl SortExec {
         Self {
             expr,
             input,
-            all_metrics: CompositeMetricsSet::new(),
+            metrics_set: CompositeMetricsSet::new(),
             preserve_partitioning,
         }
     }
@@ -476,14 +483,14 @@ impl ExecutionPlan for SortExec {
             input,
             partition,
             self.expr.clone(),
-            self.all_metrics.clone(),
+            self.metrics_set.clone(),
             runtime,
         )
         .await
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
-        Some(self.all_metrics.aggregate_all())
+        Some(self.metrics_set.aggregate_all())
     }
 
     fn fmt_as(
@@ -543,12 +550,17 @@ async fn do_sort(
     mut input: SendableRecordBatchStream,
     partition_id: usize,
     expr: Vec<PhysicalSortExpr>,
-    metrics: CompositeMetricsSet,
+    metrics_set: CompositeMetricsSet,
     runtime: Arc<RuntimeEnv>,
 ) -> Result<SendableRecordBatchStream> {
     let schema = input.schema();
-    let sorter =
-        ExternalSorter::new(partition_id, schema.clone(), expr, metrics, runtime.clone());
+    let sorter = ExternalSorter::new(
+        partition_id,
+        schema.clone(),
+        expr,
+        metrics_set,
+        runtime.clone(),
+    );
     runtime.register_requester(sorter.id());
     while let Some(batch) = input.next().await {
         let batch = batch?;

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -143,13 +143,14 @@ impl ExternalSorter {
                 let stream = read_spill_as_stream(spill, self.schema.clone())?;
                 streams.push(SortedStream::new(stream, 0));
             }
-            let baseline_metrics = self.metrics_set.new_final_baseline(partition);
+            let tracking_metrics = self
+                .metrics_set
+                .new_final_tracking(partition, self.runtime.clone());
             Ok(Box::pin(SortPreservingMergeStream::new_from_streams(
                 streams,
                 self.schema.clone(),
                 &self.expr,
-                baseline_metrics,
-                partition,
+                tracking_metrics,
                 self.runtime.clone(),
             )))
         } else if in_mem_batches.len() > 0 {

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -163,6 +163,7 @@ impl ExternalSorter {
                 &self.expr,
                 tracking_metrics,
             );
+            // Report to the memory manager we are no longer using memory
             self.metrics.mem_used().set(0);
             result
         } else {

--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -19,11 +19,11 @@
 
 use crate::physical_plan::common::AbortOnDropMany;
 use crate::physical_plan::metrics::{
-    BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet,
+    ExecutionPlanMetricsSet, MemTrackingMetrics, MetricsSet,
 };
 use std::any::Any;
 use std::collections::{BinaryHeap, VecDeque};
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -41,9 +41,6 @@ use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
 
 use crate::error::{DataFusionError, Result};
-use crate::execution::memory_manager::{
-    ConsumerType, MemoryConsumer, MemoryConsumerId, MemoryManager,
-};
 use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::sorts::{RowIndex, SortKeyCursor, SortedStream, StreamWrapper};
 use crate::physical_plan::{
@@ -161,7 +158,7 @@ impl ExecutionPlan for SortPreservingMergeExec {
             )));
         }
 
-        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        let tracking_metrics = MemTrackingMetrics::new(&self.metrics, partition);
 
         let input_partitions = self.input.output_partitioning().partition_count();
         match input_partitions {
@@ -193,8 +190,7 @@ impl ExecutionPlan for SortPreservingMergeExec {
                     AbortOnDropMany(join_handles),
                     self.schema(),
                     &self.expr,
-                    baseline_metrics,
-                    partition,
+                    tracking_metrics,
                     runtime,
                 )))
             }
@@ -223,73 +219,24 @@ impl ExecutionPlan for SortPreservingMergeExec {
     }
 }
 
+#[derive(Debug)]
 struct MergingStreams {
-    /// ConsumerId
-    id: MemoryConsumerId,
     /// The sorted input streams to merge together
     streams: Mutex<Vec<StreamWrapper>>,
     /// number of streams
     num_streams: usize,
-    /// Runtime
-    runtime: Arc<RuntimeEnv>,
-}
-
-impl Debug for MergingStreams {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        f.debug_struct("MergingStreams")
-            .field("id", &self.id())
-            .finish()
-    }
 }
 
 impl MergingStreams {
-    fn new(
-        partition: usize,
-        input_streams: Vec<StreamWrapper>,
-        runtime: Arc<RuntimeEnv>,
-    ) -> Self {
+    fn new(input_streams: Vec<StreamWrapper>) -> Self {
         Self {
-            id: MemoryConsumerId::new(partition),
             num_streams: input_streams.len(),
             streams: Mutex::new(input_streams),
-            runtime,
         }
     }
 
     fn num_streams(&self) -> usize {
         self.num_streams
-    }
-}
-
-#[async_trait]
-impl MemoryConsumer for MergingStreams {
-    fn name(&self) -> String {
-        "MergingStreams".to_owned()
-    }
-
-    fn id(&self) -> &MemoryConsumerId {
-        &self.id
-    }
-
-    fn memory_manager(&self) -> Arc<MemoryManager> {
-        self.runtime.memory_manager.clone()
-    }
-
-    fn type_(&self) -> &ConsumerType {
-        &ConsumerType::Tracking
-    }
-
-    async fn spill(&self) -> Result<usize> {
-        return Err(DataFusionError::Internal(format!(
-            "Calling spill on a tracking only consumer {}, {}",
-            self.name(),
-            self.id,
-        )));
-    }
-
-    fn mem_used(&self) -> usize {
-        let streams = self.streams.lock().unwrap();
-        streams.iter().map(StreamWrapper::mem_used).sum::<usize>()
     }
 }
 
@@ -324,7 +271,7 @@ pub(crate) struct SortPreservingMergeStream {
     sort_options: Arc<Vec<SortOptions>>,
 
     /// used to record execution metrics
-    baseline_metrics: BaselineMetrics,
+    tracking_metrics: MemTrackingMetrics,
 
     /// If the stream has encountered an error
     aborted: bool,
@@ -335,26 +282,17 @@ pub(crate) struct SortPreservingMergeStream {
     /// min heap for record comparison
     min_heap: BinaryHeap<SortKeyCursor>,
 
-    /// runtime
-    runtime: Arc<RuntimeEnv>,
-}
-
-impl Drop for SortPreservingMergeStream {
-    fn drop(&mut self) {
-        self.runtime
-            .drop_consumer(self.streams.id(), self.streams.mem_used())
-    }
+    /// target batch size
+    batch_size: usize,
 }
 
 impl SortPreservingMergeStream {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_from_receivers(
         receivers: Vec<mpsc::Receiver<ArrowResult<RecordBatch>>>,
         _drop_helper: AbortOnDropMany<()>,
         schema: SchemaRef,
         expressions: &[PhysicalSortExpr],
-        baseline_metrics: BaselineMetrics,
-        partition: usize,
+        tracking_metrics: MemTrackingMetrics,
         runtime: Arc<RuntimeEnv>,
     ) -> Self {
         let stream_count = receivers.len();
@@ -363,23 +301,21 @@ impl SortPreservingMergeStream {
             .map(|_| VecDeque::new())
             .collect();
         let wrappers = receivers.into_iter().map(StreamWrapper::Receiver).collect();
-        let streams = MergingStreams::new(partition, wrappers, runtime.clone());
-        runtime.register_requester(streams.id());
 
         SortPreservingMergeStream {
             schema,
             batches,
             cursor_finished: vec![true; stream_count],
-            streams,
+            streams: MergingStreams::new(wrappers),
             _drop_helper,
             column_expressions: expressions.iter().map(|x| x.expr.clone()).collect(),
             sort_options: Arc::new(expressions.iter().map(|x| x.options).collect()),
-            baseline_metrics,
+            tracking_metrics,
             aborted: false,
             in_progress: vec![],
             next_batch_id: 0,
             min_heap: BinaryHeap::with_capacity(stream_count),
-            runtime,
+            batch_size: runtime.batch_size(),
         }
     }
 
@@ -387,8 +323,7 @@ impl SortPreservingMergeStream {
         streams: Vec<SortedStream>,
         schema: SchemaRef,
         expressions: &[PhysicalSortExpr],
-        baseline_metrics: BaselineMetrics,
-        partition: usize,
+        tracking_metrics: MemTrackingMetrics,
         runtime: Arc<RuntimeEnv>,
     ) -> Self {
         let stream_count = streams.len();
@@ -396,27 +331,26 @@ impl SortPreservingMergeStream {
             .into_iter()
             .map(|_| VecDeque::new())
             .collect();
+        tracking_metrics.init_mem_used(streams.iter().map(|s| s.mem_used).sum());
         let wrappers = streams
             .into_iter()
             .map(|s| StreamWrapper::Stream(Some(s)))
             .collect();
-        let streams = MergingStreams::new(partition, wrappers, runtime.clone());
-        runtime.register_requester(streams.id());
 
         Self {
             schema,
             batches,
             cursor_finished: vec![true; stream_count],
-            streams,
+            streams: MergingStreams::new(wrappers),
             _drop_helper: AbortOnDropMany(vec![]),
             column_expressions: expressions.iter().map(|x| x.expr.clone()).collect(),
             sort_options: Arc::new(expressions.iter().map(|x| x.options).collect()),
-            baseline_metrics,
+            tracking_metrics,
             aborted: false,
             in_progress: vec![],
             next_batch_id: 0,
             min_heap: BinaryHeap::with_capacity(stream_count),
-            runtime,
+            batch_size: runtime.batch_size(),
         }
     }
 
@@ -578,7 +512,7 @@ impl Stream for SortPreservingMergeStream {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let poll = self.poll_next_inner(cx);
-        self.baseline_metrics.record_poll(poll)
+        self.tracking_metrics.record_poll(poll)
     }
 }
 
@@ -607,7 +541,7 @@ impl SortPreservingMergeStream {
         loop {
             // NB timer records time taken on drop, so there are no
             // calls to `timer.done()` below.
-            let elapsed_compute = self.baseline_metrics.elapsed_compute().clone();
+            let elapsed_compute = self.tracking_metrics.elapsed_compute().clone();
             let _timer = elapsed_compute.timer();
 
             match self.min_heap.pop() {
@@ -631,7 +565,7 @@ impl SortPreservingMergeStream {
                         row_idx,
                     });
 
-                    if self.in_progress.len() == self.runtime.batch_size() {
+                    if self.in_progress.len() == self.batch_size {
                         return Poll::Ready(Some(self.build_record_batch()));
                     }
 
@@ -1264,7 +1198,7 @@ mod tests {
         }
 
         let metrics = ExecutionPlanMetricsSet::new();
-        let baseline_metrics = BaselineMetrics::new(&metrics, 0);
+        let tracking_metrics = MemTrackingMetrics::new(&metrics, 0);
 
         let merge_stream = SortPreservingMergeStream::new_from_receivers(
             receivers,
@@ -1272,8 +1206,7 @@ mod tests {
             AbortOnDropMany(vec![]),
             batches.schema(),
             sort.as_slice(),
-            baseline_metrics,
-            0,
+            tracking_metrics,
             runtime.clone(),
         );
 

--- a/datafusion/tests/provider_filter_pushdown.rs
+++ b/datafusion/tests/provider_filter_pushdown.rs
@@ -25,7 +25,9 @@ use datafusion::execution::context::ExecutionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_plan::Expr;
 use datafusion::physical_plan::common::SizedRecordBatchStream;
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet};
+use datafusion::physical_plan::metrics::{
+    ExecutionPlanMetricsSet, MemTrackingMetrics,
+};
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
@@ -86,11 +88,11 @@ impl ExecutionPlan for CustomPlan {
         _runtime: Arc<RuntimeEnv>,
     ) -> Result<SendableRecordBatchStream> {
         let metrics = ExecutionPlanMetricsSet::new();
-        let baseline_metrics = BaselineMetrics::new(&metrics, partition);
+        let tracking_metrics = MemTrackingMetrics::new(&metrics, partition);
         Ok(Box::pin(SizedRecordBatchStream::new(
             self.schema(),
             self.batches.clone(),
-            baseline_metrics,
+            tracking_metrics,
         )))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1569.

 # Rationale for this change

The kinds of requesting memory consumers are pretty limited. As shown in #587, we only have 3 or 4 types of requesting memory consumers (join / sort / agg / repartition). All other consumers that take non-neglectable memory are considered tracking consumers.

Tracking consumers always have a relatively fixed pattern for memory usage. They claim some memory, use it during execution, and free it when finished. The situation for growing or shrinking memory usage can be rare. 

Considering the potentially large number of tracking consumers and the simple use case, we'd better have a simple method to achieve this kind of tracking; therefore, `MemTrackingMetrics` is proposed in this PR.

# What changes are included in this PR?

1. `MemTrackingMetrics` introduced, act similar to `BaselineMetrics`, report memory usage with `init_mem_used` and free memory when it's been dropped.
2. MemoryManager no longer stores weak references for any consumers. Simplify the registering for memory consumers as well.
3. Consumers push their memory usage to MemoryManager. No more pull from MemoryManagers for usage update.
4. Use `MemTrackingMetrics` in SortPreservingMergeStream and SizedRecordBatchStream, simplify the tracking logic.
5. Rename `AggregatedMetricsSet` to `CompositeMetricsSet`, fix start/end time aggregation.

# Are there any user-facing changes?
No.
