### PR TITLE
Add Expression Simplification API

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -20,11 +20,13 @@
 
 pub use super::Operator;
 use crate::error::{DataFusionError, Result};
+use crate::execution::context::ExecutionProps;
 use crate::field_util::get_indexed_field;
 use crate::logical_plan::{
     plan::Aggregate, window_frames, DFField, DFSchema, LogicalPlan,
 };
-use crate::physical_plan::functions::Volatility;
+use crate::optimizer::simplify_expressions::{ConstEvaluator, Simplifier};
+use crate::physical_plan::functions::{BuiltinScalarFunction, Volatility};
 use crate::physical_plan::{
     aggregates, expressions::binary_operator_data_type, functions, udf::ScalarUDF,
     window_functions,
@@ -971,6 +973,58 @@ impl Expr {
             Ok(expr)
         }
     }
+
+    /// Simplifies this [`Expr`]`s as much as possible, evaluating
+    /// constants and applying algebraic simplifications
+    ///
+    /// # Example:
+    /// `b > 2 AND b > 2`
+    /// can be written to
+    /// `b > 2`
+    ///
+    /// ```
+    /// use datafusion::logical_plan::*;
+    /// use datafusion::error::Result;
+    /// use datafusion::execution::context::ExecutionProps;
+    ///
+    /// /// Simple implementation that provides `Simplifier` the information it needs
+    /// #[derive(Default)]
+    /// struct Info {
+    ///   execution_props: ExecutionProps,
+    /// };
+    ///
+    /// impl SimplifyInfo for Info {
+    ///   fn is_boolean_type(&self, expr: &Expr) -> Result<bool> {
+    ///     Ok(false)
+    ///   }
+    ///   fn nullable(&self, expr: &Expr) -> Result<bool> {
+    ///     Ok(true)
+    ///   }
+    ///   fn execution_props(&self) -> &ExecutionProps {
+    ///     &self.execution_props
+    ///   }
+    /// }
+    ///
+    /// // b < 2
+    /// let b_lt_2 = col("b").gt(lit(2));
+    ///
+    /// // (b < 2) OR (b < 2)
+    /// let expr = b_lt_2.clone().or(b_lt_2.clone());
+    ///
+    /// // (b < 2) OR (b < 2) --> (b < 2)
+    /// let expr = expr.simplify(&Info::default()).unwrap();
+    /// assert_eq!(expr, b_lt_2);
+    /// ```
+    pub fn simplify<S: SimplifyInfo>(self, info: &S) -> Result<Self> {
+        let mut rewriter = Simplifier::new(info);
+        let mut const_evaluator = ConstEvaluator::new(info.execution_props());
+
+        // TODO iterate until no changes are made during rewrite
+        // (evaluating constants can enable new simplifications and
+        // simplifications can enable new constant evaluation)
+        // https://github.com/apache/arrow-datafusion/issues/1160
+        self.rewrite(&mut const_evaluator)?.rewrite(&mut rewriter)
+    }
 }
 
 impl Not for Expr {
@@ -1092,6 +1146,20 @@ pub trait ExprRewriter: Sized {
     fn mutate(&mut self, expr: Expr) -> Result<Expr>;
 }
 
+/// The information necessary to apply algebraic simplification to an
+/// [Expr]. See [SimplifyContext] for one implementation
+pub trait SimplifyInfo {
+    /// returns true if this Expr has boolean type
+    fn is_boolean_type(&self, expr: &Expr) -> Result<bool>;
+
+    /// returns true of this expr is nullable (could possibly be NULL)
+    fn nullable(&self, expr: &Expr) -> Result<bool>;
+
+    /// Returns details needed for partial expression evaluation
+    fn execution_props(&self) -> &ExecutionProps;
+}
+
+/// Helper struct for building [Expr::Case]
 pub struct CaseBuilder {
     expr: Option<Box<Expr>>,
     when_expr: Vec<Expr>,

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -26,7 +26,7 @@ use crate::logical_plan::{
     plan::Aggregate, window_frames, DFField, DFSchema, LogicalPlan,
 };
 use crate::optimizer::simplify_expressions::{ConstEvaluator, Simplifier};
-use crate::physical_plan::functions::{BuiltinScalarFunction, Volatility};
+use crate::physical_plan::functions::Volatility;
 use crate::physical_plan::{
     aggregates, expressions::binary_operator_data_type, functions, udf::ScalarUDF,
     window_functions,

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -47,6 +47,7 @@ pub use expr::{
     signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
     translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols, upper, when,
     Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
+    SimplifyInfo,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/tests/simplification.rs
+++ b/datafusion/tests/simplification.rs
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This program demonstrates the DataFusion expression simplification API.
+
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::{
+    error::Result,
+    execution::context::ExecutionProps,
+    logical_plan::{DFSchema, Expr, SimplifyInfo},
+    prelude::*,
+};
+
+/// In order to simplify expressions, DataFusion must have information
+/// about the expressions.
+///
+/// You can provide that information using DataFusion [DFSchema]
+/// objects or from some other implemention
+struct MyInfo {
+    /// The input schema
+    schema: DFSchema,
+
+    /// Execution specific details needed for constant evaluation such
+    /// as the current time for `now()` and [VariableProviders]
+    execution_props: ExecutionProps,
+}
+
+impl SimplifyInfo for MyInfo {
+    fn is_boolean_type(&self, expr: &Expr) -> Result<bool> {
+        Ok(matches!(expr.get_type(&self.schema)?, DataType::Boolean))
+    }
+
+    fn nullable(&self, expr: &Expr) -> Result<bool> {
+        expr.nullable(&self.schema)
+    }
+
+    fn execution_props(&self) -> &ExecutionProps {
+        &self.execution_props
+    }
+}
+
+impl From<DFSchema> for MyInfo {
+    fn from(schema: DFSchema) -> Self {
+        Self {
+            schema,
+            execution_props: ExecutionProps::new(),
+        }
+    }
+}
+
+/// A schema like:
+///
+/// a: Int32 (possibly with nulls)
+/// b: Int32
+/// s: Utf8
+fn schema() -> DFSchema {
+    Schema::new(vec![
+        Field::new("a", DataType::Int32, true),
+        Field::new("b", DataType::Int32, false),
+        Field::new("s", DataType::Utf8, false),
+    ])
+    .try_into()
+    .unwrap()
+}
+
+#[test]
+fn basic() {
+    let info: MyInfo = schema().into();
+
+    // The `Expr` is a core concept in DataFusion, and DataFusion can
+    // help simplify it.
+
+    // For example 'a < (2 + 3)' can be rewritten into the easier to
+    // optimize form `a < 5` automatically
+    let expr = col("a").lt(lit(2i32) + lit(3i32));
+
+    let simplified = expr.simplify(&info).unwrap();
+    assert_eq!(simplified, col("a").lt(lit(5i32)));
+}
+
+#[test]
+fn fold_and_simplify() {
+    let info: MyInfo = schema().into();
+
+    // What will it do with the expression `concat('foo', 'bar') == 'foobar')`?
+    let expr = concat(&[lit("foo"), lit("bar")]).eq(lit("foobar"));
+
+    // Since datafusion applies both simplification *and* rewriting
+    // some expressions can be entirely simplified
+    let simplified = expr.simplify(&info).unwrap();
+    assert_eq!(simplified, lit(true))
+}


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-datafusion/issues/1694

 # Rationale for this change
I think the expression simplification code in DataFusion is quite cool and should be able to be reused outside the crate. We would like to do so for IOx. See #1694 for more details


# What changes are included in this PR?
1. Add trait `SimplifyInfo` to provide the required information for simplification
1. Add `Expr::simplify` and refactor expression simplification
3. Add an example program / test illustrating how this works

# Are there any user-facing changes?
New Public API 

Example use:

```rust
    // For example 'a < (2 + 3)' can be rewritten into the easier to
    // optimize form `a < 5` automatically
    let expr = col("a").lt(lit(2i32) + lit(3i32));

    let simplified = expr.simplify(&info).unwrap();
    assert_eq!(simplified, col("a").lt(lit(5i32)));
```