### PR TITLE
Add logging to datafusion-cli

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -34,3 +34,4 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"
 datafusion = { path = "../datafusion", version = "6.0.0" }
 arrow = { version = "8.0.0" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0" }
+env_logger = "0.9"

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -74,6 +74,7 @@ struct Args {
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
+    env_logger::init();
     let args = Args::parse();
 
     if !args.quiet {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/1788

 # Rationale for this change
I would like access to datafusion's logs in the CLI


# What changes are included in this PR?

Add `env_logger` support so I can run :

```shell
RUST_LOG=debug cargo run --bin datafusion-cli
```


# Are there any user-facing changes?
You can now get logs if you want them by setting `RUST_LOG` as described in https://docs.rs/env_logger/latest/env_logger/.

For example

```shell
RUST_LOG='datafusion=debug' cargo run --bin datafusion-cli
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/datafusion-cli`
DataFusion CLI v6.0.0
[2022-02-08T21:11:20Z DEBUG datafusion::execution::memory_manager] Creating memory manager with initial size 11744051.2 TB
❯ create table t1 as select * from (values (11, 'a'), (22, 'b'), (33, 'c'), (44, 'd'), (77, 'e')) as sq;
[2022-02-08T21:11:23Z DEBUG datafusion::execution::context] Logical plan:
     Projection: #sq.column1, #sq.column2
      Projection: #column1, #column2, alias=sq
        Values: (Int64(11), Utf8("a")), (Int64(22), Utf8("b")), (Int64(33), Utf8("c")), (Int64(44), Utf8("d")), (Int64(77), Utf8("e"))
[2022-02-08T21:11:23Z DEBUG datafusion::execution::context] Optimized logical plan:
     Projection: #sq.column1, #sq.column2
      Projection: #column1, #column2, alias=sq
        Values: (Int64(11), Utf8("a")), (Int64(22), Utf8("b")), (Int64(33), Utf8("c")), (Int64(44), Utf8("d")), (Int64(77), Utf8("e"))
[2022-02-08T21:11:23Z DEBUG datafusion::execution::context] Logical plan:
     Projection: #sq.column1, #sq.column2
      Projection: #column1, #column2, alias=sq
        Values: (Int64(11), Utf8("a")), (Int64(22), Utf8("b")), (Int64(33), Utf8("c")), (Int64(44), Utf8("d")), (Int64(77), Utf8("e"))
[2022-02-08T21:11:23Z DEBUG datafusion::execution::context] Optimized logical plan:
     Projection: #sq.column1, #sq.column2
      Projection: #column1, #column2, alias=sq
        Values: (Int64(11), Utf8("a")), (Int64(22), Utf8("b")), (Int64(33), Utf8("c")), (Int64(44), Utf8("d")), (Int64(77), Utf8("e"))
[2022-02-08T21:11:23Z DEBUG datafusion::physical_plan::planner] Physical plan:
```
