### PR TITLE
API to get Expr's type and nullability without a `DFSchema`

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -393,7 +393,7 @@ impl PartialOrd for Expr {
 }
 
 /// Provides schema information needed by [Expr] methods such as
-/// [Expr::nullable] and [Expr::data_type]
+/// [Expr::nullable] and [Expr::data_type].
 ///
 /// Note that this trait is implemented for &[DFSchema] which is
 /// widely used in the DataFusion codebase.
@@ -405,7 +405,7 @@ pub trait ExprSchema {
     fn data_type(&self, col: &Column) -> Result<&DataType>;
 }
 
-// Implement for Arc<DFSchema>
+// Implement `ExprSchema` for `Arc<DFSchema>`
 impl<P: AsRef<DFSchema>> ExprSchema for P {
     fn nullable(&self, col: &Column) -> Result<bool> {
         self.as_ref().nullable(col)
@@ -427,13 +427,18 @@ impl ExprSchema for DFSchema {
 }
 
 impl Expr {
-    /// Returns the [arrow::datatypes::DataType] of the expression based on [DFSchema].
+    /// Returns the [arrow::datatypes::DataType] of the expression
+    /// based on [ExprSchema]
+    ///
+    /// Note: [DFSchema] implements [ExprSchema].
     ///
     /// # Errors
     ///
-    /// This function errors when it is not possible to compute its [arrow::datatypes::DataType].
-    /// This happens when e.g. the expression refers to a column that does not exist in the schema, or when
-    /// the expression is incorrectly typed (e.g. `[utf8] + [bool]`).
+    /// This function errors when it is not possible to compute its
+    /// [arrow::datatypes::DataType].  This happens when e.g. the
+    /// expression refers to a column that does not exist in the
+    /// schema, or when the expression is incorrectly typed
+    /// (e.g. `[utf8] + [bool]`).
     pub fn get_type<S: ExprSchema>(&self, schema: &S) -> Result<DataType> {
         match self {
             Expr::Alias(expr, _) | Expr::Sort { expr, .. } | Expr::Negative(expr) => {
@@ -506,12 +511,15 @@ impl Expr {
         }
     }
 
-    /// Returns the nullability of the expression based on [DFSchema].
+    /// Returns the nullability of the expression based on [ExprSchema].
+    ///
+    /// Note: [DFSchema] implements [ExprSchema].
     ///
     /// # Errors
     ///
-    /// This function errors when it is not possible to compute its nullability.
-    /// This happens when the expression refers to a column that does not exist in the schema.
+    /// This function errors when it is not possible to compute its
+    /// nullability.  This happens when the expression refers to a
+    /// column that does not exist in the schema.
     pub fn nullable<S: ExprSchema>(&self, input_schema: &S) -> Result<bool> {
         match self {
             Expr::Alias(expr, _)

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -46,8 +46,8 @@ pub use expr::{
     rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224, sha256, sha384, sha512,
     signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
     translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols, upper, when,
-    Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
-    SimplifyInfo,
+    Column, Expr, ExprRewriter, ExprSchema, ExpressionVisitor, Literal, Recursion,
+    RewriteRecursion, SimplifyInfo,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1725

 # Rationale for this change
I am trying to create a low cost (low copy) way for `Expr` simplification.  More details on https://github.com/apache/arrow-datafusion/issues/1725

# What changes are included in this PR?
1. Add a trait that can provide the needed information for schema quries to Expr
1. Change the functions on `Expr` that take a &DFSchema such as `Expr::nullable` to be nullable
3. `impl` this new trait for `DFSchema` so that existing callsites work


# Are there any user-facing changes?
1. It is now possible to get an Expr's type without constructing a `DFSchema`; Existing code should continue to work