### PR TITLE
Use ordered-float 2.10

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -68,7 +68,7 @@ md-5 = { version = "^0.10.0", optional = true }
 sha2 = { version = "^0.10.1", optional = true }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
-ordered-float = "2.0"
+ordered-float = "2.10"
 unicode-segmentation = { version = "^1.7.1", optional = true }
 regex = { version = "^1.4.3", optional = true }
 lazy_static = { version = "^1.4.0" }


### PR DESCRIPTION
Signed-off-by: Andy Grove <agrove@apache.org>

# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1744.

 # Rationale for this change

Cannot compile if old version of ordered-float is picked up. See issue for details.

# What changes are included in this PR?
Bump version of ordered-float.

# Are there any user-facing changes?
No