### PR TITLE
Update to arrow 10.0.0, pyo3 0.16

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -46,7 +46,7 @@ chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 parse_arg = "0.1.3"
 
-arrow-flight = { version = "9.1"  }
+arrow-flight = { version = "10.0"  }
 datafusion = { path = "../../../datafusion", version = "7.0.0" }
 datafusion-proto = { path = "../../../datafusion-proto", version = "7.0.0" }
 

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -399,7 +399,7 @@ message FileScanExecConf {
 
 message ParquetScanExecNode {
   FileScanExecConf base_conf = 1;
-  LogicalExprNode pruning_predicate = 2;
+  datafusion.LogicalExprNode pruning_predicate = 2;
 }
 
 message CsvScanExecNode {

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -29,8 +29,8 @@ edition = "2018"
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-arrow = { version = "9.1"  }
-arrow-flight = { version = "9.1"  }
+arrow = { version = "10.0"  }
+arrow-flight = { version = "10.0"  }
 anyhow = "1"
 async-trait = "0.1.36"
 ballista-core = { path = "../core", version = "0.6.0" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "3", features = ["derive", "cargo"] }
 rustyline = "9.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 datafusion = { path = "../datafusion", version = "7.0.0" }
-arrow = { version = "9.1" }
+arrow = { version = "10.0" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0", optional=true }
 env_logger = "0.9"
 mimalloc = { version = "*", default-features = false }

--- a/datafusion-common/Cargo.toml
+++ b/datafusion-common/Cargo.toml
@@ -38,10 +38,10 @@ pyarrow = ["pyo3"]
 jit = ["cranelift-module"]
 
 [dependencies]
-arrow = { version = "9.1", features = ["prettyprint"] }
-parquet = { version = "9.1", features = ["arrow"], optional = true }
+arrow = { version = "10.0", features = ["prettyprint"] }
+parquet = { version = "10.0", features = ["arrow"], optional = true }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
-pyo3 = { version = "0.15", optional = true }
+pyo3 = { version = "0.16", optional = true }
 sqlparser = "0.14"
 ordered-float = "2.10"
 cranelift-module = { version = "0.82.0", optional = true }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { version = "9.1" }
+arrow-flight = { version = "10.0" }
 datafusion = { path = "../datafusion" }
 prost = "0.9"
 tonic = "0.6"

--- a/datafusion-expr/Cargo.toml
+++ b/datafusion-expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
-arrow = { version = "9.1", features = ["prettyprint"] }
+arrow = { version = "10.0", features = ["prettyprint"] }
 sqlparser = "0.14"
 ahash = { version = "0.7", default-features = false }

--- a/datafusion-physical-expr/Cargo.toml
+++ b/datafusion-physical-expr/Cargo.toml
@@ -41,7 +41,7 @@ unicode_expressions = ["unicode-segmentation"]
 [dependencies]
 datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
 datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
-arrow = { version = "9.1", features = ["prettyprint"] }
+arrow = { version = "10.0", features = ["prettyprint"] }
 paste = "^1.0"
 ahash = { version = "0.7", default-features = false }
 ordered-float = "2.10"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -60,8 +60,8 @@ datafusion-jit = { path = "../datafusion-jit", version = "7.0.0", optional = tru
 datafusion-physical-expr = { path = "../datafusion-physical-expr", version = "7.0.0" }
 ahash = { version = "0.7", default-features = false }
 hashbrown = { version = "0.12", features = ["raw"] }
-arrow = { version = "9.1", features = ["prettyprint"] }
-parquet = { version = "9.1", features = ["arrow"] }
+arrow = { version = "10.0", features = ["prettyprint"] }
+parquet = { version = "10.0", features = ["arrow"] }
 sqlparser = "0.14"
 paste = "^1.0"
 num_cpus = "1.13.0"
@@ -78,7 +78,7 @@ smallvec = { version = "1.6", features = ["union"] }
 rand = "0.8"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 num-traits = { version = "0.2", optional = true }
-pyo3 = { version = "0.15", optional = true }
+pyo3 = { version = "0.16", optional = true }
 tempfile = "3"
 parking_lot = "0.12"
 

--- a/datafusion/fuzz-utils/Cargo.toml
+++ b/datafusion/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { version = "9.1", features = ["prettyprint"] }
+arrow = { version = "10.0", features = ["prettyprint"] }
 rand = "0.8"
 env_logger = "0.9.0"


### PR DESCRIPTION
Builds on https://github.com/apache/arrow-datafusion/pull/1957 (fix logical conflict)

Closes https://github.com/apache/arrow-datafusion/pull/1957

Update datafusion to use the arrow 10.0.0 release so that any new features in that release can be used here.

Also updates `pyo3` dependency to `0.16. to match arrow