### PR TITLE
Do not repartition sorted inputs `SortPreservingMerge`

### DIFF
--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -128,6 +128,12 @@ impl ExecutionPlan for SortPreservingMergeExec {
         Distribution::UnspecifiedDistribution
     }
 
+    fn should_repartition_children(&self) -> bool {
+        // if the children are repartitioned they may no longer remain
+        // sorted
+        false
+    }
+
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         vec![self.input.clone()]
     }


### PR DESCRIPTION
# Which issue does this PR close?

Along with https://github.com/apache/arrow-datafusion/pull/1732, Fixes https://github.com/apache/arrow-datafusion/issues/423 (the last part).

re https://github.com/apache/arrow-datafusion/issues/424

 # Rationale for this change
Repartitioning the input to an operator that relies on its input to be sorted is incorrect as the repartitioning will intermix the partitions and effectively "unsort" the input stream

We found this in IOx here https://github.com/influxdata/influxdb_iox/pull/3633#issuecomment-1030126757

Here is a picture showing the problem:

```
    ┌─────────────────────────────────┐
    │                                 │
    │     SortPreservingMergeExec     │
    │                                 │
    └─────────────────────────────────┘
              ▲      ▲       ▲            Input may not
              │      │       │             be sorted!
      ┌───────┘      │       └───────┐
      │              │               │
      │              │               │
┌───────────┐  ┌───────────┐   ┌───────────┐
│           │  │           │   │           │
│ batch A1  │  │ batch A3  │   │ batch B3  │
│           │  │           │   │           │
├───────────┤  ├───────────┤   ├───────────┤
│           │  │           │   │           │
│ batch B2  │  │ batch B1  │   │ batch A2  │
│           │  │           │   │           │
└───────────┘  └───────────┘   └───────────┘
      ▲              ▲               ▲
      │              │               │
      └─────────┐    │    ┌──────────┘
                │    │    │                  Outputs
                │    │    │                batches are
    ┌─────────────────────────────────┐   repartitioned
    │       RepartitionExec(3)        │    and may not
    │           RoundRobin            │   remain sorted
    │                                 │
    └─────────────────────────────────┘
                ▲         ▲
                │         │                Inputs are
          ┌─────┘         └─────┐            sorted
          │                     │
          │                     │
          │                     │
    ┌───────────┐         ┌───────────┐
    │           │         │           │
    │ batch A1  │         │ batch B1  │
    │           │         │           │
    ├───────────┤         ├───────────┤
    │           │         │           │
    │ batch A2  │         │ batch B2  │
    │           │         │           │
    ├───────────┤         ├───────────┤
    │           │         │           │
    │ batch A3  │         │ batch B3  │
    │           │         │           │
    └───────────┘         └───────────┘


     Sorted Input          Sorted Input
           A                     B
```

The streams need to remain the way they were

```
┌─────────────────────────────────┐
│                                 │
│     SortPreservingMergeExec     │
│                                 │
└─────────────────────────────────┘
            ▲         ▲
            │         │         Inputs are
      ┌─────┘         └─────┐   sorted, as
      │                     │    required
      │                     │
      │                     │
┌───────────┐         ┌───────────┐
│           │         │           │
│ batch A1  │         │ batch B1  │
│           │         │           │
├───────────┤         ├───────────┤
│           │         │           │
│ batch A2  │         │ batch B2  │
│           │         │           │
├───────────┤         ├───────────┤
│           │         │           │
│ batch A3  │         │ batch B3  │
│           │         │           │
└───────────┘         └───────────┘


 Sorted Input          Sorted Input
       A                     B
```

# What changes are included in this PR?
1. use flag introduced in https://github.com/apache/arrow-datafusion/pull/1732 to not repartition the input to `SortPreservingMerge` operator
2. Test to ensure it is not repartitioned

# Are there any user-facing changes?
Probably not (yet) as `SortPreservingMerge` isn't used as part of SQL planning

cc @tustvold @Dandandan 