### PR TITLE
Fix logical conflict

### DIFF
--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -591,6 +591,7 @@ mod tests {
     use datafusion::logical_plan::{
         col, DFSchemaRef, Expr, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode,
     };
+    use datafusion::physical_plan::expressions::PhysicalSortExpr;
     use datafusion::physical_plan::planner::{DefaultPhysicalPlanner, ExtensionPlanner};
     use datafusion::physical_plan::{
         DisplayFormatType, Distribution, ExecutionPlan, Partitioning, PhysicalPlanner,
@@ -722,6 +723,10 @@ mod tests {
 
         fn output_partitioning(&self) -> Partitioning {
             Partitioning::UnknownPartitioning(1)
+        }
+
+        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+            None
         }
 
         fn required_child_distribution(&self) -> Distribution {


### PR DESCRIPTION
Fix logical conflict between 1bedaf33986ea01d78d21cf1878da40497b1b828 (https://github.com/apache/arrow-datafusion/commit/1bedaf33986ea01d78d21cf1878da40497b1b828) which added a new example `ExecutionPlan` and  071f14ade65b7e491898c06e7b086282cf12a442 (https://github.com/apache/arrow-datafusion/pull/1776) that added a new required trait method for `ExecutionPlan` 
