### PR TITLE
Update README.md for datafusion-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Projects that adapt to or serve as plugins to DataFusion:
 
 - [datafusion-python](https://github.com/datafusion-contrib/datafusion-python)
 - [datafusion-java](https://github.com/datafusion-contrib/datafusion-java)
-- [datafusion-ruby](https://github.com/j-a-m-l/datafusion-ruby)
 - [datafusion-objectstore-s3](https://github.com/datafusion-contrib/datafusion-objectstore-s3)
 - [datafusion-hdfs-native](https://github.com/datafusion-contrib/datafusion-hdfs-native)
 


### PR DESCRIPTION
# Rationale for this change
the repo `datafusion-ruby` seems imcomplete, as of 2022-02-13, the two branch [master](https://github.com/j-a-m-l/datafusion-ruby) and [rutie](https://github.com/j-a-m-l/datafusion-ruby/blob/rutie/src/lib.rs) didn't include interface for Arrow Datafusion.

And seems `datafusion-ruby` haven't been published to rubygems.org, `gem install datafusion` is mentioned in [README](https://github.com/j-a-m-l/datafusion-ruby/blob/609fde4ec44638cb14ad79bfe37ab994163f68d7/README.md?plain=1#L18) but the [datafusion gem in rubygems](https://rubygems.org/gems/datafusion) is not related to Arrow Datafusion.

so to reduce confusion, I proposes to remove the link first. Feel free to add back when `datafusion-ruby` is ready.
cc `datafusion-ruby` creator @j-a-m-l .

# What changes are included in this PR?
Remove link of datafusion-ruby.

# Are there any user-facing changes?
NA