### PR TITLE
Implement  EXTRACT expression with week, month, day, hour

### DIFF
--- a/datafusion-physical-expr/src/datetime_expressions.rs
+++ b/datafusion-physical-expr/src/datetime_expressions.rs
@@ -349,8 +349,11 @@ pub fn date_part(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     };
 
     let arr = match date_part.to_lowercase().as_str() {
-        "hour" => extract_date_part!(array, temporal::hour),
         "year" => extract_date_part!(array, temporal::year),
+        "month" => extract_date_part!(array, temporal::month),
+        "week" => extract_date_part!(array, temporal::week),
+        "day" => extract_date_part!(array, temporal::day),
+        "hour" => extract_date_part!(array, temporal::hour),
         "minute" => extract_date_part!(array, temporal::minute),
         "second" => extract_date_part!(array, temporal::second),
         _ => Err(DataFusionError::Execution(format!(

--- a/datafusion/tests/sql/expr.rs
+++ b/datafusion/tests/sql/expr.rs
@@ -714,16 +714,35 @@ async fn in_list_array() -> Result<()> {
 
 #[tokio::test]
 async fn test_extract_date_part() -> Result<()> {
-    test_expression!("date_part('hour', CAST('2020-01-01' AS DATE))", "0");
-    test_expression!("EXTRACT(HOUR FROM CAST('2020-01-01' AS DATE))", "0");
-    test_expression!(
-        "EXTRACT(HOUR FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
-        "12"
-    );
     test_expression!("date_part('YEAR', CAST('2000-01-01' AS DATE))", "2000");
     test_expression!(
         "EXTRACT(year FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
         "2020"
+    );
+    test_expression!("date_part('MONTH', CAST('2000-01-01' AS DATE))", "1");
+    test_expression!(
+        "EXTRACT(month FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+        "9"
+    );
+    test_expression!("date_part('WEEK', CAST('2003-01-01' AS DATE))", "1");
+
+    //TODO Creating logical plan for 'SELECT EXTRACT(WEEK FROM to_timestamp('2020-09-08T12:00:00+00:00'))'
+    // SQL(ParserError("Expected date/time field, found: WEEK"))'
+    // will fix in sqlparser
+
+    // test_expression!(
+    //     "EXTRACT(WEEK FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+    //     "23"
+    // );
+    test_expression!("date_part('DAY', CAST('2000-01-01' AS DATE))", "1");
+    test_expression!(
+        "EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+        "8"
+    );
+    test_expression!("date_part('HOUR', CAST('2000-01-01' AS DATE))", "0");
+    test_expression!(
+        "EXTRACT(hour FROM to_timestamp('2020-09-08T12:03:03+00:00'))",
+        "12"
     );
     test_expression!(
         "EXTRACT(minute FROM to_timestamp('2020-09-08T12:12:00+00:00'))",


### PR DESCRIPTION
# Which issue does this PR close?


Closes #1896.

 # Rationale for this change
Already add compute method in `arrow-rs`, will fix `EXTRACT(WEEK FROM to_timestamp('2020-09-08T12:00:00+00:00'))` in `sqlparser`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
