### PR TITLE
Rename DEVELOPERS.md to CONTRIBUTING.md and added introduction

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -69,6 +69,6 @@ jobs:
             '{ballista,datafusion,datafusion-examples,docs,python}/**/*.md' \
             '!{ballista,datafusion,python}/CHANGELOG.md' \
             README.md \
-            DEVELOPERS.md \
+            CONTRIBUTING.md \
             'ballista/**/*.{ts,tsx}'
           git diff --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,17 @@
   under the License.
 -->
 
+# Introduction
+
+We welcome and encourage contributions of all kinds, such as:
+
+1. Tickets with issue reports of feature requests
+2. Documentation improvements
+3. Code (PR or PR Review)
+
+In addition to submitting new PRs, we have a healthy tradition of community members helping review each other's PRs. Doing so is a great way to help the community as well as get more familiar with Rust and the relevant codebases.
+
+
 # Developer's guide
 
 This section describes how you can get started at developing DataFusion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,9 @@ We welcome and encourage contributions of all kinds, such as:
 
 In addition to submitting new PRs, we have a healthy tradition of community members helping review each other's PRs. Doing so is a great way to help the community as well as get more familiar with Rust and the relevant codebases.
 
+You can find a curated
+[good-first-issue](https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+list to help you get started.
 
 # Developer's guide
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ There is no formal document describing DataFusion's architecture yet, but the fo
 
 Please see [User Guide](https://arrow.apache.org/datafusion/) for more information about DataFusion.
 
-## Developer's guide
+## Contribution Guide
 
-Please see [Developers Guide](DEVELOPERS.md) for information about developing DataFusion.
+Please see [Contibution Guid](CONTRIBUTING.md) for information about contributing to DataFusion.

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ Please see [User Guide](https://arrow.apache.org/datafusion/) for more informati
 
 ## Contribution Guide
 
-Please see [Contibution Guid](CONTRIBUTING.md) for information about contributing to DataFusion.
+Please see [Contribution Guide](CONTRIBUTING.md) for information about contributing to DataFusion.

--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -73,9 +73,10 @@ We will send a summary of all sync ups to the dev@arrow.apache.org mailing list.
 ## Contributing
 
 Our source code is hosted on
-[GitHub](https://github.com/apache/arrow-datafusion). For developers new to
-the project, we have curated a
-[good-first-issue](https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+[GitHub](https://github.com/apache/arrow-datafusion). More information on contributing is in
+the [Contribution Guide](https://github.com/apache/arrow-datafusion/blob/master/CONTRIBUTING.md)
+, and we have curated a [good-first-issue]
+(https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 list to help you get started. You can find datafusion's major designs in docs/source/specification.
 
 We use GitHub issues for maintaining a queue of development work and as the


### PR DESCRIPTION
Similar to https://github.com/apache/arrow-rs/pull/1396

As the community grows, I am trying to help it scale and not be bottlenecked on review by the maintainers.

Ideally by the time one of the maintainers sees a PR it is more or less ready to go (though maybe that is wishful thinking)

You can see the rendered version here https://github.com/alamb/arrow-datafusion/blob/alamb/contributing/CONTRIBUTING.md