### PR TITLE
tweak doc publishing instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ version of the docs, follow these steps:
 2. Clone the arrow-site repo
 3. Checkout to the `asf-site` branch (NOT `master`)
 4. Copy build artifacts into `arrow-site` repo's `datafusion` folder with a command such as
-  * `cp -rT ./build/html/ ../../arrow-site/datafusion/` (doesn't work on mac)
-  * `rsync -avzr ./build/html/ ../../arrow-site/datafusion/`
+
+- `cp -rT ./build/html/ ../../arrow-site/datafusion/` (doesn't work on mac)
+- `rsync -avzr ./build/html/ ../../arrow-site/datafusion/`
+
 5. Commit changes in `arrow-site` and send a PR.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,10 @@ The documentation is served through the
 [arrow-site](https://github.com/apache/arrow-site/) repo. To release a new
 version of the docs, follow these steps:
 
-- Run `make html` inside `docs` folder to generate the docs website inside the `build/html` folder.
-- Clone the arrow-site repo and checkout to the `asf-site` branch
-- Copy build artifacts into `arrow-site` repo's `datafusion` folder: `'cp' -rT ./build/html/ ../arrow-site/datafusion/`
-- Commit changes in `arrow-site` and send a PR.
+1. Run `make html` inside `docs` folder to generate the docs website inside the `build/html` folder.
+2. Clone the arrow-site repo
+3. Checkout to the `asf-site` branch (NOT `master`)
+4. Copy build artifacts into `arrow-site` repo's `datafusion` folder with a command such as
+  * `cp -rT ./build/html/ ../../arrow-site/datafusion/` (doesn't work on mac)
+  * `rsync -avzr ./build/html/ ../../arrow-site/datafusion/`
+5. Commit changes in `arrow-site` and send a PR.


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change
I got a little confused while creating https://github.com/apache/arrow-site/pull/191 (due to my own fault for not reading the instructions carefully)

# What changes are included in this PR?
tweak the instructions for publishing new content for the documentation

# Are there any user-facing changes?
NO