### PR TITLE
Make parquet support optional for datafusion-common crate

### DIFF
--- a/datafusion-common/Cargo.toml
+++ b/datafusion-common/Cargo.toml
@@ -39,7 +39,7 @@ jit = ["cranelift-module"]
 
 [dependencies]
 arrow = { version = "9.0.0", features = ["prettyprint"] }
-parquet = { version = "9.0.0", features = ["arrow"] }
+parquet = { version = "9.0.0", features = ["arrow"], optional = true }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 pyo3 = { version = "0.15", optional = true }
 sqlparser = "0.14"

--- a/datafusion-common/src/error.rs
+++ b/datafusion-common/src/error.rs
@@ -27,6 +27,7 @@ use arrow::error::ArrowError;
 use avro_rs::Error as AvroError;
 #[cfg(feature = "jit")]
 use cranelift_module::ModuleError;
+#[cfg(feature = "parquet")]
 use parquet::errors::ParquetError;
 use sqlparser::parser::ParserError;
 
@@ -42,6 +43,7 @@ pub enum DataFusionError {
     /// Error returned by arrow.
     ArrowError(ArrowError),
     /// Wraps an error from the Parquet crate
+    #[cfg(feature = "parquet")]
     ParquetError(ParquetError),
     /// Wraps an error from the Avro crate
     #[cfg(feature = "avro")]
@@ -98,6 +100,7 @@ impl From<DataFusionError> for ArrowError {
     }
 }
 
+#[cfg(feature = "parquet")]
 impl From<ParquetError> for DataFusionError {
     fn from(e: ParquetError) -> Self {
         DataFusionError::ParquetError(e)
@@ -134,6 +137,7 @@ impl Display for DataFusionError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             DataFusionError::ArrowError(ref desc) => write!(f, "Arrow error: {}", desc),
+            #[cfg(feature = "parquet")]
             DataFusionError::ParquetError(ref desc) => {
                 write!(f, "Parquet error: {}", desc)
             }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -54,7 +54,7 @@ row = []
 jit = ["datafusion-jit"]
 
 [dependencies]
-datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
+datafusion-common = { path = "../datafusion-common", version = "7.0.0", features = ["parquet"] }
 datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
 datafusion-jit = { path = "../datafusion-jit", version = "7.0.0", optional = true }
 datafusion-physical-expr = { path = "../datafusion-physical-expr", version = "7.0.0" }


### PR DESCRIPTION
 # Rationale for this change
Hi! This is a small PR that makes the `parquet` dependency of the new `datafusion-common` crate optional.  The motivation is that I'd like to depend on `datafusion-common` in the WebAssembly logic of [VegaFusion](https://vegafusion.io/), and the parquet dependency is the only thing preventing `datafusion-common` from compiling to WASM.

# What changes are included in this PR?
The `parquet` dependency in `datafusion-common` has been marked as `optional`, and feature gates are used in the `error.rs` file (following the pattern of the optional `avro` dependency).  This feature is then enabled by the `datafusion` crate.

# Are there any user-facing changes?
No
