### PR TITLE
#1768 Support TimeUnit::Second in hasher

### DIFF
--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -22,9 +22,9 @@ use ahash::{CallHasher, RandomState};
 use arrow::array::{
     Array, ArrayRef, BooleanArray, Date32Array, Date64Array, DecimalArray,
     DictionaryArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
-    Int8Array, LargeStringArray, StringArray, TimestampSecondArray, TimestampMicrosecondArray,
-    TimestampMillisecondArray, TimestampNanosecondArray, UInt16Array, UInt32Array,
-    UInt64Array, UInt8Array,
+    Int8Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
+    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow::datatypes::{
     ArrowDictionaryKeyType, ArrowNativeType, DataType, Int16Type, Int32Type, Int64Type,

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -22,7 +22,7 @@ use ahash::{CallHasher, RandomState};
 use arrow::array::{
     Array, ArrayRef, BooleanArray, Date32Array, Date64Array, DecimalArray,
     DictionaryArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
-    Int8Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
+    Int8Array, LargeStringArray, StringArray, TimestampSecondArray, TimestampMicrosecondArray,
     TimestampMillisecondArray, TimestampNanosecondArray, UInt16Array, UInt32Array,
     UInt64Array, UInt8Array,
 };
@@ -382,6 +382,16 @@ pub fn create_hashes<'a>(
                     Float64Array,
                     col,
                     u64,
+                    hashes_buffer,
+                    random_state,
+                    multi_col
+                );
+            }
+            DataType::Timestamp(TimeUnit::Second, None) => {
+                hash_array_primitive!(
+                    TimestampSecondArray,
+                    col,
+                    i64,
                     hashes_buffer,
                     random_state,
                     multi_col


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1768.

 # Rationale for this change
supports `to_timestamp_seconds` in `group by`, align with other timestamp methods like `to_timestamp_millis`, `to_timestamp_micros` and `to_timestamp`

# What changes are included in this PR?
add `DataType::Timestamp(TimeUnit::Second, None)` to pattern match 

# Are there any user-facing changes?
NA