### PR TITLE
Add support for `~/.datafusionrc` and cli option for overriding it to datafusion-cli

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -36,3 +36,4 @@ arrow = { version = "9.1" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0", optional=true }
 env_logger = "0.9"
 mimalloc = { version = "*", default-features = false }
+dirs = "4.0.0"

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -83,7 +83,7 @@ pub async fn exec_from_files(
         .collect::<Vec<_>>();
     for file in files {
         let mut reader = BufReader::new(file);
-        exec_from_lines(ctx, &mut reader, &print_options).await;
+        exec_from_lines(ctx, &mut reader, print_options).await;
     }
 }
 

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -72,6 +72,21 @@ pub async fn exec_from_lines(
     }
 }
 
+pub async fn exec_from_files(
+    files: Vec<String>,
+    ctx: &mut Context,
+    print_options: &PrintOptions,
+) {
+    let files = files
+        .into_iter()
+        .map(|file_path| File::open(file_path).unwrap())
+        .collect::<Vec<_>>();
+    for file in files {
+        let mut reader = BufReader::new(file);
+        exec_from_lines(ctx, &mut reader, &print_options).await;
+    }
+}
+
 /// run and execute SQL statements and commands against a context with the given print options
 pub async fn exec_from_repl(ctx: &mut Context, print_options: &mut PrintOptions) {
     let mut rl = Editor::<CliHelper>::new();

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -22,7 +22,6 @@ use datafusion_cli::{
     context::Context, exec, print_format::PrintFormat, print_options::PrintOptions,
     DATAFUSION_CLI_VERSION,
 };
-use dirs;
 use mimalloc::MiMalloc;
 use std::env;
 use std::path::Path;
@@ -121,16 +120,11 @@ pub async fn main() -> Result<()> {
         None => {
             let mut files = Vec::new();
             let home = dirs::home_dir();
-            match home {
-                Some(p) => {
-                    let home_rc = p.join(".datafusionrc");
-                    if home_rc.exists() {
-                        files.push(String::from(
-                            home_rc.into_os_string().into_string().unwrap(),
-                        ));
-                    }
+            if let Some(p) = home {
+                let home_rc = p.join(".datafusionrc");
+                if home_rc.exists() {
+                    files.push(home_rc.into_os_string().into_string().unwrap());
                 }
-                None => (),
             }
             files
         }

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
         help = "Execute commands from file(s), then exit",
         validator(is_valid_file)
     )]
-    file: Vec<String>,
+    file_exit: Vec<String>,
 
     #[clap(
         short,
@@ -65,7 +65,7 @@ struct Args {
         validator(is_valid_file),
         conflicts_with = "file"
     )]
-    run: Vec<String>,
+    file_run: Vec<String>,
 
     #[clap(long, arg_enum, default_value_t = PrintFormat::Table)]
     format: PrintFormat,
@@ -114,8 +114,8 @@ pub async fn main() -> Result<()> {
         quiet: args.quiet,
     };
 
-    let files_to_run_then_quit = args.file;
-    let files_to_run = args.run;
+    let files_to_run_then_quit = args.file_exit;
+    let files_to_run = args.file_run;
     if !files_to_run_then_quit.is_empty() {
         exec::exec_from_files(files_to_run_then_quit, &mut ctx, &print_options).await
     } else {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1872 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
datafusion-cli will now by default look for `~/.datafusionrc` file and run that before placing user in REPL.

User can optionally override the default `.datafusionrc` file using the `-r / --rc` option when starting datafusion-cli.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Maybe a changed option.  If no change to that, then just a new command line option.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
