### PR TITLE
Return `Error` when parquet reader fails rather than no data with `println!`

### DIFF
--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -520,7 +520,7 @@ fn read_partition(
 #[cfg(test)]
 mod tests {
     use crate::{
-        assert_batches_sorted_eq,
+        assert_batches_sorted_eq, assert_contains,
         datasource::{
             file_format::{parquet::ParquetFormat, FileFormat},
             object_store::{
@@ -530,7 +530,7 @@ mod tests {
                 FileMeta, SizedFile,
             },
         },
-        physical_plan::collect, assert_contains,
+        physical_plan::collect,
     };
 
     use super::*;
@@ -965,8 +965,10 @@ mod tests {
         let mut results = parquet_exec.execute(0, runtime).await?;
         let batch = results.next().await.unwrap();
         // invalid file should produce an error to that effect
-        assert_contains!(batch.unwrap_err().to_string(),
-                         "External error: Parquet error: Arrow: IO error: No such file or directory");
+        assert_contains!(
+            batch.unwrap_err().to_string(),
+            "External error: Parquet error: Arrow: IO error: No such file or directory"
+        );
         assert!(results.next().await.is_none());
 
         Ok(())

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -962,7 +962,7 @@ mod tests {
         // invalid file should produce an error to that effect
         assert_contains!(
             batch.unwrap_err().to_string(),
-            "External error: Parquet error: Arrow: IO error: No such file or directory"
+            "External error: Parquet error: Arrow: IO error"
         );
         assert!(results.next().await.is_none());
 


### PR DESCRIPTION
# Which issue does this PR close?

Fixes: https://github.com/apache/arrow-datafusion/issues/1767 (cc @andygrove )
I believe this also fixes https://github.com/apache/arrow-datafusion/issues/1651 (cc @thinkharderdev )

 # Rationale for this change
Errors are getting ignored during processing. See #1767 for details

# What changes are included in this PR?
1. Send the error back to the `ParquetExec` stream
2. Tests for same

# Are there any user-facing changes?
Errors are reported when there are real errors 
