### PR TITLE
Draft: Fix build on m1 mac

### DIFF
--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -775,6 +775,12 @@ mod tests {
             // better statistics inference could be provided
             Statistics::default()
         }
+
+        fn output_ordering(
+            &self,
+        ) -> Option<&[datafusion::physical_plan::expressions::PhysicalSortExpr]> {
+            todo!()
+        }
     }
 
     struct TopKPlanner {}


### PR DESCRIPTION
# Which issue does this PR close?

This looks like a dupe with https://github.com/apache/arrow-datafusion/pull/1801, will wait for that to be merged then test and close.

 # Rationale for this change
Fixing the following error message on M1 Mac

```
   Compiling datafusion-cli v7.0.0 (/Users/realno/Dev/arrow-datafusion/datafusion-cli)
error[E0046]: not all trait items implemented, missing: `output_ordering`
   --> ballista/rust/core/src/serde/mod.rs:713:5
    |
713 |     impl ExecutionPlan for TopKExec {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `output_ordering` in implementation
    |
    = help: implement the missing item: `fn output_ordering(&self) -> std::option::Option<&[PhysicalSortExpr]> { todo!() }`

For more information about this error, try `rustc --explain E0046`.
error: could not compile `ballista-core` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed

```

# What changes are included in this PR?
Fixing build issue.

# Are there any user-facing changes?
No