### PR TITLE
Clippy fix on nightly

### DIFF
--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -287,7 +287,7 @@ async fn fetch_partition(
         BallistaClient::try_new(metadata.host.as_str(), metadata.port as u16)
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
-    Ok(ballista_client
+    ballista_client
         .fetch_partition(
             &partition_id.job_id,
             partition_id.stage_id as usize,
@@ -295,5 +295,5 @@ async fn fetch_partition(
             &location.path,
         )
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?)
+        .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))
 }

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -208,7 +208,7 @@ async fn fetch_partition(
         BallistaClient::try_new(metadata.host.as_str(), metadata.port as u16)
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
-    Ok(ballista_client
+    ballista_client
         .fetch_partition(
             &partition_id.job_id,
             partition_id.stage_id as usize,
@@ -216,7 +216,7 @@ async fn fetch_partition(
             &location.path,
         )
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?)
+        .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))
 }
 
 #[cfg(test)]

--- a/ballista/rust/executor/src/cpu_bound_executor.rs
+++ b/ballista/rust/executor/src/cpu_bound_executor.rs
@@ -203,7 +203,7 @@ fn set_current_thread_priority(prio: i32) {
 }
 
 #[cfg(not(unix))]
-fn set_current_thread_priority(prio: i32) {
+fn set_current_thread_priority(_prio: i32) {
     warn!("Setting worker thread priority not supported on this platform");
 }
 

--- a/ballista/rust/scheduler/src/lib.rs
+++ b/ballista/rust/scheduler/src/lib.rs
@@ -227,7 +227,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
 
     async fn fetch_tasks(
         &self,
-        available_executors: &mut Vec<ExecutorData>,
+        available_executors: &mut [ExecutorData],
         job_id: &str,
     ) -> Result<(Vec<Vec<TaskDefinition>>, usize), BallistaError> {
         let mut ret: Vec<Vec<TaskDefinition>> =

--- a/ballista/rust/scheduler/src/main.rs
+++ b/ballista/rust/scheduler/src/main.rs
@@ -106,7 +106,7 @@ async fn start_server(
             ),
         };
 
-    Ok(Server::bind(&addr)
+    Server::bind(&addr)
         .serve(make_service_fn(move |request: &AddrStream| {
             let scheduler_grpc_server =
                 SchedulerGrpcServer::new(scheduler_server.clone());
@@ -145,7 +145,7 @@ async fn start_server(
             ))
         }))
         .await
-        .context("Could not start grpc server")?)
+        .context("Could not start grpc server")
 }
 
 #[tokio::main]

--- a/datafusion-physical-expr/src/tdigest/mod.rs
+++ b/datafusion-physical-expr/src/tdigest/mod.rs
@@ -357,7 +357,7 @@ impl TDigest {
     }
 
     fn external_merge(
-        centroids: &mut Vec<Centroid>,
+        centroids: &mut [Centroid],
         first: usize,
         middle: usize,
         last: usize,

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -122,8 +122,8 @@ impl FileFormat for ParquetFormat {
 }
 
 fn summarize_min_max(
-    max_values: &mut Vec<Option<MaxAccumulator>>,
-    min_values: &mut Vec<Option<MinAccumulator>>,
+    max_values: &mut [Option<MaxAccumulator>],
+    min_values: &mut [Option<MinAccumulator>],
     fields: &[Field],
     i: usize,
     stat: &ParquetStatistics,

--- a/datafusion/src/datasource/mod.rs
+++ b/datafusion/src/datasource/mod.rs
@@ -177,8 +177,8 @@ fn create_max_min_accs(
 fn get_col_stats(
     schema: &Schema,
     null_counts: Vec<usize>,
-    max_values: &mut Vec<Option<MaxAccumulator>>,
-    min_values: &mut Vec<Option<MinAccumulator>>,
+    max_values: &mut [Option<MaxAccumulator>],
+    min_values: &mut [Option<MinAccumulator>],
 ) -> Vec<ColumnStatistics> {
     (0..schema.fields().len())
         .map(|i| {

--- a/datafusion/src/logical_plan/extension.rs
+++ b/datafusion/src/logical_plan/extension.rs
@@ -71,6 +71,7 @@ pub trait UserDefinedLogicalNode: fmt::Debug {
     /// of self.inputs and self.exprs.
     ///
     /// So, `self.from_template(exprs, ..).expressions() == exprs
+    #[allow(clippy::wrong_self_convention)]
     fn from_template(
         &self,
         exprs: &[Expr],

--- a/datafusion/src/physical_plan/hash_utils.rs
+++ b/datafusion/src/physical_plan/hash_utils.rs
@@ -42,7 +42,7 @@ fn combine_hashes(l: u64, r: u64) -> u64 {
 fn hash_decimal128<'a>(
     array: &ArrayRef,
     random_state: &RandomState,
-    hashes_buffer: &'a mut Vec<u64>,
+    hashes_buffer: &'a mut [u64],
     mul_col: bool,
 ) {
     let array = array.as_any().downcast_ref::<DecimalArray>().unwrap();
@@ -207,7 +207,7 @@ macro_rules! hash_array_float {
 fn create_hashes_dictionary<K: ArrowDictionaryKeyType>(
     array: &ArrayRef,
     random_state: &RandomState,
-    hashes_buffer: &mut Vec<u64>,
+    hashes_buffer: &mut [u64],
     multi_col: bool,
 ) -> Result<()> {
     let dict_array = array.as_any().downcast_ref::<DictionaryArray<K>>().unwrap();


### PR DESCRIPTION
 # Rationale for this change
I'm using `nightly-x86_64-pc-windows-msvc unchanged - rustc 1.61.0-nightly (8769f4ef2 2022-03-02)` and find the clippy failures using our `cargo clippy --all-targets --workspace -- -D warnings` each time.

# What changes are included in this PR?
Clippy fix.

# Are there any user-facing changes?
No.
