### PR TITLE
Pruning serialization

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -648,6 +648,7 @@ message FileScanExecConf {
 
 message ParquetScanExecNode {
   FileScanExecConf base_conf = 1;
+  LogicalExprNode pruning_predicate = 2;
 }
 
 message CsvScanExecNode {

--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -97,6 +97,8 @@ pub struct PruningPredicate {
     predicate_expr: Arc<dyn PhysicalExpr>,
     /// The statistics required to evaluate this predicate
     required_columns: RequiredStatColumns,
+    /// Logical predicate from which this predicate expr is derived (required for serialization)
+    logical_expr: Expr,
 }
 
 impl PruningPredicate {
@@ -143,6 +145,7 @@ impl PruningPredicate {
             schema,
             predicate_expr,
             required_columns,
+            logical_expr: expr.clone(),
         })
     }
 
@@ -201,6 +204,11 @@ impl PruningPredicate {
     /// Return a reference to the input schema
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
+    }
+
+    /// Returns a reference to the logical expr used to construct this pruning predicate
+    pub fn logical_expr(&self) -> &Expr {
+        &self.logical_expr
     }
 }
 

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -131,6 +131,11 @@ impl ParquetExec {
     pub fn base_config(&self) -> &FileScanConfig {
         &self.base_config
     }
+
+    /// Optional reference to this parquet scan's pruning predicate
+    pub fn pruning_predicate(&self) -> Option<&PruningPredicate> {
+        self.pruning_predicate.as_ref()
+    }
 }
 
 impl ParquetFileMetrics {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, we don't preserve pruning predicates in `ParquetExec` when serializing for Ballista. This was probably the case because the `PruningPredicate` requires the original logical `Expr` to reconstruct. This PR preserves the original `Expr` in `PruningPredicate` so we can serialize it. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Preserve the original logical `Expr` in the `PruningPredicate` struct.2. 
2. Serialize the pruning `Expr` in the protobuf message which encodes the `ParquetExec` 
3. Reconstruct the `PruninPredicate` when deserializing the `ParquetExec`. 
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No