### PR TITLE
protobuf OctetLength should be deserialized as octet_length, not length

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -880,7 +880,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                         Ok(signum((&args[0]).try_into()?))
                     }
                     protobuf::ScalarFunction::Octetlength => {
-                        Ok(length((&args[0]).try_into()?))
+                        Ok(octet_length((&args[0]).try_into()?))
                     }
                     // // protobuf::ScalarFunction::Concat => Ok(concat((&args[0]).try_into()?)),
                     protobuf::ScalarFunction::Lower => Ok(lower((&args[0]).try_into()?)),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1833.

 # Rationale for this change

This seems wrong.

# What changes are included in this PR?

Deserializing `OctetLength` as `octet_length` instead of `length`.

# Are there any user-facing changes?

Deserializing should be correct, if `OctetLength` is used?