### PR TITLE
Add RAT to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 version: 2
 updates:
   - package-ecosystem: cargo


### PR DESCRIPTION
# Which issue does this PR close?

re #1587 

# Rationale for this change
while trying to create a release candidate this file was flagged as "not RAT":

```shell
(arrow_dev) alamb@MacBook-Pro-2:~/Software/arrow-datafusion$ GH_TOKEN=$ARROW_GITHUB_API_TOKEN ./dev/release/create-tarball.sh 7.0.0 1
Attempting to create  from tag 7.0.0-rc1
Draft email for dev@arrow.apache.org mailing list
....
Running rat license checker on /Users/alamb/Software/arrow-datafusion/dev/dist/apache-arrow-datafusion-7.0.0-rc1/apache-arrow-datafusion-7.0.0.tar.gz
NOT APPROVED: .github/dependabot.yml (apache-arrow-datafusion-7.0.0/.github/dependabot.yml): false
       1 unapproved licences. Check rat report: rat.txt
```

# What changes are included in this PR?
Add apache license to a config file

# Are there any user-facing changes?
no