### PR TITLE
Avoid repeated `open` for one single file and simplify object reader API on the `sync` part

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -850,7 +850,7 @@ mod roundtrip_tests {
     use core::panic;
     use datafusion::datasource::listing::ListingTable;
     use datafusion::datasource::object_store::{
-        ObjectReaderWrapper, FileMetaStream, ListEntryStream, ObjectStore, SizedFile,
+        FileMetaStream, ListEntryStream, ObjectReaderWrapper, ObjectStore, SizedFile,
     };
     use datafusion::error::DataFusionError;
     use datafusion::{

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -850,7 +850,7 @@ mod roundtrip_tests {
     use core::panic;
     use datafusion::datasource::listing::ListingTable;
     use datafusion::datasource::object_store::{
-        ChunkObjectReader, FileMetaStream, ListEntryStream, ObjectStore, SizedFile,
+        ObjectReaderWrapper, FileMetaStream, ListEntryStream, ObjectStore, SizedFile,
     };
     use datafusion::error::DataFusionError;
     use datafusion::{
@@ -895,7 +895,7 @@ mod roundtrip_tests {
         fn file_reader(
             &self,
             _file: SizedFile,
-        ) -> datafusion::error::Result<ChunkObjectReader> {
+        ) -> datafusion::error::Result<ObjectReaderWrapper> {
             Err(DataFusionError::NotImplemented(
                 "this is only a test object store".to_string(),
             ))

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -850,7 +850,7 @@ mod roundtrip_tests {
     use core::panic;
     use datafusion::datasource::listing::ListingTable;
     use datafusion::datasource::object_store::{
-        FileMetaStream, ListEntryStream, ObjectReader, ObjectStore, SizedFile,
+        ChunkObjectReader, FileMetaStream, ListEntryStream, ObjectStore, SizedFile,
     };
     use datafusion::error::DataFusionError;
     use datafusion::{
@@ -895,7 +895,7 @@ mod roundtrip_tests {
         fn file_reader(
             &self,
             _file: SizedFile,
-        ) -> datafusion::error::Result<Arc<dyn ObjectReader>> {
+        ) -> datafusion::error::Result<ChunkObjectReader> {
             Err(DataFusionError::NotImplemented(
                 "this is only a test object store".to_string(),
             ))

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -27,7 +27,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use crate::avro_to_arrow::read_avro_schema_from_reader;
-use crate::datasource::object_store::{ObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{AvroExec, FileScanConfig};
@@ -49,7 +49,7 @@ impl FileFormat for AvroFormat {
     async fn infer_schema(&self, mut readers: ObjectReaderStream) -> Result<SchemaRef> {
         let mut schemas = vec![];
         while let Some(obj_reader) = readers.next().await {
-            let mut reader = obj_reader?.sync_reader()?;
+            let mut reader = obj_reader?;
             let schema = read_avro_schema_from_reader(&mut reader)?;
             schemas.push(schema);
         }
@@ -57,7 +57,7 @@ impl FileFormat for AvroFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -27,7 +27,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use crate::avro_to_arrow::read_avro_schema_from_reader;
-use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{AvroExec, FileScanConfig};
@@ -57,7 +57,7 @@ impl FileFormat for AvroFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ObjectReaderWrapper) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -27,7 +27,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use crate::avro_to_arrow::read_avro_schema_from_reader;
-use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderStream, ObjectReaderWrapper};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{AvroExec, FileScanConfig};

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 
 use super::FileFormat;
-use crate::datasource::object_store::{ObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{CsvExec, FileScanConfig};
@@ -98,7 +98,7 @@ impl FileFormat for CsvFormat {
         let mut records_to_read = self.schema_infer_max_rec.unwrap_or(std::usize::MAX);
 
         while let Some(obj_reader) = readers.next().await {
-            let mut reader = obj_reader?.sync_reader()?;
+            let mut reader = obj_reader?;
             let (schema, records_read) = arrow::csv::reader::infer_reader_schema(
                 &mut reader,
                 self.delimiter,
@@ -119,7 +119,7 @@ impl FileFormat for CsvFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 
 use super::FileFormat;
-use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{CsvExec, FileScanConfig};
@@ -119,7 +119,7 @@ impl FileFormat for CsvFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ObjectReaderWrapper) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/csv.rs
+++ b/datafusion/src/datasource/file_format/csv.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 
 use super::FileFormat;
-use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderStream, ObjectReaderWrapper};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::{CsvExec, FileScanConfig};

--- a/datafusion/src/datasource/file_format/json.rs
+++ b/datafusion/src/datasource/file_format/json.rs
@@ -30,7 +30,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use super::FileScanConfig;
-use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderStream, ObjectReaderWrapper};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::NdJsonExec;

--- a/datafusion/src/datasource/file_format/json.rs
+++ b/datafusion/src/datasource/file_format/json.rs
@@ -30,7 +30,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use super::FileScanConfig;
-use crate::datasource::object_store::{ObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::NdJsonExec;
@@ -64,7 +64,7 @@ impl FileFormat for JsonFormat {
         let mut schemas = Vec::new();
         let mut records_to_read = self.schema_infer_max_rec.unwrap_or(usize::MAX);
         while let Some(obj_reader) = readers.next().await {
-            let mut reader = BufReader::new(obj_reader?.sync_reader()?);
+            let mut reader = BufReader::new(obj_reader?);
             let iter = ValueIter::new(&mut reader, None);
             let schema = infer_json_schema_from_iterator(iter.take_while(|_| {
                 let should_take = records_to_read > 0;
@@ -81,7 +81,7 @@ impl FileFormat for JsonFormat {
         Ok(Arc::new(schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/json.rs
+++ b/datafusion/src/datasource/file_format/json.rs
@@ -30,7 +30,7 @@ use futures::StreamExt;
 
 use super::FileFormat;
 use super::FileScanConfig;
-use crate::datasource::object_store::{ChunkObjectReader, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
 use crate::error::Result;
 use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::NdJsonExec;
@@ -81,7 +81,7 @@ impl FileFormat for JsonFormat {
         Ok(Arc::new(schema))
     }
 
-    async fn infer_stats(&self, _reader: ChunkObjectReader) -> Result<Statistics> {
+    async fn infer_stats(&self, _reader: ObjectReaderWrapper) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 

--- a/datafusion/src/datasource/file_format/mod.rs
+++ b/datafusion/src/datasource/file_format/mod.rs
@@ -32,9 +32,10 @@ use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::FileScanConfig;
 use crate::physical_plan::{ExecutionPlan, Statistics};
 
+use crate::datasource::object_store::ChunkObjectReader;
 use async_trait::async_trait;
 
-use super::object_store::{ObjectReader, ObjectReaderStream};
+use super::object_store::ObjectReaderStream;
 
 /// This trait abstracts all the file format specific implementations
 /// from the `TableProvider`. This helps code re-utilization accross
@@ -53,7 +54,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
 
     /// Infer the statistics for the provided object. The cost and accuracy of the
     /// estimated statistics might vary greatly between file formats.
-    async fn infer_stats(&self, reader: Arc<dyn ObjectReader>) -> Result<Statistics>;
+    async fn infer_stats(&self, reader: ChunkObjectReader) -> Result<Statistics>;
 
     /// Take a list of files and convert it to the appropriate executor
     /// according to this file format.

--- a/datafusion/src/datasource/file_format/mod.rs
+++ b/datafusion/src/datasource/file_format/mod.rs
@@ -32,7 +32,7 @@ use crate::logical_plan::Expr;
 use crate::physical_plan::file_format::FileScanConfig;
 use crate::physical_plan::{ExecutionPlan, Statistics};
 
-use crate::datasource::object_store::ChunkObjectReader;
+use crate::datasource::object_store::ObjectReaderWrapper;
 use async_trait::async_trait;
 
 use super::object_store::ObjectReaderStream;
@@ -54,7 +54,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
 
     /// Infer the statistics for the provided object. The cost and accuracy of the
     /// estimated statistics might vary greatly between file formats.
-    async fn infer_stats(&self, reader: ChunkObjectReader) -> Result<Statistics>;
+    async fn infer_stats(&self, reader: ObjectReaderWrapper) -> Result<Statistics>;
 
     /// Take a list of files and convert it to the appropriate executor
     /// according to this file format.

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -268,8 +268,7 @@ fn summarize_min_max(
 
 /// Read and parse the schema of the Parquet file at location `path`
 fn fetch_schema(object_reader: ChunkObjectReader) -> Result<Schema> {
-    let obj_reader = object_reader;
-    let file_reader = Arc::new(SerializedFileReader::new(obj_reader)?);
+    let file_reader = Arc::new(SerializedFileReader::new(object_reader)?);
     let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
     let schema = arrow_reader.get_schema()?;
 
@@ -278,8 +277,7 @@ fn fetch_schema(object_reader: ChunkObjectReader) -> Result<Schema> {
 
 /// Read and parse the statistics of the Parquet file at location `path`
 fn fetch_statistics(object_reader: ChunkObjectReader) -> Result<Statistics> {
-    let obj_reader = object_reader;
-    let file_reader = Arc::new(SerializedFileReader::new(obj_reader)?);
+    let file_reader = Arc::new(SerializedFileReader::new(object_reader)?);
     let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
     let schema = arrow_reader.get_schema()?;
     let num_fields = schema.fields().len();

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -40,7 +40,7 @@ use crate::arrow::array::{
     BooleanArray, Float32Array, Float64Array, Int32Array, Int64Array,
 };
 use crate::arrow::datatypes::{DataType, Field};
-use crate::datasource::object_store::{ObjectReaderWrapper, ObjectReaderStream};
+use crate::datasource::object_store::{ObjectReaderStream, ObjectReaderWrapper};
 use crate::datasource::{create_max_min_accs, get_col_stats};
 use crate::error::DataFusionError;
 use crate::error::Result;

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -18,7 +18,7 @@
 //! Object store that represents the Local File System.
 
 use std::fs::{self, File, Metadata};
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -84,6 +84,7 @@ impl LocalFileReader {
     fn set_chunk(&mut self, start: u64, length: usize) -> Result<()> {
         let end = start + length as u64;
         assert!(end <= self.total_size);
+        self.r.seek(SeekFrom::Start(start))?;
         self.current_pos = start;
         self.chunk_range = Some((start, end));
         Ok(())

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -26,7 +26,7 @@ use futures::{stream, AsyncRead, StreamExt};
 use parking_lot::Mutex;
 
 use crate::datasource::object_store::{
-    ChunkObjectReader, FileMeta, FileMetaStream, ListEntryStream, ObjectReader,
+    ObjectReaderWrapper, FileMeta, FileMetaStream, ListEntryStream, ObjectReader,
     ObjectStore,
 };
 use crate::datasource::PartitionedFile;
@@ -57,8 +57,8 @@ impl ObjectStore for LocalFileSystem {
         todo!()
     }
 
-    fn file_reader(&self, file: SizedFile) -> Result<ChunkObjectReader> {
-        Ok(ChunkObjectReader(Arc::new(Mutex::new(
+    fn file_reader(&self, file: SizedFile) -> Result<ObjectReaderWrapper> {
+        Ok(ObjectReaderWrapper(Arc::new(Mutex::new(
             LocalFileReader::new(file)?,
         ))))
     }
@@ -186,7 +186,7 @@ pub fn local_object_reader_stream(files: Vec<String>) -> ObjectReaderStream {
 }
 
 /// Helper method to convert a file location to a `LocalFileReader`
-pub fn local_object_reader(file: String) -> ChunkObjectReader {
+pub fn local_object_reader(file: String) -> ObjectReaderWrapper {
     LocalFileSystem
         .file_reader(local_unpartitioned_file(file).file_meta.sized_file)
         .expect("File not found")

--- a/datafusion/src/datasource/object_store/local.rs
+++ b/datafusion/src/datasource/object_store/local.rs
@@ -26,7 +26,7 @@ use futures::{stream, AsyncRead, StreamExt};
 use parking_lot::Mutex;
 
 use crate::datasource::object_store::{
-    ObjectReaderWrapper, FileMeta, FileMetaStream, ListEntryStream, ObjectReader,
+    FileMeta, FileMetaStream, ListEntryStream, ObjectReader, ObjectReaderWrapper,
     ObjectStore,
 };
 use crate::datasource::PartitionedFile;

--- a/datafusion/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/src/physical_plan/file_format/file_stream.rs
@@ -21,7 +21,7 @@
 //! Note: Most traits here need to be marked `Sync + Send` to be
 //! compliant with the `SendableRecordBatchStream` trait.
 
-use crate::datasource::object_store::ChunkObjectReader;
+use crate::datasource::object_store::ObjectReaderWrapper;
 use crate::{
     datasource::{object_store::ObjectStore, PartitionedFile},
     physical_plan::RecordBatchStream,
@@ -48,12 +48,12 @@ pub type BatchIter = Box<dyn Iterator<Item = ArrowResult<RecordBatch>> + Send + 
 /// A closure that creates a file format reader (iterator over `RecordBatch`) from a `Read` object
 /// and an optional number of required records.
 pub trait FormatReaderOpener:
-    FnMut(ChunkObjectReader, &Option<usize>) -> BatchIter + Send + Unpin + 'static
+    FnMut(ObjectReaderWrapper, &Option<usize>) -> BatchIter + Send + Unpin + 'static
 {
 }
 
 impl<T> FormatReaderOpener for T where
-    T: FnMut(ChunkObjectReader, &Option<usize>) -> BatchIter + Send + Unpin + 'static
+    T: FnMut(ObjectReaderWrapper, &Option<usize>) -> BatchIter + Send + Unpin + 'static
 {
 }
 

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -960,7 +960,7 @@ mod tests {
         // invalid file should produce an error to that effect
         assert_contains!(
             batch.unwrap_err().to_string(),
-            "External error: Parquet error: Arrow: IO error"
+            "External error: IO error: No such file or directory"
         );
         assert!(results.next().await.is_none());
 

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -958,10 +958,7 @@ mod tests {
         let mut results = parquet_exec.execute(0, runtime).await?;
         let batch = results.next().await.unwrap();
         // invalid file should produce an error to that effect
-        assert_contains!(
-            batch.unwrap_err().to_string(),
-            "External error: IO error: No such file or directory"
-        );
+        assert_contains!(batch.unwrap_err().to_string(), "External error: IO error");
         assert!(results.next().await.is_none());
 
         Ok(())

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -21,7 +21,6 @@ use std::fmt;
 use std::sync::Arc;
 use std::{any::Any, convert::TryInto};
 
-use crate::datasource::file_format::parquet::ChunkObjectReader;
 use crate::datasource::object_store::ObjectStore;
 use crate::datasource::PartitionedFile;
 use crate::physical_plan::expressions::PhysicalSortExpr;
@@ -462,8 +461,7 @@ fn read_partition(
         );
         let object_reader =
             object_store.file_reader(partitioned_file.file_meta.sized_file.clone())?;
-        let mut file_reader =
-            SerializedFileReader::new(ChunkObjectReader(object_reader))?;
+        let mut file_reader = SerializedFileReader::new(object_reader)?;
         if let Some(pruning_predicate) = pruning_predicate {
             let row_group_predicate = build_row_group_predicate(
                 pruning_predicate,

--- a/datafusion/src/test/object_store.rs
+++ b/datafusion/src/test/object_store.rs
@@ -16,6 +16,7 @@
 // under the License.
 //! Object store implem used for testing
 
+use std::io::Seek;
 use std::{io, io::Read, sync::Arc};
 
 use crate::datasource::object_store::ChunkObjectReader;
@@ -102,6 +103,12 @@ impl Read for EmptyObjectReader {
     }
 }
 
+impl Seek for EmptyObjectReader {
+    fn seek(&mut self, _pos: io::SeekFrom) -> io::Result<u64> {
+        Ok(0)
+    }
+}
+
 #[async_trait]
 impl ObjectReader for EmptyObjectReader {
     async fn chunk_reader(
@@ -112,11 +119,11 @@ impl ObjectReader for EmptyObjectReader {
         unimplemented!()
     }
 
-    fn set_chunk(&mut self, _start: u64, _length: usize) -> Result<()> {
-        Ok(())
+    fn set_limit(&mut self, limit: usize) {
+        self.0 = limit as u64;
     }
 
-    fn chunk_length(&self) -> u64 {
+    fn length(&self) -> u64 {
         self.0
     }
 }

--- a/datafusion/src/test/object_store.rs
+++ b/datafusion/src/test/object_store.rs
@@ -19,7 +19,7 @@
 use std::io::Seek;
 use std::{io, io::Read, sync::Arc};
 
-use crate::datasource::object_store::ChunkObjectReader;
+use crate::datasource::object_store::ObjectReaderWrapper;
 use crate::{
     datasource::object_store::{
         FileMeta, FileMetaStream, ListEntryStream, ObjectReader, ObjectStore, SizedFile,
@@ -77,9 +77,9 @@ impl ObjectStore for TestObjectStore {
         unimplemented!()
     }
 
-    fn file_reader(&self, file: SizedFile) -> Result<ChunkObjectReader> {
+    fn file_reader(&self, file: SizedFile) -> Result<ObjectReaderWrapper> {
         match self.files.iter().find(|item| file.path == item.0) {
-            Some((_, size)) if *size == file.size => Ok(ChunkObjectReader(Arc::new(
+            Some((_, size)) if *size == file.size => Ok(ObjectReaderWrapper(Arc::new(
                 Mutex::new(EmptyObjectReader(*size)),
             ))),
             Some(_) => Err(DataFusionError::IoError(io::Error::new(

--- a/datafusion/tests/path_partition.rs
+++ b/datafusion/tests/path_partition.rs
@@ -20,7 +20,7 @@
 use std::{fs, io, sync::Arc};
 
 use async_trait::async_trait;
-use datafusion::datasource::object_store::ChunkObjectReader;
+use datafusion::datasource::object_store::ObjectReaderWrapper;
 use datafusion::{
     assert_batches_sorted_eq,
     datasource::{
@@ -377,7 +377,7 @@ impl ObjectStore for MirroringObjectStore {
         unimplemented!()
     }
 
-    fn file_reader(&self, file: SizedFile) -> Result<ChunkObjectReader> {
+    fn file_reader(&self, file: SizedFile) -> Result<ObjectReaderWrapper> {
         assert_eq!(
             self.file_size, file.size,
             "Requested files should have the same size as the mirrored file"

--- a/datafusion/tests/path_partition.rs
+++ b/datafusion/tests/path_partition.rs
@@ -20,6 +20,7 @@
 use std::{fs, io, sync::Arc};
 
 use async_trait::async_trait;
+use datafusion::datasource::object_store::ChunkObjectReader;
 use datafusion::{
     assert_batches_sorted_eq,
     datasource::{
@@ -27,7 +28,7 @@ use datafusion::{
         listing::{ListingOptions, ListingTable, ListingTableConfig},
         object_store::{
             local::LocalFileSystem, FileMeta, FileMetaStream, ListEntryStream,
-            ObjectReader, ObjectStore, SizedFile,
+            ObjectStore, SizedFile,
         },
     },
     error::{DataFusionError, Result},
@@ -376,7 +377,7 @@ impl ObjectStore for MirroringObjectStore {
         unimplemented!()
     }
 
-    fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>> {
+    fn file_reader(&self, file: SizedFile) -> Result<ChunkObjectReader> {
         assert_eq!(
             self.file_size, file.size,
             "Requested files should have the same size as the mirrored file"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
- The extra `chunk` semantic introduced in ObjectReader introduces irrelevant file format details to object stores and incurs needless complexity.
- Repeated open one single file brings unnecessary overhead.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- `ObjectReader` API simplification.
- Avoid repeated `open` for one single file in the LocalObjectStore.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes. The `ObjectReader` API.