### PR TITLE
Less verbose plans in debug logging

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -38,7 +38,7 @@ use crate::{
         hash_build_probe_order::HashBuildProbeOrder, optimizer::PhysicalOptimizerRule,
     },
 };
-use log::debug;
+use log::{debug, trace};
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -807,12 +807,14 @@ impl ExecutionContext {
         let execution_props = execution_props.start_execution();
 
         let mut new_plan = plan.clone();
-        debug!("Logical plan:\n {:?}", plan);
+        debug!("Input logical plan:\n{}\n", plan.display_indent());
+        trace!("Full input logical plan:\n{:?}", plan);
         for optimizer in optimizers {
             new_plan = optimizer.optimize(&new_plan, execution_props)?;
             observer(&new_plan, optimizer.as_ref());
         }
-        debug!("Optimized logical plan:\n {:?}", new_plan);
+        debug!("Optimized logical plan:\n{}\n", new_plan.display_indent());
+        trace!("Full Optimized logical plan:\n {:?}", plan);
         Ok(new_plan)
     }
 }

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -64,7 +64,7 @@ use async_trait::async_trait;
 use expressions::col;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use log::debug;
+use log::{debug, trace};
 use std::sync::Arc;
 
 fn create_function_physical_name(
@@ -1398,7 +1398,11 @@ impl DefaultPhysicalPlanner {
         F: FnMut(&dyn ExecutionPlan, &dyn PhysicalOptimizerRule),
     {
         let optimizers = &ctx_state.config.physical_optimizers;
-        debug!("Physical plan:\n{:?}", plan);
+        debug!(
+            "Input physical plan:\n{}\n",
+            displayable(plan.as_ref()).indent()
+        );
+        trace!("Detailed input physical plan:\n{:?}", plan);
 
         let mut new_plan = plan;
         for optimizer in optimizers {
@@ -1406,10 +1410,10 @@ impl DefaultPhysicalPlanner {
             observer(new_plan.as_ref(), optimizer.as_ref())
         }
         debug!(
-            "Optimized physical plan short version:\n{}\n",
+            "Optimized physical plan:\n{}\n",
             displayable(new_plan.as_ref()).indent()
         );
-        debug!("Optimized physical plan:\n{:?}", new_plan);
+        trace!("Detailed optimized physical plan:\n{:?}", new_plan);
         Ok(new_plan)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/1786


 # Rationale for this change
with `debug!` logging and non trivial plans, the log is spammed with lots of useless output (see https://github.com/apache/arrow-datafusion/issues/1786 for example)

# What changes are included in this PR?
1. In `debug!` level only print summarized plan
2. in `trace!` level print all details

# Are there any user-facing changes?
Less is written to logs in `debug` level

# Example output:

Need to have logging added to datafusion cli to run these examples -- See https://github.com/apache/arrow-datafusion/pull/1789

```shell
RUST_LOG=debug cargo run --bin datafusion-cli
```


```
[2022-02-08T21:03:18Z DEBUG datafusion::execution::context] Input logical plan:
    Projection: #t1.column1, #t1.column2
      TableScan: t1 projection=Some([0, 1])
    
[2022-02-08T21:03:18Z DEBUG datafusion::execution::context] Optimized logical plan:
    Projection: #t1.column1, #t1.column2
      TableScan: t1 projection=Some([0, 1])
    
[2022-02-08T21:03:18Z DEBUG datafusion::physical_plan::planner] Input physical plan:
    ProjectionExec: expr=[column1@0 as column1, column2@1 as column2]
      MemoryExec: partitions=16, partition_sizes=[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
    
    
[2022-02-08T21:03:18Z DEBUG datafusion::physical_plan::planner] Optimized physical plan:
    ProjectionExec: expr=[column1@0 as column1, column2@1 as column2]
      MemoryExec: partitions=16, partition_sizes=[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
   
```

You can see how this looks with tracing (and what it used to look like prior to this PR in debug:

```shell
RUST_LOG=trace cargo run --bin datafusion-cli
```

```
[2022-02-08T21:04:51Z TRACE datafusion::physical_plan::planner] Detailed input physical plan:
    ProjectionExec { expr: [(Column { name: "column1", index: 0 }, "column1"), (Column { name: "column2", index: 1 }, "column2")], schema: Schema { fields: [Field { name: "column1", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: "column2", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, input: partitions: [...]schema: Schema { fields: [Field { name: "column1", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: "column2", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }projection: Some([0, 1]), metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [] } } } }
[2022-02-08T21:04:51Z TRACE datafusion::physical_plan::planner] Detailed optimized physical plan:
    ProjectionExec { expr: [(Column { name: "column1", index: 0 }, "column1"), (Column { name: "column2", index: 1 }, "column2")], schema: Schema { fields: [Field { name: "column1", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: "column2", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, input: partitions: [...]schema: Schema { fields: [Field { name: "column1", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: "column2", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }projection: Some([0, 1]), metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [] } } } }
```

🤮 