### PR TITLE
Remove allow unused imports from ballista-core, then fix all warnings

### DIFF
--- a/ballista/rust/core/src/client.rs
+++ b/ballista/rust/core/src/client.rs
@@ -19,7 +19,7 @@
 
 use parking_lot::Mutex;
 use std::sync::Arc;
-use std::{collections::HashMap, pin::Pin};
+
 use std::{
     convert::{TryFrom, TryInto},
     task::{Context, Poll},
@@ -27,27 +27,22 @@ use std::{
 
 use crate::error::{ballista_error, BallistaError, Result};
 use crate::serde::protobuf::{self};
-use crate::serde::scheduler::{
-    Action, ExecutePartition, ExecutePartitionResult, PartitionId, PartitionStats,
-};
+use crate::serde::scheduler::Action;
 
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::Ticket;
 use arrow_flight::{flight_service_client::FlightServiceClient, FlightData};
 use datafusion::arrow::{
-    array::{StringArray, StructArray},
     datatypes::{Schema, SchemaRef},
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
-use datafusion::physical_plan::common::collect;
-use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
-use datafusion::{logical_plan::LogicalPlan, physical_plan::RecordBatchStream};
+
+use datafusion::physical_plan::{RecordBatchStream, SendableRecordBatchStream};
 use futures::{Stream, StreamExt};
 use log::debug;
 use prost::Message;
 use tonic::Streaming;
-use uuid::Uuid;
 
 /// Client for interacting with Ballista executors.
 #[derive(Clone)]

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -22,12 +22,10 @@ use clap::ArgEnum;
 use core::fmt;
 use std::collections::HashMap;
 use std::result;
-use std::string::ParseError;
 
 use crate::error::{BallistaError, Result};
 
 use datafusion::arrow::datatypes::DataType;
-use log::warn;
 
 pub const BALLISTA_DEFAULT_SHUFFLE_PARTITIONS: &str = "ballista.shuffle.partitions";
 pub const BALLISTA_WITH_INFORMATION_SCHEMA: &str = "ballista.with_information_schema";

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -16,11 +16,10 @@
 // under the License.
 
 use std::any::Any;
-use std::convert::TryInto;
+
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::marker::Send;
-use std::pin::Pin;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,8 +37,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::{
-    DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
-    SendableRecordBatchStream, Statistics,
+    DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
 
 use crate::serde::{AsLogicalPlan, DefaultLogicalExtensionCodec, LogicalExtensionCodec};

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::{any::Any, pin::Pin};
 
@@ -25,25 +24,22 @@ use crate::serde::scheduler::{PartitionLocation, PartitionStats};
 use crate::utils::WrappedStream;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::error::Result as ArrowResult;
-use datafusion::arrow::record_batch::RecordBatch;
+
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::metrics::{
     ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use datafusion::physical_plan::{
-    DisplayFormatType, ExecutionPlan, Metric, Partitioning, SendableRecordBatchStream,
-    Statistics,
+    DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::RecordBatchStream,
 };
-use futures::{future, Stream, StreamExt};
-use hashbrown::HashMap;
+use futures::{future, StreamExt};
+
 use log::info;
-use std::time::Instant;
 
 /// ShuffleReaderExec reads partitions that have already been materialized by a ShuffleWriterExec
 /// being executed by an executor

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -21,19 +21,17 @@
 //! will use the ShuffleReaderExec to read these results.
 
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
-use parking_lot::Mutex;
-use std::fs::File;
+
+use std::any::Any;
 use std::iter::Iterator;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use std::{any::Any, pin::Pin};
 
-use crate::error::BallistaError;
 use crate::utils;
 
 use crate::serde::protobuf::ShuffleWritePartition;
-use crate::serde::scheduler::{PartitionLocation, PartitionStats};
+use crate::serde::scheduler::PartitionStats;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
     Array, ArrayBuilder, ArrayRef, StringBuilder, StructBuilder, UInt32Builder,
@@ -41,8 +39,7 @@ use datafusion::arrow::array::{
 };
 use datafusion::arrow::compute::take;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::arrow::ipc::reader::FileReader;
-use datafusion::arrow::ipc::writer::FileWriter;
+
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -52,16 +49,13 @@ use datafusion::physical_plan::memory::MemoryStream;
 use datafusion::physical_plan::metrics::{
     self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
-use datafusion::physical_plan::repartition::RepartitionExec;
-use datafusion::physical_plan::Partitioning::RoundRobinBatch;
+
 use datafusion::physical_plan::{
-    DisplayFormatType, ExecutionPlan, Metric, Partitioning, RecordBatchStream,
-    SendableRecordBatchStream, Statistics,
+    DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
 use futures::StreamExt;
-use hashbrown::HashMap;
+
 use log::{debug, info};
-use uuid::Uuid;
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
 /// can be executed as one unit with each partition being executed in parallel. The output of each
@@ -452,7 +446,7 @@ mod tests {
     use datafusion::arrow::array::{StringArray, StructArray, UInt32Array, UInt64Array};
     use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use datafusion::physical_plan::expressions::Column;
-    use datafusion::physical_plan::limit::GlobalLimitExec;
+
     use datafusion::physical_plan::memory::MemoryExec;
     use tempfile::TempDir;
 

--- a/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
@@ -15,24 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::any::Any;
 use std::sync::Arc;
-use std::{any::Any, pin::Pin};
-
-use crate::serde::scheduler::PartitionLocation;
 
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
-use datafusion::{
-    error::{DataFusionError, Result},
-    physical_plan::RecordBatchStream,
-};
-use log::info;
-use std::fmt::Formatter;
 
 /// UnresolvedShuffleExec represents a dependency on the results of a ShuffleWriterExec node which hasn't computed yet.
 ///

--- a/ballista/rust/core/src/lib.rs
+++ b/ballista/rust/core/src/lib.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 #![doc = include_str!("../README.md")]
-#![allow(unused_imports)]
 pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn print_version() {

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -28,24 +28,21 @@ use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
-use datafusion::datasource::object_store::local::LocalFileSystem;
-use datafusion::logical_plan::plan::Extension;
+
 use datafusion::logical_plan::plan::{
     Aggregate, EmptyRelation, Filter, Join, Projection, Sort, Window,
 };
 use datafusion::logical_plan::{
-    exprlist_to_fields,
-    window_frames::{WindowFrame, WindowFrameBound, WindowFrameUnits},
-    Column, CreateExternalTable, CrossJoin, Expr, JoinConstraint, JoinType, Limit,
-    LogicalPlan, LogicalPlanBuilder, Repartition, TableScan, Values,
+    Column, CreateExternalTable, CrossJoin, Expr, JoinConstraint, Limit, LogicalPlan,
+    LogicalPlanBuilder, Repartition, TableScan, Values,
 };
 use datafusion::prelude::ExecutionContext;
-use log::error;
-use prost::bytes::{Buf, BufMut};
+
+use prost::bytes::BufMut;
 use prost::Message;
 use protobuf::listing_table_scan_node::FileFormatType;
 use protobuf::logical_plan_node::LogicalPlanType;
-use protobuf::{logical_expr_node::ExprType, scalar_type, LogicalPlanNode};
+use protobuf::LogicalPlanNode;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -855,22 +852,20 @@ mod roundtrip_tests {
     use datafusion::datasource::object_store::{
         FileMetaStream, ListEntryStream, ObjectReader, ObjectStore, SizedFile,
     };
-    use datafusion::datasource::TableProvider;
     use datafusion::error::DataFusionError;
     use datafusion::{
         arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit, UnionMode},
         datasource::object_store::local::LocalFileSystem,
         logical_plan::{
-            col, CreateExternalTable, Expr, LogicalPlan, LogicalPlanBuilder,
-            Partitioning, Repartition, ToDFSchema,
+            col, CreateExternalTable, Expr, LogicalPlan, LogicalPlanBuilder, Repartition,
+            ToDFSchema,
         },
         physical_plan::{aggregates, functions::BuiltinScalarFunction::Sqrt},
         prelude::*,
         scalar::ScalarValue,
         sql::parser::FileType,
     };
-    use protobuf::arrow_type;
-    use sqlparser::test_utils::table;
+
     use std::{convert::TryInto, sync::Arc};
 
     #[derive(Debug)]

--- a/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -20,40 +20,23 @@
 //! processes.
 
 use super::super::proto_error;
-use crate::serde::{byte_to_string, protobuf, BallistaError};
+use crate::serde::{protobuf, BallistaError};
 use datafusion::arrow::datatypes::{
     DataType, Field, IntervalUnit, Schema, SchemaRef, TimeUnit, UnionMode,
 };
-use datafusion::datasource::file_format::avro::AvroFormat;
-use datafusion::datasource::file_format::csv::CsvFormat;
-use datafusion::datasource::TableProvider;
 
-use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::ListingTable;
-use datafusion::logical_plan::plan::{
-    Aggregate, EmptyRelation, Filter, Join, Projection, Sort, Window,
-};
 use datafusion::logical_plan::{
-    exprlist_to_fields,
     window_frames::{WindowFrame, WindowFrameBound, WindowFrameUnits},
-    Column, CreateExternalTable, CrossJoin, Expr, JoinConstraint, JoinType, Limit,
-    LogicalPlan, Repartition, TableScan, Values,
+    Column, Expr,
 };
 use datafusion::physical_plan::aggregates::AggregateFunction;
 use datafusion::physical_plan::functions::BuiltinScalarFunction;
 use datafusion::physical_plan::window_functions::{
     BuiltInWindowFunction, WindowFunction,
 };
-use datafusion::physical_plan::{ColumnStatistics, Statistics};
-use protobuf::listing_table_scan_node::FileFormatType;
-use protobuf::{
-    arrow_type, logical_expr_node::ExprType, scalar_type, DateUnit, PrimitiveScalarType,
-    ScalarListValue, ScalarType,
-};
-use std::{
-    boxed,
-    convert::{TryFrom, TryInto},
-};
+
+use protobuf::{logical_expr_node::ExprType, scalar_type};
+use std::convert::{TryFrom, TryInto};
 
 impl protobuf::IntervalUnit {
     pub fn from_arrow_interval_unit(interval_unit: &IntervalUnit) -> Self {
@@ -179,7 +162,7 @@ impl TryInto<DataType> for &Box<protobuf::List> {
 impl From<&DataType> for protobuf::arrow_type::ArrowTypeEnum {
     fn from(val: &DataType) -> protobuf::arrow_type::ArrowTypeEnum {
         use protobuf::arrow_type::ArrowTypeEnum;
-        use protobuf::ArrowType;
+
         use protobuf::EmptyMessage;
         match val {
             DataType::Null => ArrowTypeEnum::None(EmptyMessage {}),
@@ -301,7 +284,7 @@ fn is_valid_scalar_type_no_list_check(datatype: &DataType) -> bool {
 impl TryFrom<&DataType> for protobuf::scalar_type::Datatype {
     type Error = BallistaError;
     fn try_from(val: &DataType) -> Result<Self, Self::Error> {
-        use protobuf::{List, PrimitiveScalarType};
+        use protobuf::PrimitiveScalarType;
         let scalar_value = match val {
             DataType::Boolean => scalar_type::Datatype::Scalar(PrimitiveScalarType::Bool as i32),
             DataType::Int8 => scalar_type::Datatype::Scalar(PrimitiveScalarType::Int8 as i32),
@@ -635,8 +618,6 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
     type Error = BallistaError;
 
     fn try_into(self) -> Result<protobuf::LogicalExprNode, Self::Error> {
-        use datafusion::scalar::ScalarValue;
-        use protobuf::scalar_value::Value;
         match self {
             Expr::Column(c) => {
                 let expr = protobuf::LogicalExprNode {

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -18,16 +18,14 @@
 //! This crate contains code generated from the Ballista Protocol Buffer Definition as well
 //! as convenience code for interacting with the generated code.
 
-use prost::bytes::{Buf, BufMut};
+use prost::bytes::BufMut;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{convert::TryInto, io::Cursor};
 
 use datafusion::arrow::datatypes::{IntervalUnit, UnionMode};
-use datafusion::logical_plan::{
-    JoinConstraint, JoinType, LogicalPlan, Operator, UserDefinedLogicalNode,
-};
+use datafusion::logical_plan::{JoinConstraint, JoinType, LogicalPlan, Operator};
 use datafusion::physical_plan::aggregates::AggregateFunction;
 use datafusion::physical_plan::window_functions::BuiltInWindowFunction;
 
@@ -600,7 +598,7 @@ mod tests {
     use datafusion::prelude::{CsvReadOptions, ExecutionConfig, ExecutionContext};
     use prost::Message;
     use std::any::Any;
-    use std::collections::BTreeMap;
+
     use std::convert::TryInto;
     use std::fmt;
     use std::fmt::{Debug, Formatter};
@@ -608,7 +606,6 @@ mod tests {
 
     pub mod proto {
         use crate::serde::protobuf;
-        use prost::Message;
 
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct TopKPlanProto {
@@ -629,8 +626,7 @@ mod tests {
     use crate::error::BallistaError;
     use crate::serde::protobuf::{LogicalPlanNode, PhysicalPlanNode};
     use crate::serde::{
-        AsExecutionPlan, AsLogicalPlan, BallistaCodec, LogicalExtensionCodec,
-        PhysicalExtensionCodec,
+        AsExecutionPlan, AsLogicalPlan, LogicalExtensionCodec, PhysicalExtensionCodec,
     };
     use proto::{TopKExecProto, TopKPlanProto};
 

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -23,7 +23,7 @@ use crate::serde::physical_plan::from_proto::parse_protobuf_hash_partitioning;
 use crate::serde::protobuf::physical_expr_node::ExprType;
 use crate::serde::protobuf::physical_plan_node::PhysicalPlanType;
 use crate::serde::protobuf::repartition_exec_node::PartitionMethod;
-use crate::serde::protobuf::ShuffleReaderPartition;
+
 use crate::serde::protobuf::{PhysicalExtensionNode, PhysicalPlanNode};
 use crate::serde::scheduler::PartitionLocation;
 use crate::serde::{
@@ -926,7 +926,7 @@ macro_rules! into_physical_plan {
 
 #[cfg(test)]
 mod roundtrip_tests {
-    use std::{convert::TryInto, sync::Arc};
+    use std::sync::Arc;
 
     use crate::serde::{AsExecutionPlan, BallistaCodec};
     use datafusion::physical_plan::sorts::sort::SortExec;
@@ -945,8 +945,7 @@ mod roundtrip_tests {
             hash_aggregate::{AggregateMode, HashAggregateExec},
             hash_join::{HashJoinExec, PartitionMode},
             limit::{GlobalLimitExec, LocalLimitExec},
-            AggregateExpr, ColumnarValue, Distribution, ExecutionPlan, Partitioning,
-            PhysicalExpr,
+            AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr,
         },
         scalar::ScalarValue,
     };

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -26,54 +26,26 @@ use std::{
     sync::Arc,
 };
 
-use datafusion::physical_plan::hash_join::{HashJoinExec, PartitionMode};
-use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
-use datafusion::physical_plan::projection::ProjectionExec;
-use datafusion::physical_plan::sorts::sort::SortExec;
-use datafusion::physical_plan::{cross_join::CrossJoinExec, ColumnStatistics};
+use datafusion::physical_plan::expressions::{CastExpr, TryCastExpr};
+use datafusion::physical_plan::ColumnStatistics;
 use datafusion::physical_plan::{
     expressions::{
         CaseExpr, InListExpr, IsNotNullExpr, IsNullExpr, NegativeExpr, NotExpr,
     },
     Statistics,
 };
-use datafusion::physical_plan::{
-    expressions::{CastExpr, TryCastExpr},
-    file_format::ParquetExec,
-};
-use datafusion::physical_plan::{file_format::AvroExec, filter::FilterExec};
-use datafusion::physical_plan::{
-    file_format::FileScanConfig, hash_aggregate::AggregateMode,
-};
-use datafusion::{
-    datasource::PartitionedFile, physical_plan::coalesce_batches::CoalesceBatchesExec,
-};
-use datafusion::{logical_plan::JoinType, physical_plan::file_format::CsvExec};
-use datafusion::{
-    physical_plan::expressions::{Count, Literal},
-    scalar::ScalarValue,
-};
 
-use datafusion::physical_plan::{
-    empty::EmptyExec,
-    expressions::{Avg, BinaryExpr, Column, Max, Min, Sum},
-    Partitioning,
-};
-use datafusion::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr};
+use datafusion::datasource::PartitionedFile;
+use datafusion::physical_plan::file_format::FileScanConfig;
 
-use datafusion::physical_plan::hash_aggregate::HashAggregateExec;
-use protobuf::physical_plan_node::PhysicalPlanType;
+use datafusion::physical_plan::expressions::{Count, Literal};
 
-use crate::serde::protobuf::repartition_exec_node::PartitionMethod;
-use crate::serde::scheduler::PartitionLocation;
+use datafusion::physical_plan::expressions::{Avg, BinaryExpr, Column, Max, Min, Sum};
+use datafusion::physical_plan::{AggregateExpr, PhysicalExpr};
+
 use crate::serde::{protobuf, BallistaError};
-use crate::{
-    execution_plans::{ShuffleReaderExec, ShuffleWriterExec, UnresolvedShuffleExec},
-    serde::byte_to_string,
-};
-use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+
 use datafusion::physical_plan::functions::{BuiltinScalarFunction, ScalarFunctionExpr};
-use datafusion::physical_plan::repartition::RepartitionExec;
 
 impl TryInto<protobuf::PhysicalExprNode> for Arc<dyn AggregateExpr> {
     type Error = BallistaError;

--- a/ballista/rust/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/from_proto.rs
@@ -15,17 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{collections::HashMap, convert::TryInto};
+use std::convert::TryInto;
 
 use crate::error::BallistaError;
 use crate::serde::protobuf;
 use crate::serde::protobuf::action::ActionType;
-use crate::serde::scheduler::{
-    Action, ExecutePartition, PartitionId, PartitionLocation, PartitionStats,
-};
-
-use datafusion::logical_plan::LogicalPlan;
-use uuid::Uuid;
+use crate::serde::scheduler::{Action, PartitionId, PartitionLocation, PartitionStats};
 
 impl TryInto<Action> for protobuf::Action {
     type Error = BallistaError;

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -18,14 +18,13 @@
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use datafusion::arrow::array::{
-    ArrayBuilder, ArrayRef, StructArray, StructBuilder, UInt64Array, UInt64Builder,
+    ArrayBuilder, StructArray, StructBuilder, UInt64Array, UInt64Builder,
 };
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::logical_plan::LogicalPlan;
+use datafusion::arrow::datatypes::{DataType, Field};
+
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::Partitioning;
 use serde::Serialize;
-use uuid::Uuid;
 
 use super::protobuf;
 use crate::error::BallistaError;

--- a/ballista/rust/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/rust/core/src/serde/scheduler/to_proto.rs
@@ -20,9 +20,7 @@ use std::convert::TryInto;
 use crate::error::BallistaError;
 use crate::serde::protobuf;
 use crate::serde::protobuf::action::ActionType;
-use crate::serde::scheduler::{
-    Action, ExecutePartition, PartitionId, PartitionLocation, PartitionStats,
-};
+use crate::serde::scheduler::{Action, PartitionId, PartitionLocation, PartitionStats};
 use datafusion::physical_plan::Partitioning;
 
 impl TryInto<protobuf::Action> for Action {

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
-use std::ops::Deref;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::{fs::File, pin::Pin};
@@ -35,38 +34,27 @@ use async_trait::async_trait;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::error::Result as ArrowResult;
 use datafusion::arrow::{
-    array::{
-        ArrayBuilder, ArrayRef, StructArray, StructBuilder, UInt64Array, UInt64Builder,
-    },
-    datatypes::{DataType, Field, SchemaRef},
-    ipc::reader::FileReader,
-    ipc::writer::FileWriter,
-    record_batch::RecordBatch,
+    datatypes::SchemaRef, ipc::writer::FileWriter, record_batch::RecordBatch,
 };
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::{
     ExecutionConfig, ExecutionContext, ExecutionContextState, QueryPlanner,
 };
-use datafusion::logical_plan::{LogicalPlan, Operator, TableScan};
-use datafusion::physical_optimizer::coalesce_batches::CoalesceBatches;
-use datafusion::physical_optimizer::merge_exec::AddCoalescePartitionsExec;
-use datafusion::physical_optimizer::optimizer::PhysicalOptimizerRule;
+use datafusion::logical_plan::LogicalPlan;
+
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::common::batch_byte_size;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::expressions::{BinaryExpr, Column, Literal};
+
 use datafusion::physical_plan::file_format::{CsvExec, ParquetExec};
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::hash_aggregate::HashAggregateExec;
 use datafusion::physical_plan::hash_join::HashJoinExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
-use datafusion::physical_plan::{
-    metrics, AggregateExpr, ExecutionPlan, Metric, PhysicalExpr, RecordBatchStream,
-};
-use futures::{future, Stream, StreamExt};
-use std::time::Instant;
+use datafusion::physical_plan::{metrics, ExecutionPlan, RecordBatchStream};
+use futures::{Stream, StreamExt};
 
 /// Stream data to disk in Arrow IPC format
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1852.

 # Rationale for this change

I think most Rust developers expect this lint to let them know when imports are no longer needed.

# What changes are included in this PR?

- I removed the `allow`
- I fixed all the warnings
- I ran rustfmt

# Are there any user-facing changes?

Nope!