### PR TITLE
Implement TableProvider for DataFrameImpl

### DIFF
--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -92,7 +92,6 @@ impl TableProvider for DataFrameImpl {
     async fn scan(
         &self,
         projection: &Option<Vec<usize>>,
-        _batch_size: usize,
         filters: &[Expr],
         // limit can be used to reduce the amount scanned
         // from the datasource as a performance optimization.

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -111,9 +111,9 @@ impl TableProvider for DataFrameImpl {
                 },
             )?
             // add predicates, otherwise use `true` as the predicate
-            .filter(filters.iter().fold(
+            .filter(filters.iter().cloned().fold(
                 Expr::Literal(ScalarValue::Boolean(Some(true))),
-                |acc, new| acc.and(new.clone()),
+                |acc, new| acc.and(new),
             ))?;
         // add a limit if given
         Self::new(

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -558,7 +558,7 @@ mod tests {
 
         // pull the table out and compare the plans
         let table = ctx.table("test_table")?;
-        assert_same_plan(&table.to_logical_plan(), &table.to_logical_plan());
+        assert_same_plan(&df.to_logical_plan(), &table.to_logical_plan());
 
         // check that we correctly read from the table
         let results = &table

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -93,10 +93,6 @@ impl TableProvider for DataFrameImpl {
         &self,
         projection: &Option<Vec<usize>>,
         filters: &[Expr],
-        // limit can be used to reduce the amount scanned
-        // from the datasource as a performance optimization.
-        // If set, it contains the amount of rows needed by the `LogicalPlan`,
-        // The datasource should return *at least* this number of rows if available.
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let expr = projection

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -585,14 +585,9 @@ mod tests {
         assert_batches_sorted_eq!(expected_lines, table_results);
         Ok(())
     }
-
     /// Compare the formatted string representation of two plans for equality
     fn assert_same_plan(plan1: &LogicalPlan, plan2: &LogicalPlan) {
-        let plan1_str = format!("{:?}", plan1);
-        let plan2_str = format!("{:?}", plan2);
-        println!("{}", plan1_str);
-        println!("{}", plan2_str);
-        assert_eq!(plan1_str, plan2_str);
+        assert_eq!(format!("{:?}", plan1), format!("{:?}", plan2));
     }
 
     /// Create a logical plan from a SQL query

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -560,7 +560,7 @@ mod tests {
         let table = ctx.table("test_table")?;
 
         // check that we correctly read from the table
-        let df_results = &table
+        let df_results = &df_impl
             .aggregate(vec![col("c1")], vec![sum(col("c12"))])?
             .collect()
             .await?;

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -560,13 +560,16 @@ mod tests {
         // pull the table out and compare the plans
         let table = ctx.table("test_table")?;
 
+        let group_expr = vec![col("c1")];
+        let aggr_expr = vec![sum(col("c12"))];
+
         // check that we correctly read from the table
         let df_results = &df_impl
-            .aggregate(vec![col("c1")], vec![sum(col("c12"))])?
+            .aggregate(group_expr.clone(), aggr_expr.clone())?
             .collect()
             .await?;
         let table_results = &table
-            .aggregate(vec![col("c1")], vec![sum(col("c12"))])?
+            .aggregate(group_expr, aggr_expr)?
             .collect()
             .await?;
 

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -70,13 +70,10 @@ impl DataFrameImpl {
 
 #[async_trait]
 impl TableProvider for DataFrameImpl {
-    /// Returns the table provider as [`Any`](std::any::Any) so that it can be
-    /// downcast to a specific implementation.
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    /// Get a reference to the schema for this table
     fn schema(&self) -> SchemaRef {
         Arc::new(Schema::new(
             self.plan
@@ -88,15 +85,10 @@ impl TableProvider for DataFrameImpl {
         ))
     }
 
-    /// Get the type of this table for metadata/catalog purposes.
     fn table_type(&self) -> TableType {
         TableType::View
     }
 
-    /// Create an ExecutionPlan that will scan the table.
-    /// The table provider will be usually responsible of grouping
-    /// the source data into partitions that can be efficiently
-    /// parallelized or distributed.
     async fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -75,15 +75,10 @@ impl TableProvider for DataFrameImpl {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::new(Schema::new(
-            self.plan
-                .schema()
-                .fields()
-                .iter()
-                .map(|f| f.field().clone())
-                .collect(),
-        ))
+        let schema: Schema = self.plan.schema().as_ref().into();
+        Arc::new(schema)
     }
+
 
     fn table_type(&self) -> TableType {
         TableType::View

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -557,6 +557,17 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn register_table() -> Result<()> {
+        let df = test_table().await?.select_columns(&["c1", "c3"])?;
+        let mut ctx = ExecutionContext::new();
+        let df_impl = DataFrameImpl::new(ctx.state.clone(), &df.to_logical_plan());
+        ctx.register_table("test_table", Arc::new(df_impl))?;
+        let table = ctx.table("test_table")?;
+        assert_same_plan(&table.to_logical_plan(), &table.to_logical_plan());
+        Ok(())
+    }
+
     /// Compare the formatted string representation of two plans for equality
     fn assert_same_plan(plan1: &LogicalPlan, plan2: &LogicalPlan) {
         assert_eq!(format!("{:?}", plan1), format!("{:?}", plan2));

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -568,10 +568,7 @@ mod tests {
             .aggregate(group_expr.clone(), aggr_expr.clone())?
             .collect()
             .await?;
-        let table_results = &table
-            .aggregate(group_expr, aggr_expr)?
-            .collect()
-            .await?;
+        let table_results = &table.aggregate(group_expr, aggr_expr)?.collect().await?;
 
         assert_batches_sorted_eq!(
             vec![

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -557,7 +557,7 @@ mod tests {
         // register a dataframe as a table
         ctx.register_table("test_table", df_impl.clone())?;
 
-        // pull the table out and compare the plans
+        // pull the table out
         let table = ctx.table("test_table")?;
 
         let group_expr = vec![col("c1")];


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1698.

# Rationale for this change

See #1698.

# What changes are included in this PR?

1. An implementation of `TableProvider` for `DataFrameImpl`
2. A test to verify that a table can be registered in context and that the
   registered table's plan is equivalent to the one used for registration

# Are there any user-facing changes?

Yes, the ability to register plan through `DataFrameImpl` is a new addition to the API.
I think rustdoc should take care of listing the additional `impl` of `TableProvider`.

Let me know if there's another place I should add docs.
