### PR TITLE
generalize table provider df impl

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1573,7 +1573,9 @@ mod tests {
         let tmp_dir = TempDir::new()?;
         let ctx = create_ctx(&tmp_dir, 1).await?;
 
-        let schema: Schema = DataFrame::schema(&*ctx.table("test").unwrap()).clone().into();
+        let schema: Schema = DataFrame::schema(&*ctx.table("test").unwrap())
+            .clone()
+            .into();
         assert!(!schema.field_with_name("c1")?.is_nullable());
 
         let plan = LogicalPlanBuilder::scan_empty(None, &schema, None)?

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1573,7 +1573,7 @@ mod tests {
         let tmp_dir = TempDir::new()?;
         let ctx = create_ctx(&tmp_dir, 1).await?;
 
-        let schema: Schema = ctx.table("test").unwrap().schema().clone().into();
+        let schema: Schema = DataFrame::schema(&*ctx.table("test").unwrap()).clone().into();
         assert!(!schema.field_with_name("c1")?.is_nullable());
 
         let plan = LogicalPlanBuilder::scan_empty(None, &schema, None)?

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -602,6 +602,17 @@ mod tests {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn register_dataframe() -> Result<()> {
+        let df = test_table().await?.select_columns(&["c1", "c12"])?;
+        let mut ctx = ExecutionContext::new();
+
+        // register a dataframe as a table
+        ctx.register_table("test_table", df)?;
+        Ok(())
+    }
+
     /// Compare the formatted string representation of two plans for equality
     fn assert_same_plan(plan1: &LogicalPlan, plan2: &LogicalPlan) {
         assert_eq!(format!("{:?}", plan1), format!("{:?}", plan2));


### PR DESCRIPTION
This is a draft PR following up a [discussion](https://github.com/apache/arrow-datafusion/pull/1699#discussion_r794994473) on #1699.

Issues:

1. The execution context state is using `Default`, it compiles and tests pass,
   but I don't know if that's the right thing to do there.
1. It doesn't appear that it's possible to allow registration of `dyn
   DataFrame` without the `trait_upcasting` feature, which is unstable.
1. The `schema` methods are ambiguous when `use datafusion::prelude::*` is used (because both traits have a `schema` method), which makes using either's method without fully qualified syntax pretty ugly.