### PR TITLE
Fixup some doc warnings

### DIFF
--- a/datafusion-common/src/dfschema.rs
+++ b/datafusion-common/src/dfschema.rs
@@ -402,8 +402,8 @@ impl Display for DFSchema {
     }
 }
 
-/// Provides schema information needed by [Expr] methods such as
-/// [Expr::nullable] and [Expr::data_type].
+/// Provides schema information needed by certain methods of `Expr`
+/// (defined in the datafusion-common crate).
 ///
 /// Note that this trait is implemented for &[DFSchema] which is
 /// widely used in the DataFusion codebase.

--- a/datafusion/src/logical_plan/expr_simplier.rs
+++ b/datafusion/src/logical_plan/expr_simplier.rs
@@ -23,8 +23,10 @@ use crate::execution::context::ExecutionProps;
 use crate::optimizer::simplify_expressions::{ConstEvaluator, Simplifier};
 use datafusion_common::Result;
 
+#[allow(rustdoc::private_intra_doc_links)]
 /// The information necessary to apply algebraic simplification to an
-/// [Expr]. See [SimplifyContext] for one implementation
+/// [Expr]. See [SimplifyContext](crate::optimizer::simplify_expressions::SimplifyContext)
+/// for one implementation
 pub trait SimplifyInfo {
     /// returns true if this Expr has boolean type
     fn is_boolean_type(&self, expr: &Expr) -> Result<bool>;

--- a/datafusion/src/optimizer/simplify_expressions.rs
+++ b/datafusion/src/optimizer/simplify_expressions.rs
@@ -35,7 +35,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 /// Provides simplification information based on schema and properties
-struct SimplifyContext<'a, 'b> {
+pub(crate) struct SimplifyContext<'a, 'b> {
     schemas: Vec<&'a DFSchemaRef>,
     props: &'b ExecutionProps,
 }
@@ -245,6 +245,7 @@ impl SimplifyExpressions {
     }
 }
 
+#[allow(rustdoc::private_intra_doc_links)]
 /// Partially evaluate `Expr`s so constant subtrees are evaluated at plan time.
 ///
 /// Note it does not handle algebraic rewrites such as `(a or false)`

--- a/datafusion/src/physical_plan/expressions/approx_percentile_cont.rs
+++ b/datafusion/src/physical_plan/expressions/approx_percentile_cont.rs
@@ -118,6 +118,7 @@ impl AggregateExpr for ApproxPercentileCont {
         Ok(Field::new(&self.name, self.input_data_type.clone(), false))
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
     /// See [`TDigest::to_scalar_state()`] for a description of the serialised
     /// state.
     fn state_fields(&self) -> Result<Vec<Field>> {

--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -257,7 +257,7 @@ pub(crate) struct SortPreservingMergeStream {
     /// The sorted input streams to merge together
     streams: MergingStreams,
 
-    /// Drop helper for tasks feeding the [`receivers`](Self::receivers)
+    /// Drop helper for tasks feeding the input [`streams`](Self::streams)
     _drop_helper: AbortOnDropMany<()>,
 
     /// For each input stream maintain a dequeue of RecordBatches


### PR DESCRIPTION
# Which issue does this PR close?


follow on to the great work from @HaoYang670 in https://github.com/apache/arrow-datafusion/pull/1808

re: https://github.com/apache/arrow-datafusion/issues/1741


 # Rationale for this change
It would be nice to make sure the datafusion docs are looking good prior to release

# What changes are included in this PR?
Fix up docstrings

Now this command runs without warning:
```shell
cargo doc --document-private-items --no-deps --workspace 
```

# Are there any user-facing changes?
Not really
