### PR TITLE
Fix select from EmptyExec always return 0 row.

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -542,4 +542,24 @@ mod tests {
         let results = df.collect().await.unwrap();
         pretty::print_batches(&results);
     }
+
+    #[tokio::test]
+    #[cfg(feature = "standalone")]
+    async fn test_empty_exec_with_one_row() {
+        use crate::context::BallistaContext;
+        use ballista_core::config::{
+            BallistaConfigBuilder, BALLISTA_WITH_INFORMATION_SCHEMA,
+        };
+
+        let config = BallistaConfigBuilder::default()
+            .set(BALLISTA_WITH_INFORMATION_SCHEMA, "true")
+            .build()
+            .unwrap();
+        let context = BallistaContext::standalone(&config, 1).await.unwrap();
+
+        let sql = "select EXTRACT(year FROM to_timestamp('2020-09-08T12:13:14+00:00'));";
+
+        let df = context.sql(sql).await.unwrap();
+        assert!(!df.collect().await.unwrap().is_empty());
+    }
 }

--- a/datafusion/src/physical_plan/empty.rs
+++ b/datafusion/src/physical_plan/empty.rs
@@ -183,7 +183,7 @@ mod tests {
     fn with_new_children() -> Result<()> {
         let schema = test_util::aggr_test_schema();
         let empty = EmptyExec::new(false, schema.clone());
-        let empty_with_row = EmptyExec::new(true, schema.clone());
+        let empty_with_row = EmptyExec::new(true, schema);
 
         let empty2 = empty.with_new_children(vec![])?;
         assert_eq!(empty.schema(), empty2.schema());

--- a/datafusion/src/physical_plan/empty.rs
+++ b/datafusion/src/physical_plan/empty.rs
@@ -108,7 +108,10 @@ impl ExecutionPlan for EmptyExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match children.len() {
-            0 => Ok(Arc::new(EmptyExec::new(false, self.schema.clone()))),
+            0 => Ok(Arc::new(EmptyExec::new(
+                self.produce_one_row,
+                self.schema.clone(),
+            ))),
             _ => Err(DataFusionError::Internal(
                 "EmptyExec wrong number of children".to_string(),
             )),
@@ -179,10 +182,14 @@ mod tests {
     #[test]
     fn with_new_children() -> Result<()> {
         let schema = test_util::aggr_test_schema();
-        let empty = EmptyExec::new(false, schema);
+        let empty = EmptyExec::new(false, schema.clone());
+        let empty_with_row = EmptyExec::new(true, schema.clone());
 
         let empty2 = empty.with_new_children(vec![])?;
         assert_eq!(empty.schema(), empty2.schema());
+
+        let empty_with_row_2 = empty_with_row.with_new_children(vec![])?;
+        assert_eq!(empty_with_row.schema(), empty_with_row_2.schema());
 
         let too_many_kids = vec![empty2];
         assert!(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1937.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
```
=== [Ef30eos/1/0] Physical plan with metrics ===
ShuffleWriterExec: None, metrics=[output_rows=0, input_rows=0, write_time=924.332µs]
  ProjectionExec: expr=[1 as Int64(1)], metrics=[output_rows=0, elapsed_compute=NOT RECORDED, spill_count=0, spilled_bytes=0, mem_used=0]
    EmptyExec: produce_one_row=false, metrics=[]
```

Executor always get EmptyExec: produce_one_row=**false** in `select  1 ;`
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
