### PR TITLE
The returned path value of get_by_uri should be self-described with entire path

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -81,6 +81,7 @@ num-traits = { version = "0.2", optional = true }
 pyo3 = { version = "0.15", optional = true }
 tempfile = "3"
 parking_lot = "0.12"
+url = "^2.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -81,7 +81,6 @@ num-traits = { version = "0.2", optional = true }
 pyo3 = { version = "0.15", optional = true }
 tempfile = "3"
 parking_lot = "0.12"
-url = "^2.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -39,6 +39,11 @@ pub struct LocalFileSystem;
 #[async_trait]
 impl ObjectStore for LocalFileSystem {
     async fn list_file(&self, prefix: &str) -> Result<FileMetaStream> {
+        let prefix = if let Some((_scheme, path)) = prefix.split_once("://") {
+            path
+        } else {
+            prefix
+        };
         list_all(prefix.to_owned()).await
     }
 

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -220,13 +220,12 @@ impl ObjectStoreRegistry {
     /// Get a suitable store for the URI based on it's scheme. For example:
     /// - URI with scheme `file://` or no schema will return the default LocalFS store
     /// - URI with scheme `s3://` will return the S3 store if it's registered
-    /// Returns a tuple with the store and the path of the file in that store
-    /// (URI=scheme://path).
+    /// Returns a tuple with the store and the self-described uri of the file in that store
     pub fn get_by_uri<'a>(
         &self,
         uri: &'a str,
     ) -> Result<(Arc<dyn ObjectStore>, &'a str)> {
-        if let Some((scheme, path)) = uri.split_once("://") {
+        if let Some((scheme, _path)) = uri.split_once("://") {
             let stores = self.object_stores.read();
             let store = stores
                 .get(&*scheme.to_lowercase())
@@ -237,7 +236,7 @@ impl ObjectStoreRegistry {
                         scheme
                     ))
                 })?;
-            Ok((store, path))
+            Ok((store, uri))
         } else {
             Ok((Arc::new(LocalFileSystem), uri))
         }

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::{AsyncRead, Stream, StreamExt};
-use url::Url;
 
 use local::LocalFileSystem;
 
@@ -220,42 +219,24 @@ impl ObjectStoreRegistry {
 
     /// Get a suitable store for the URI based on it's scheme. For example:
     /// - URI with scheme `file://` or no schema will return the default LocalFS store
-    /// - URI with scheme `s3://host:port` will return the S3 store if it's registered
+    /// - URI with scheme `s3://` will return the S3 store if it's registered
     /// Returns a tuple with the store and the self-described uri of the file in that store
     pub fn get_by_uri<'a>(
         &self,
         uri: &'a str,
     ) -> Result<(Arc<dyn ObjectStore>, &'a str)> {
-        // We do not support the remote object store on Windows OS
-        if let Some((_scheme, _path)) = uri.split_once("://") {
-            match Url::parse(uri) {
-                Ok(url) => {
-                    let host = if url.has_host() {
-                        format!("://{}", url.host().unwrap())
-                    } else {
-                        "".to_string()
-                    };
-                    let port = if url.port().is_some() {
-                        format!(":{}", url.port().unwrap())
-                    } else {
-                        "".to_string()
-                    };
-                    let store_key = format!("{}{}{}", url.scheme(), host, port);
-                    let stores = self.object_stores.read();
-                    let store =
-                        stores.get(&store_key).map(Clone::clone).ok_or_else(|| {
-                            DataFusionError::Internal(format!(
-                                "No suitable object store found for {}",
-                                store_key
-                            ))
-                        })?;
-                    Ok((store, uri))
-                }
-                Err(_) => {
-                    // in case of the uri is a relative URL without a base
-                    Ok((Arc::new(LocalFileSystem), uri))
-                }
-            }
+        if let Some((scheme, _path)) = uri.split_once("://") {
+            let stores = self.object_stores.read();
+            let store = stores
+                .get(&*scheme.to_lowercase())
+                .map(Clone::clone)
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "No suitable object store found for {}",
+                        scheme
+                    ))
+                })?;
+            Ok((store, uri))
         } else {
             Ok((Arc::new(LocalFileSystem), uri))
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1778.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

There are two changes in this PR.
- The key of object store considers the host and port rather than just scheme.
- The returned path value of get_by_uri is self-described with information of scheme, host, port and path in the object store.
