### PR TITLE
Fix warnings with default features disabled

### DIFF
--- a/datafusion/tests/dataframe_functions.rs
+++ b/datafusion/tests/dataframe_functions.rs
@@ -174,6 +174,7 @@ async fn test_fn_approx_percentile_cont() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_character_length() -> Result<()> {
     let expr = character_length(col("a"));
 
@@ -231,6 +232,7 @@ async fn test_fn_initcap() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_left() -> Result<()> {
     let expr = left(col("a"), lit(3));
 
@@ -271,6 +273,7 @@ async fn test_fn_lower() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_lpad() -> Result<()> {
     let expr = lpad(vec![col("a"), lit(10)]);
 
@@ -291,6 +294,7 @@ async fn test_fn_lpad() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_lpad_with_string() -> Result<()> {
     let expr = lpad(vec![col("a"), lit(10), lit("*")]);
 
@@ -348,6 +352,7 @@ async fn test_fn_ltrim_with_columns() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_md5() -> Result<()> {
     let expr = md5(col("a"));
 
@@ -371,6 +376,7 @@ async fn test_fn_md5() -> Result<()> {
 //       https://github.com/apache/arrow-datafusion/issues/1429
 //       g flag doesn't compile
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_regexp_match() -> Result<()> {
     let expr = regexp_match(vec![col("a"), lit("[a-z]")]);
     // The below will fail
@@ -393,6 +399,7 @@ async fn test_fn_regexp_match() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_regexp_replace() -> Result<()> {
     let expr = regexp_replace(vec![col("a"), lit("[a-z]"), lit("x"), lit("g")]);
 
@@ -453,6 +460,7 @@ async fn test_fn_repeat() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_reverse() -> Result<()> {
     let expr = reverse(col("a"));
 
@@ -473,6 +481,7 @@ async fn test_fn_reverse() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_right() -> Result<()> {
     let expr = right(col("a"), lit(3));
 
@@ -493,6 +502,7 @@ async fn test_fn_right() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_rpad() -> Result<()> {
     let expr = rpad(vec![col("a"), lit(11)]);
 
@@ -513,6 +523,7 @@ async fn test_fn_rpad() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_rpad_with_characters() -> Result<()> {
     let expr = rpad(vec![col("a"), lit(11), lit("x")]);
 
@@ -533,6 +544,7 @@ async fn test_fn_rpad_with_characters() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_sha224() -> Result<()> {
     let expr = sha224(col("a"));
 
@@ -592,6 +604,7 @@ async fn test_fn_starts_with() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_strpos() -> Result<()> {
     let expr = strpos(col("a"), lit("f"));
 
@@ -611,6 +624,7 @@ async fn test_fn_strpos() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_substr() -> Result<()> {
     let expr = substr(col("a"), lit(2));
 
@@ -649,6 +663,7 @@ async fn test_fn_to_hex() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "unicode_expressions")]
 async fn test_fn_translate() -> Result<()> {
     let expr = translate(col("a"), lit("bc"), lit("xx"));
 

--- a/datafusion/tests/sql/mod.rs
+++ b/datafusion/tests/sql/mod.rs
@@ -99,7 +99,7 @@ pub mod window;
 mod explain;
 pub mod information_schema;
 mod partitioned_csv;
-#[cfg_attr(not(feature = "unicode_expressions"), ignore)]
+#[cfg(feature = "unicode_expressions")]
 pub mod unicode;
 
 fn assert_float_eq<T>(expected: &[Vec<T>], received: &[Vec<String>])
@@ -599,27 +599,6 @@ fn result_vec(results: &[RecordBatch]) -> Vec<Vec<String>> {
         }
     }
     result
-}
-
-async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
-    datatype: DataType,
-) -> Result<()> {
-    let schema = Arc::new(Schema::new(vec![Field::new("c1", datatype, false)]));
-
-    let data = RecordBatch::try_new(
-        schema.clone(),
-        vec![Arc::new(T::from(vec!["", "a", "aa", "aaa"]))],
-    )?;
-
-    let table = MemTable::try_new(schema, vec![vec![data]])?;
-
-    let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table))?;
-    let sql = "SELECT length(c1) FROM test";
-    let actual = execute(&mut ctx, sql).await;
-    let expected = vec![vec!["0"], vec!["1"], vec!["2"], vec!["3"]];
-    assert_eq!(expected, actual);
-    Ok(())
 }
 
 async fn register_simple_aggregate_csv_with_decimal_by_sql(ctx: &mut ExecutionContext) {

--- a/datafusion/tests/sql/unicode.rs
+++ b/datafusion/tests/sql/unicode.rs
@@ -103,3 +103,24 @@ async fn test_unicode_expressions() -> Result<()> {
     test_expression!("translate('12345', '143', NULL)", "NULL");
     Ok(())
 }
+
+async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
+    datatype: DataType,
+) -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", datatype, false)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(T::from(vec!["", "a", "aa", "aaa"]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let mut ctx = ExecutionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT length(c1) FROM test";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["0"], vec!["1"], vec!["2"], vec!["3"]];
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

N/A
 # Rationale for this change

In an attempt to speed up development iteration, I am running this command
```shell
cargo test --no-default-features -p datafusion
```
I see several warnings 

```
warning: unused variable: `expr`
    --> datafusion/src/sql/planner.rs:1585:17
     |
1585 |                 expr,
     |                 ^^^^ help: try ignoring the field: `expr: _`
     |
     = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `substring_from`
    --> datafusion/src/sql/planner.rs:1586:17
     |
1586 |                 substring_from,
     |                 ^^^^^^^^^^^^^^ help: try ignoring the field: `substring_from: _`

warning: unused variable: `substring_for`
    --> datafusion/src/sql/planner.rs:1587:17
     |
1587 |                 substring_for,
     |                 ^^^^^^^^^^^^^ help: try ignoring the field: `substring_for: _`

warning: `datafusion` (lib) generated 3 warnings

```

and several tests do not pass:

```
---- test_fn_translate stdout ----
Error: ArrowError(ExternalError(Internal("function translate requires compilation with feature flag: unicode_expressions.")))
thread 'test_fn_translate' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/test/src/lib.rs:195:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::panicking::assert_failed_inner
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:182:23
   3: core::panicking::assert_failed
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:145:5
   4: test::assert_test_result
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/test/src/lib.rs:195:5
   5: dataframe_functions::test_fn_translate::{{closure}}
             at ./tests/dataframe_functions.rs:652:7
   6: core::ops::function::FnOnce::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/ops/function.rs:227:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```


# What changes are included in this PR?
1. Fix warnings 
2. `cfg` out tests that require unicode expressions

# Are there any user-facing changes?
no
