### PR TITLE
Fix compiling ballista  in standalone mode, add build to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,6 +142,8 @@ jobs:
           cd ballista/rust
           # snmalloc requires cmake so build without default features
           cargo test --no-default-features --features sled
+          # Ensure also compiles in standalone mode
+          cargo test --no-default-features --features standalone
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -470,6 +470,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "standalone")]
     #[ignore]
+    // Tracking: https://github.com/apache/arrow-datafusion/issues/1840
     async fn test_task_stuck_when_referenced_task_failed() {
         use super::*;
         use datafusion::arrow::datatypes::Schema;

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -70,6 +70,8 @@ impl BallistaContextState {
         concurrent_tasks: usize,
     ) -> ballista_core::error::Result<Self> {
         use ballista_core::serde::protobuf::scheduler_grpc_client::SchedulerGrpcClient;
+        use ballista_core::serde::protobuf::PhysicalPlanNode;
+        use ballista_core::serde::BallistaCodec;
 
         log::info!("Running in local mode. Scheduler will be run in-proc");
 
@@ -90,7 +92,16 @@ impl BallistaContextState {
             }
         };
 
-        ballista_executor::new_standalone_executor(scheduler, concurrent_tasks).await?;
+        let default_codec: BallistaCodec<LogicalPlanNode, PhysicalPlanNode> =
+            BallistaCodec::default();
+
+        ballista_executor::new_standalone_executor(
+            scheduler,
+            concurrent_tasks,
+            default_codec,
+        )
+        .await?;
+
         Ok(Self {
             config: config.clone(),
             scheduler_host: "localhost".to_string(),
@@ -464,7 +475,9 @@ mod tests {
         use datafusion::arrow::util::pretty;
         use datafusion::datasource::file_format::csv::CsvFormat;
         use datafusion::datasource::file_format::parquet::ParquetFormat;
-        use datafusion::datasource::listing::{ListingOptions, ListingTable};
+        use datafusion::datasource::listing::{
+            ListingOptions, ListingTable, ListingTableConfig,
+        };
 
         use ballista_core::config::{
             BallistaConfigBuilder, BALLISTA_WITH_INFORMATION_SCHEMA,
@@ -502,12 +515,16 @@ mod tests {
                         collect_stat: x.collect_stat,
                         target_partitions: x.target_partitions,
                     };
-                    let error_table = ListingTable::new(
+
+                    let config = ListingTableConfig::new(
                         listing_table.object_store().clone(),
                         listing_table.table_path().to_string(),
-                        Arc::new(Schema::new(vec![])),
-                        error_options,
-                    );
+                    )
+                    .with_schema(Arc::new(Schema::new(vec![])))
+                    .with_listing_options(error_options);
+
+                    let error_table = ListingTable::try_new(config).unwrap();
+
                     // change the table to an error table
                     guard
                         .tables

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -469,6 +469,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "standalone")]
+    #[ignore]
     async fn test_task_stuck_when_referenced_task_failed() {
         use super::*;
         use datafusion::arrow::datatypes::Schema;


### PR DESCRIPTION
# Which issue does this PR close?

TBD

 # Rationale for this change


As pointed by @thinkharderdev on https://github.com/apache/arrow-datafusion/pull/1810 https://github.com/apache/arrow-datafusion/pull/1810#discussion_r807259524 compiling with ballista is currently broken (likely by https://github.com/apache/arrow-datafusion/pull/1677 and https://github.com/apache/arrow-datafusion/pull/1715):

```rust
(arrow_dev) alamb@MacBook-Pro-2:~/Software/arrow-datafusion/ballista/rust$ cargo test --no-default-features --features standalone
   Compiling etcd-client v0.8.3
   Compiling ballista-scheduler v0.6.0 (/Users/alamb/Software/arrow-datafusion/ballista/rust/scheduler)
   Compiling ballista v0.6.0 (/Users/alamb/Software/arrow-datafusion/ballista/rust/client)
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
  --> ballista/rust/client/src/context.rs:93:9
   |
93 |         ballista_executor::new_standalone_executor(scheduler, concurrent_tasks).await?;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------  ---------------- supplied 2 arguments
   |         |
   |         expected 3 arguments
   |
note: function defined here
  --> /Users/alamb/Software/arrow-datafusion/ballista/rust/executor/src/standalone.rs:38:14
   |
38 | pub async fn new_standalone_executor<
   |              ^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0061`.
error: could not compile `ballista` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

# What changes are included in this PR?
1. Fix compile
2. Add `cargo test --features=standalone` for ballista to CI
3. Disabled `test_task_stuck_when_referenced_task_failed` test due to https://github.com/apache/arrow-datafusion/issues/1840


# Are there any user-facing changes?
No
