### PR TITLE
fix logical conflict with protobuf

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -399,7 +399,7 @@ message FileScanExecConf {
 
 message ParquetScanExecNode {
   FileScanExecConf base_conf = 1;
-  LogicalExprNode pruning_predicate = 2;
+  datafusion.LogicalExprNode pruning_predicate = 2;
 }
 
 message CsvScanExecNode {


### PR DESCRIPTION
https://github.com/apache/arrow-datafusion/pull/1941 introduced a small logical conflict with  https://github.com/apache/arrow-datafusion/pull/1887 which results in a compile error on master:

https://github.com/apache/arrow-datafusion/runs/5467727177?check_suite_focus=true

```
error: failed to run custom build command for `ballista-core v0.6.0 (/__w/arrow-datafusion/arrow-datafusion/ballista/rust/core)`

Caused by:
  process didn't exit successfully: `/github/home/target/debug/debug/build/ballista-core-8af276defa9847ff/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=FORCE_REBUILD
  cargo:rerun-if-changed=proto/ballista.proto
  cargo:rerun-if-changed=proto/datafusion.proto

  --- stderr
  Error: "protobuf compilation failed: protoc failed: ballista.proto:402:3: \"LogicalExprNode\" is not defined.\n"
warning: build failed, waiting for other jobs to finish...
error: build failed
Error: Process completed with exit code 101.
```

This PR fixes the problem
