### PR TITLE
Move optimize test out of context.rs

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -1347,44 +1347,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn optimize_explain() {
-        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
-
-        let plan = LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
-            .unwrap()
-            .explain(true, false)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        if let LogicalPlan::Explain(e) = &plan {
-            assert_eq!(e.stringified_plans.len(), 1);
-        } else {
-            panic!("plan was not an explain: {:?}", plan);
-        }
-
-        // now optimize the plan and expect to see more plans
-        let optimized_plan = ExecutionContext::new().optimize(&plan).unwrap();
-        if let LogicalPlan::Explain(e) = &optimized_plan {
-            // should have more than one plan
-            assert!(
-                e.stringified_plans.len() > 1,
-                "plans: {:#?}",
-                e.stringified_plans
-            );
-            // should have at least one optimized plan
-            let opt = e
-                .stringified_plans
-                .iter()
-                .any(|p| matches!(p.plan_type, PlanType::OptimizedLogicalPlan { .. }));
-
-            assert!(opt, "plans: {:#?}", e.stringified_plans);
-        } else {
-            panic!("plan was not an explain: {:?}", plan);
-        }
-    }
-
     #[tokio::test]
     async fn parallel_projection() -> Result<()> {
         let partition_count = 4;

--- a/datafusion/tests/sql/explain.rs
+++ b/datafusion/tests/sql/explain.rs
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, Schema, Field};
+use datafusion::{logical_plan::{LogicalPlanBuilder, LogicalPlan, PlanType}, prelude::ExecutionContext};
+
+
+#[test]
+fn optimize_explain() {
+    let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+
+    let plan = LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
+        .unwrap()
+        .explain(true, false)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    if let LogicalPlan::Explain(e) = &plan {
+        assert_eq!(e.stringified_plans.len(), 1);
+    } else {
+        panic!("plan was not an explain: {:?}", plan);
+    }
+
+    // now optimize the plan and expect to see more plans
+    let optimized_plan = ExecutionContext::new().optimize(&plan).unwrap();
+    if let LogicalPlan::Explain(e) = &optimized_plan {
+        // should have more than one plan
+        assert!(
+            e.stringified_plans.len() > 1,
+            "plans: {:#?}",
+            e.stringified_plans
+        );
+        // should have at least one optimized plan
+        let opt = e
+            .stringified_plans
+            .iter()
+            .any(|p| matches!(p.plan_type, PlanType::OptimizedLogicalPlan { .. }));
+
+        assert!(opt, "plans: {:#?}", e.stringified_plans);
+    } else {
+        panic!("plan was not an explain: {:?}", plan);
+    }
+}

--- a/datafusion/tests/sql/explain.rs
+++ b/datafusion/tests/sql/explain.rs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::datatypes::{DataType, Schema, Field};
-use datafusion::{logical_plan::{LogicalPlanBuilder, LogicalPlan, PlanType}, prelude::ExecutionContext};
-
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::{
+    logical_plan::{LogicalPlan, LogicalPlanBuilder, PlanType},
+    prelude::ExecutionContext,
+};
 
 #[test]
 fn optimize_explain() {

--- a/datafusion/tests/sql/mod.rs
+++ b/datafusion/tests/sql/mod.rs
@@ -99,6 +99,7 @@ pub mod window;
 pub mod information_schema;
 #[cfg_attr(not(feature = "unicode_expressions"), ignore)]
 pub mod unicode;
+mod explain;
 
 fn assert_float_eq<T>(expected: &[Vec<T>], received: &[Vec<String>])
 where

--- a/datafusion/tests/sql/mod.rs
+++ b/datafusion/tests/sql/mod.rs
@@ -96,10 +96,10 @@ pub mod udf;
 pub mod union;
 pub mod window;
 
+mod explain;
 pub mod information_schema;
 #[cfg_attr(not(feature = "unicode_expressions"), ignore)]
 pub mod unicode;
-mod explain;
 
 fn assert_float_eq<T>(expected: &[Vec<T>], received: &[Vec<String>])
 where


### PR DESCRIPTION
# Which issue does this PR close?

re  https://github.com/apache/arrow-datafusion/issues/743
re https://github.com/apache/arrow-datafusion/issues/348

Follow on to https://github.com/apache/arrow-datafusion/pull/1684

 # Rationale for this change
There are a bunch of tests in execution/context.rs that are not related to `ExecutionContext` (they are end to end tests for sql that happen to use the functions in `ExecutionContext`)

This both slows down compile times in the `datafusion` crate as well as makes it harder to discover existing test coverage.

This was annoying me recently when working in the `context` module so I decided to start moving the code over incrementally


# What changes are included in this PR?
Move a test

# Are there any user-facing changes?
No