### PR TITLE
Fix incorrect aggregation in case that GROUP BY contains duplicate column names

### DIFF
--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -163,6 +163,19 @@ impl HashAggregateExec {
         &self.group_expr
     }
 
+    /// Grouping expressions as they occur in the output schema
+    pub fn output_group_expr(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        // Update column indices. Since the group by columns come first in the output schema, their
+        // indices are simply 0..self.group_expr(len).
+        self.group_expr
+            .iter()
+            .enumerate()
+            .map(|(index, (_col, name))| {
+                Arc::new(Column::new(name, index)) as Arc<dyn PhysicalExpr>
+            })
+            .collect()
+    }
+
     /// Aggregate expressions
     pub fn aggr_expr(&self) -> &[Arc<dyn AggregateExpr>] {
         &self.aggr_expr

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -61,7 +61,6 @@ use arrow::compute::SortOptions;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::{compute::can_cast_types, datatypes::DataType};
 use async_trait::async_trait;
-use expressions::col;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use log::{debug, trace};
@@ -524,9 +523,7 @@ impl DefaultPhysicalPlanner {
                     )?);
 
                     // update group column indices based on partial aggregate plan evaluation
-                    let final_group: Vec<Arc<dyn PhysicalExpr>> = (0..groups.len())
-                        .map(|i| col(&groups[i].1, &initial_aggr.schema()))
-                        .collect::<Result<_>>()?;
+                    let final_group: Vec<Arc<dyn PhysicalExpr>> = initial_aggr.output_group_expr();
 
                     // TODO: dictionary type not yet supported in Hash Repartition
                     let contains_dict = groups

--- a/datafusion/tests/sql/aggregates.rs
+++ b/datafusion/tests/sql/aggregates.rs
@@ -477,6 +477,46 @@ async fn csv_query_approx_percentile_cont() -> Result<()> {
 }
 
 #[tokio::test]
+async fn csv_query_sum_crossjoin() {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv_by_sql(&mut ctx).await;
+    let sql = "SELECT a.c1, b.c1, SUM(a.c2) FROM aggregate_test_100 as a CROSS JOIN aggregate_test_100 as b GROUP BY a.c1, b.c1 ORDER BY a.c1, b.c1";
+    let actual = execute_to_batches(&mut ctx, sql).await;
+    let expected = vec![
+        "+----+----+-----------+",
+        "| c1 | c1 | SUM(a.c2) |",
+        "+----+----+-----------+",
+        "| a  | a  | 1260      |",
+        "| a  | b  | 1140      |",
+        "| a  | c  | 1260      |",
+        "| a  | d  | 1080      |",
+        "| a  | e  | 1260      |",
+        "| b  | a  | 1302      |",
+        "| b  | b  | 1178      |",
+        "| b  | c  | 1302      |",
+        "| b  | d  | 1116      |",
+        "| b  | e  | 1302      |",
+        "| c  | a  | 1176      |",
+        "| c  | b  | 1064      |",
+        "| c  | c  | 1176      |",
+        "| c  | d  | 1008      |",
+        "| c  | e  | 1176      |",
+        "| d  | a  | 924       |",
+        "| d  | b  | 836       |",
+        "| d  | c  | 924       |",
+        "| d  | d  | 792       |",
+        "| d  | e  | 924       |",
+        "| e  | a  | 1323      |",
+        "| e  | b  | 1197      |",
+        "| e  | c  | 1323      |",
+        "| e  | d  | 1134      |",
+        "| e  | e  | 1323      |",
+        "+----+----+-----------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+}
+
+#[tokio::test]
 async fn query_count_without_from() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     let sql = "SELECT count(1 + 1)";


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1854 .

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Add `HashAggregateExec::output_group_expr` that provides the GROUP BY columns with indices that correctly correspond to the schema of the `RecordBatchStream` created by this `ExecutionPlan`.
* Use `HashAggregateExec::output_group_expr` in `DefaultPhysicalPlanner` when planning a `LogicalPlan::Aggregate`. (The latter is planned as two `HashAggregateExec`s and the second one needs to correctly use the output columns of the first as input.)
* Add test `csv_query_sum_crossjoin` to `datafusion/tests/sql/aggregates.rs` that checks against regressions from the correct behavior.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The added `HashAggregateExec::output_group_expr` is marked as `pub`. As this is only an addition, it does not break any existing public API. (The added function could also be marked `pub(crate)` or `pub(super)`, but this did not seem in line with the rest of the methods that `HashAggregateExec` exposes.)

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
