### PR TITLE
Create built-in scalar functions programmatically

### DIFF
--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -2194,9 +2194,9 @@ pub fn exprlist_to_fields<'a>(
 /// use datafusion::logical_plan::*;
 ///
 /// // create the expression sin(x) < 0.2
-/// let expr = call_buildin_scalar_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
+/// let expr = call_builtin_scalar_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
 /// ```
-pub fn call_buildin_scalar_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
+pub fn call_builtin_scalar_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
     match name.as_ref().parse::<functions::BuiltinScalarFunction>() {
         Ok(fun) => Ok(Expr::ScalarFunction { fun, args }),
         Err(e) => Err(e),

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -2194,9 +2194,9 @@ pub fn exprlist_to_fields<'a>(
 /// use datafusion::logical_plan::*;
 ///
 /// // create the expression sin(x) < 0.2
-/// let expr = call_builtin_scalar_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
+/// let expr = call_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
 /// ```
-pub fn call_builtin_scalar_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
+pub fn call_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
     match name.as_ref().parse::<functions::BuiltinScalarFunction>() {
         Ok(fun) => Ok(Expr::ScalarFunction { fun, args }),
         Err(e) => Err(e),

--- a/datafusion/src/logical_plan/expr.rs
+++ b/datafusion/src/logical_plan/expr.rs
@@ -2121,6 +2121,20 @@ pub fn exprlist_to_fields<'a>(
     expr.into_iter().map(|e| e.to_field(input_schema)).collect()
 }
 
+/// Calls a named built in function
+/// ```
+/// use datafusion::logical_plan::*;
+///
+/// // create the expression sin(x) < 0.2
+/// let expr = call_buildin_scalar_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
+/// ```
+pub fn call_buildin_scalar_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
+    match name.as_ref().parse::<functions::BuiltinScalarFunction>() {
+        Ok(fun) => Ok(Expr::ScalarFunction { fun, args }),
+        Err(e) => Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{col, lit, when};

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -37,17 +37,17 @@ pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
     abs, acos, and, approx_distinct, approx_percentile_cont, array, ascii, asin, atan,
-    avg, binary_expr, bit_length, btrim, call_builtin_scalar_fn, case, ceil,
-    character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws, cos,
-    count, count_distinct, create_udaf, create_udf, date_part, date_trunc, digest, exp,
-    exprlist_to_fields, floor, in_list, initcap, left, length, lit, lit_timestamp_nano,
-    ln, log10, log2, lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols,
-    now, octet_length, or, random, regexp_match, regexp_replace, repeat, replace,
-    replace_col, reverse, rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224,
-    sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr,
-    sum, tan, to_hex, translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols,
-    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
-    RewriteRecursion, SimplifyInfo,
+    avg, binary_expr, bit_length, btrim, call_fn, case, ceil, character_length, chr, col,
+    columnize_expr, combine_filters, concat, concat_ws, cos, count, count_distinct,
+    create_udaf, create_udf, date_part, date_trunc, digest, exp, exprlist_to_fields,
+    floor, in_list, initcap, left, length, lit, lit_timestamp_nano, ln, log10, log2,
+    lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols, now, octet_length,
+    or, random, regexp_match, regexp_replace, repeat, replace, replace_col, reverse,
+    rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224, sha256, sha384, sha512,
+    signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
+    translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols, upper, when,
+    Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
+    SimplifyInfo,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -37,16 +37,17 @@ pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
     abs, acos, and, approx_distinct, approx_percentile_cont, array, ascii, asin, atan,
-    avg, binary_expr, bit_length, btrim, case, ceil, character_length, chr, col,
-    columnize_expr, combine_filters, concat, concat_ws, cos, count, count_distinct,
-    create_udaf, create_udf, date_part, date_trunc, digest, exp, exprlist_to_fields,
-    floor, in_list, initcap, left, length, lit, lit_timestamp_nano, ln, log10, log2,
-    lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols, now, octet_length,
-    or, random, regexp_match, regexp_replace, repeat, replace, replace_col, reverse,
-    rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224, sha256, sha384, sha512,
-    signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
-    translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols, upper, when,
-    Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
+    avg, binary_expr, bit_length, btrim, call_buildin_scalar_fn, case, ceil,
+    character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws, cos,
+    count, count_distinct, create_udaf, create_udf, date_part, date_trunc, digest, exp,
+    exprlist_to_fields, floor, in_list, initcap, left, length, lit, lit_timestamp_nano,
+    ln, log10, log2, lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols,
+    now, octet_length, or, random, regexp_match, regexp_replace, repeat, replace,
+    replace_col, reverse, rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224,
+    sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr,
+    sum, tan, to_hex, translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols,
+    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
+    RewriteRecursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -37,17 +37,17 @@ pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
     abs, acos, and, approx_distinct, approx_percentile_cont, array, ascii, asin, atan,
-    avg, binary_expr, bit_length, btrim, case, ceil, character_length, chr, col,
-    columnize_expr, combine_filters, concat, concat_ws, cos, count, count_distinct,
-    create_udaf, create_udf, date_part, date_trunc, digest, exp, exprlist_to_fields,
-    floor, in_list, initcap, left, length, lit, lit_timestamp_nano, ln, log10, log2,
-    lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols, now, octet_length,
-    or, random, regexp_match, regexp_replace, repeat, replace, replace_col, reverse,
-    rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224, sha256, sha384, sha512,
-    signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
-    translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols, upper, when,
-    Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, RewriteRecursion,
-    SimplifyInfo,
+    avg, binary_expr, bit_length, btrim, call_buildin_scalar_fn, case, ceil,
+    character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws, cos,
+    count, count_distinct, create_udaf, create_udf, date_part, date_trunc, digest, exp,
+    exprlist_to_fields, floor, in_list, initcap, left, length, lit, lit_timestamp_nano,
+    ln, log10, log2, lower, lpad, ltrim, max, md5, min, normalize_col, normalize_cols,
+    now, octet_length, or, random, regexp_match, regexp_replace, repeat, replace,
+    replace_col, reverse, rewrite_sort_cols_by_aggs, right, round, rpad, rtrim, sha224,
+    sha256, sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr,
+    sum, tan, to_hex, translate, trim, trunc, unalias, unnormalize_col, unnormalize_cols,
+    upper, when, Column, Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
+    RewriteRecursion, SimplifyInfo,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/datafusion/src/logical_plan/mod.rs
+++ b/datafusion/src/logical_plan/mod.rs
@@ -37,7 +37,7 @@ pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
     abs, acos, and, approx_distinct, approx_percentile_cont, array, ascii, asin, atan,
-    avg, binary_expr, bit_length, btrim, call_buildin_scalar_fn, case, ceil,
+    avg, binary_expr, bit_length, btrim, call_builtin_scalar_fn, case, ceil,
     character_length, chr, col, columnize_expr, combine_filters, concat, concat_ws, cos,
     count, count_distinct, create_udaf, create_udf, date_part, date_trunc, digest, exp,
     exprlist_to_fields, floor, in_list, initcap, left, length, lit, lit_timestamp_nano,

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -735,8 +735,8 @@ mod tests {
     use super::*;
     use crate::assert_contains;
     use crate::logical_plan::{
-        and, binary_expr, call_builtin_scalar_fn, col, create_udf, lit,
-        lit_timestamp_nano, DFField, Expr, LogicalPlanBuilder,
+        and, binary_expr, call_fn, col, create_udf, lit, lit_timestamp_nano, DFField,
+        Expr, LogicalPlanBuilder,
     };
     use crate::physical_plan::functions::{make_scalar_function, BuiltinScalarFunction};
     use crate::physical_plan::udf::ScalarUDF;
@@ -1010,34 +1010,29 @@ mod tests {
     #[test]
     fn test_const_evaluator_scalar_functions() {
         // concat("foo", "bar") --> "foobar"
-        let expr =
-            call_builtin_scalar_fn("concat", vec![lit("foo"), lit("bar")]).unwrap();
+        let expr = call_fn("concat", vec![lit("foo"), lit("bar")]).unwrap();
         test_evaluate(expr, lit("foobar"));
 
         // ensure arguments are also constant folded
         // concat("foo", concat("bar", "baz")) --> "foobarbaz"
-        let concat1 =
-            call_builtin_scalar_fn("concat", vec![lit("bar"), lit("baz")]).unwrap();
-        let expr = call_builtin_scalar_fn("concat", vec![lit("foo"), concat1]).unwrap();
+        let concat1 = call_fn("concat", vec![lit("bar"), lit("baz")]).unwrap();
+        let expr = call_fn("concat", vec![lit("foo"), concat1]).unwrap();
         test_evaluate(expr, lit("foobarbaz"));
 
         // Check non string arguments
         // to_timestamp("2020-09-08T12:00:00+00:00") --> timestamp(1599566400000000000i64)
-        let expr = call_builtin_scalar_fn(
-            "to_timestamp",
-            vec![lit("2020-09-08T12:00:00+00:00")],
-        )
-        .unwrap();
+        let expr =
+            call_fn("to_timestamp", vec![lit("2020-09-08T12:00:00+00:00")]).unwrap();
         test_evaluate(expr, lit_timestamp_nano(1599566400000000000i64));
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = call_builtin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
+        let expr = call_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = call_builtin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
+        let expr = call_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // volatile / stable functions should not be evaluated
@@ -1078,7 +1073,7 @@ mod tests {
     }
 
     fn now_expr() -> Expr {
-        call_builtin_scalar_fn("now", vec![]).unwrap()
+        call_fn("now", vec![]).unwrap()
     }
 
     fn cast_to_int64_expr(expr: Expr) -> Expr {
@@ -1089,7 +1084,7 @@ mod tests {
     }
 
     fn to_timestamp_expr(arg: impl Into<String>) -> Expr {
-        call_builtin_scalar_fn("to_timestamp", vec![lit(arg.into())]).unwrap()
+        call_fn("to_timestamp", vec![lit(arg.into())]).unwrap()
     }
 
     #[test]

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -735,7 +735,7 @@ mod tests {
     use super::*;
     use crate::assert_contains;
     use crate::logical_plan::{
-        and, binary_expr, call_buildin_scalar_fn, col, create_udf, lit,
+        and, binary_expr, call_builtin_scalar_fn, col, create_udf, lit,
         lit_timestamp_nano, DFField, Expr, LogicalPlanBuilder,
     };
     use crate::physical_plan::functions::{make_scalar_function, BuiltinScalarFunction};
@@ -1011,19 +1011,19 @@ mod tests {
     fn test_const_evaluator_scalar_functions() {
         // concat("foo", "bar") --> "foobar"
         let expr =
-            call_buildin_scalar_fn("concat", vec![lit("foo"), lit("bar")]).unwrap();
+            call_builtin_scalar_fn("concat", vec![lit("foo"), lit("bar")]).unwrap();
         test_evaluate(expr, lit("foobar"));
 
         // ensure arguments are also constant folded
         // concat("foo", concat("bar", "baz")) --> "foobarbaz"
         let concat1 =
-            call_buildin_scalar_fn("concat", vec![lit("bar"), lit("baz")]).unwrap();
-        let expr = call_buildin_scalar_fn("concat", vec![lit("foo"), concat1]).unwrap();
+            call_builtin_scalar_fn("concat", vec![lit("bar"), lit("baz")]).unwrap();
+        let expr = call_builtin_scalar_fn("concat", vec![lit("foo"), concat1]).unwrap();
         test_evaluate(expr, lit("foobarbaz"));
 
         // Check non string arguments
         // to_timestamp("2020-09-08T12:00:00+00:00") --> timestamp(1599566400000000000i64)
-        let expr = call_buildin_scalar_fn(
+        let expr = call_builtin_scalar_fn(
             "to_timestamp",
             vec![lit("2020-09-08T12:00:00+00:00")],
         )
@@ -1032,12 +1032,12 @@ mod tests {
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = call_buildin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
+        let expr = call_builtin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = call_buildin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
+        let expr = call_builtin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // volatile / stable functions should not be evaluated
@@ -1078,7 +1078,7 @@ mod tests {
     }
 
     fn now_expr() -> Expr {
-        call_buildin_scalar_fn("now", vec![]).unwrap()
+        call_builtin_scalar_fn("now", vec![]).unwrap()
     }
 
     fn cast_to_int64_expr(expr: Expr) -> Expr {
@@ -1089,7 +1089,7 @@ mod tests {
     }
 
     fn to_timestamp_expr(arg: impl Into<String>) -> Expr {
-        call_buildin_scalar_fn("to_timestamp", vec![lit(arg.into())]).unwrap()
+        call_builtin_scalar_fn("to_timestamp", vec![lit(arg.into())]).unwrap()
     }
 
     #[test]

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -722,8 +722,8 @@ mod tests {
     use super::*;
     use crate::assert_contains;
     use crate::logical_plan::{
-        and, binary_expr, col, create_udf, lit, lit_timestamp_nano, DFField, Expr,
-        LogicalPlanBuilder,
+        and, binary_expr, call_buildin_scalar_fn, col, create_udf, lit,
+        lit_timestamp_nano, DFField, Expr, LogicalPlanBuilder,
     };
     use crate::physical_plan::functions::{make_scalar_function, BuiltinScalarFunction};
     use crate::physical_plan::udf::ScalarUDF;
@@ -997,46 +997,34 @@ mod tests {
     #[test]
     fn test_const_evaluator_scalar_functions() {
         // concat("foo", "bar") --> "foobar"
-        let expr = Expr::ScalarFunction {
-            args: vec![lit("foo"), lit("bar")],
-            fun: BuiltinScalarFunction::Concat,
-        };
+        let expr =
+            call_buildin_scalar_fn("concat", vec![lit("foo"), lit("bar")]).unwrap();
         test_evaluate(expr, lit("foobar"));
 
         // ensure arguments are also constant folded
         // concat("foo", concat("bar", "baz")) --> "foobarbaz"
-        let concat1 = Expr::ScalarFunction {
-            args: vec![lit("bar"), lit("baz")],
-            fun: BuiltinScalarFunction::Concat,
-        };
-        let expr = Expr::ScalarFunction {
-            args: vec![lit("foo"), concat1],
-            fun: BuiltinScalarFunction::Concat,
-        };
+        let concat1 =
+            call_buildin_scalar_fn("concat", vec![lit("bar"), lit("baz")]).unwrap();
+        let expr = call_buildin_scalar_fn("concat", vec![lit("foo"), concat1]).unwrap();
         test_evaluate(expr, lit("foobarbaz"));
 
         // Check non string arguments
         // to_timestamp("2020-09-08T12:00:00+00:00") --> timestamp(1599566400000000000i64)
-        let expr = Expr::ScalarFunction {
-            args: vec![lit("2020-09-08T12:00:00+00:00")],
-            fun: BuiltinScalarFunction::ToTimestamp,
-        };
+        let expr = call_buildin_scalar_fn(
+            "to_timestamp",
+            vec![lit("2020-09-08T12:00:00+00:00")],
+        )
+        .unwrap();
         test_evaluate(expr, lit_timestamp_nano(1599566400000000000i64));
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = Expr::ScalarFunction {
-            args: vec![col("a")],
-            fun: BuiltinScalarFunction::ToTimestamp,
-        };
+        let expr = call_buildin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // check that non foldable arguments are folded
         // to_timestamp(a) --> to_timestamp(a) [no rewrite possible]
-        let expr = Expr::ScalarFunction {
-            args: vec![col("a")],
-            fun: BuiltinScalarFunction::ToTimestamp,
-        };
+        let expr = call_buildin_scalar_fn("to_timestamp", vec![col("a")]).unwrap();
         test_evaluate(expr.clone(), expr);
 
         // volatile / stable functions should not be evaluated
@@ -1077,10 +1065,7 @@ mod tests {
     }
 
     fn now_expr() -> Expr {
-        Expr::ScalarFunction {
-            args: vec![],
-            fun: BuiltinScalarFunction::Now,
-        }
+        call_buildin_scalar_fn("now", vec![]).unwrap()
     }
 
     fn cast_to_int64_expr(expr: Expr) -> Expr {
@@ -1091,10 +1076,7 @@ mod tests {
     }
 
     fn to_timestamp_expr(arg: impl Into<String>) -> Expr {
-        Expr::ScalarFunction {
-            args: vec![lit(arg.into())],
-            fun: BuiltinScalarFunction::ToTimestamp,
-        }
+        call_buildin_scalar_fn("to_timestamp", vec![lit(arg.into())]).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1718.
Re #1727.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We create a cleaner way to call built-in scalar functions by calling `call_builtin_scalar_fn`.
 
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

A new function `call_builtin_scalar_fn`

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
