### PR TITLE
omit some clone when converting sql to logical plan

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -300,7 +300,7 @@ impl ExecutionContext {
     ///
     /// This function is intended for internal use and should not be called directly.
     pub fn create_logical_plan(&self, sql: &str) -> Result<LogicalPlan> {
-        let statements = DFParser::parse_sql(sql)?;
+        let mut statements = DFParser::parse_sql(sql)?;
 
         if statements.len() != 1 {
             return Err(DataFusionError::NotImplemented(
@@ -311,7 +311,7 @@ impl ExecutionContext {
         // create a query planner
         let state = self.state.lock().clone();
         let query_planner = SqlToRel::new(&state);
-        query_planner.statement_to_plan(&statements[0])
+        query_planner.statement_to_plan(statements.remove(0))
     }
 
     /// Registers a variable provider within this context.

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -129,24 +129,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     }
 
     /// Generate a logical plan from an DataFusion SQL statement
-    pub fn statement_to_plan(&self, statement: &DFStatement) -> Result<LogicalPlan> {
+    pub fn statement_to_plan(&self, statement: DFStatement) -> Result<LogicalPlan> {
         match statement {
             DFStatement::CreateExternalTable(s) => self.external_table_to_plan(s),
-            DFStatement::Statement(s) => self.sql_statement_to_plan(s),
+            DFStatement::Statement(s) => self.sql_statement_to_plan(*s),
         }
     }
 
     /// Generate a logical plan from an SQL statement
-    pub fn sql_statement_to_plan(&self, sql: &Statement) -> Result<LogicalPlan> {
+    pub fn sql_statement_to_plan(&self, sql: Statement) -> Result<LogicalPlan> {
         match sql {
             Statement::Explain {
                 verbose,
                 statement,
                 analyze,
                 describe_alias: _,
-            } => self.explain_statement_to_plan(*verbose, *analyze, statement),
-            Statement::Query(query) => self.query_to_plan(query),
-            Statement::ShowVariable { variable } => self.show_variable_to_plan(variable),
+            } => self.explain_statement_to_plan(verbose, analyze, *statement),
+            Statement::Query(query) => self.query_to_plan(*query),
+            Statement::ShowVariable { variable } => self.show_variable_to_plan(&variable),
             Statement::CreateTable {
                 query: Some(query),
                 name,
@@ -171,7 +171,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 && table_properties.is_empty()
                 && with_options.is_empty() =>
             {
-                let plan = self.query_to_plan(query)?;
+                let plan = self.query_to_plan(*query)?;
 
                 Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
                     name: name.to_string(),
@@ -194,7 +194,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             {
                 Ok(LogicalPlan::DropTable(DropTable {
                     name: names.get(0).unwrap().to_string(),
-                    if_exist: *if_exists,
+                    if_exist: if_exists,
                     schema: DFSchemaRef::new(DFSchema::empty()),
                 }))
             }
@@ -204,7 +204,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 full,
                 table_name,
                 filter,
-            } => self.show_columns_to_plan(*extended, *full, table_name, filter.as_ref()),
+            } => self.show_columns_to_plan(extended, full, &table_name, filter.as_ref()),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported SQL statement: {:?}",
                 sql
@@ -213,22 +213,22 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     }
 
     /// Generate a logic plan from an SQL query
-    pub fn query_to_plan(&self, query: &Query) -> Result<LogicalPlan> {
+    pub fn query_to_plan(&self, query: Query) -> Result<LogicalPlan> {
         self.query_to_plan_with_alias(query, None, &mut HashMap::new())
     }
 
     /// Generate a logic plan from an SQL query with optional alias
     pub fn query_to_plan_with_alias(
         &self,
-        query: &Query,
+        query: Query,
         alias: Option<String>,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<LogicalPlan> {
-        let set_expr = &query.body;
-        if let Some(with) = &query.with {
+        let set_expr = query.body;
+        if let Some(with) = query.with {
             // Process CTEs from top to bottom
             // do not allow self-references
-            for cte in &with.cte_tables {
+            for cte in with.cte_tables {
                 // A `WITH` block can't use the same name for many times
                 let cte_name: &str = cte.alias.name.value.as_ref();
                 if ctes.contains_key(cte_name) {
@@ -239,7 +239,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
                 // create logical plan & pass backreferencing CTEs
                 let logical_plan = self.query_to_plan_with_alias(
-                    &cte.query,
+                    cte.query,
                     Some(cte.alias.name.value.clone()),
                     &mut ctes.clone(),
                 )?;
@@ -255,12 +255,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn set_expr_to_plan(
         &self,
-        set_expr: &SetExpr,
+        set_expr: SetExpr,
         alias: Option<String>,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<LogicalPlan> {
         match set_expr {
-            SetExpr::Select(s) => self.select_to_plan(s.as_ref(), ctes, alias),
+            SetExpr::Select(s) => self.select_to_plan(*s, ctes, alias),
             SetExpr::Values(v) => self.sql_values_to_plan(v),
             SetExpr::SetOperation {
                 op,
@@ -268,8 +268,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 right,
                 all,
             } => {
-                let left_plan = self.set_expr_to_plan(left.as_ref(), None, ctes)?;
-                let right_plan = self.set_expr_to_plan(right.as_ref(), None, ctes)?;
+                let left_plan = self.set_expr_to_plan(*left, None, ctes)?;
+                let right_plan = self.set_expr_to_plan(*right, None, ctes)?;
                 match (op, all) {
                     (SetOperator::Union, true) => {
                         union_with_alias(left_plan, right_plan, alias)
@@ -302,7 +302,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Generate a logical plan from a CREATE EXTERNAL TABLE statement
     pub fn external_table_to_plan(
         &self,
-        statement: &CreateExternalTable,
+        statement: CreateExternalTable,
     ) -> Result<LogicalPlan> {
         let CreateExternalTable {
             name,
@@ -313,7 +313,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         } = statement;
 
         // semantic checks
-        match *file_type {
+        match file_type {
             FileType::CSV => {}
             FileType::Parquet => {
                 if !columns.is_empty() {
@@ -331,10 +331,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         Ok(LogicalPlan::CreateExternalTable(PlanCreateExternalTable {
             schema: schema.to_dfschema_ref()?,
-            name: name.clone(),
-            location: location.clone(),
-            file_type: *file_type,
-            has_header: *has_header,
+            name,
+            location,
+            file_type,
+            has_header,
         }))
     }
 
@@ -344,7 +344,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         verbose: bool,
         analyze: bool,
-        statement: &Statement,
+        statement: Statement,
     ) -> Result<LogicalPlan> {
         let plan = self.sql_statement_to_plan(statement)?;
         let plan = Arc::new(plan);
@@ -369,8 +369,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn build_schema(&self, columns: &[SQLColumnDef]) -> Result<Schema> {
-        let mut fields = Vec::new();
+    fn build_schema(&self, columns: Vec<SQLColumnDef>) -> Result<Schema> {
+        let mut fields = Vec::with_capacity(columns.len());
 
         for column in columns {
             let data_type = self.make_data_type(&column.data_type)?;
@@ -412,13 +412,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn plan_from_tables(
         &self,
-        from: &[TableWithJoins],
+        from: Vec<TableWithJoins>,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<Vec<LogicalPlan>> {
         match from.len() {
             0 => Ok(vec![LogicalPlanBuilder::empty(true).build()?]),
             _ => from
-                .iter()
+                .into_iter()
                 .map(|t| self.plan_table_with_joins(t, ctes))
                 .collect::<Result<Vec<_>>>(),
         }
@@ -426,16 +426,18 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn plan_table_with_joins(
         &self,
-        t: &TableWithJoins,
+        t: TableWithJoins,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<LogicalPlan> {
-        let left = self.create_relation(&t.relation, ctes)?;
+        let left = self.create_relation(t.relation, ctes)?;
         match t.joins.len() {
             0 => Ok(left),
-            n => {
-                let mut left = self.parse_relation_join(left, &t.joins[0], ctes)?;
-                for i in 1..n {
-                    left = self.parse_relation_join(left, &t.joins[i], ctes)?;
+            _ => {
+                let mut joins = t.joins.into_iter();
+                let mut left =
+                    self.parse_relation_join(left, joins.next().unwrap(), ctes)?;
+                while let Some(join) = joins.next() {
+                    left = self.parse_relation_join(left, join, ctes)?;
                 }
                 Ok(left)
             }
@@ -445,11 +447,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     fn parse_relation_join(
         &self,
         left: LogicalPlan,
-        join: &Join,
+        join: Join,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<LogicalPlan> {
-        let right = self.create_relation(&join.relation, ctes)?;
-        match &join.join_operator {
+        let right = self.create_relation(join.relation, ctes)?;
+        match join.join_operator {
             JoinOperator::LeftOuter(constraint) => {
                 self.parse_join(left, right, constraint, JoinType::Left)
             }
@@ -469,6 +471,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             ))),
         }
     }
+
     fn parse_cross_join(
         &self,
         left: LogicalPlan,
@@ -481,7 +484,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         left: LogicalPlan,
         right: LogicalPlan,
-        constraint: &JoinConstraint,
+        constraint: JoinConstraint,
         join_type: JoinType,
     ) -> Result<LogicalPlan> {
         match constraint {
@@ -490,13 +493,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let join_schema = left.schema().join(right.schema())?;
 
                 // parse ON expression
-                let expr = self.sql_to_rex(sql_expr, &join_schema)?;
+                let expr = self.sql_to_rex(&sql_expr, &join_schema)?;
 
                 // expression that didn't match equi-join pattern
                 let mut filter = vec![];
 
                 // extract join keys
-                extract_join_keys(&expr, &mut keys, &mut filter);
+                extract_join_keys(expr, &mut keys, &mut filter);
 
                 let mut cols = HashSet::new();
                 exprlist_to_columns(&filter, &mut cols)?;
@@ -518,11 +521,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         join_type,
                         (left_keys, right_keys),
                     )?;
+                    let join_filter_init = filter.remove(0);
                     join.filter(
                         filter
-                            .iter()
-                            .skip(1)
-                            .fold(filter[0].clone(), |acc, e| acc.and(e.clone())),
+                            .into_iter()
+                            .fold(join_filter_init, |acc, e| acc.and(e)),
                     )?
                     .build()
                 }
@@ -542,16 +545,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         },
                     )
                 {
+                    let join_filter_init = filter.remove(0);
                     LogicalPlanBuilder::from(left)
                         .join(
                             &LogicalPlanBuilder::from(right)
                                 .filter(
                                     filter
-                                        .iter()
-                                        .skip(1)
-                                        .fold(filter[0].clone(), |acc, e| {
-                                            acc.and(e.clone())
-                                        }),
+                                        .into_iter()
+                                        .fold(join_filter_init, |acc, e| acc.and(e)),
                                 )?
                                 .build()?,
                             join_type,
@@ -574,12 +575,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         },
                     )
                 {
+                    let join_filter_init = filter.remove(0);
                     LogicalPlanBuilder::from(left)
                         .filter(
                             filter
-                                .iter()
-                                .skip(1)
-                                .fold(filter[0].clone(), |acc, e| acc.and(e.clone())),
+                                .into_iter()
+                                .fold(join_filter_init, |acc, e| acc.and(e)),
                         )?
                         .join(&right, join_type, (left_keys, right_keys))?
                         .build()
@@ -592,8 +593,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
             JoinConstraint::Using(idents) => {
                 let keys: Vec<Column> = idents
-                    .iter()
-                    .map(|x| Column::from_name(x.value.clone()))
+                    .into_iter()
+                    .map(|x| Column::from_name(x.value))
                     .collect();
                 LogicalPlanBuilder::from(left)
                     .join_using(&right, join_type, keys)?
@@ -613,11 +614,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn create_relation(
         &self,
-        relation: &TableFactor,
+        relation: TableFactor,
         ctes: &mut HashMap<String, LogicalPlan>,
     ) -> Result<LogicalPlan> {
         let (plan, alias) = match relation {
-            TableFactor::Table { name, alias, .. } => {
+            TableFactor::Table {
+                ref name, alias, ..
+            } => {
                 let table_name = name.to_string();
                 let cte = ctes.get(&table_name);
                 (
@@ -654,7 +657,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     ));
                 }
                 let logical_plan = self.query_to_plan_with_alias(
-                    subquery,
+                    *subquery,
                     alias.as_ref().map(|a| a.name.value.to_string()),
                     ctes,
                 )?;
@@ -672,7 +675,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 )
             }
             TableFactor::NestedJoin(table_with_joins) => {
-                (self.plan_table_with_joins(table_with_joins, ctes)?, &None)
+                (self.plan_table_with_joins(*table_with_joins, ctes)?, None)
             }
             // @todo Support TableFactory::TableFunction?
             _ => {
@@ -714,10 +717,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Related PR: <https://github.com/apache/arrow-datafusion/pull/1566>
     fn plan_selection(
         &self,
-        select: &Select,
+        selection: Option<SQLExpr>,
         plans: Vec<LogicalPlan>,
     ) -> Result<LogicalPlan> {
-        let plan = match &select.selection {
+        let plan = match &selection {
             Some(predicate_expr) => {
                 // build join schema
                 let mut fields = vec![];
@@ -840,18 +843,23 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Generate a logic plan from an SQL select
     fn select_to_plan(
         &self,
-        select: &Select,
+        select: Select,
         ctes: &mut HashMap<String, LogicalPlan>,
         alias: Option<String>,
     ) -> Result<LogicalPlan> {
         // process `from` clause
-        let plans = self.plan_from_tables(&select.from, ctes)?;
+        let plans = self.plan_from_tables(select.from, ctes)?;
+        let empty_from = match plans.first() {
+            Some(LogicalPlan::EmptyRelation(_)) => true,
+            _ => false,
+        };
 
         // process `where` clause
-        let plan = self.plan_selection(select, plans)?;
+        let plan = self.plan_selection(select.selection, plans)?;
 
         // process the SELECT expressions, with wildcards expanded.
-        let select_exprs = self.prepare_select_exprs(&plan, select)?;
+        let select_exprs =
+            self.prepare_select_exprs(&plan, select.projection, empty_from)?;
 
         // having and group by clause may reference aliases defined in select projection
         let projected_plan = self.project(plan.clone(), select_exprs.clone())?;
@@ -987,10 +995,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     fn prepare_select_exprs(
         &self,
         plan: &LogicalPlan,
-        select: &Select,
+        projection: Vec<SelectItem>,
+        empty_from: bool,
     ) -> Result<Vec<Expr>> {
         let input_schema = plan.schema();
-        let projection = &select.projection;
         projection
             .iter()
             .map(|expr| self.sql_select_to_rex(expr, input_schema))
@@ -999,7 +1007,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .map(|expr| {
                 Ok(match expr {
                     Expr::Wildcard => {
-                        if select.from.is_empty() {
+                        if empty_from {
                             return Err(DataFusionError::Plan(
                                 "SELECT * with no tables specified is not valid"
                                     .to_string(),
@@ -1349,7 +1357,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn sql_values_to_plan(&self, values: &SQLValues) -> Result<LogicalPlan> {
+    fn sql_values_to_plan(&self, values: SQLValues) -> Result<LogicalPlan> {
         // values should not be based on any other schema
         let schema = DFSchema::empty();
         let values = values
@@ -1982,9 +1990,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let variable = ObjectName(variable.to_vec()).to_string();
         if variable.as_str().eq_ignore_ascii_case("tables") {
             if self.has_table("information_schema", "tables") {
-                let rewrite =
+                let mut rewrite =
                     DFParser::parse_sql("SELECT * FROM information_schema.tables;")?;
-                self.statement_to_plan(&rewrite[0])
+                self.statement_to_plan(rewrite.remove(0))
             } else {
                 Err(DataFusionError::Plan(
                     "SHOW TABLES is not supported unless information_schema is enabled"
@@ -2053,8 +2061,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             select_list, where_clause
         );
 
-        let rewrite = DFParser::parse_sql(&query)?;
-        self.statement_to_plan(&rewrite[0])
+        let mut rewrite = DFParser::parse_sql(&query)?;
+        self.statement_to_plan(rewrite.remove(0))
     }
 
     /// Return true if there is a table provider available for "schema.table"
@@ -2111,37 +2119,41 @@ fn remove_join_expressions(
 /// foo = bar AND baz > 1 => accum=[(foo, bar)] accum_filter=[baz > 1]
 /// ```
 fn extract_join_keys(
-    expr: &Expr,
+    expr: Expr,
     accum: &mut Vec<(Column, Column)>,
     accum_filter: &mut Vec<Expr>,
 ) {
-    match expr {
+    match &expr {
         Expr::BinaryExpr { left, op, right } => match op {
             Operator::Eq => match (left.as_ref(), right.as_ref()) {
                 (Expr::Column(l), Expr::Column(r)) => {
                     accum.push((l.clone(), r.clone()));
                 }
                 _other => {
-                    accum_filter.push(expr.clone());
+                    accum_filter.push(expr);
                 }
             },
             Operator::And => {
-                extract_join_keys(left, accum, accum_filter);
-                extract_join_keys(right, accum, accum_filter);
+                if let Expr::BinaryExpr { left, op: _, right } = expr {
+                    extract_join_keys(*left, accum, accum_filter);
+                    extract_join_keys(*right, accum, accum_filter);
+                }
             }
             _other
                 if matches!(**left, Expr::Column(_))
                     || matches!(**right, Expr::Column(_)) =>
             {
-                accum_filter.push(expr.clone());
+                accum_filter.push(expr);
             }
             _other => {
-                extract_join_keys(left, accum, accum_filter);
-                extract_join_keys(right, accum, accum_filter);
+                if let Expr::BinaryExpr { left, op: _, right } = expr {
+                    extract_join_keys(*left, accum, accum_filter);
+                    extract_join_keys(*right, accum, accum_filter);
+                }
             }
         },
         _other => {
-            accum_filter.push(expr.clone());
+            accum_filter.push(expr);
         }
     }
 }
@@ -3852,8 +3864,8 @@ mod tests {
     fn logical_plan(sql: &str) -> Result<LogicalPlan> {
         let planner = SqlToRel::new(&MockContextProvider {});
         let result = DFParser::parse_sql(sql);
-        let ast = result.unwrap();
-        planner.statement_to_plan(&ast[0])
+        let mut ast = result.unwrap();
+        planner.statement_to_plan(ast.remove(0))
     }
 
     /// Create logical plan, write with formatter, compare to expected output


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1469.

# What changes are included in this PR?
It's an api change.
Take ownership of sql-parser components to emit some clones.
It's hard to me - a new comer of rust and df, and the mutual calls between functions are very complex, so please bear with me :)