### PR TITLE
Add `output_

### DIFF
--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -19,13 +19,105 @@
 use std::sync::Arc;
 
 use super::optimizer::PhysicalOptimizerRule;
-use crate::physical_plan::Partitioning::*;
 use crate::physical_plan::{
     empty::EmptyExec, repartition::RepartitionExec, ExecutionPlan,
 };
+use crate::physical_plan::{Distribution, Partitioning::*};
 use crate::{error::Result, execution::context::ExecutionConfig};
 
-/// Optimizer that introduces repartition to introduce more parallelism in the plan
+/// Optimizer that introduces repartition to introduce more
+/// parallelism in the plan
+///
+/// For example, given an input such as:
+///
+///
+/// ```text
+/// ┌─────────────────────────────────┐
+/// │                                 │
+/// │          ExecutionPlan          │
+/// │                                 │
+/// └─────────────────────────────────┘
+///             ▲         ▲
+///             │         │
+///       ┌─────┘         └─────┐
+///       │                     │
+///       │                     │
+///       │                     │
+/// ┌───────────┐         ┌───────────┐
+/// │           │         │           │
+/// │ batch A1  │         │ batch B1  │
+/// │           │         │           │
+/// ├───────────┤         ├───────────┤
+/// │           │         │           │
+/// │ batch A2  │         │ batch B2  │
+/// │           │         │           │
+/// ├───────────┤         ├───────────┤
+/// │           │         │           │
+/// │ batch A3  │         │ batch B3  │
+/// │           │         │           │
+/// └───────────┘         └───────────┘
+///
+///      Input                 Input
+///        A                     B
+/// ```
+///
+/// This optimizer will attempt to add a `RepartitionExec` to increase
+/// the parallism (to 3 in this case)
+///
+/// ```text
+///     ┌─────────────────────────────────┐
+///     │                                 │
+///     │          ExecutionPlan          │
+///     │                                 │
+///     └─────────────────────────────────┘
+///               ▲      ▲       ▲            Input now has 3
+///               │      │       │             partitions
+///       ┌───────┘      │       └───────┐
+///       │              │               │
+///       │              │               │
+/// ┌───────────┐  ┌───────────┐   ┌───────────┐
+/// │           │  │           │   │           │
+/// │ batch A1  │  │ batch A3  │   │ batch B3  │
+/// │           │  │           │   │           │
+/// ├───────────┤  ├───────────┤   ├───────────┤
+/// │           │  │           │   │           │
+/// │ batch B2  │  │ batch B1  │   │ batch A2  │
+/// │           │  │           │   │           │
+/// └───────────┘  └───────────┘   └───────────┘
+///       ▲              ▲               ▲
+///       │              │               │
+///       └─────────┐    │    ┌──────────┘
+///                 │    │    │
+///                 │    │    │
+///     ┌─────────────────────────────────┐   batches are
+///     │       RepartitionExec(3)        │   repartitioned
+///     │           RoundRobin            │
+///     │                                 │
+///     └─────────────────────────────────┘
+///                 ▲         ▲
+///                 │         │
+///           ┌─────┘         └─────┐
+///           │                     │
+///           │                     │
+///           │                     │
+///     ┌───────────┐         ┌───────────┐
+///     │           │         │           │
+///     │ batch A1  │         │ batch B1  │
+///     │           │         │           │
+///     ├───────────┤         ├───────────┤
+///     │           │         │           │
+///     │ batch A2  │         │ batch B2  │
+///     │           │         │           │
+///     ├───────────┤         ├───────────┤
+///     │           │         │           │
+///     │ batch A3  │         │ batch B3  │
+///     │           │         │           │
+///     └───────────┘         └───────────┘
+///
+///
+///      Input                 Input
+///        A                     B
+/// ```
 #[derive(Default)]
 pub struct Repartition {}
 
@@ -36,18 +128,53 @@ impl Repartition {
     }
 }
 
+/// Recursively visits all `plan`s puts and then optionally adds a
+/// `RepartitionExec` at the output of `plan` to match
+/// `target_partitions`
+///
+/// if `can_reorder` is false, means that the output of this node
+/// can not be reordered as as something upstream is relying on that order
+///
+/// If 'would_benefit` is false, the upstream operator doesn't
+///  benefit from additional reordering
+///
 fn optimize_partitions(
     target_partitions: usize,
     plan: Arc<dyn ExecutionPlan>,
-    should_repartition: bool,
+    can_reorder: bool,
+    would_benefit: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    // Recurse into children bottom-up (added nodes should be as deep as possible)
+    // Recurse into children bottom-up (attempt to repartition as
+    // early as possible)
 
     let new_plan = if plan.children().is_empty() {
         // leaf node - don't replace children
         plan.clone()
     } else {
-        let should_repartition_children = plan.should_repartition_children();
+        let can_reorder_children =
+            match (plan.relies_on_input_order(), plan.maintains_input_order()) {
+                (true, _) => {
+                    // `plan` itself relies on the order of its
+                    // children, so don't reorder them!
+                    false
+                }
+                (false, false) => {
+                    // `plan` may reorder the input itself, so no need
+                    // to preserve the order of any children
+                    true
+                }
+                (false, true) => {
+                    // `plan` will maintain the order, so we can only
+                    // repartition children if it is ok to reorder the
+                    // output of this node
+                    let requires_single_partition = matches!(
+                        plan.required_child_distribution(),
+                        Distribution::SinglePartition
+                    );
+                    can_reorder && !requires_single_partition
+                }
+            };
+
         let children = plan
             .children()
             .iter()
@@ -55,14 +182,16 @@ fn optimize_partitions(
                 optimize_partitions(
                     target_partitions,
                     child.clone(),
-                    should_repartition_children,
+                    can_reorder_children,
+                    plan.benefits_from_input_partitioning(),
                 )
             })
             .collect::<Result<_>>()?;
         plan.with_new_children(children)?
     };
 
-    let perform_repartition = match new_plan.output_partitioning() {
+    // decide if we should bother trying to repartition the output of this plan
+    let could_repartition = match new_plan.output_partitioning() {
         // Apply when underlying node has less than `self.target_partitions` amount of concurrency
         RoundRobinBatch(x) => x < target_partitions,
         UnknownPartitioning(x) => x < target_partitions,
@@ -75,7 +204,7 @@ fn optimize_partitions(
     // But also not very useful to inlude
     let is_empty_exec = plan.as_any().downcast_ref::<EmptyExec>().is_some();
 
-    if perform_repartition && should_repartition && !is_empty_exec {
+    if would_benefit && could_repartition && can_reorder && !is_empty_exec {
         Ok(Arc::new(RepartitionExec::try_new(
             new_plan,
             RoundRobinBatch(target_partitions),
@@ -95,7 +224,7 @@ impl PhysicalOptimizerRule for Repartition {
         if config.target_partitions == 1 {
             Ok(plan)
         } else {
-            optimize_partitions(config.target_partitions, plan, false)
+            optimize_partitions(config.target_partitions, plan, false, false)
         }
     }
 
@@ -105,6 +234,7 @@ impl PhysicalOptimizerRule for Repartition {
 }
 #[cfg(test)]
 mod tests {
+    use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 
     use super::*;
@@ -114,6 +244,8 @@ mod tests {
     use crate::physical_plan::filter::FilterExec;
     use crate::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
     use crate::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+    use crate::physical_plan::projection::ProjectionExec;
+    use crate::physical_plan::sorts::sort::SortExec;
     use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
     use crate::physical_plan::union::UnionExec;
     use crate::physical_plan::{displayable, Statistics};
@@ -153,6 +285,19 @@ mod tests {
         Arc::new(FilterExec::try_new(col("c1", &schema()).unwrap(), input).unwrap())
     }
 
+    fn sort_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let sort_exprs = vec![PhysicalSortExpr {
+            expr: col("c1", &schema()).unwrap(),
+            options: SortOptions::default(),
+        }];
+        Arc::new(SortExec::try_new(sort_exprs, input).unwrap())
+    }
+
+    fn projection_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let exprs = vec![(col("c1", &schema()).unwrap(), "c1".to_string())];
+        Arc::new(ProjectionExec::try_new(exprs, input).unwrap())
+    }
+
     fn hash_aggregate(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
         let schema = schema();
         Arc::new(
@@ -190,38 +335,46 @@ mod tests {
             .collect()
     }
 
+    /// Runs the repartition optimizer and asserts the plan against the expected
+    macro_rules! assert_optimized {
+        ($EXPECTED_LINES: expr, $PLAN: expr) => {
+            let expected_lines: Vec<&str> = $EXPECTED_LINES.iter().map(|s| *s).collect();
+
+            // run optimizer
+            let optimizer = Repartition {};
+            let optimized = optimizer
+                .optimize($PLAN, &ExecutionConfig::new().with_target_partitions(10))?;
+
+            // Now format correctly
+            let plan = displayable(optimized.as_ref()).indent().to_string();
+            let actual_lines = trim_plan_display(&plan);
+
+            assert_eq!(
+                &expected_lines, &actual_lines,
+                "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+                expected_lines, actual_lines
+            );
+        };
+    }
+
     #[test]
     fn added_repartition_to_single_partition() -> Result<()> {
-        let optimizer = Repartition {};
+        let plan = hash_aggregate(parquet_exec());
 
-        let optimized = optimizer.optimize(
-            hash_aggregate(parquet_exec()),
-            &ExecutionConfig::new().with_target_partitions(10),
-        )?;
-
-        let plan = displayable(optimized.as_ref()).indent().to_string();
-
-        let expected = &[
+        let expected = [
             "HashAggregateExec: mode=Final, gby=[], aggr=[]",
             "HashAggregateExec: mode=Partial, gby=[], aggr=[]",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
             "ParquetExec: limit=None, partitions=[x]",
         ];
 
-        assert_eq!(&trim_plan_display(&plan), &expected);
+        assert_optimized!(expected, plan);
         Ok(())
     }
 
     #[test]
     fn repartition_deepest_node() -> Result<()> {
-        let optimizer = Repartition {};
-
-        let optimized = optimizer.optimize(
-            hash_aggregate(filter_exec(parquet_exec())),
-            &ExecutionConfig::new().with_target_partitions(10),
-        )?;
-
-        let plan = displayable(optimized.as_ref()).indent().to_string();
+        let plan = hash_aggregate(filter_exec(parquet_exec()));
 
         let expected = &[
             "HashAggregateExec: mode=Final, gby=[], aggr=[]",
@@ -231,20 +384,64 @@ mod tests {
             "ParquetExec: limit=None, partitions=[x]",
         ];
 
-        assert_eq!(&trim_plan_display(&plan), &expected);
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_unsorted_limit() -> Result<()> {
+        let plan = limit_exec(filter_exec(parquet_exec()));
+
+        let expected = &[
+            "GlobalLimitExec: limit=100",
+            "LocalLimitExec: limit=100",
+            "FilterExec: c1@0",
+            // nothing sorts the data, so the local limit doesn't require sorted data either
+            "RepartitionExec: partitioning=RoundRobinBatch(10)",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_sorted_limit() -> Result<()> {
+        let plan = limit_exec(sort_exec(parquet_exec()));
+
+        let expected = &[
+            "GlobalLimitExec: limit=100",
+            "LocalLimitExec: limit=100",
+            // data is sorted so can't repartition here
+            "SortExec: [c1@0 ASC]",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_sorted_limit_with_filter() -> Result<()> {
+        let plan = limit_exec(filter_exec(sort_exec(parquet_exec())));
+
+        let expected = &[
+            "GlobalLimitExec: limit=100",
+            "LocalLimitExec: limit=100",
+            "FilterExec: c1@0",
+            // data is sorted so can't repartition here even though
+            // filter would benefit from parallelism, the answers might be wrong
+            "SortExec: [c1@0 ASC]",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
         Ok(())
     }
 
     #[test]
     fn repartition_ignores_limit() -> Result<()> {
-        let optimizer = Repartition {};
-
-        let optimized = optimizer.optimize(
-            hash_aggregate(limit_exec(filter_exec(limit_exec(parquet_exec())))),
-            &ExecutionConfig::new().with_target_partitions(10),
-        )?;
-
-        let plan = displayable(optimized.as_ref()).indent().to_string();
+        let plan = hash_aggregate(limit_exec(filter_exec(limit_exec(parquet_exec()))));
 
         let expected = &[
             "HashAggregateExec: mode=Final, gby=[], aggr=[]",
@@ -253,6 +450,7 @@ mod tests {
             "GlobalLimitExec: limit=100",
             "LocalLimitExec: limit=100",
             "FilterExec: c1@0",
+            // repartition should happen prior to the filter to maximize parallelism
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
             "GlobalLimitExec: limit=100",
             "LocalLimitExec: limit=100",
@@ -260,20 +458,15 @@ mod tests {
             "ParquetExec: limit=None, partitions=[x]",
         ];
 
-        assert_eq!(&trim_plan_display(&plan), &expected);
+        assert_optimized!(expected, plan);
         Ok(())
     }
 
+    // repartition works differently for limit when there is a sort below it
+
     #[test]
     fn repartition_ignores_union() -> Result<()> {
-        let optimizer = Repartition {};
-
-        let optimized = optimizer.optimize(
-            Arc::new(UnionExec::new(vec![parquet_exec(); 5])),
-            &ExecutionConfig::new().with_target_partitions(5),
-        )?;
-
-        let plan = displayable(optimized.as_ref()).indent().to_string();
+        let plan = Arc::new(UnionExec::new(vec![parquet_exec(); 5]));
 
         let expected = &[
             "UnionExec",
@@ -285,20 +478,13 @@ mod tests {
             "ParquetExec: limit=None, partitions=[x]",
         ];
 
-        assert_eq!(&trim_plan_display(&plan), &expected);
+        assert_optimized!(expected, plan);
         Ok(())
     }
 
     #[test]
     fn repartition_ignores_sort_preserving_merge() -> Result<()> {
-        let optimizer = Repartition {};
-
-        let optimized = optimizer.optimize(
-            sort_preserving_merge_exec(parquet_exec()),
-            &ExecutionConfig::new().with_target_partitions(5),
-        )?;
-
-        let plan = displayable(optimized.as_ref()).indent().to_string();
+        let plan = sort_preserving_merge_exec(parquet_exec());
 
         let expected = &[
             "SortPreservingMergeExec: [c1@0 ASC]",
@@ -306,7 +492,78 @@ mod tests {
             "ParquetExec: limit=None, partitions=[x]",
         ];
 
-        assert_eq!(&trim_plan_display(&plan), &expected);
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_does_not_repartition_transitively() -> Result<()> {
+        let plan = sort_preserving_merge_exec(projection_exec(parquet_exec()));
+
+        let expected = &[
+            "SortPreservingMergeExec: [c1@0 ASC]",
+            // Expect no repartition of SortPreservingMergeExec
+            // even though there is a projection exec between it
+            "ProjectionExec: expr=[c1@0 as c1]",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_transitively_past_sort_with_projection() -> Result<()> {
+        let plan = sort_preserving_merge_exec(sort_exec(projection_exec(parquet_exec())));
+
+        let expected = &[
+            "SortPreservingMergeExec: [c1@0 ASC]",
+            // Expect repartition on the input to the sort (as it can benefit from additional parallelism)
+            "SortExec: [c1@0 ASC]",
+            "ProjectionExec: expr=[c1@0 as c1]",
+            "RepartitionExec: partitioning=RoundRobinBatch(10)",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_transitively_past_sort_with_filter() -> Result<()> {
+        let plan = sort_preserving_merge_exec(sort_exec(filter_exec(parquet_exec())));
+
+        let expected = &[
+            "SortPreservingMergeExec: [c1@0 ASC]",
+            // Expect repartition on the input to the sort (as it can benefit from additional parallelism)
+            "SortExec: [c1@0 ASC]",
+            "FilterExec: c1@0",
+            "RepartitionExec: partitioning=RoundRobinBatch(10)",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_transitively_past_sort_with_projection_and_filter() -> Result<()> {
+        let plan = sort_preserving_merge_exec(sort_exec(projection_exec(filter_exec(
+            parquet_exec(),
+        ))));
+
+        let expected = &[
+            "SortPreservingMergeExec: [c1@0 ASC]",
+            // Expect repartition on the input to the sort (as it can benefit from additional parallelism)
+            "SortExec: [c1@0 ASC]",
+            "ProjectionExec: expr=[c1@0 as c1]",
+            "FilterExec: c1@0",
+            // repartition is lowest down
+            "RepartitionExec: partitioning=RoundRobinBatch(10)",
+            "ParquetExec: limit=None, partitions=[x]",
+        ];
+
+        assert_optimized!(expected, plan);
         Ok(())
     }
 }

--- a/datafusion/src/physical_plan/analyze.rs
+++ b/datafusion/src/physical_plan/analyze.rs
@@ -30,6 +30,7 @@ use crate::{
 use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
 use futures::StreamExt;
 
+use super::expressions::PhysicalSortExpr;
 use super::{stream::RecordBatchReceiverStream, Distribution, SendableRecordBatchStream};
 use crate::execution::runtime_env::RuntimeEnv;
 use async_trait::async_trait;
@@ -80,6 +81,10 @@ impl ExecutionPlan for AnalyzeExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/coalesce_batches.rs
+++ b/datafusion/src/physical_plan/coalesce_batches.rs
@@ -38,6 +38,7 @@ use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
 use log::debug;
 
+use super::expressions::PhysicalSortExpr;
 use super::metrics::{BaselineMetrics, MetricsSet};
 use super::{metrics::ExecutionPlanMetricsSet, Statistics};
 
@@ -95,6 +96,10 @@ impl ExecutionPlan for CoalesceBatchesExec {
     fn output_partitioning(&self) -> Partitioning {
         // The coalesce batches operator does not make any changes to the partitioning of its input
         self.input.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/coalesce_partitions.rs
+++ b/datafusion/src/physical_plan/coalesce_partitions.rs
@@ -31,6 +31,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::{datatypes::SchemaRef, error::Result as ArrowResult};
 
 use super::common::AbortOnDropMany;
+use super::expressions::PhysicalSortExpr;
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use super::{RecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
@@ -84,6 +85,10 @@ impl ExecutionPlan for CoalescePartitionsExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/cross_join.rs
+++ b/datafusion/src/physical_plan/cross_join.rs
@@ -27,6 +27,7 @@ use arrow::record_batch::RecordBatch;
 
 use futures::{Stream, TryStreamExt};
 
+use super::expressions::PhysicalSortExpr;
 use super::{
     coalesce_partitions::CoalescePartitionsExec, join_utils::check_join_is_valid,
     ColumnStatistics, Statistics,
@@ -135,6 +136,10 @@ impl ExecutionPlan for CrossJoinExec {
 
     fn output_partitioning(&self) -> Partitioning {
         self.right.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     async fn execute(

--- a/datafusion/src/physical_plan/empty.rs
+++ b/datafusion/src/physical_plan/empty.rs
@@ -28,6 +28,7 @@ use arrow::array::NullArray;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 
+use super::expressions::PhysicalSortExpr;
 use super::{common, SendableRecordBatchStream, Statistics};
 
 use crate::execution::runtime_env::RuntimeEnv;
@@ -96,6 +97,10 @@ impl ExecutionPlan for EmptyExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/explain.rs
+++ b/datafusion/src/physical_plan/explain.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
 
-use super::SendableRecordBatchStream;
+use super::{expressions::PhysicalSortExpr, SendableRecordBatchStream};
 use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 use async_trait::async_trait;
@@ -87,6 +87,10 @@ impl ExecutionPlan for ExplainExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/file_format/avro.rs
+++ b/datafusion/src/physical_plan/file_format/avro.rs
@@ -19,6 +19,7 @@
 #[cfg(feature = "avro")]
 use crate::avro_to_arrow;
 use crate::error::{DataFusionError, Result};
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
@@ -72,6 +73,10 @@ impl ExecutionPlan for AvroExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -18,6 +18,7 @@
 //! Execution plan for reading CSV files
 
 use crate::error::{DataFusionError, Result};
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
@@ -86,6 +87,10 @@ impl ExecutionPlan for CsvExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/src/physical_plan/file_format/json.rs
+++ b/datafusion/src/physical_plan/file_format/json.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 
 use crate::error::{DataFusionError, Result};
 use crate::execution::runtime_env::RuntimeEnv;
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
@@ -63,6 +64,10 @@ impl ExecutionPlan for NdJsonExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -24,6 +24,7 @@ use std::{any::Any, convert::TryInto};
 use crate::datasource::file_format::parquet::ChunkObjectReader;
 use crate::datasource::object_store::ObjectStore;
 use crate::datasource::PartitionedFile;
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::{
     error::{DataFusionError, Result},
     logical_plan::{Column, Expr},
@@ -172,6 +173,10 @@ impl ExecutionPlan for ParquetExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/filter.rs
+++ b/datafusion/src/physical_plan/filter.rs
@@ -23,6 +23,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use super::expressions::PhysicalSortExpr;
 use super::{RecordBatchStream, SendableRecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{
@@ -102,6 +103,15 @@ impl ExecutionPlan for FilterExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn maintains_input_order(&self) -> bool {
+        // tell optimizer this operator doesn't reorder its input
+        true
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.input.output_ordering()
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -52,6 +52,7 @@ use crate::execution::runtime_env::RuntimeEnv;
 use async_trait::async_trait;
 
 use super::common::AbortOnDropSingle;
+use super::expressions::PhysicalSortExpr;
 use super::metrics::{
     self, BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput,
 };
@@ -206,6 +207,10 @@ impl ExecutionPlan for HashAggregateExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     async fn execute(
@@ -1146,6 +1151,10 @@ mod tests {
 
         fn output_partitioning(&self) -> Partitioning {
             Partitioning::UnknownPartitioning(1)
+        }
+
+        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+            None
         }
 
         fn with_new_children(

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -54,6 +54,7 @@ use hashbrown::raw::RawTable;
 
 use super::{
     coalesce_partitions::CoalescePartitionsExec,
+    expressions::PhysicalSortExpr,
     join_utils::{build_join_schema, check_join_is_valid, ColumnIndex, JoinOn, JoinSide},
 };
 use super::{
@@ -276,6 +277,10 @@ impl ExecutionPlan for HashJoinExec {
 
     fn output_partitioning(&self) -> Partitioning {
         self.right.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     async fn execute(

--- a/datafusion/src/physical_plan/memory.rs
+++ b/datafusion/src/physical_plan/memory.rs
@@ -22,6 +22,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use super::expressions::PhysicalSortExpr;
 use super::{
     common, project_schema, DisplayFormatType, ExecutionPlan, Partitioning,
     RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -75,6 +76,10 @@ impl ExecutionPlan for MemoryExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.partitions.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1877,6 +1877,10 @@ mod tests {
             Partitioning::UnknownPartitioning(1)
         }
 
+        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+            None
+        }
+
         fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
             vec![]
         }

--- a/datafusion/src/physical_plan/projection.rs
+++ b/datafusion/src/physical_plan/projection.rs
@@ -34,7 +34,7 @@ use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
-use super::expressions::Column;
+use super::expressions::{Column, PhysicalSortExpr};
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use super::{RecordBatchStream, SendableRecordBatchStream, Statistics};
 use crate::execution::runtime_env::RuntimeEnv;
@@ -120,6 +120,15 @@ impl ExecutionPlan for ProjectionExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn maintains_input_order(&self) -> bool {
+        // tell optimizer this operator doesn't reorder its input
+        true
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.input.output_ordering()
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -32,6 +32,7 @@ use arrow::{compute::take, datatypes::SchemaRef};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::common::{AbortOnDropMany, AbortOnDropSingle};
+use super::expressions::PhysicalSortExpr;
 use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{RecordBatchStream, SendableRecordBatchStream};
 use async_trait::async_trait;
@@ -163,6 +164,10 @@ impl ExecutionPlan for RepartitionExec {
 
     fn output_partitioning(&self) -> Partitioning {
         self.partitioning.clone()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     async fn execute(

--- a/datafusion/src/physical_plan/sorts/sort.rs
+++ b/datafusion/src/physical_plan/sorts/sort.rs
@@ -445,6 +445,14 @@ impl ExecutionPlan for SortExec {
         vec![self.input.clone()]
     }
 
+    fn benefits_from_input_partitioning(&self) -> bool {
+        false
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        Some(&self.expr)
+    }
+
     fn with_new_children(
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,

--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -128,6 +128,12 @@ impl ExecutionPlan for SortPreservingMergeExec {
         Distribution::UnspecifiedDistribution
     }
 
+    fn should_repartition_children(&self) -> bool {
+        // if the children are repartitioned they may no longer remain
+        // sorted
+        false
+    }
+
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         vec![self.input.clone()]
     }

--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -128,10 +128,12 @@ impl ExecutionPlan for SortPreservingMergeExec {
         Distribution::UnspecifiedDistribution
     }
 
-    fn should_repartition_children(&self) -> bool {
-        // if the children are repartitioned they may no longer remain
-        // sorted
-        false
+    fn relies_on_input_order(&self) -> bool {
+        true
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        Some(&self.expr)
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/src/physical_plan/union.rs
+++ b/datafusion/src/physical_plan/union.rs
@@ -27,6 +27,7 @@ use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use futures::StreamExt;
 
 use super::{
+    expressions::PhysicalSortExpr,
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
     ColumnStatistics, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -83,6 +84,10 @@ impl ExecutionPlan for UnionExec {
         // TODO: this loses partitioning info in case of same partitioning scheme (for example `Partitioning::Hash`)
         // https://issues.apache.org/jira/browse/ARROW-11991
         Partitioning::UnknownPartitioning(num_partitions)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(
@@ -144,7 +149,7 @@ impl ExecutionPlan for UnionExec {
             .unwrap_or_default()
     }
 
-    fn should_repartition_children(&self) -> bool {
+    fn benefits_from_input_partitioning(&self) -> bool {
         false
     }
 }

--- a/datafusion/src/physical_plan/values.rs
+++ b/datafusion/src/physical_plan/values.rs
@@ -17,6 +17,7 @@
 
 //! Values execution plan
 
+use super::expressions::PhysicalSortExpr;
 use super::{common, SendableRecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
 use crate::execution::runtime_env::RuntimeEnv;
@@ -117,6 +118,10 @@ impl ExecutionPlan for ValuesExec {
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/src/physical_plan/windows/window_agg_exec.rs
@@ -20,6 +20,7 @@
 use crate::error::{DataFusionError, Result};
 use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::common::AbortOnDropSingle;
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet,
 };
@@ -112,6 +113,14 @@ impl ExecutionPlan for WindowAggExec {
         // this would be either 1 or more than 1 depending on the presense of
         // repartitioning
         self.input.output_partitioning()
+    }
+
+    fn maintains_input_order(&self) -> bool {
+        true
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.input.output_ordering()
     }
 
     fn required_child_distribution(&self) -> Distribution {

--- a/datafusion/src/test/exec.rs
+++ b/datafusion/src/test/exec.rs
@@ -33,7 +33,6 @@ use arrow::{
 };
 use futures::Stream;
 
-use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::{
     common, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -41,6 +40,9 @@ use crate::physical_plan::{
 use crate::{
     error::{DataFusionError, Result},
     physical_plan::stream::RecordBatchReceiverStream,
+};
+use crate::{
+    execution::runtime_env::RuntimeEnv, physical_plan::expressions::PhysicalSortExpr,
 };
 
 /// Index into the data that has been returned so far
@@ -149,6 +151,10 @@ impl ExecutionPlan for MockExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
@@ -286,6 +292,10 @@ impl ExecutionPlan for BarrierExec {
         Partitioning::UnknownPartitioning(self.data.len())
     }
 
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         unimplemented!()
     }
@@ -383,6 +393,10 @@ impl ExecutionPlan for ErrorExec {
         Partitioning::UnknownPartitioning(1)
     }
 
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         unimplemented!()
     }
@@ -457,6 +471,10 @@ impl ExecutionPlan for StatisticsExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(2)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
@@ -558,6 +576,10 @@ impl ExecutionPlan for BlockingExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.n_partitions)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn with_new_children(

--- a/datafusion/tests/custom_sources.rs
+++ b/datafusion/tests/custom_sources.rs
@@ -22,6 +22,7 @@ use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use datafusion::from_slice::FromSlice;
 use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::scalar::ScalarValue;
 use datafusion::{datasource::TableProvider, physical_plan::collect};
 use datafusion::{
@@ -112,6 +113,9 @@ impl ExecutionPlan for CustomExecutionPlan {
     }
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         vec![]

--- a/datafusion/tests/provider_filter_pushdown.rs
+++ b/datafusion/tests/provider_filter_pushdown.rs
@@ -25,6 +25,7 @@ use datafusion::execution::context::ExecutionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_plan::Expr;
 use datafusion::physical_plan::common::SizedRecordBatchStream;
+use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
@@ -67,6 +68,10 @@ impl ExecutionPlan for CustomPlan {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/tests/statistics.rs
+++ b/datafusion/tests/statistics.rs
@@ -25,8 +25,9 @@ use datafusion::{
     error::{DataFusionError, Result},
     logical_plan::Expr,
     physical_plan::{
-        project_schema, ColumnStatistics, DisplayFormatType, ExecutionPlan, Partitioning,
-        SendableRecordBatchStream, Statistics,
+        expressions::PhysicalSortExpr, project_schema, ColumnStatistics,
+        DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+        Statistics,
     },
     prelude::ExecutionContext,
     scalar::ScalarValue,
@@ -117,6 +118,10 @@ impl ExecutionPlan for StatisticsValidation {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(2)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -74,6 +74,7 @@ use datafusion::{
     logical_plan::{Expr, LogicalPlan, UserDefinedLogicalNode},
     optimizer::{optimizer::OptimizerRule, utils::optimize_children},
     physical_plan::{
+        expressions::PhysicalSortExpr,
         planner::{DefaultPhysicalPlanner, ExtensionPlanner},
         DisplayFormatType, Distribution, ExecutionPlan, Partitioning, PhysicalPlanner,
         RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -430,6 +431,10 @@ impl ExecutionPlan for TopKExec {
 
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
     }
 
     fn required_child_distribution(&self) -> Distribution {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/424

Along with https://github.com/apache/arrow-datafusion/pull/1732, fixes https://github.com/apache/arrow-datafusion/issues/423 (the last part).


 # Rationale for this change
Repartitioning the input to an operator that relies on its input to be sorted is incorrect as the repartitioning will intermix the partitions and effectively "unsort" the input stream

We found this in IOx here https://github.com/influxdata/influxdb_iox/pull/3633#issuecomment-1030126757

Here is a picture showing the problem:

```
    ┌─────────────────────────────────┐
    │                                 │
    │     SortPreservingMergeExec     │
    │                                 │
    └─────────────────────────────────┘
              ▲      ▲       ▲            Input may not
              │      │       │             be sorted!
      ┌───────┘      │       └───────┐
      │              │               │
      │              │               │
┌───────────┐  ┌───────────┐   ┌───────────┐
│           │  │           │   │           │
│ batch A1  │  │ batch A3  │   │ batch B3  │
│           │  │           │   │           │
├───────────┤  ├───────────┤   ├───────────┤
│           │  │           │   │           │
│ batch B2  │  │ batch B1  │   │ batch A2  │
│           │  │           │   │           │
└───────────┘  └───────────┘   └───────────┘
      ▲              ▲               ▲
      │              │               │
      └─────────┐    │    ┌──────────┘
                │    │    │                  Outputs
                │    │    │                batches are
    ┌─────────────────────────────────┐   repartitioned
    │       RepartitionExec(3)        │    and may not
    │           RoundRobin            │   remain sorted
    │                                 │
    └─────────────────────────────────┘
                ▲         ▲
                │         │                Inputs are
          ┌─────┘         └─────┐            sorted
          │                     │
          │                     │
          │                     │
    ┌───────────┐         ┌───────────┐
    │           │         │           │
    │ batch A1  │         │ batch B1  │
    │           │         │           │
    ├───────────┤         ├───────────┤
    │           │         │           │
    │ batch A2  │         │ batch B2  │
    │           │         │           │
    ├───────────┤         ├───────────┤
    │           │         │           │
    │ batch A3  │         │ batch B3  │
    │           │         │           │
    └───────────┘         └───────────┘


     Sorted Input          Sorted Input
           A                     B
```

The streams need to remain the way they were

```
┌─────────────────────────────────┐
│                                 │
│     SortPreservingMergeExec     │
│                                 │
└─────────────────────────────────┘
            ▲         ▲
            │         │         Inputs are
      ┌─────┘         └─────┐   sorted, as
      │                     │    required
      │                     │
      │                     │
┌───────────┐         ┌───────────┐
│           │         │           │
│ batch A1  │         │ batch B1  │
│           │         │           │
├───────────┤         ├───────────┤
│           │         │           │
│ batch A2  │         │ batch B2  │
│           │         │           │
├───────────┤         ├───────────┤
│           │         │           │
│ batch A3  │         │ batch B3  │
│           │         │           │
└───────────┘         └───────────┘


 Sorted Input          Sorted Input
       A                     B
```

# What changes are included in this PR?
1. Add several "metadata" functions to `ExecutionPlan` that describe its sortedness and the invariants required for its input
2. Teach the repartitioning optimizer pass to respect the invariants

# Are there any user-facing changes?
Yes: All `ExecutionPlan`s are now required to implement `output_ordering` as described by @andygrove  here https://github.com/apache/arrow-datafusion/issues/424#issuecomment-847857451

The rationale for not providing a default implementation (`None`) was to force anyone who `impl ExecutionPlan` to think about sort orders. If they do not (very!) subtle bugs are possible as DataFusion starts to rely more on sortedness for optimizations

cc @tustvold @Dandandan 