### PR TITLE
arrow2 branch: Pin to specific commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,4 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", branch = "main" }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2.git", branch = "main" }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", rev = "dc516495a5a49ae41d3c68caab4e33dd57337640" }


### PR DESCRIPTION
The latest commit patched the version of arrow2 to the 'main' branch, which is now incompatible

parquet2 was also patched but appears to be compatible with the latest tagged release (I think at the time the required commit had yet to be released)