### PR TITLE
Rename `ExecutionContext` to `SessionContext`, `ExecutionContextState` to `SessionState`, add `TaskContext` to support multi-tenancy configurations - Part 1

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -34,7 +34,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_plan::{CreateExternalTable, LogicalPlan, TableScan};
 use datafusion::prelude::{
-    AvroReadOptions, CsvReadOptions, ExecutionConfig, ExecutionContext,
+    AvroReadOptions, CsvReadOptions, SessionConfig, SessionContext,
 };
 use datafusion::sql::parser::{DFParser, FileType, Statement as DFStatement};
 
@@ -304,8 +304,8 @@ impl BallistaContext {
         // the show tables、 show columns sql can not run at scheduler because the tables is store at client
         if is_show {
             let state = self.state.lock();
-            ctx = ExecutionContext::with_config(
-                ExecutionConfig::new().with_information_schema(
+            ctx = SessionContext::with_config(
+                SessionConfig::new().with_information_schema(
                     state.config.default_with_information_schema(),
                 ),
             );

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -42,7 +42,7 @@ use datafusion::physical_plan::{
 
 use crate::serde::{AsLogicalPlan, DefaultLogicalExtensionCodec, LogicalExtensionCodec};
 use async_trait::async_trait;
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::TaskContext;
 use futures::future;
 use futures::StreamExt;
 use log::{error, info};
@@ -150,7 +150,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
 

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -25,7 +25,6 @@ use crate::utils::WrappedStream;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 
-use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::metrics::{
     ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
@@ -39,6 +38,7 @@ use datafusion::{
 };
 use futures::{future, StreamExt};
 
+use datafusion::execution::context::TaskContext;
 use log::info;
 
 /// ShuffleReaderExec reads partitions that have already been materialized by a ShuffleWriterExec
@@ -106,7 +106,7 @@ impl ExecutionPlan for ShuffleReaderExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         info!("ShuffleReaderExec::execute({})", partition);
 

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -42,7 +42,6 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::common::IPCWriter;
 use datafusion::physical_plan::hash_utils::create_hashes;
 use datafusion::physical_plan::memory::MemoryStream;
@@ -55,6 +54,7 @@ use datafusion::physical_plan::{
 };
 use futures::StreamExt;
 
+use datafusion::execution::context::TaskContext;
 use log::{debug, info};
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
@@ -138,11 +138,11 @@ impl ShuffleWriterExec {
     pub async fn execute_shuffle_write(
         &self,
         input_partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<Vec<ShuffleWritePartition>> {
         let now = Instant::now();
 
-        let mut stream = self.plan.execute(input_partition, runtime).await?;
+        let mut stream = self.plan.execute(input_partition, context).await?;
 
         let mut path = PathBuf::from(&self.work_dir);
         path.push(&self.job_id);
@@ -358,9 +358,9 @@ impl ExecutionPlan for ShuffleWriterExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let part_loc = self.execute_shuffle_write(partition, runtime).await?;
+        let part_loc = self.execute_shuffle_write(partition, context).await?;
 
         // build metadata result batch
         let num_writers = part_loc.len();
@@ -448,11 +448,13 @@ mod tests {
     use datafusion::physical_plan::expressions::Column;
 
     use datafusion::physical_plan::memory::MemoryExec;
+    use datafusion::prelude::SessionContext;
     use tempfile::TempDir;
 
     #[tokio::test]
     async fn test() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
 
         let input_plan = Arc::new(CoalescePartitionsExec::new(create_input_plan()?));
         let work_dir = TempDir::new()?;
@@ -463,7 +465,7 @@ mod tests {
             work_dir.into_path().to_str().unwrap().to_owned(),
             Some(Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 2)),
         )?;
-        let mut stream = query_stage.execute(0, runtime).await?;
+        let mut stream = query_stage.execute(0, task_ctx).await?;
         let batches = utils::collect_stream(&mut stream)
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
@@ -506,7 +508,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_partitioned() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
 
         let input_plan = create_input_plan()?;
         let work_dir = TempDir::new()?;
@@ -517,7 +520,7 @@ mod tests {
             work_dir.into_path().to_str().unwrap().to_owned(),
             Some(Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 2)),
         )?;
-        let mut stream = query_stage.execute(0, runtime).await?;
+        let mut stream = query_stage.execute(0, task_ctx).await?;
         let batches = utils::collect_stream(&mut stream)
             .await
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;

--- a/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/rust/core/src/execution_plans/unresolved_shuffle.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
@@ -104,7 +104,7 @@ impl ExecutionPlan for UnresolvedShuffleExec {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Err(DataFusionError::Plan(
             "Ballista UnresolvedShuffleExec does not support execution".to_owned(),

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -36,7 +36,7 @@ use datafusion::logical_plan::{
     Column, CreateExternalTable, CrossJoin, Expr, JoinConstraint, Limit, LogicalPlan,
     LogicalPlanBuilder, Repartition, TableScan, Values,
 };
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 use prost::bytes::BufMut;
 use prost::Message;
@@ -70,7 +70,7 @@ impl AsLogicalPlan for LogicalPlanNode {
 
     fn try_into_logical_plan(
         &self,
-        ctx: &ExecutionContext,
+        ctx: &SessionContext,
         extension_codec: &dyn LogicalExtensionCodec,
     ) -> Result<LogicalPlan, BallistaError> {
         let plan = self.logical_plan_type.as_ref().ok_or_else(|| {
@@ -920,7 +920,7 @@ mod roundtrip_tests {
             roundtrip_test!($initial_struct, protobuf::LogicalPlanNode, $struct_type);
         };
         ($initial_struct:ident) => {
-            let ctx = ExecutionContext::new();
+            let ctx = SessionContext::new();
             let codec: BallistaCodec<
                 protobuf::LogicalPlanNode,
                 protobuf::PhysicalPlanNode,
@@ -1252,7 +1252,7 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_logical_plan_custom_ctx() -> Result<()> {
-        let ctx = ExecutionContext::new();
+        let ctx = SessionContext::new();
         let codec: BallistaCodec<protobuf::LogicalPlanNode, protobuf::PhysicalPlanNode> =
             BallistaCodec::default();
         let custom_object_store = Arc::new(TestObjectStore {});

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -30,7 +30,7 @@ use crate::{error::BallistaError, serde::scheduler::Action as BallistaAction};
 
 use datafusion::logical_plan::plan::Extension;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use prost::Message;
 
 // include the generated protobuf source as a submodule
@@ -67,7 +67,7 @@ pub trait AsLogicalPlan: Debug + Send + Sync + Clone {
 
     fn try_into_logical_plan(
         &self,
-        ctx: &ExecutionContext,
+        ctx: &SessionContext,
         extension_codec: &dyn LogicalExtensionCodec,
     ) -> Result<LogicalPlan, BallistaError>;
 
@@ -130,7 +130,7 @@ pub trait AsExecutionPlan: Debug + Send + Sync + Clone {
 
     fn try_into_physical_plan(
         &self,
-        ctx: &ExecutionContext,
+        ctx: &SessionContext,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>, BallistaError>;
 
@@ -345,8 +345,7 @@ mod tests {
     use datafusion::arrow::datatypes::SchemaRef;
     use datafusion::datasource::object_store::local::LocalFileSystem;
     use datafusion::error::DataFusionError;
-    use datafusion::execution::context::{ExecutionContextState, QueryPlanner};
-    use datafusion::execution::runtime_env::RuntimeEnv;
+    use datafusion::execution::context::{QueryPlanner, SessionState, TaskContext};
     use datafusion::logical_plan::plan::Extension;
     use datafusion::logical_plan::{
         col, DFSchemaRef, Expr, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode,
@@ -357,7 +356,7 @@ mod tests {
         DisplayFormatType, Distribution, ExecutionPlan, Partitioning, PhysicalPlanner,
         SendableRecordBatchStream, Statistics,
     };
-    use datafusion::prelude::{CsvReadOptions, ExecutionConfig, ExecutionContext};
+    use datafusion::prelude::{CsvReadOptions, SessionConfig, SessionContext};
     use prost::Message;
     use std::any::Any;
 
@@ -512,7 +511,7 @@ mod tests {
         async fn execute(
             &self,
             _partition: usize,
-            _runtime: Arc<RuntimeEnv>,
+            _context: Arc<TaskContext>,
         ) -> datafusion::error::Result<SendableRecordBatchStream> {
             Err(DataFusionError::NotImplemented(
                 "not implemented".to_string(),
@@ -548,7 +547,7 @@ mod tests {
             node: &dyn UserDefinedLogicalNode,
             logical_inputs: &[&LogicalPlan],
             physical_inputs: &[Arc<dyn ExecutionPlan>],
-            _ctx_state: &ExecutionContextState,
+            _session_state: &SessionState,
         ) -> datafusion::error::Result<Option<Arc<dyn ExecutionPlan>>> {
             Ok(
                 if let Some(topk_node) = node.as_any().downcast_ref::<TopKPlanNode>() {
@@ -575,7 +574,7 @@ mod tests {
         async fn create_physical_plan(
             &self,
             logical_plan: &LogicalPlan,
-            ctx_state: &ExecutionContextState,
+            session_state: &SessionState,
         ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
             // Teach the default physical planner how to plan TopK nodes.
             let physical_planner =
@@ -584,7 +583,7 @@ mod tests {
                 )]);
             // Delegate most work of physical planning to the default physical planner
             physical_planner
-                .create_physical_plan(logical_plan, ctx_state)
+                .create_physical_plan(logical_plan, session_state)
                 .await
         }
     }
@@ -694,9 +693,9 @@ mod tests {
     async fn test_extension_plan() -> crate::error::Result<()> {
         let store = Arc::new(LocalFileSystem {});
         let config =
-            ExecutionConfig::new().with_query_planner(Arc::new(TopKQueryPlanner {}));
+            SessionConfig::new().with_query_planner(Arc::new(TopKQueryPlanner {}));
 
-        let ctx = ExecutionContext::with_config(config);
+        let ctx = SessionContext::with_config(config);
 
         let scan = LogicalPlanBuilder::scan_csv(
             store,

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -56,7 +56,7 @@ use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
     AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr, WindowExpr,
 };
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use prost::bytes::BufMut;
 use prost::Message;
 use std::convert::TryInto;
@@ -87,7 +87,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
 
     fn try_into_physical_plan(
         &self,
-        ctx: &ExecutionContext,
+        ctx: &SessionContext,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>, BallistaError> {
         let plan = self.physical_plan_type.as_ref().ok_or_else(|| {
@@ -883,7 +883,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
 
 fn decode_scan_config(
     proto: &protobuf::FileScanExecConf,
-    ctx: &ExecutionContext,
+    ctx: &SessionContext,
 ) -> Result<FileScanConfig, BallistaError> {
     let schema = Arc::new(convert_required!(proto.schema)?);
     let projection = proto
@@ -940,7 +940,7 @@ mod roundtrip_tests {
     use datafusion::datasource::object_store::local::LocalFileSystem;
     use datafusion::datasource::PartitionedFile;
     use datafusion::physical_plan::sorts::sort::SortExec;
-    use datafusion::prelude::ExecutionContext;
+    use datafusion::prelude::SessionContext;
     use datafusion::{
         arrow::{
             compute::kernels::sort::SortOptions,
@@ -969,7 +969,7 @@ mod roundtrip_tests {
     use crate::serde::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 
     fn roundtrip_test(exec_plan: Arc<dyn ExecutionPlan>) -> Result<()> {
-        let ctx = ExecutionContext::new();
+        let ctx = SessionContext::new();
         let codec: BallistaCodec<LogicalPlanNode, PhysicalPlanNode> =
             BallistaCodec::default();
         let proto: protobuf::PhysicalPlanNode =

--- a/ballista/rust/executor/src/collect.rs
+++ b/ballista/rust/executor/src/collect.rs
@@ -27,7 +27,7 @@ use datafusion::arrow::{
     datatypes::SchemaRef, error::Result as ArrowResult, record_batch::RecordBatch,
 };
 use datafusion::error::DataFusionError;
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
@@ -81,12 +81,12 @@ impl ExecutionPlan for CollectExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
         let num_partitions = self.plan.output_partitioning().partition_count();
 
-        let futures = (0..num_partitions).map(|i| self.plan.execute(i, runtime.clone()));
+        let futures = (0..num_partitions).map(|i| self.plan.execute(i, context.clone()));
         let streams = futures::future::join_all(futures)
             .await
             .into_iter()

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -42,7 +42,7 @@ use ballista_core::{print_version, BALLISTA_VERSION};
 use ballista_executor::executor::Executor;
 use ballista_executor::flight_service::BallistaFlightService;
 use config::prelude::*;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 #[macro_use]
 extern crate configure_me;
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
     let executor = Arc::new(Executor::new(
         executor_meta,
         &work_dir,
-        Arc::new(ExecutionContext::new()),
+        Arc::new(SessionContext::new()),
     ));
 
     let scheduler = SchedulerGrpcClient::connect(scheduler_url)

--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -27,7 +27,7 @@ use ballista_core::{
     serde::protobuf::{scheduler_grpc_client::SchedulerGrpcClient, ExecutorRegistration},
     BALLISTA_VERSION,
 };
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use log::info;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
@@ -71,7 +71,7 @@ pub async fn new_standalone_executor<
         .into_string()
         .unwrap();
     info!("work_dir: {}", work_dir);
-    let ctx = Arc::new(ExecutionContext::new());
+    let ctx = Arc::new(SessionContext::new());
     let executor = Arc::new(Executor::new(executor_meta, &work_dir, ctx));
 
     let service = BallistaFlightService::new(executor.clone());

--- a/ballista/rust/scheduler/src/main.rs
+++ b/ballista/rust/scheduler/src/main.rs
@@ -62,7 +62,7 @@ mod config {
 }
 
 use config::prelude::*;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 async fn start_server(
     config_backend: Arc<dyn StateBackendClient>,
@@ -85,13 +85,13 @@ async fn start_server(
                 config_backend.clone(),
                 namespace.clone(),
                 policy,
-                Arc::new(RwLock::new(ExecutionContext::new())),
+                Arc::new(RwLock::new(SessionContext::new())),
                 BallistaCodec::default(),
             ),
             _ => SchedulerServer::new(
                 config_backend.clone(),
                 namespace.clone(),
-                Arc::new(RwLock::new(ExecutionContext::new())),
+                Arc::new(RwLock::new(SessionContext::new())),
                 BallistaCodec::default(),
             ),
         };

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -259,7 +259,7 @@ mod test {
         coalesce_partitions::CoalescePartitionsExec, projection::ProjectionExec,
     };
     use datafusion::physical_plan::{displayable, ExecutionPlan};
-    use datafusion::prelude::ExecutionContext;
+    use datafusion::prelude::SessionContext;
 
     use ballista_core::serde::protobuf::{LogicalPlanNode, PhysicalPlanNode};
     use std::sync::Arc;
@@ -574,7 +574,7 @@ order by
     fn roundtrip_operator(
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>, BallistaError> {
-        let ctx = ExecutionContext::new();
+        let ctx = SessionContext::new();
         let codec: BallistaCodec<LogicalPlanNode, PhysicalPlanNode> =
             BallistaCodec::default();
         let proto: protobuf::PhysicalPlanNode =

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -490,7 +490,7 @@ mod test {
     };
     use ballista_core::serde::scheduler::ExecutorSpecification;
     use ballista_core::serde::BallistaCodec;
-    use datafusion::prelude::ExecutionContext;
+    use datafusion::prelude::SessionContext;
 
     use super::{SchedulerGrpc, SchedulerServer};
 
@@ -502,7 +502,7 @@ mod test {
             SchedulerServer::new(
                 state_storage.clone(),
                 namespace.to_owned(),
-                Arc::new(RwLock::new(ExecutionContext::new())),
+                Arc::new(RwLock::new(SessionContext::new())),
                 BallistaCodec::default(),
             );
         let exec_meta = ExecutorRegistration {

--- a/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -30,7 +30,7 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan};
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 use crate::planner::DistributedPlanner;
 use crate::scheduler_server::event_loop::SchedulerServerEvent;
@@ -45,14 +45,14 @@ pub(crate) struct QueryStageScheduler<
     T: 'static + AsLogicalPlan,
     U: 'static + AsExecutionPlan,
 > {
-    ctx: Arc<RwLock<ExecutionContext>>,
+    ctx: Arc<RwLock<SessionContext>>,
     state: Arc<SchedulerState<T, U>>,
     event_sender: Option<EventSender<SchedulerServerEvent>>,
 }
 
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageScheduler<T, U> {
     pub(crate) fn new(
-        ctx: Arc<RwLock<ExecutionContext>>,
+        ctx: Arc<RwLock<SessionContext>>,
         state: Arc<SchedulerState<T, U>>,
         event_sender: Option<EventSender<SchedulerServerEvent>>,
     ) -> Self {

--- a/ballista/rust/scheduler/src/standalone.rs
+++ b/ballista/rust/scheduler/src/standalone.rs
@@ -21,7 +21,7 @@ use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use log::info;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
@@ -39,7 +39,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
         SchedulerServer::new(
             Arc::new(client),
             "ballista".to_string(),
-            Arc::new(RwLock::new(ExecutionContext::new())),
+            Arc::new(RwLock::new(SessionContext::new())),
             BallistaCodec::default(),
         );
     scheduler_server.init().await?;

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -35,7 +35,7 @@ use ballista_core::serde::scheduler::{
     ExecutorData, ExecutorDataChange, ExecutorMetadata, PartitionId, PartitionStats,
 };
 use ballista_core::serde::{protobuf, AsExecutionPlan, AsLogicalPlan, BallistaCodec};
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 use super::planner::remove_unresolved_shuffles;
 
@@ -134,7 +134,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         ret
     }
 
-    pub async fn init(&self, ctx: &ExecutionContext) -> Result<()> {
+    pub async fn init(&self, ctx: &SessionContext) -> Result<()> {
         self.persistent_state.init(ctx).await?;
 
         Ok(())

--- a/ballista/rust/scheduler/src/state/persistent_state.rs
+++ b/ballista/rust/scheduler/src/state/persistent_state.rs
@@ -30,7 +30,7 @@ use crate::state::backend::StateBackendClient;
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use ballista_core::serde::{protobuf, AsExecutionPlan, AsLogicalPlan, BallistaCodec};
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 
 type StageKey = (String, u32);
 
@@ -70,7 +70,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     }
 
     /// Load the state stored in storage into memory
-    pub(crate) async fn init(&self, ctx: &ExecutionContext) -> Result<()> {
+    pub(crate) async fn init(&self, ctx: &SessionContext) -> Result<()> {
         self.init_executors_metadata_from_storage().await?;
         self.init_jobs_from_storage().await?;
         self.init_stages_from_storage(ctx).await?;
@@ -111,7 +111,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         Ok(())
     }
 
-    async fn init_stages_from_storage(&self, ctx: &ExecutionContext) -> Result<()> {
+    async fn init_stages_from_storage(&self, ctx: &SessionContext) -> Result<()> {
         let entries = self
             .config_client
             .get_from_prefix(&get_stage_prefix(&self.namespace))

--- a/ballista/rust/scheduler/src/test_utils.rs
+++ b/ballista/rust/scheduler/src/test_utils.rs
@@ -18,18 +18,17 @@
 use ballista_core::error::Result;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
+use datafusion::execution::context::{SessionConfig, SessionContext};
 use datafusion::prelude::CsvReadOptions;
 
 pub const TPCH_TABLES: &[&str] = &[
     "part", "supplier", "partsupp", "customer", "orders", "lineitem", "nation", "region",
 ];
 
-pub async fn datafusion_test_context(path: &str) -> Result<ExecutionContext> {
+pub async fn datafusion_test_context(path: &str) -> Result<SessionContext> {
     let default_shuffle_partitions = 2;
-    let config =
-        ExecutionConfig::new().with_target_partitions(default_shuffle_partitions);
-    let mut ctx = ExecutionContext::with_config(config);
+    let config = SessionConfig::new().with_target_partitions(default_shuffle_partitions);
+    let mut ctx = SessionContext::with_config(config);
     for table in TPCH_TABLES {
         let schema = get_tpch_schema(table);
         let options = CsvReadOptions::new()

--- a/datafusion-cli/src/context.rs
+++ b/datafusion-cli/src/context.rs
@@ -19,13 +19,13 @@
 
 use datafusion::dataframe::DataFrame;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
+use datafusion::execution::context::{SessionConfig, SessionContext};
 use std::sync::Arc;
 
 /// The CLI supports using a local DataFusion context or a distributed BallistaContext
 pub enum Context {
     /// In-process execution with DataFusion
-    Local(ExecutionContext),
+    Local(SessionContext),
     /// Distributed execution with Ballista (if available)
     Remote(BallistaContext),
 }
@@ -37,8 +37,8 @@ impl Context {
     }
 
     /// create a local context using the given config
-    pub fn new_local(config: &ExecutionConfig) -> Context {
-        Context::Local(ExecutionContext::with_config(config.clone()))
+    pub fn new_local(config: &SessionConfig) -> Context {
+        Context::Local(SessionContext::with_config(config.clone()))
     }
 
     /// execute an SQL statement against the context

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionConfig;
+use datafusion::execution::context::SessionConfig;
 use datafusion_cli::{
     context::Context, exec, print_format::PrintFormat, print_options::PrintOptions,
     DATAFUSION_CLI_VERSION,
@@ -98,15 +98,15 @@ pub async fn main() -> Result<()> {
         env::set_current_dir(&p).unwrap();
     };
 
-    let mut execution_config = ExecutionConfig::new().with_information_schema(true);
+    let mut session_config = SessionConfig::new().with_information_schema(true);
 
     if let Some(batch_size) = args.batch_size {
-        execution_config = execution_config.with_batch_size(batch_size);
+        session_config = session_config.with_batch_size(batch_size);
     };
 
     let mut ctx: Context = match (args.host, args.port) {
         (Some(ref h), Some(p)) => Context::new_remote(h, p)?,
-        _ => Context::new_local(&execution_config),
+        _ => Context::new_local(&session_config),
     };
 
     let mut print_options = PrintOptions {

--- a/datafusion-examples/examples/avro_sql.rs
+++ b/datafusion-examples/examples/avro_sql.rs
@@ -25,7 +25,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> Result<()> {
     // create local execution context
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let testdata = datafusion::arrow::util::test_util::arrow_test_data();
 

--- a/datafusion-examples/examples/csv_sql.rs
+++ b/datafusion-examples/examples/csv_sql.rs
@@ -23,7 +23,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> Result<()> {
     // create local execution context
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let testdata = datafusion::test_util::arrow_test_data();
 

--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -22,7 +22,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::TaskContext;
 use datafusion::logical_plan::{Expr, LogicalPlanBuilder};
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::memory::MemoryStream;
@@ -57,7 +57,7 @@ async fn search_accounts(
     expected_result_length: usize,
 ) -> Result<()> {
     // create local execution context
-    let ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
 
     // create logical plan composed of a single TableScan
     let logical_plan =
@@ -235,7 +235,7 @@ impl ExecutionPlan for CustomExec {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let users: Vec<User> = {
             let db = self.db.inner.lock().unwrap();

--- a/datafusion-examples/examples/dataframe.rs
+++ b/datafusion-examples/examples/dataframe.rs
@@ -23,7 +23,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> Result<()> {
     // create local execution context
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let testdata = datafusion::arrow::util::test_util::parquet_test_data();
 

--- a/datafusion-examples/examples/dataframe_in_memory.rs
+++ b/datafusion-examples/examples/dataframe_in_memory.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     )?;
 
     // declare a new context. In spark API, this corresponds to a new spark SQLsession
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;

--- a/datafusion-examples/examples/flight_server.rs
+++ b/datafusion-examples/examples/flight_server.rs
@@ -90,7 +90,7 @@ impl FlightService for FlightServiceImpl {
                 println!("do_get: {}", sql);
 
                 // create local execution context
-                let mut ctx = ExecutionContext::new();
+                let mut ctx = SessionContext::new();
 
                 let testdata = datafusion::arrow::util::test_util::parquet_test_data();
 

--- a/datafusion-examples/examples/memtable.rs
+++ b/datafusion-examples/examples/memtable.rs
@@ -20,7 +20,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::MemTable;
 use datafusion::error::Result;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     let mem_table = create_memtable()?;
 
     // create local execution context
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // Register the in-memory table containing the data
     ctx.register_table("users", Arc::new(mem_table))?;

--- a/datafusion-examples/examples/parquet_sql.rs
+++ b/datafusion-examples/examples/parquet_sql.rs
@@ -22,8 +22,8 @@ use datafusion::prelude::*;
 /// fetching results
 #[tokio::main]
 async fn main() -> Result<()> {
-    // create local execution context
-    let mut ctx = ExecutionContext::new();
+    // create local session context
+    let mut ctx = SessionContext::new();
 
     let testdata = datafusion::arrow::util::test_util::parquet_test_data();
 

--- a/datafusion-examples/examples/parquet_sql_multiple_files.rs
+++ b/datafusion-examples/examples/parquet_sql_multiple_files.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<()> {
     // create local execution context
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let testdata = datafusion::arrow::util::test_util::parquet_test_data();
 

--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -28,8 +28,8 @@ use datafusion::{error::Result, logical_plan::create_udaf, physical_plan::Accumu
 use datafusion::{prelude::*, scalar::ScalarValue};
 use std::sync::Arc;
 
-// create local execution context with an in-memory table
-fn create_context() -> Result<ExecutionContext> {
+// create local session context with an in-memory table
+fn create_context() -> Result<SessionContext> {
     use datafusion::arrow::datatypes::{Field, Schema};
     use datafusion::datasource::MemTable;
     // define a schema.
@@ -46,7 +46,7 @@ fn create_context() -> Result<ExecutionContext> {
     )?;
 
     // declare a new context. In spark API, this corresponds to a new spark SQLsession
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;

--- a/datafusion-examples/examples/simple_udf.rs
+++ b/datafusion-examples/examples/simple_udf.rs
@@ -30,7 +30,7 @@ use datafusion::{error::Result, physical_plan::functions::make_scalar_function};
 use std::sync::Arc;
 
 // create local execution context with an in-memory table
-fn create_context() -> Result<ExecutionContext> {
+fn create_context() -> Result<SessionContext> {
     use datafusion::arrow::datatypes::{Field, Schema};
     use datafusion::datasource::MemTable;
     // define a schema.
@@ -49,7 +49,7 @@ fn create_context() -> Result<ExecutionContext> {
     )?;
 
     // declare a new context. In spark API, this corresponds to a new spark SQLsession
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -81,6 +81,7 @@ num-traits = { version = "0.2", optional = true }
 pyo3 = { version = "0.16", optional = true }
 tempfile = "3"
 parking_lot = "0.12"
+uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/datafusion/benches/aggregate_query_sql.rs
+++ b/datafusion/benches/aggregate_query_sql.rs
@@ -24,12 +24,12 @@ mod data_utils;
 use crate::criterion::Criterion;
 use data_utils::create_table_provider;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
-fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
+fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
     let rt = Runtime::new().unwrap();
     let df = rt.block_on(ctx.lock().sql(sql)).unwrap();
     criterion::black_box(rt.block_on(df.collect()).unwrap());
@@ -39,8 +39,8 @@ fn create_context(
     partitions_len: usize,
     array_len: usize,
     batch_size: usize,
-) -> Result<Arc<Mutex<ExecutionContext>>> {
-    let mut ctx = ExecutionContext::new();
+) -> Result<Arc<Mutex<SessionContext>>> {
+    let mut ctx = SessionContext::new();
     let provider = create_table_provider(partitions_len, array_len, batch_size)?;
     ctx.register_table("t", provider)?;
     Ok(Arc::new(Mutex::new(ctx)))

--- a/datafusion/benches/filter_query_sql.rs
+++ b/datafusion/benches/filter_query_sql.rs
@@ -22,13 +22,13 @@ use arrow::{
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::from_slice::FromSlice;
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use datafusion::{datasource::MemTable, error::Result};
 use futures::executor::block_on;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
-async fn query(ctx: &mut ExecutionContext, sql: &str) {
+async fn query(ctx: &mut SessionContext, sql: &str) {
     let rt = Runtime::new().unwrap();
 
     // execute the query
@@ -36,7 +36,7 @@ async fn query(ctx: &mut ExecutionContext, sql: &str) {
     criterion::black_box(rt.block_on(df.collect()).unwrap());
 }
 
-fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContext> {
+fn create_context(array_len: usize, batch_size: usize) -> Result<SessionContext> {
     // define a schema.
     let schema = Arc::new(Schema::new(vec![
         Field::new("f32", DataType::Float32, false),
@@ -57,7 +57,7 @@ fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContex
         })
         .collect::<Vec<_>>();
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;

--- a/datafusion/benches/math_query_sql.rs
+++ b/datafusion/benches/math_query_sql.rs
@@ -34,10 +34,10 @@ use arrow::{
 };
 use datafusion::datasource::MemTable;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 use datafusion::from_slice::FromSlice;
 
-fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
+fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
     let rt = Runtime::new().unwrap();
 
     // execute the query
@@ -48,7 +48,7 @@ fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
 fn create_context(
     array_len: usize,
     batch_size: usize,
-) -> Result<Arc<Mutex<ExecutionContext>>> {
+) -> Result<Arc<Mutex<SessionContext>>> {
     // define a schema.
     let schema = Arc::new(Schema::new(vec![
         Field::new("f32", DataType::Float32, false),
@@ -69,7 +69,7 @@ fn create_context(
         })
         .collect::<Vec<_>>();
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;

--- a/datafusion/benches/parquet_query_sql.rs
+++ b/datafusion/benches/parquet_query_sql.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::{
 };
 use arrow::record_batch::RecordBatch;
 use criterion::{criterion_group, criterion_main, Criterion};
-use datafusion::prelude::ExecutionContext;
+use datafusion::prelude::SessionContext;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::{WriterProperties, WriterVersion};
 use rand::distributions::uniform::SampleUniform;
@@ -193,7 +193,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     assert!(Path::new(&file_path).exists(), "path not found");
     println!("Using parquet file {}", file_path);
 
-    let mut context = ExecutionContext::new();
+    let mut context = SessionContext::new();
 
     let rt = tokio::runtime::Builder::new_multi_thread().build().unwrap();
     rt.block_on(context.register_parquet("t", file_path.as_str()))

--- a/datafusion/benches/sort_limit_query_sql.rs
+++ b/datafusion/benches/sort_limit_query_sql.rs
@@ -31,11 +31,11 @@ extern crate datafusion;
 use arrow::datatypes::{DataType, Field, Schema};
 
 use datafusion::datasource::MemTable;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 
 use tokio::runtime::Runtime;
 
-fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
+fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
     let rt = Runtime::new().unwrap();
 
     // execute the query
@@ -43,7 +43,7 @@ fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
     rt.block_on(df.collect()).unwrap();
 }
 
-fn create_context() -> Arc<Mutex<ExecutionContext>> {
+fn create_context() -> Arc<Mutex<SessionContext>> {
     // define schema for data source (csv file)
     let schema = Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),
@@ -76,18 +76,18 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
 
     let rt = Runtime::new().unwrap();
 
-    let ctx_holder: Arc<Mutex<Vec<Arc<Mutex<ExecutionContext>>>>> =
+    let ctx_holder: Arc<Mutex<Vec<Arc<Mutex<SessionContext>>>>> =
         Arc::new(Mutex::new(vec![]));
 
     let partitions = 16;
 
     rt.block_on(async {
-        // create local execution context
-        let mut ctx = ExecutionContext::new();
+        // create local session context
+        let mut ctx = SessionContext::new();
         ctx.state.lock().config.target_partitions = 1;
-        let runtime = ctx.state.lock().runtime_env.clone();
 
-        let mem_table = MemTable::load(Arc::new(csv.await), Some(partitions), runtime)
+        let task_ctx = ctx.task_ctx();
+        let mem_table = MemTable::load(Arc::new(csv.await), Some(partitions), task_ctx)
             .await
             .unwrap();
         ctx.register_table("aggregate_test_100", Arc::new(mem_table))

--- a/datafusion/benches/window_query_sql.rs
+++ b/datafusion/benches/window_query_sql.rs
@@ -24,12 +24,12 @@ mod data_utils;
 use crate::criterion::Criterion;
 use data_utils::create_table_provider;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
-fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
+fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
     let rt = Runtime::new().unwrap();
     let df = rt.block_on(ctx.lock().sql(sql)).unwrap();
     criterion::black_box(rt.block_on(df.collect()).unwrap());
@@ -39,8 +39,8 @@ fn create_context(
     partitions_len: usize,
     array_len: usize,
     batch_size: usize,
-) -> Result<Arc<Mutex<ExecutionContext>>> {
-    let mut ctx = ExecutionContext::new();
+) -> Result<Arc<Mutex<SessionContext>>> {
+    let mut ctx = SessionContext::new();
     let provider = create_table_provider(partitions_len, array_len, batch_size)?;
     ctx.register_table("t", provider)?;
     Ok(Arc::new(Mutex::new(ctx)))

--- a/datafusion/src/catalog/schema.rs
+++ b/datafusion/src/catalog/schema.rs
@@ -251,7 +251,7 @@ mod tests {
     };
     use crate::datasource::empty::EmptyTable;
     use crate::datasource::object_store::local::LocalFileSystem;
-    use crate::execution::context::ExecutionContext;
+    use crate::execution::context::SessionContext;
 
     use futures::StreamExt;
 
@@ -290,7 +290,7 @@ mod tests {
         let catalog = MemoryCatalogProvider::new();
         catalog.register_schema("active", Arc::new(schema));
 
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
 
         ctx.register_catalog("cat", Arc::new(catalog));
 

--- a/datafusion/src/datasource/file_format/avro.rs
+++ b/datafusion/src/datasource/file_format/avro.rs
@@ -84,6 +84,7 @@ mod tests {
 
     use super::*;
     use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+    use crate::prelude::{SessionConfig, SessionContext};
     use arrow::array::{
         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
         TimestampMicrosecondArray,
@@ -92,10 +93,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_small_batches() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::new().with_batch_size(2))?);
+        let config = SessionConfig::new().with_batch_size(2);
+        let ctx = SessionContext::with_config(config);
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
-        let stream = exec.execute(0, runtime).await?;
+        let stream = exec.execute(0, task_ctx).await?;
 
         let tt_batches = stream
             .map(|batch| {
@@ -113,10 +116,11 @@ mod tests {
 
     #[tokio::test]
     async fn read_limit() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec("alltypes_plain.avro", &projection, Some(1)).await?;
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(11, batches[0].num_columns());
         assert_eq!(1, batches[0].num_rows());
@@ -126,7 +130,8 @@ mod tests {
 
     #[tokio::test]
     async fn read_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
@@ -153,7 +158,7 @@ mod tests {
             x
         );
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
 
         let expected =  vec![
@@ -177,11 +182,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_bool_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![1]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -206,11 +212,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_i32_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![0]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -232,11 +239,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_i96_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![10]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -258,11 +266,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_f32_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![6]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -287,11 +296,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_f64_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![7]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -316,11 +326,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_binary_alltypes_plain_avro() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![9]);
         let exec = get_exec("alltypes_plain.avro", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(batches.len(), 1);
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());

--- a/datafusion/src/datasource/file_format/json.rs
+++ b/datafusion/src/datasource/file_format/json.rs
@@ -100,7 +100,7 @@ mod tests {
     use arrow::array::Int64Array;
 
     use super::*;
-    use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+    use crate::prelude::{SessionConfig, SessionContext};
     use crate::{
         datasource::{
             file_format::FileScanConfig,
@@ -114,10 +114,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_small_batches() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::new().with_batch_size(2))?);
+        let config = SessionConfig::new().with_batch_size(2);
+        let ctx = SessionContext::with_config(config);
         let projection = None;
         let exec = get_exec(&projection, None).await?;
-        let stream = exec.execute(0, runtime).await?;
+        let task_ctx = ctx.task_ctx();
+        let stream = exec.execute(0, task_ctx).await?;
 
         let tt_batches: i32 = stream
             .map(|batch| {
@@ -139,10 +141,11 @@ mod tests {
 
     #[tokio::test]
     async fn read_limit() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec(&projection, Some(1)).await?;
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(4, batches[0].num_columns());
         assert_eq!(1, batches[0].num_rows());
@@ -168,11 +171,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_int_column() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![0]);
         let exec = get_exec(&projection, None).await?;
 
-        let batches = collect(exec, runtime).await.expect("Collect batches");
+        let batches = collect(exec, task_ctx).await.expect("Collect batches");
 
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());

--- a/datafusion/src/datasource/file_format/parquet.rs
+++ b/datafusion/src/datasource/file_format/parquet.rs
@@ -367,7 +367,7 @@ mod tests {
 
     use super::*;
 
-    use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+    use crate::prelude::{SessionConfig, SessionContext};
     use arrow::array::{
         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
         TimestampNanosecondArray,
@@ -376,10 +376,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_small_batches() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::new().with_batch_size(2))?);
+        let config = SessionConfig::new().with_batch_size(2);
+        let ctx = SessionContext::with_config(config);
         let projection = None;
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
-        let stream = exec.execute(0, runtime).await?;
+        let task_ctx = ctx.task_ctx();
+        let stream = exec.execute(0, task_ctx).await?;
 
         let tt_batches = stream
             .map(|batch| {
@@ -401,7 +403,8 @@ mod tests {
 
     #[tokio::test]
     async fn read_limit() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec("alltypes_plain.parquet", &projection, Some(1)).await?;
 
@@ -409,7 +412,7 @@ mod tests {
         assert_eq!(exec.statistics().num_rows, Some(8));
         assert_eq!(exec.statistics().total_byte_size, Some(671));
         assert!(exec.statistics().is_exact);
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(11, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -419,7 +422,8 @@ mod tests {
 
     #[tokio::test]
     async fn read_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = None;
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
@@ -445,7 +449,7 @@ mod tests {
             y
         );
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
 
         assert_eq!(1, batches.len());
         assert_eq!(11, batches[0].num_columns());
@@ -456,11 +460,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_bool_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![1]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -485,11 +490,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_i32_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![0]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -511,11 +517,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_i96_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![10]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -537,11 +544,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_f32_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![6]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -566,11 +574,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_f64_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![7]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());
@@ -595,11 +604,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_binary_alltypes_plain_parquet() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let projection = Some(vec![9]);
         let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
 
-        let batches = collect(exec, runtime).await?;
+        let batches = collect(exec, task_ctx).await?;
         assert_eq!(1, batches.len());
         assert_eq!(1, batches[0].num_columns());
         assert_eq!(8, batches[0].num_rows());

--- a/datafusion/src/datasource/listing/helpers.rs
+++ b/datafusion/src/datasource/listing/helpers.rs
@@ -37,7 +37,7 @@ use log::debug;
 
 use crate::{
     error::Result,
-    execution::context::ExecutionContext,
+    execution::context::SessionContext,
     logical_plan::{self, Expr, ExprVisitable, ExpressionVisitor, Recursion},
     physical_plan::functions::Volatility,
     scalar::ScalarValue,
@@ -242,7 +242,7 @@ pub async fn pruned_partition_list(
         // Filter the partitions using a local datafusion context
         // TODO having the external context would allow us to resolve `Volatility::Stable`
         // scalar functions (`ScalarFunction` & `ScalarUDF`) and `ScalarVariable`s
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let mut df = ctx.read_table(Arc::new(mem_table))?;
         for filter in applicable_filters {
             df = df.filter(filter.clone())?;

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
-//! let mut ctx = ExecutionContext::new();
+//! let mut ctx = SessionContext::new();
 //!
 //! // create the dataframe
 //! let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
@@ -73,7 +73,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
-//! let mut ctx = ExecutionContext::new();
+//! let mut ctx = SessionContext::new();
 //!
 //! ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new()).await?;
 //!
@@ -111,7 +111,7 @@
 //! 3. The planner [`SqlToRel`](sql::planner::SqlToRel) converts logical nodes on the AST to a [`LogicalPlan`](logical_plan::LogicalPlan).
 //! 4. [`OptimizerRules`](optimizer::optimizer::OptimizerRule) are applied to the [`LogicalPlan`](logical_plan::LogicalPlan) to optimize it.
 //! 5. The [`LogicalPlan`](logical_plan::LogicalPlan) is converted to an [`ExecutionPlan`](physical_plan::ExecutionPlan) by a [`PhysicalPlanner`](physical_plan::PhysicalPlanner)
-//! 6. The [`ExecutionPlan`](physical_plan::ExecutionPlan) is executed against data through the [`ExecutionContext`](execution::context::ExecutionContext)
+//! 6. The [`ExecutionPlan`](physical_plan::ExecutionPlan) is executed against data through the [`SessionContext`](execution::context::SessionContext)
 //!
 //! With a [`DataFrame`](dataframe::DataFrame) API, steps 1-3 are not used as the DataFrame builds the [`LogicalPlan`](logical_plan::LogicalPlan) directly.
 //!

--- a/datafusion/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/src/physical_optimizer/aggregate_statistics.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 
-use crate::execution::context::ExecutionConfig;
+use crate::execution::context::SessionConfig;
 use crate::physical_plan::empty::EmptyExec;
 use crate::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
 use crate::physical_plan::projection::ProjectionExec;
@@ -48,7 +48,7 @@ impl PhysicalOptimizerRule for AggregateStatistics {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        execution_config: &ExecutionConfig,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if let Some(partial_agg_exec) = take_optimizable(&*plan) {
             let partial_agg_exec = partial_agg_exec
@@ -84,10 +84,10 @@ impl PhysicalOptimizerRule for AggregateStatistics {
                     Arc::new(EmptyExec::new(true, Arc::new(Schema::empty()))),
                 )?))
             } else {
-                optimize_children(self, plan, execution_config)
+                optimize_children(self, plan, config)
             }
         } else {
-            optimize_children(self, plan, execution_config)
+            optimize_children(self, plan, config)
         }
     }
 
@@ -259,7 +259,6 @@ mod tests {
     use arrow::record_batch::RecordBatch;
 
     use crate::error::Result;
-    use crate::execution::runtime_env::RuntimeEnv;
     use crate::logical_plan::Operator;
     use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use crate::physical_plan::common;
@@ -267,6 +266,7 @@ mod tests {
     use crate::physical_plan::filter::FilterExec;
     use crate::physical_plan::hash_aggregate::HashAggregateExec;
     use crate::physical_plan::memory::MemoryExec;
+    use crate::prelude::SessionContext;
 
     /// Mock data using a MemoryExec which has an exact count statistic
     fn mock_data() -> Result<Arc<MemoryExec>> {
@@ -295,8 +295,9 @@ mod tests {
         plan: HashAggregateExec,
         nulls: bool,
     ) -> Result<()> {
-        let conf = ExecutionConfig::new();
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let conf = session_ctx.state.lock().clone().config;
         let optimized = AggregateStatistics::new().optimize(Arc::new(plan), &conf)?;
 
         let (col, count) = match nulls {
@@ -306,7 +307,7 @@ mod tests {
 
         // A ProjectionExec is a sign that the count optimization was applied
         assert!(optimized.as_any().is::<ProjectionExec>());
-        let result = common::collect(optimized.execute(0, runtime).await?).await?;
+        let result = common::collect(optimized.execute(0, task_ctx).await?).await?;
         assert_eq!(result[0].schema(), Arc::new(Schema::new(vec![col])));
         assert_eq!(
             result[0]
@@ -473,7 +474,7 @@ mod tests {
             Arc::clone(&schema),
         )?;
 
-        let conf = ExecutionConfig::new();
+        let conf = SessionConfig::new();
         let optimized =
             AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
 
@@ -515,7 +516,7 @@ mod tests {
             Arc::clone(&schema),
         )?;
 
-        let conf = ExecutionConfig::new();
+        let conf = SessionConfig::new();
         let optimized =
             AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
 

--- a/datafusion/src/physical_optimizer/coalesce_batches.rs
+++ b/datafusion/src/physical_optimizer/coalesce_batches.rs
@@ -42,7 +42,7 @@ impl PhysicalOptimizerRule for CoalesceBatches {
     fn optimize(
         &self,
         plan: Arc<dyn crate::physical_plan::ExecutionPlan>,
-        config: &crate::execution::context::ExecutionConfig,
+        config: &crate::execution::context::SessionConfig,
     ) -> Result<Arc<dyn crate::physical_plan::ExecutionPlan>> {
         // wrap operators in CoalesceBatches to avoid lots of tiny batches when we have
         // highly selective filters

--- a/datafusion/src/physical_optimizer/hash_build_probe_order.rs
+++ b/datafusion/src/physical_optimizer/hash_build_probe_order.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 
-use crate::execution::context::ExecutionConfig;
+use crate::execution::context::SessionConfig;
 use crate::logical_plan::JoinType;
 use crate::physical_plan::cross_join::CrossJoinExec;
 use crate::physical_plan::expressions::Column;
@@ -113,9 +113,9 @@ impl PhysicalOptimizerRule for HashBuildProbeOrder {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        execution_config: &ExecutionConfig,
+        session_config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let plan = optimize_children(self, plan, execution_config)?;
+        let plan = optimize_children(self, plan, session_config)?;
         if let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() {
             let left = hash_join.left();
             let right = hash_join.right();
@@ -212,7 +212,7 @@ mod tests {
         .unwrap();
 
         let optimized_join = HashBuildProbeOrder::new()
-            .optimize(Arc::new(join), &ExecutionConfig::new())
+            .optimize(Arc::new(join), &SessionConfig::new())
             .unwrap();
 
         let swapping_projection = optimized_join
@@ -259,7 +259,7 @@ mod tests {
         .unwrap();
 
         let optimized_join = HashBuildProbeOrder::new()
-            .optimize(Arc::new(join), &ExecutionConfig::new())
+            .optimize(Arc::new(join), &SessionConfig::new())
             .unwrap();
 
         let swapped_join = optimized_join

--- a/datafusion/src/physical_optimizer/merge_exec.rs
+++ b/datafusion/src/physical_optimizer/merge_exec.rs
@@ -40,7 +40,7 @@ impl PhysicalOptimizerRule for AddCoalescePartitionsExec {
     fn optimize(
         &self,
         plan: Arc<dyn crate::physical_plan::ExecutionPlan>,
-        config: &crate::execution::context::ExecutionConfig,
+        config: &crate::execution::context::SessionConfig,
     ) -> Result<Arc<dyn crate::physical_plan::ExecutionPlan>> {
         if plan.children().is_empty() {
             // leaf node, children cannot be replaced

--- a/datafusion/src/physical_optimizer/optimizer.rs
+++ b/datafusion/src/physical_optimizer/optimizer.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use crate::{
-    error::Result, execution::context::ExecutionConfig, physical_plan::ExecutionPlan,
+    error::Result, execution::context::SessionConfig, physical_plan::ExecutionPlan,
 };
 
 /// `PhysicalOptimizerRule` transforms one ['ExecutionPlan'] into another which
@@ -31,7 +31,7 @@ pub trait PhysicalOptimizerRule {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ExecutionConfig,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     /// A human readable name for this optimizer rule

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use super::optimizer::PhysicalOptimizerRule;
 use crate::physical_plan::Partitioning::*;
 use crate::physical_plan::{repartition::RepartitionExec, ExecutionPlan};
-use crate::{error::Result, execution::context::ExecutionConfig};
+use crate::{error::Result, execution::context::SessionConfig};
 
 /// Optimizer that introduces repartition to introduce more
 /// parallelism in the plan
@@ -218,7 +218,7 @@ impl PhysicalOptimizerRule for Repartition {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ExecutionConfig,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Don't run optimizer if target_partitions == 1
         if config.target_partitions == 1 {
@@ -343,7 +343,7 @@ mod tests {
             // run optimizer
             let optimizer = Repartition {};
             let optimized = optimizer
-                .optimize($PLAN, &ExecutionConfig::new().with_target_partitions(10))?;
+                .optimize($PLAN, &SessionConfig::new().with_target_partitions(10))?;
 
             // Now format correctly
             let plan = displayable(optimized.as_ref()).indent().to_string();

--- a/datafusion/src/physical_optimizer/utils.rs
+++ b/datafusion/src/physical_optimizer/utils.rs
@@ -18,7 +18,7 @@
 //! Collection of utility functions that are leveraged by the query optimizer rules
 
 use super::optimizer::PhysicalOptimizerRule;
-use crate::execution::context::ExecutionConfig;
+use crate::execution::context::SessionConfig;
 
 use crate::error::Result;
 use crate::physical_plan::ExecutionPlan;
@@ -31,12 +31,12 @@ use std::sync::Arc;
 pub fn optimize_children(
     optimizer: &impl PhysicalOptimizerRule,
     plan: Arc<dyn ExecutionPlan>,
-    execution_config: &ExecutionConfig,
+    session_config: &SessionConfig,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let children = plan
         .children()
         .iter()
-        .map(|child| optimizer.optimize(Arc::clone(child), execution_config))
+        .map(|child| optimizer.optimize(Arc::clone(child), session_config))
         .collect::<Result<Vec<_>>>()?;
 
     if children.is_empty() {

--- a/datafusion/src/physical_plan/coalesce_batches.rs
+++ b/datafusion/src/physical_plan/coalesce_batches.rs
@@ -29,7 +29,7 @@ use crate::physical_plan::{
     SendableRecordBatchStream,
 };
 
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use arrow::compute::kernels::concat::concat;
 use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
@@ -124,10 +124,10 @@ impl ExecutionPlan for CoalesceBatchesExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(CoalesceBatchesStream {
-            input: self.input.execute(partition, runtime).await?,
+            input: self.input.execute(partition, context).await?,
             schema: self.input.schema(),
             target_batch_size: self.target_batch_size,
             buffer: Vec::new(),
@@ -305,6 +305,7 @@ pub fn concat_batches(
 mod tests {
     use super::*;
     use crate::physical_plan::{memory::MemoryExec, repartition::RepartitionExec};
+    use crate::prelude::SessionContext;
     use crate::test::create_vec_batches;
     use arrow::datatypes::{DataType, Field, Schema};
 
@@ -348,10 +349,11 @@ mod tests {
         // execute and collect results
         let output_partition_count = exec.output_partitioning().partition_count();
         let mut output_partitions = Vec::with_capacity(output_partition_count);
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
         for i in 0..output_partition_count {
             // execute this *output* partition and collect all batches
-            let mut stream = exec.execute(i, runtime.clone()).await?;
+            let task_ctx = session_ctx.task_ctx();
+            let mut stream = exec.execute(i, task_ctx.clone()).await?;
             let mut batches = vec![];
             while let Some(result) = stream.next().await {
                 batches.push(result?);

--- a/datafusion/src/physical_plan/common.rs
+++ b/datafusion/src/physical_plan/common.rs
@@ -19,7 +19,7 @@
 
 use super::{RecordBatchStream, SendableRecordBatchStream};
 use crate::error::{DataFusionError, Result};
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use crate::physical_plan::metrics::MemTrackingMetrics;
 use crate::physical_plan::{ColumnStatistics, ExecutionPlan, Statistics};
 use arrow::compute::concat;
@@ -176,10 +176,10 @@ pub(crate) fn spawn_execution(
     input: Arc<dyn ExecutionPlan>,
     mut output: mpsc::Sender<ArrowResult<RecordBatch>>,
     partition: usize,
-    runtime: Arc<RuntimeEnv>,
+    context: Arc<TaskContext>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let mut stream = match input.execute(partition, runtime).await {
+        let mut stream = match input.execute(partition, context).await {
             Err(e) => {
                 // If send fails, plan being torn
                 // down, no place to send the error

--- a/datafusion/src/physical_plan/explain.rs
+++ b/datafusion/src/physical_plan/explain.rs
@@ -31,7 +31,7 @@ use crate::{
 use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
 
 use super::{expressions::PhysicalSortExpr, SendableRecordBatchStream};
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 use async_trait::async_trait;
 
@@ -114,7 +114,7 @@ impl ExecutionPlan for ExplainExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         if 0 != partition {
             return Err(DataFusionError::Internal(format!(

--- a/datafusion/src/physical_plan/file_format/avro.rs
+++ b/datafusion/src/physical_plan/file_format/avro.rs
@@ -27,7 +27,7 @@ use arrow::datatypes::SchemaRef;
 #[cfg(feature = "avro")]
 use arrow::error::ArrowError;
 
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use async_trait::async_trait;
 use std::any::Any;
 use std::sync::Arc;
@@ -105,7 +105,7 @@ impl ExecutionPlan for AvroExec {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Err(DataFusionError::NotImplemented(
             "Cannot execute avro plan without avro feature enabled".to_string(),
@@ -116,11 +116,11 @@ impl ExecutionPlan for AvroExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let proj = self.base_config.projected_file_column_names();
 
-        let batch_size = runtime.batch_size();
+        let batch_size = context.runtime.batch_size();
         let file_schema = Arc::clone(&self.base_config.file_schema);
 
         // The avro reader cannot limit the number of records, so `remaining` is ignored.

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -27,7 +27,7 @@ use std::{any::Any, convert::TryInto};
 use crate::datasource::file_format::parquet::ChunkObjectReader;
 use crate::datasource::object_store::ObjectStore;
 use crate::datasource::PartitionedFile;
-use crate::execution::context::ExecutionContext;
+use crate::execution::context::{SessionContext, TaskContext};
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::{
     error::{DataFusionError, Result},
@@ -68,7 +68,6 @@ use tokio::{
     task,
 };
 
-use crate::execution::runtime_env::RuntimeEnv;
 use crate::physical_plan::file_format::SchemaAdapter;
 use async_trait::async_trait;
 
@@ -210,7 +209,7 @@ impl ExecutionPlan for ParquetExec {
     async fn execute(
         &self,
         partition_index: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // because the parquet implementation is not thread-safe, it is necessary to execute
         // on a thread and communicate with channels
@@ -226,7 +225,7 @@ impl ExecutionPlan for ParquetExec {
             None => (0..self.base_config.file_schema.fields().len()).collect(),
         };
         let pruning_predicate = self.pruning_predicate.clone();
-        let batch_size = runtime.batch_size();
+        let batch_size = context.runtime.batch_size();
         let limit = self.base_config.limit;
         let object_store = Arc::clone(&self.base_config.object_store);
         let partition_col_proj = PartitionColumnProjector::new(
@@ -528,7 +527,7 @@ fn read_partition(
 
 /// Executes a query and writes the results to a partitioned Parquet file.
 pub async fn plan_to_parquet(
-    context: &ExecutionContext,
+    context: &SessionContext,
     plan: Arc<dyn ExecutionPlan>,
     path: impl AsRef<str>,
     writer_properties: Option<WriterProperties>,
@@ -536,7 +535,6 @@ pub async fn plan_to_parquet(
     let path = path.as_ref();
     // create directory to contain the Parquet files (one per partition)
     let fs_path = Path::new(path);
-    let runtime = context.runtime_env();
     match fs::create_dir(fs_path) {
         Ok(()) => {
             let mut tasks = vec![];
@@ -550,7 +548,8 @@ pub async fn plan_to_parquet(
                     plan.schema(),
                     writer_properties.clone(),
                 )?;
-                let stream = plan.execute(i, runtime.clone()).await?;
+                let task_ctx = context.task_ctx();
+                let stream = plan.execute(i, task_ctx).await?;
                 let handle: JoinHandle<Result<()>> = task::spawn(async move {
                     stream
                         .map(|batch| writer.write(&batch?))
@@ -589,7 +588,7 @@ mod tests {
 
     use super::*;
     use crate::execution::options::CsvReadOptions;
-    use crate::prelude::ExecutionConfig;
+    use crate::prelude::SessionConfig;
     use arrow::array::Float32Array;
     use arrow::{
         array::{Int64Array, Int8Array, StringArray},
@@ -669,8 +668,9 @@ mod tests {
             None,
         );
 
-        let runtime = Arc::new(RuntimeEnv::default());
-        collect(Arc::new(parquet_exec), runtime).await
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        collect(Arc::new(parquet_exec), task_ctx).await
     }
 
     // Add a new column with the specified field name to the RecordBatch
@@ -887,7 +887,8 @@ mod tests {
 
     #[tokio::test]
     async fn parquet_exec_with_projection() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let testdata = crate::test_util::parquet_test_data();
         let filename = format!("{}/alltypes_plain.parquet", testdata);
         let parquet_exec = ParquetExec::new(
@@ -906,7 +907,7 @@ mod tests {
         );
         assert_eq!(parquet_exec.output_partitioning().partition_count(), 1);
 
-        let mut results = parquet_exec.execute(0, runtime).await?;
+        let mut results = parquet_exec.execute(0, task_ctx).await?;
         let batch = results.next().await.unwrap()?;
 
         assert_eq!(8, batch.num_rows());
@@ -931,7 +932,8 @@ mod tests {
 
     #[tokio::test]
     async fn parquet_exec_with_partition() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let testdata = crate::test_util::parquet_test_data();
         let filename = format!("{}/alltypes_plain.parquet", testdata);
         let mut partitioned_file = local_unpartitioned_file(filename.clone());
@@ -961,7 +963,7 @@ mod tests {
         );
         assert_eq!(parquet_exec.output_partitioning().partition_count(), 1);
 
-        let mut results = parquet_exec.execute(0, runtime).await?;
+        let mut results = parquet_exec.execute(0, task_ctx).await?;
         let batch = results.next().await.unwrap()?;
         let expected = vec![
             "+----+----------+-------------+-------+",
@@ -987,7 +989,8 @@ mod tests {
 
     #[tokio::test]
     async fn parquet_exec_with_error() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let testdata = crate::test_util::parquet_test_data();
         let filename = format!("{}/alltypes_plain.parquet", testdata);
         let partitioned_file = PartitionedFile {
@@ -1016,7 +1019,7 @@ mod tests {
             None,
         );
 
-        let mut results = parquet_exec.execute(0, runtime).await?;
+        let mut results = parquet_exec.execute(0, task_ctx).await?;
         let batch = results.next().await.unwrap();
         // invalid file should produce an error to that effect
         assert_contains!(
@@ -1318,9 +1321,8 @@ mod tests {
         // create partitioned input file and context
         let tmp_dir = TempDir::new()?;
         // let mut ctx = create_ctx(&tmp_dir, 4).await?;
-        let mut ctx = ExecutionContext::with_config(
-            ExecutionConfig::new().with_target_partitions(8),
-        );
+        let mut ctx =
+            SessionContext::with_config(SessionConfig::new().with_target_partitions(8));
         let schema = populate_csv_partitions(&tmp_dir, 4, ".csv")?;
         // register csv file with the execution context
         ctx.register_csv(
@@ -1337,7 +1339,7 @@ mod tests {
         // write_parquet(&mut ctx, "SELECT c1, c2 FROM test", &out_dir, None).await?;
 
         // create a new context and verify that the results were saved to a partitioned csv file
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
 
         // register each partition as well as the top level dir
         ctx.register_parquet("part0", &format!("{}/part-0.parquet", out_dir))

--- a/datafusion/src/physical_plan/hash_join.rs
+++ b/datafusion/src/physical_plan/hash_join.rs
@@ -71,7 +71,7 @@ use super::{
 };
 use crate::arrow::array::BooleanBufferBuilder;
 use crate::arrow::datatypes::TimeUnit;
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use crate::physical_plan::coalesce_batches::concat_batches;
 use crate::physical_plan::PhysicalExpr;
 use log::debug;
@@ -290,7 +290,7 @@ impl ExecutionPlan for HashJoinExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let on_left = self.on.iter().map(|on| on.0.clone()).collect::<Vec<_>>();
         // we only want to compute the build side once for PartitionMode::CollectLeft
@@ -306,7 +306,7 @@ impl ExecutionPlan for HashJoinExec {
 
                             // merge all left parts into a single stream
                             let merge = CoalescePartitionsExec::new(self.left.clone());
-                            let stream = merge.execute(0, runtime.clone()).await?;
+                            let stream = merge.execute(0, context.clone()).await?;
 
                             // This operation performs 2 steps at once:
                             // 1. creates a [JoinHashMap] of all batches from the stream
@@ -359,7 +359,7 @@ impl ExecutionPlan for HashJoinExec {
                     let start = Instant::now();
 
                     // Load 1 partition of left side in memory
-                    let stream = self.left.execute(partition, runtime.clone()).await?;
+                    let stream = self.left.execute(partition, context.clone()).await?;
 
                     // This operation performs 2 steps at once:
                     // 1. creates a [JoinHashMap] of all batches from the stream
@@ -410,7 +410,7 @@ impl ExecutionPlan for HashJoinExec {
         // we have the batches and the hash map with their keys. We can how create a stream
         // over the right that uses this information to issue new batches.
 
-        let right_stream = self.right.execute(partition, runtime.clone()).await?;
+        let right_stream = self.right.execute(partition, context.clone()).await?;
         let on_right = self.on.iter().map(|on| on.1.clone()).collect::<Vec<_>>();
 
         let num_rows = left_data.1.num_rows();
@@ -1063,6 +1063,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::prelude::SessionContext;
     use std::sync::Arc;
 
     fn build_table(
@@ -1098,12 +1099,12 @@ mod tests {
         on: JoinOn,
         join_type: &JoinType,
         null_equals_null: bool,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
         let join = join(left, right, on, join_type, null_equals_null)?;
         let columns = columns(&join.schema());
 
-        let stream = join.execute(0, runtime).await?;
+        let stream = join.execute(0, context).await?;
         let batches = common::collect(stream).await?;
 
         Ok((columns, batches))
@@ -1115,7 +1116,7 @@ mod tests {
         on: JoinOn,
         join_type: &JoinType,
         null_equals_null: bool,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
         let partition_count = 4;
 
@@ -1148,7 +1149,7 @@ mod tests {
 
         let mut batches = vec![];
         for i in 0..partition_count {
-            let stream = join.execute(i, runtime.clone()).await?;
+            let stream = join.execute(i, context.clone()).await?;
             let more_batches = common::collect(stream).await?;
             batches.extend(
                 more_batches
@@ -1163,7 +1164,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_inner_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 5]), // this has a repetition
@@ -1186,7 +1188,7 @@ mod tests {
             on.clone(),
             &JoinType::Inner,
             false,
-            runtime,
+            task_ctx,
         )
         .await?;
 
@@ -1208,7 +1210,8 @@ mod tests {
 
     #[tokio::test]
     async fn partitioned_join_inner_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 5]), // this has a repetition
@@ -1230,7 +1233,7 @@ mod tests {
             on.clone(),
             &JoinType::Inner,
             false,
-            runtime,
+            task_ctx,
         )
         .await?;
 
@@ -1252,7 +1255,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_inner_one_no_shared_column_names() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 5]), // this has a repetition
@@ -1269,7 +1273,7 @@ mod tests {
         )];
 
         let (columns, batches) =
-            join_collect(left, right, on, &JoinType::Inner, false, runtime).await?;
+            join_collect(left, right, on, &JoinType::Inner, false, task_ctx).await?;
 
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
@@ -1290,7 +1294,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_inner_two() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 2]),
             ("b2", &vec![1, 2, 2]),
@@ -1313,7 +1318,7 @@ mod tests {
         ];
 
         let (columns, batches) =
-            join_collect(left, right, on, &JoinType::Inner, false, runtime).await?;
+            join_collect(left, right, on, &JoinType::Inner, false, task_ctx).await?;
 
         assert_eq!(columns, vec!["a1", "b2", "c1", "a1", "b2", "c2"]);
 
@@ -1337,7 +1342,8 @@ mod tests {
     /// Test where the left has 2 parts, the right with 1 part => 1 part
     #[tokio::test]
     async fn join_inner_one_two_parts_left() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let batch1 = build_table_i32(
             ("a1", &vec![1, 2]),
             ("b2", &vec![1, 2]),
@@ -1367,7 +1373,7 @@ mod tests {
         ];
 
         let (columns, batches) =
-            join_collect(left, right, on, &JoinType::Inner, false, runtime).await?;
+            join_collect(left, right, on, &JoinType::Inner, false, task_ctx).await?;
 
         assert_eq!(columns, vec!["a1", "b2", "c1", "a1", "b2", "c2"]);
 
@@ -1391,7 +1397,8 @@ mod tests {
     /// Test where the left has 1 part, the right has 2 parts => 2 parts
     #[tokio::test]
     async fn join_inner_one_two_parts_right() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 5]), // this has a repetition
@@ -1421,7 +1428,7 @@ mod tests {
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
 
         // first part
-        let stream = join.execute(0, runtime.clone()).await?;
+        let stream = join.execute(0, task_ctx.clone()).await?;
         let batches = common::collect(stream).await?;
         assert_eq!(batches.len(), 1);
 
@@ -1435,7 +1442,7 @@ mod tests {
         assert_batches_sorted_eq!(expected, &batches);
 
         // second part
-        let stream = join.execute(1, runtime.clone()).await?;
+        let stream = join.execute(1, task_ctx.clone()).await?;
         let batches = common::collect(stream).await?;
         assert_eq!(batches.len(), 1);
         let expected = vec![
@@ -1466,7 +1473,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_left_multi_batch() {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
@@ -1487,7 +1495,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
 
-        let stream = join.execute(0, runtime).await.unwrap();
+        let stream = join.execute(0, task_ctx).await.unwrap();
         let batches = common::collect(stream).await.unwrap();
 
         let expected = vec![
@@ -1507,7 +1515,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_full_multi_batch() {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
@@ -1529,7 +1538,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
-        let stream = join.execute(0, runtime).await.unwrap();
+        let stream = join.execute(0, task_ctx).await.unwrap();
         let batches = common::collect(stream).await.unwrap();
 
         let expected = vec![
@@ -1551,7 +1560,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_left_empty_right() {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]),
@@ -1569,7 +1579,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
 
-        let stream = join.execute(0, runtime).await.unwrap();
+        let stream = join.execute(0, task_ctx).await.unwrap();
         let batches = common::collect(stream).await.unwrap();
 
         let expected = vec![
@@ -1587,7 +1597,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_full_empty_right() {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]),
@@ -1605,7 +1616,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
-        let stream = join.execute(0, runtime).await.unwrap();
+        let stream = join.execute(0, task_ctx).await.unwrap();
         let batches = common::collect(stream).await.unwrap();
 
         let expected = vec![
@@ -1623,7 +1634,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_left_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
@@ -1645,7 +1657,7 @@ mod tests {
             on.clone(),
             &JoinType::Left,
             false,
-            runtime,
+            task_ctx,
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
@@ -1666,7 +1678,8 @@ mod tests {
 
     #[tokio::test]
     async fn partitioned_join_left_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
@@ -1688,7 +1701,7 @@ mod tests {
             on.clone(),
             &JoinType::Left,
             false,
-            runtime,
+            task_ctx,
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
@@ -1709,7 +1722,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_semi() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 2, 3]),
             ("b1", &vec![4, 5, 5, 7]), // 7 does not exist on the right
@@ -1730,7 +1744,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1"]);
 
-        let stream = join.execute(0, runtime).await?;
+        let stream = join.execute(0, task_ctx).await?;
         let batches = common::collect(stream).await?;
 
         let expected = vec![
@@ -1749,7 +1763,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_anti() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 2, 3, 5]),
             ("b1", &vec![4, 5, 5, 7, 7]), // 7 does not exist on the right
@@ -1770,7 +1785,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1"]);
 
-        let stream = join.execute(0, runtime).await?;
+        let stream = join.execute(0, task_ctx).await?;
         let batches = common::collect(stream).await?;
 
         let expected = vec![
@@ -1787,7 +1802,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_right_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]),
@@ -1804,7 +1820,7 @@ mod tests {
         )];
 
         let (columns, batches) =
-            join_collect(left, right, on, &JoinType::Right, false, runtime).await?;
+            join_collect(left, right, on, &JoinType::Right, false, task_ctx).await?;
 
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
 
@@ -1825,7 +1841,8 @@ mod tests {
 
     #[tokio::test]
     async fn partitioned_join_right_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]),
@@ -1842,7 +1859,7 @@ mod tests {
         )];
 
         let (columns, batches) =
-            partitioned_join_collect(left, right, on, &JoinType::Right, false, runtime)
+            partitioned_join_collect(left, right, on, &JoinType::Right, false, task_ctx)
                 .await?;
 
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b1", "c2"]);
@@ -1864,7 +1881,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_full_one() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a1", &vec![1, 2, 3]),
             ("b1", &vec![4, 5, 7]), // 7 does not exist on the right
@@ -1885,7 +1903,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
-        let stream = join.execute(0, runtime).await?;
+        let stream = join.execute(0, task_ctx).await?;
         let batches = common::collect(stream).await?;
 
         let expected = vec![
@@ -1955,7 +1973,8 @@ mod tests {
 
     #[tokio::test]
     async fn join_with_duplicated_column_names() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let left = build_table(
             ("a", &vec![1, 2, 3]),
             ("b", &vec![4, 5, 7]),
@@ -1977,7 +1996,7 @@ mod tests {
         let columns = columns(&join.schema());
         assert_eq!(columns, vec!["a", "b", "c", "a", "b", "c"]);
 
-        let stream = join.execute(0, runtime).await?;
+        let stream = join.execute(0, task_ctx).await?;
         let batches = common::collect(stream).await?;
 
         let expected = vec![

--- a/datafusion/src/physical_plan/limit.rs
+++ b/datafusion/src/physical_plan/limit.rs
@@ -41,7 +41,7 @@ use super::{
     RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use async_trait::async_trait;
 
 /// Limit execution plan
@@ -134,7 +134,7 @@ impl ExecutionPlan for GlobalLimitExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // GlobalLimitExec has a single output partition
         if 0 != partition {
@@ -152,7 +152,7 @@ impl ExecutionPlan for GlobalLimitExec {
         }
 
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
-        let stream = self.input.execute(0, runtime).await?;
+        let stream = self.input.execute(0, context).await?;
         Ok(Box::pin(LimitStream::new(
             stream,
             self.limit,
@@ -285,10 +285,10 @@ impl ExecutionPlan for LocalLimitExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
-        let stream = self.input.execute(partition, runtime).await?;
+        let stream = self.input.execute(partition, context).await?;
         Ok(Box::pin(LimitStream::new(
             stream,
             self.limit,
@@ -432,11 +432,13 @@ mod tests {
     use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use crate::physical_plan::common;
     use crate::physical_plan::file_format::{CsvExec, FileScanConfig};
+    use crate::prelude::SessionContext;
     use crate::{test, test_util};
 
     #[tokio::test]
     async fn limit() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let schema = test_util::aggr_test_schema();
 
         let num_partitions = 4;
@@ -464,7 +466,7 @@ mod tests {
             GlobalLimitExec::new(Arc::new(CoalescePartitionsExec::new(Arc::new(csv))), 7);
 
         // the result should contain 4 batches (one per input partition)
-        let iter = limit.execute(0, runtime).await?;
+        let iter = limit.execute(0, task_ctx).await?;
         let batches = common::collect(iter).await?;
 
         // there should be a total of 100 rows

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -22,7 +22,7 @@ use super::{
     aggregates, empty::EmptyExec, expressions::binary, functions,
     hash_join::PartitionMode, udaf, union::UnionExec, values::ValuesExec, windows,
 };
-use crate::execution::context::{ExecutionContextState, ExecutionProps};
+use crate::execution::context::{ExecutionProps, SessionState};
 use crate::logical_plan::plan::{
     Aggregate, EmptyRelation, Filter, Join, Projection, Sort, TableScan, Window,
 };
@@ -217,7 +217,7 @@ pub trait PhysicalPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     /// Create a physical expression from a logical expression
@@ -233,7 +233,7 @@ pub trait PhysicalPlanner {
         expr: &Expr,
         input_dfschema: &DFSchema,
         input_schema: &Schema,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Arc<dyn PhysicalExpr>>;
 }
 
@@ -255,7 +255,7 @@ pub trait ExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>>;
 }
 
@@ -272,13 +272,15 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        match self.handle_explain(logical_plan, ctx_state).await? {
+        match self.handle_explain(logical_plan, session_state).await? {
             Some(plan) => Ok(plan),
             None => {
-                let plan = self.create_initial_plan(logical_plan, ctx_state).await?;
-                self.optimize_internal(plan, ctx_state, |_, _| {})
+                let plan = self
+                    .create_initial_plan(logical_plan, session_state)
+                    .await?;
+                self.optimize_internal(plan, session_state, |_, _| {})
             }
         }
     }
@@ -296,13 +298,13 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
         expr: &Expr,
         input_dfschema: &DFSchema,
         input_schema: &Schema,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         create_physical_expr(
             expr,
             input_dfschema,
             input_schema,
-            &ctx_state.execution_props,
+            &session_state.execution_props,
         )
     }
 }
@@ -322,7 +324,7 @@ impl DefaultPhysicalPlanner {
     fn create_initial_plan<'a>(
         &'a self,
         logical_plan: &'a LogicalPlan,
-        ctx_state: &'a ExecutionContextState,
+        session_state: &'a SessionState,
     ) -> BoxFuture<'a, Result<Arc<dyn ExecutionPlan>>> {
         async move {
             let exec_plan: Result<Arc<dyn ExecutionPlan>> = match logical_plan {
@@ -352,7 +354,7 @@ impl DefaultPhysicalPlanner {
                                     expr,
                                     schema,
                                     &exec_schema,
-                                    ctx_state,
+                                    session_state,
                                 )
                             })
                             .collect::<Result<Vec<Arc<dyn PhysicalExpr>>>>()
@@ -373,15 +375,15 @@ impl DefaultPhysicalPlanner {
                         ));
                     }
 
-                    let input_exec = self.create_initial_plan(input, ctx_state).await?;
+                    let input_exec = self.create_initial_plan(input, session_state).await?;
 
                     // at this moment we are guaranteed by the logical planner
                     // to have all the window_expr to have equal sort key
                     let partition_keys = window_expr_common_partition_keys(window_expr)?;
 
                     let can_repartition = !partition_keys.is_empty()
-                        && ctx_state.config.target_partitions > 1
-                        && ctx_state.config.repartition_windows;
+                        && session_state.config.target_partitions > 1
+                        && session_state.config.repartition_windows;
 
                     let input_exec = if can_repartition {
                         let partition_keys = partition_keys
@@ -391,7 +393,7 @@ impl DefaultPhysicalPlanner {
                                     e,
                                     input.schema(),
                                     &input_exec.schema(),
-                                    ctx_state,
+                                    session_state,
                                 )
                             })
                             .collect::<Result<Vec<Arc<dyn PhysicalExpr>>>>()?;
@@ -399,7 +401,7 @@ impl DefaultPhysicalPlanner {
                             input_exec,
                             Partitioning::Hash(
                                 partition_keys,
-                                ctx_state.config.target_partitions,
+                                session_state.config.target_partitions,
                             ),
                         )?)
                     } else {
@@ -446,7 +448,7 @@ impl DefaultPhysicalPlanner {
                                         descending: !*asc,
                                         nulls_first: *nulls_first,
                                     },
-                                    &ctx_state.execution_props,
+                                    &session_state.execution_props,
                                 ),
                                 _ => unreachable!(),
                             })
@@ -466,7 +468,7 @@ impl DefaultPhysicalPlanner {
                                 e,
                                 logical_input_schema,
                                 &physical_input_schema,
-                                &ctx_state.execution_props,
+                                &session_state.execution_props,
                             )
                         })
                         .collect::<Result<Vec<_>>>()?;
@@ -484,7 +486,7 @@ impl DefaultPhysicalPlanner {
                     ..
                 }) => {
                     // Initially need to perform the aggregate and then merge the partitions
-                    let input_exec = self.create_initial_plan(input, ctx_state).await?;
+                    let input_exec = self.create_initial_plan(input, session_state).await?;
                     let physical_input_schema = input_exec.schema();
                     let logical_input_schema = input.as_ref().schema();
 
@@ -496,7 +498,7 @@ impl DefaultPhysicalPlanner {
                                     e,
                                     logical_input_schema,
                                     &physical_input_schema,
-                                    ctx_state,
+                                    session_state,
                                 ),
                                 physical_name(e),
                             ))
@@ -509,7 +511,7 @@ impl DefaultPhysicalPlanner {
                                 e,
                                 logical_input_schema,
                                 &physical_input_schema,
-                                &ctx_state.execution_props,
+                                &session_state.execution_props,
                             )
                         })
                         .collect::<Result<Vec<_>>>()?;
@@ -532,8 +534,8 @@ impl DefaultPhysicalPlanner {
                         .any(|x| matches!(x, DataType::Dictionary(_, _)));
 
                     let can_repartition = !groups.is_empty()
-                        && ctx_state.config.target_partitions > 1
-                        && ctx_state.config.repartition_aggregations
+                        && session_state.config.target_partitions > 1
+                        && session_state.config.repartition_aggregations
                         && !contains_dict;
 
                     let (initial_aggr, next_partition_mode): (
@@ -545,7 +547,7 @@ impl DefaultPhysicalPlanner {
                             initial_aggr,
                             Partitioning::Hash(
                                 final_group.clone(),
-                                ctx_state.config.target_partitions,
+                                session_state.config.target_partitions,
                             ),
                         )?);
                         // Combine hash aggregates within the partition
@@ -569,7 +571,7 @@ impl DefaultPhysicalPlanner {
                     )?) )
                 }
                 LogicalPlan::Projection(Projection { input, expr, .. }) => {
-                    let input_exec = self.create_initial_plan(input, ctx_state).await?;
+                    let input_exec = self.create_initial_plan(input, session_state).await?;
                     let input_schema = input.as_ref().schema();
 
                     let physical_exprs = expr
@@ -608,7 +610,7 @@ impl DefaultPhysicalPlanner {
                                     e,
                                     input_schema,
                                     &input_exec.schema(),
-                                    ctx_state,
+                                    session_state,
                                 ),
                                 physical_name,
                             ))
@@ -623,7 +625,7 @@ impl DefaultPhysicalPlanner {
                 LogicalPlan::Filter(Filter {
                     input, predicate, ..
                 }) => {
-                    let physical_input = self.create_initial_plan(input, ctx_state).await?;
+                    let physical_input = self.create_initial_plan(input, session_state).await?;
                     let input_schema = physical_input.as_ref().schema();
                     let input_dfschema = input.as_ref().schema();
 
@@ -631,13 +633,13 @@ impl DefaultPhysicalPlanner {
                         predicate,
                         input_dfschema,
                         &input_schema,
-                        ctx_state,
+                        session_state,
                     )?;
                     Ok(Arc::new(FilterExec::try_new(runtime_expr, physical_input)?) )
                 }
                 LogicalPlan::Union(Union { inputs, .. }) => {
                     let physical_plans = futures::stream::iter(inputs)
-                        .then(|lp| self.create_initial_plan(lp, ctx_state))
+                        .then(|lp| self.create_initial_plan(lp, session_state))
                         .try_collect::<Vec<_>>()
                         .await?;
                     Ok(Arc::new(UnionExec::new(physical_plans)) )
@@ -646,7 +648,7 @@ impl DefaultPhysicalPlanner {
                     input,
                     partitioning_scheme,
                 }) => {
-                    let physical_input = self.create_initial_plan(input, ctx_state).await?;
+                    let physical_input = self.create_initial_plan(input, session_state).await?;
                     let input_schema = physical_input.schema();
                     let input_dfschema = input.as_ref().schema();
                     let physical_partitioning = match partitioning_scheme {
@@ -661,7 +663,7 @@ impl DefaultPhysicalPlanner {
                                         e,
                                         input_dfschema,
                                         &input_schema,
-                                        ctx_state,
+                                        session_state,
                                     )
                                 })
                                 .collect::<Result<Vec<_>>>()?;
@@ -674,7 +676,7 @@ impl DefaultPhysicalPlanner {
                     )?) )
                 }
                 LogicalPlan::Sort(Sort { expr, input, .. }) => {
-                    let physical_input = self.create_initial_plan(input, ctx_state).await?;
+                    let physical_input = self.create_initial_plan(input, session_state).await?;
                     let input_schema = physical_input.as_ref().schema();
                     let input_dfschema = input.as_ref().schema();
                     let sort_expr = expr
@@ -692,7 +694,7 @@ impl DefaultPhysicalPlanner {
                                     descending: !*asc,
                                     nulls_first: *nulls_first,
                                 },
-                                &ctx_state.execution_props,
+                                &session_state.execution_props,
                             ),
                             _ => Err(DataFusionError::Plan(
                                 "Sort only accepts sort expressions".to_string(),
@@ -710,9 +712,9 @@ impl DefaultPhysicalPlanner {
                     ..
                 }) => {
                     let left_df_schema = left.schema();
-                    let physical_left = self.create_initial_plan(left, ctx_state).await?;
+                    let physical_left = self.create_initial_plan(left, session_state).await?;
                     let right_df_schema = right.schema();
-                    let physical_right = self.create_initial_plan(right, ctx_state).await?;
+                    let physical_right = self.create_initial_plan(right, session_state).await?;
                     let join_on = keys
                         .iter()
                         .map(|(l, r)| {
@@ -723,8 +725,8 @@ impl DefaultPhysicalPlanner {
                         })
                         .collect::<Result<join_utils::JoinOn>>()?;
 
-                    if ctx_state.config.target_partitions > 1
-                        && ctx_state.config.repartition_joins
+                    if session_state.config.target_partitions > 1
+                        && session_state.config.repartition_joins
                     {
                         let (left_expr, right_expr) = join_on
                             .iter()
@@ -742,14 +744,14 @@ impl DefaultPhysicalPlanner {
                                 physical_left,
                                 Partitioning::Hash(
                                     left_expr,
-                                    ctx_state.config.target_partitions,
+                                    session_state.config.target_partitions,
                                 ),
                             )?),
                             Arc::new(RepartitionExec::try_new(
                                 physical_right,
                                 Partitioning::Hash(
                                     right_expr,
-                                    ctx_state.config.target_partitions,
+                                    session_state.config.target_partitions,
                                 ),
                             )?),
                             join_on,
@@ -769,8 +771,8 @@ impl DefaultPhysicalPlanner {
                     }
                 }
                 LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
-                    let left = self.create_initial_plan(left, ctx_state).await?;
-                    let right = self.create_initial_plan(right, ctx_state).await?;
+                    let left = self.create_initial_plan(left, session_state).await?;
+                    let right = self.create_initial_plan(right, session_state).await?;
                     Ok(Arc::new(CrossJoinExec::try_new(left, right)?))
                 }
                 LogicalPlan::EmptyRelation(EmptyRelation {
@@ -782,7 +784,7 @@ impl DefaultPhysicalPlanner {
                 ))),
                 LogicalPlan::Limit(Limit { input, n, .. }) => {
                     let limit = *n;
-                    let input = self.create_initial_plan(input, ctx_state).await?;
+                    let input = self.create_initial_plan(input, session_state).await?;
 
                     // GlobalLimitExec requires a single partition for input
                     let input = if input.output_partitioning().partition_count() == 1 {
@@ -815,13 +817,13 @@ impl DefaultPhysicalPlanner {
                     "Unsupported logical plan: Explain must be root of the plan".to_string(),
                 )),
                 LogicalPlan::Analyze(a) => {
-                    let input = self.create_initial_plan(&a.input, ctx_state).await?;
+                    let input = self.create_initial_plan(&a.input, session_state).await?;
                     let schema = SchemaRef::new((*a.schema).clone().into());
                     Ok(Arc::new(AnalyzeExec::new(a.verbose, input, schema)))
                 }
                 LogicalPlan::Extension(e) => {
                     let physical_inputs = futures::stream::iter(e.node.inputs())
-                        .then(|lp| self.create_initial_plan(lp, ctx_state))
+                        .then(|lp| self.create_initial_plan(lp, session_state))
                         .try_collect::<Vec<_>>()
                         .await?;
 
@@ -836,7 +838,7 @@ impl DefaultPhysicalPlanner {
                                     e.node.as_ref(),
                                     &e.node.inputs(),
                                     &physical_inputs,
-                                    ctx_state,
+                                    session_state,
                                 )
                             }
                         },
@@ -1351,7 +1353,7 @@ impl DefaultPhysicalPlanner {
     async fn handle_explain(
         &self,
         logical_plan: &LogicalPlan,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         if let LogicalPlan::Explain(e) = logical_plan {
             use PlanType::*;
@@ -1359,16 +1361,19 @@ impl DefaultPhysicalPlanner {
 
             stringified_plans.push(e.plan.to_stringified(FinalLogicalPlan));
 
-            let input = self.create_initial_plan(e.plan.as_ref(), ctx_state).await?;
+            let input = self
+                .create_initial_plan(e.plan.as_ref(), session_state)
+                .await?;
 
             stringified_plans
                 .push(displayable(input.as_ref()).to_stringified(InitialPhysicalPlan));
 
-            let input = self.optimize_internal(input, ctx_state, |plan, optimizer| {
-                let optimizer_name = optimizer.name().to_string();
-                let plan_type = OptimizedPhysicalPlan { optimizer_name };
-                stringified_plans.push(displayable(plan).to_stringified(plan_type));
-            })?;
+            let input =
+                self.optimize_internal(input, session_state, |plan, optimizer| {
+                    let optimizer_name = optimizer.name().to_string();
+                    let plan_type = OptimizedPhysicalPlan { optimizer_name };
+                    stringified_plans.push(displayable(plan).to_stringified(plan_type));
+                })?;
 
             stringified_plans
                 .push(displayable(input.as_ref()).to_stringified(FinalPhysicalPlan));
@@ -1388,13 +1393,13 @@ impl DefaultPhysicalPlanner {
     fn optimize_internal<F>(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        ctx_state: &ExecutionContextState,
+        session_state: &SessionState,
         mut observer: F,
     ) -> Result<Arc<dyn ExecutionPlan>>
     where
         F: FnMut(&dyn ExecutionPlan, &dyn PhysicalOptimizerRule),
     {
-        let optimizers = &ctx_state.config.physical_optimizers;
+        let optimizers = &session_state.config.physical_optimizers;
         debug!(
             "Input physical plan:\n{}\n",
             displayable(plan.as_ref()).indent()
@@ -1403,7 +1408,7 @@ impl DefaultPhysicalPlanner {
 
         let mut new_plan = plan;
         for optimizer in optimizers {
-            new_plan = optimizer.optimize(new_plan, &ctx_state.config)?;
+            new_plan = optimizer.optimize(new_plan, &session_state.config)?;
             observer(new_plan.as_ref(), optimizer.as_ref())
         }
         debug!(
@@ -1428,8 +1433,8 @@ fn tuple_err<T, R>(value: (Result<T>, Result<R>)) -> Result<(T, R)> {
 mod tests {
     use super::*;
     use crate::datasource::object_store::local::LocalFileSystem;
+    use crate::execution::context::TaskContext;
     use crate::execution::options::CsvReadOptions;
-    use crate::execution::runtime_env::RuntimeEnv;
     use crate::logical_plan::plan::Extension;
     use crate::physical_plan::{
         expressions, DisplayFormatType, Partitioning, Statistics,
@@ -1448,15 +1453,17 @@ mod tests {
     use std::convert::TryFrom;
     use std::{any::Any, fmt};
 
-    fn make_ctx_state() -> ExecutionContextState {
-        ExecutionContextState::new()
+    fn make_session_state() -> SessionState {
+        SessionState::new()
     }
 
     async fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut ctx_state = make_ctx_state();
-        ctx_state.config.target_partitions = 4;
+        let mut session_state = make_session_state();
+        session_state.config.target_partitions = 4;
         let planner = DefaultPhysicalPlanner::default();
-        planner.create_physical_plan(logical_plan, &ctx_state).await
+        planner
+            .create_physical_plan(logical_plan, &session_state)
+            .await
     }
 
     #[tokio::test]
@@ -1502,7 +1509,7 @@ mod tests {
             &col("a").not(),
             &dfschema,
             &schema,
-            &make_ctx_state(),
+            &make_session_state(),
         )?;
         let expected = expressions::not(expressions::col("a", &schema)?, &schema)?;
 
@@ -1581,13 +1588,13 @@ mod tests {
 
     #[tokio::test]
     async fn default_extension_planner() {
-        let ctx_state = make_ctx_state();
+        let session_state = make_session_state();
         let planner = DefaultPhysicalPlanner::default();
         let logical_plan = LogicalPlan::Extension(Extension {
             node: Arc::new(NoOpExtensionNode::default()),
         });
         let plan = planner
-            .create_physical_plan(&logical_plan, &ctx_state)
+            .create_physical_plan(&logical_plan, &session_state)
             .await;
 
         let expected_error =
@@ -1607,7 +1614,7 @@ mod tests {
     async fn bad_extension_planner() {
         // Test that creating an execution plan whose schema doesn't
         // match the logical plan's schema generates an error.
-        let ctx_state = make_ctx_state();
+        let session_state = make_session_state();
         let planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
             BadExtensionPlanner {},
         )]);
@@ -1616,7 +1623,7 @@ mod tests {
             node: Arc::new(NoOpExtensionNode::default()),
         });
         let plan = planner
-            .create_physical_plan(&logical_plan, &ctx_state)
+            .create_physical_plan(&logical_plan, &session_state)
             .await;
 
         let expected_error: &str = "Error during planning: \
@@ -1905,7 +1912,7 @@ mod tests {
         async fn execute(
             &self,
             _partition: usize,
-            _runtime: Arc<RuntimeEnv>,
+            _context: Arc<TaskContext>,
         ) -> Result<SendableRecordBatchStream> {
             unimplemented!("NoOpExecutionPlan::execute");
         }
@@ -1939,7 +1946,7 @@ mod tests {
             _node: &dyn UserDefinedLogicalNode,
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],
-            _ctx_state: &ExecutionContextState,
+            _session_state: &SessionState,
         ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
             Ok(Some(Arc::new(NoOpExecutionPlan {
                 schema: SchemaRef::new(Schema::new(vec![Field::new(

--- a/datafusion/src/physical_plan/projection.rs
+++ b/datafusion/src/physical_plan/projection.rs
@@ -37,7 +37,7 @@ use arrow::record_batch::RecordBatch;
 use super::expressions::{Column, PhysicalSortExpr};
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use super::{RecordBatchStream, SendableRecordBatchStream, Statistics};
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use async_trait::async_trait;
 use futures::stream::Stream;
 use futures::stream::StreamExt;
@@ -153,12 +153,12 @@ impl ExecutionPlan for ProjectionExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(ProjectionStream {
             schema: self.schema.clone(),
             expr: self.expr.iter().map(|x| x.0.clone()).collect(),
-            input: self.input.execute(partition, runtime).await?,
+            input: self.input.execute(partition, context).await?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
         }))
     }
@@ -303,6 +303,7 @@ mod tests {
     use crate::datasource::object_store::local::LocalFileSystem;
     use crate::physical_plan::expressions::{self, col};
     use crate::physical_plan::file_format::{CsvExec, FileScanConfig};
+    use crate::prelude::SessionContext;
     use crate::scalar::ScalarValue;
     use crate::test::{self};
     use crate::test_util;
@@ -310,7 +311,8 @@ mod tests {
 
     #[tokio::test]
     async fn project_first_column() -> Result<()> {
-        let runtime = Arc::new(RuntimeEnv::default());
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
         let schema = test_util::aggr_test_schema();
 
         let partitions = 4;
@@ -346,7 +348,7 @@ mod tests {
         let mut row_count = 0;
         for partition in 0..projection.output_partitioning().partition_count() {
             partition_count += 1;
-            let stream = projection.execute(partition, runtime.clone()).await?;
+            let stream = projection.execute(partition, task_ctx.clone()).await?;
 
             row_count += stream
                 .map(|batch| {

--- a/datafusion/src/physical_plan/values.rs
+++ b/datafusion/src/physical_plan/values.rs
@@ -20,7 +20,7 @@
 use super::expressions::PhysicalSortExpr;
 use super::{common, SendableRecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use crate::physical_plan::{
     memory::MemoryStream, ColumnarValue, DisplayFormatType, Distribution, ExecutionPlan,
     Partitioning, PhysicalExpr,
@@ -146,7 +146,7 @@ impl ExecutionPlan for ValuesExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // GlobalLimitExec has a single output partition
         if 0 != partition {

--- a/datafusion/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/src/physical_plan/windows/window_agg_exec.rs
@@ -18,7 +18,7 @@
 //! Stream and channel implementations for window function expressions.
 
 use crate::error::{DataFusionError, Result};
-use crate::execution::runtime_env::RuntimeEnv;
+use crate::execution::context::TaskContext;
 use crate::physical_plan::common::AbortOnDropSingle;
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{
@@ -158,9 +158,9 @@ impl ExecutionPlan for WindowAggExec {
     async fn execute(
         &self,
         partition: usize,
-        runtime: Arc<RuntimeEnv>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let input = self.input.execute(partition, runtime).await?;
+        let input = self.input.execute(partition, context).await?;
         let stream = Box::pin(WindowAggStream::new(
             self.schema.clone(),
             self.window_expr.clone(),

--- a/datafusion/src/prelude.rs
+++ b/datafusion/src/prelude.rs
@@ -26,7 +26,7 @@
 //! ```
 
 pub use crate::dataframe::DataFrame;
-pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
+pub use crate::execution::context::{SessionConfig, SessionContext};
 pub use crate::execution::options::AvroReadOptions;
 pub use crate::execution::options::{CsvReadOptions, NdJsonReadOptions};
 pub use crate::logical_plan::{

--- a/datafusion/src/test/exec.rs
+++ b/datafusion/src/test/exec.rs
@@ -33,6 +33,8 @@ use arrow::{
 };
 use futures::Stream;
 
+use crate::execution::context::TaskContext;
+use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::{
     common, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -40,9 +42,6 @@ use crate::physical_plan::{
 use crate::{
     error::{DataFusionError, Result},
     physical_plan::stream::RecordBatchReceiverStream,
-};
-use crate::{
-    execution::runtime_env::RuntimeEnv, physical_plan::expressions::PhysicalSortExpr,
 };
 
 /// Index into the data that has been returned so far
@@ -172,7 +171,7 @@ impl ExecutionPlan for MockExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(partition, 0);
 
@@ -311,7 +310,7 @@ impl ExecutionPlan for BarrierExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert!(partition < self.data.len());
 
@@ -412,7 +411,7 @@ impl ExecutionPlan for ErrorExec {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Err(DataFusionError::Internal(format!(
             "ErrorExec, unsurprisingly, errored in partition {}",
@@ -497,7 +496,7 @@ impl ExecutionPlan for StatisticsExec {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         unimplemented!("This plan only serves for testing statistics")
     }
@@ -595,7 +594,7 @@ impl ExecutionPlan for BlockingExec {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(BlockingStream {
             schema: Arc::clone(&self.schema),

--- a/datafusion/tests/dataframe.rs
+++ b/datafusion/tests/dataframe.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use datafusion::assert_batches_eq;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 use datafusion::logical_plan::{col, Expr};
 use datafusion::{datasource::MemTable, prelude::JoinType};
 use datafusion_expr::lit;
@@ -58,7 +58,7 @@ async fn join() -> Result<()> {
         ],
     )?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let table1 = MemTable::try_new(schema1, vec![vec![batch1]])?;
     let table2 = MemTable::try_new(schema2, vec![vec![batch2]])?;
@@ -96,7 +96,7 @@ async fn sort_on_unprojected_columns() -> Result<()> {
     )
     .unwrap();
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]]).unwrap();
     ctx.register_table("t", Arc::new(provider)).unwrap();
 
@@ -132,7 +132,7 @@ async fn filter_with_alias_overwrite() -> Result<()> {
     )
     .unwrap();
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]]).unwrap();
     ctx.register_table("t", Arc::new(provider)).unwrap();
 

--- a/datafusion/tests/dataframe_functions.rs
+++ b/datafusion/tests/dataframe_functions.rs
@@ -31,7 +31,7 @@ use datafusion::error::Result;
 // use datafusion::logical_plan::Expr;
 use datafusion::prelude::*;
 
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::SessionContext;
 
 use datafusion::assert_batches_eq;
 
@@ -55,7 +55,7 @@ fn create_test_table() -> Result<Arc<DataFrame>> {
         ],
     )?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let table = MemTable::try_new(schema, vec![vec![batch]])?;
 

--- a/datafusion/tests/merge_fuzz.rs
+++ b/datafusion/tests/merge_fuzz.rs
@@ -23,15 +23,13 @@ use arrow::{
     compute::SortOptions,
     record_batch::RecordBatch,
 };
-use datafusion::{
-    execution::runtime_env::{RuntimeConfig, RuntimeEnv},
-    physical_plan::{
-        collect,
-        expressions::{col, PhysicalSortExpr},
-        memory::MemoryExec,
-        sorts::sort_preserving_merge::SortPreservingMergeExec,
-    },
+use datafusion::physical_plan::{
+    collect,
+    expressions::{col, PhysicalSortExpr},
+    memory::MemoryExec,
+    sorts::sort_preserving_merge::SortPreservingMergeExec,
 };
+use datafusion::prelude::{SessionConfig, SessionContext};
 use fuzz_utils::{add_empty_batches, batches_to_vec, partitions_to_sorted_vec};
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
@@ -120,10 +118,10 @@ async fn run_merge_test(input: Vec<Vec<RecordBatch>>) {
         let exec = MemoryExec::try_new(&input, schema, None).unwrap();
         let merge = Arc::new(SortPreservingMergeExec::new(sort, Arc::new(exec)));
 
-        let runtime_config = RuntimeConfig::new().with_batch_size(batch_size);
-
-        let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
-        let collected = collect(merge, runtime).await.unwrap();
+        let session_config = SessionConfig::new().with_batch_size(batch_size);
+        let ctx = SessionContext::with_config(session_config);
+        let task_ctx = ctx.task_ctx();
+        let collected = collect(merge, task_ctx).await.unwrap();
 
         // verify the output batch size: all batches except the last
         // should contain `batch_size` rows

--- a/datafusion/tests/path_partition.rs
+++ b/datafusion/tests/path_partition.rs
@@ -32,14 +32,14 @@ use datafusion::{
     },
     error::{DataFusionError, Result},
     physical_plan::ColumnStatistics,
-    prelude::ExecutionContext,
+    prelude::SessionContext,
     test_util::{self, arrow_test_data, parquet_test_data},
 };
 use futures::{stream, StreamExt};
 
 #[tokio::test]
 async fn csv_filter_with_file_col() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_partitioned_aggregate_csv(
         &mut ctx,
@@ -75,7 +75,7 @@ async fn csv_filter_with_file_col() -> Result<()> {
 
 #[tokio::test]
 async fn csv_projection_on_partition() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_partitioned_aggregate_csv(
         &mut ctx,
@@ -111,7 +111,7 @@ async fn csv_projection_on_partition() -> Result<()> {
 
 #[tokio::test]
 async fn csv_grouping_by_partition() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_partitioned_aggregate_csv(
         &mut ctx,
@@ -145,7 +145,7 @@ async fn csv_grouping_by_partition() -> Result<()> {
 
 #[tokio::test]
 async fn parquet_multiple_partitions() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_partitioned_alltypes_parquet(
         &mut ctx,
@@ -187,7 +187,7 @@ async fn parquet_multiple_partitions() -> Result<()> {
 
 #[tokio::test]
 async fn parquet_statistics() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_partitioned_alltypes_parquet(
         &mut ctx,
@@ -246,7 +246,7 @@ async fn parquet_statistics() -> Result<()> {
 
 #[tokio::test]
 async fn parquet_overlapping_columns() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // `id` is both a column of the file and a partitioning col
     register_partitioned_alltypes_parquet(
@@ -272,7 +272,7 @@ async fn parquet_overlapping_columns() -> Result<()> {
 }
 
 fn register_partitioned_aggregate_csv(
-    ctx: &mut ExecutionContext,
+    ctx: &mut SessionContext,
     store_paths: &[&str],
     partition_cols: &[&str],
     table_path: &str,
@@ -295,7 +295,7 @@ fn register_partitioned_aggregate_csv(
 }
 
 async fn register_partitioned_alltypes_parquet(
-    ctx: &mut ExecutionContext,
+    ctx: &mut SessionContext,
     store_paths: &[&str],
     partition_cols: &[&str],
     table_path: &str,

--- a/datafusion/tests/provider_filter_pushdown.rs
+++ b/datafusion/tests/provider_filter_pushdown.rs
@@ -21,8 +21,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::datasource::datasource::{TableProvider, TableProviderFilterPushDown};
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::{SessionContext, TaskContext};
 use datafusion::logical_plan::Expr;
 use datafusion::physical_plan::common::SizedRecordBatchStream;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
@@ -88,7 +87,7 @@ impl ExecutionPlan for CustomPlan {
     async fn execute(
         &self,
         partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let metrics = ExecutionPlanMetricsSet::new();
         let tracking_metrics = MemTrackingMetrics::new(&metrics, partition);
@@ -174,7 +173,7 @@ async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()
         one_batch: create_batch(1, 5)?,
     };
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let df = ctx
         .read_table(Arc::new(provider.clone()))?
         .filter(col("flag").eq(lit(value)))?

--- a/datafusion/tests/sql/aggregates.rs
+++ b/datafusion/tests/sql/aggregates.rs
@@ -20,14 +20,14 @@ use datafusion::scalar::ScalarValue;
 
 #[tokio::test]
 async fn csv_query_avg_multi_batch() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT avg(c12) FROM aggregate_test_100";
     let plan = ctx.create_logical_plan(sql).unwrap();
     let plan = ctx.optimize(&plan).unwrap();
     let plan = ctx.create_physical_plan(&plan).await.unwrap();
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let results = collect(plan, runtime).await.unwrap();
+    let task_ctx = ctx.task_ctx();
+    let results = collect(plan, task_ctx).await.unwrap();
     let batch = &results[0];
     let column = batch.column(0);
     let array = column.as_any().downcast_ref::<Float64Array>().unwrap();
@@ -41,7 +41,7 @@ async fn csv_query_avg_multi_batch() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_avg() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT avg(c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -53,7 +53,7 @@ async fn csv_query_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_covariance_1() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT covar_pop(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -65,7 +65,7 @@ async fn csv_query_covariance_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_covariance_2() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT covar(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -77,7 +77,7 @@ async fn csv_query_covariance_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_correlation() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT corr(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -89,7 +89,7 @@ async fn csv_query_correlation() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_1() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT var_pop(c2) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -101,7 +101,7 @@ async fn csv_query_variance_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_2() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT var_pop(c6) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -113,7 +113,7 @@ async fn csv_query_variance_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_3() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT var_pop(c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -125,7 +125,7 @@ async fn csv_query_variance_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_4() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT var(c2) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -137,7 +137,7 @@ async fn csv_query_variance_4() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_5() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT var_samp(c2) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -149,7 +149,7 @@ async fn csv_query_variance_5() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_1() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT stddev_pop(c2) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -161,7 +161,7 @@ async fn csv_query_stddev_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_2() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT stddev_pop(c6) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -173,7 +173,7 @@ async fn csv_query_stddev_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_3() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT stddev_pop(c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -185,7 +185,7 @@ async fn csv_query_stddev_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_4() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT stddev(c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -197,7 +197,7 @@ async fn csv_query_stddev_4() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_5() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT stddev_samp(c12) FROM aggregate_test_100";
     let mut actual = execute(&mut ctx, sql).await;
@@ -209,7 +209,7 @@ async fn csv_query_stddev_5() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_6() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "select stddev(sq.column1) from (values (1.1), (2.0), (3.0)) as sq";
     let mut actual = execute(&mut ctx, sql).await;
@@ -221,7 +221,7 @@ async fn csv_query_stddev_6() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_1() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT approx_median(c2) FROM aggregate_test_100";
     let actual = execute(&mut ctx, sql).await;
@@ -232,7 +232,7 @@ async fn csv_query_median_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_2() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT approx_median(c6) FROM aggregate_test_100";
     let actual = execute(&mut ctx, sql).await;
@@ -243,7 +243,7 @@ async fn csv_query_median_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_3() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT approx_median(c12) FROM aggregate_test_100";
     let actual = execute(&mut ctx, sql).await;
@@ -254,10 +254,10 @@ async fn csv_query_median_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_external_table_count() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT COUNT(c12) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------+",
         "| COUNT(aggregate_test_100.c12) |",
@@ -271,12 +271,12 @@ async fn csv_query_external_table_count() {
 
 #[tokio::test]
 async fn csv_query_external_table_sum() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     // cast smallint and int to bigint to avoid overflow during calculation
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql =
         "SELECT SUM(CAST(c7 AS BIGINT)), SUM(CAST(c8 AS BIGINT)) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------------------+-------------------------------------------+",
         "| SUM(CAST(aggregate_test_100.c7 AS Int64)) | SUM(CAST(aggregate_test_100.c8 AS Int64)) |",
@@ -289,10 +289,10 @@ async fn csv_query_external_table_sum() {
 
 #[tokio::test]
 async fn csv_query_count() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT count(c12) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------+",
         "| COUNT(aggregate_test_100.c12) |",
@@ -306,10 +306,10 @@ async fn csv_query_count() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_distinct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT count(distinct c2) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------------------------+",
         "| COUNT(DISTINCT aggregate_test_100.c2) |",
@@ -323,10 +323,10 @@ async fn csv_query_count_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_distinct_expr() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT count(distinct c2 % 2) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------------------------------------------+",
         "| COUNT(DISTINCT aggregate_test_100.c2 % Int64(2)) |",
@@ -340,10 +340,10 @@ async fn csv_query_count_distinct_expr() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_star() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT COUNT(*) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",
         "| COUNT(UInt8(1)) |",
@@ -356,10 +356,10 @@ async fn csv_query_count_star() {
 
 #[tokio::test]
 async fn csv_query_count_one() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT COUNT(1) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",
         "| COUNT(UInt8(1)) |",
@@ -372,10 +372,10 @@ async fn csv_query_count_one() {
 
 #[tokio::test]
 async fn csv_query_approx_count() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT approx_distinct(c9) count_c9, approx_distinct(cast(c9 as varchar)) count_c9_str FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+--------------+",
         "| count_c9 | count_c9_str |",
@@ -412,7 +412,7 @@ async fn csv_query_approx_count() -> Result<()> {
 // float values.
 #[tokio::test]
 async fn csv_query_approx_percentile_cont() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
 
     // Generate an assertion that the estimated $percentile value for $column is
@@ -420,7 +420,7 @@ async fn csv_query_approx_percentile_cont() -> Result<()> {
     macro_rules! percentile_test {
         ($ctx:ident, column=$column:literal, percentile=$percentile:literal, actual=$actual:literal) => {
             let sql = format!("SELECT (ABS(1 - CAST(approx_percentile_cont({}, {}) AS DOUBLE) / {}) < 0.05) AS q FROM aggregate_test_100", $column, $percentile, $actual);
-            let actual = execute_to_batches(&mut ctx, &sql).await;
+            let actual = execute_to_batches(&ctx, &sql).await;
             //
             //   "+------+",
             //   "| q    |",
@@ -478,10 +478,10 @@ async fn csv_query_approx_percentile_cont() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_sum_crossjoin() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT a.c1, b.c1, SUM(a.c2) FROM aggregate_test_100 as a CROSS JOIN aggregate_test_100 as b GROUP BY a.c1, b.c1 ORDER BY a.c1, b.c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+-----------+",
         "| c1 | c1 | SUM(a.c2) |",
@@ -518,9 +518,9 @@ async fn csv_query_sum_crossjoin() {
 
 #[tokio::test]
 async fn query_count_without_from() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT count(1 + 1)";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------+",
         "| COUNT(Int64(1) + Int64(1)) |",
@@ -534,11 +534,11 @@ async fn query_count_without_from() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 ORDER BY c13 LIMIT 2) test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------------------------------------------------------------------+",
         "| ARRAYAGG(test.c13)                                               |",
@@ -552,11 +552,11 @@ async fn csv_query_array_agg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_empty() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 LIMIT 0) test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------------+",
         "| ARRAYAGG(test.c13) |",
@@ -570,11 +570,11 @@ async fn csv_query_array_agg_empty() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_one() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 ORDER BY c13 LIMIT 1) test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------------+",
         "| ARRAYAGG(test.c13)               |",
@@ -588,10 +588,10 @@ async fn csv_query_array_agg_one() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_distinct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT array_agg(distinct c2) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     // The results for this query should be something like the following:
     //    +------------------------------------------+
@@ -638,7 +638,7 @@ async fn csv_query_array_agg_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_sum() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = plan_and_collect(
@@ -655,11 +655,11 @@ async fn aggregate_timestamps_sum() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_count() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT count(nanos), count(micros), count(millis), count(secs) FROM t",
     )
     .await;
@@ -678,11 +678,11 @@ async fn aggregate_timestamps_count() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_min() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT min(nanos), min(micros), min(millis), min(secs) FROM t",
     )
     .await;
@@ -701,11 +701,11 @@ async fn aggregate_timestamps_min() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_max() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT max(nanos), max(micros), max(millis), max(secs) FROM t",
     )
     .await;
@@ -724,7 +724,7 @@ async fn aggregate_timestamps_max() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_avg() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = plan_and_collect(

--- a/datafusion/tests/sql/avro.rs
+++ b/datafusion/tests/sql/avro.rs
@@ -17,7 +17,7 @@
 
 use super::*;
 
-async fn register_alltypes_avro(ctx: &mut ExecutionContext) {
+async fn register_alltypes_avro(ctx: &mut SessionContext) {
     let testdata = datafusion::test_util::arrow_test_data();
     ctx.register_avro(
         "alltypes_plain",
@@ -30,12 +30,12 @@ async fn register_alltypes_avro(ctx: &mut ExecutionContext) {
 
 #[tokio::test]
 async fn avro_query() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_avro(&mut ctx).await;
     // NOTE that string_col is actually a binary column and does not have the UTF8 logical type
     // so we need an explicit cast
     let sql = "SELECT id, CAST(string_col AS varchar) FROM alltypes_plain";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-----------------------------------------+",
         "| id | CAST(alltypes_plain.string_col AS Utf8) |",
@@ -71,7 +71,7 @@ async fn avro_query_multiple_files() {
     )
     .unwrap();
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_avro(
         "alltypes_plain",
         table_path.display().to_string().as_str(),
@@ -82,7 +82,7 @@ async fn avro_query_multiple_files() {
     // NOTE that string_col is actually a binary column and does not have the UTF8 logical type
     // so we need an explicit cast
     let sql = "SELECT id, CAST(string_col AS varchar) FROM alltypes_plain";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-----------------------------------------+",
         "| id | CAST(alltypes_plain.string_col AS Utf8) |",
@@ -111,7 +111,7 @@ async fn avro_query_multiple_files() {
 
 #[tokio::test]
 async fn avro_single_nan_schema() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let testdata = datafusion::test_util::arrow_test_data();
     ctx.register_avro(
         "single_nan",
@@ -134,7 +134,7 @@ async fn avro_single_nan_schema() {
 
 #[tokio::test]
 async fn avro_explain() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_avro(&mut ctx).await;
 
     let sql = "EXPLAIN SELECT count(*) from alltypes_plain";

--- a/datafusion/tests/sql/create_drop.rs
+++ b/datafusion/tests/sql/create_drop.rs
@@ -23,14 +23,14 @@ use super::*;
 
 #[tokio::test]
 async fn create_table_as() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql = "CREATE TABLE my_table AS SELECT * FROM aggregate_simple";
     ctx.sql(sql).await.unwrap();
 
     let sql_all = "SELECT * FROM my_table order by c1 LIMIT 1";
-    let results_all = execute_to_batches(&mut ctx, sql_all).await;
+    let results_all = execute_to_batches(&ctx, sql_all).await;
 
     let expected = vec![
         "+---------+----------------+------+",
@@ -47,7 +47,7 @@ async fn create_table_as() -> Result<()> {
 
 #[tokio::test]
 async fn drop_table() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql = "CREATE TABLE my_table AS SELECT * FROM aggregate_simple";
@@ -67,10 +67,10 @@ async fn drop_table() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_create_external_table() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT c1, c2, c3, c4, c5, c6, c7, c8, c9, 10, c11, c12, c13 FROM aggregate_test_100 LIMIT 1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+----+-------+------------+----------------------+----+-------+------------+-----------+-------------+--------------------+--------------------------------+",
         "| c1 | c2 | c3 | c4    | c5         | c6                   | c7 | c8    | c9         | Int64(10) | c11         | c12                | c13                            |",
@@ -83,7 +83,7 @@ async fn csv_query_create_external_table() {
 
 #[tokio::test]
 async fn create_external_table_with_timestamps() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let data = "Jorge,2018-12-13T12:12:10.011Z\n\
                 Andrew,2018-11-13T17:11:10.011Z";

--- a/datafusion/tests/sql/explain.rs
+++ b/datafusion/tests/sql/explain.rs
@@ -18,7 +18,7 @@
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::{
     logical_plan::{LogicalPlan, LogicalPlanBuilder, PlanType},
-    prelude::ExecutionContext,
+    prelude::SessionContext,
 };
 
 #[test]
@@ -39,7 +39,7 @@ fn optimize_explain() {
     }
 
     // now optimize the plan and expect to see more plans
-    let optimized_plan = ExecutionContext::new().optimize(&plan).unwrap();
+    let optimized_plan = SessionContext::new().optimize(&plan).unwrap();
     if let LogicalPlan::Explain(e) = &optimized_plan {
         // should have more than one plan
         assert!(

--- a/datafusion/tests/sql/explain_analyze.rs
+++ b/datafusion/tests/sql/explain_analyze.rs
@@ -21,8 +21,8 @@ use super::*;
 async fn explain_analyze_baseline_metrics() {
     // This test uses the execute function to run an actual plan under EXPLAIN ANALYZE
     // and then validate the presence of baseline metrics for supported operators
-    let config = ExecutionConfig::new().with_target_partitions(3);
-    let mut ctx = ExecutionContext::with_config(config);
+    let config = SessionConfig::new().with_target_partitions(3);
+    let mut ctx = SessionContext::with_config(config);
     register_aggregate_csv_by_sql(&mut ctx).await;
     // a query with as many operators as we have metrics for
     let sql = "EXPLAIN ANALYZE \
@@ -41,8 +41,8 @@ async fn explain_analyze_baseline_metrics() {
     let plan = ctx.create_logical_plan(sql).unwrap();
     let plan = ctx.optimize(&plan).unwrap();
     let physical_plan = ctx.create_physical_plan(&plan).await.unwrap();
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let results = collect(physical_plan.clone(), runtime).await.unwrap();
+    let task_ctx = ctx.task_ctx();
+    let results = collect(physical_plan.clone(), task_ctx).await.unwrap();
     let formatted = arrow::util::pretty::pretty_format_batches(&results)
         .unwrap()
         .to_string();
@@ -168,7 +168,7 @@ async fn explain_analyze_baseline_metrics() {
 async fn csv_explain_plans() {
     // This test verify the look of each plan in its full cycle plan creation
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "EXPLAIN SELECT c1 FROM aggregate_test_100 where c2 > 10";
 
@@ -329,8 +329,8 @@ async fn csv_explain_plans() {
     //
     // Execute plan
     let msg = format!("Executing physical plan for '{}': {:?}", sql, plan);
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let results = collect(plan, runtime).await.expect(&msg);
+    let task_ctx = ctx.task_ctx();
+    let results = collect(plan, task_ctx).await.expect(&msg);
     let actual = result_vec(&results);
     // flatten to a single string
     let actual = actual.into_iter().map(|r| r.join("\t")).collect::<String>();
@@ -342,7 +342,7 @@ async fn csv_explain_plans() {
 
 #[tokio::test]
 async fn csv_explain_verbose() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "EXPLAIN VERBOSE SELECT c1 FROM aggregate_test_100 where c2 > 10";
     let actual = execute(&mut ctx, sql).await;
@@ -365,7 +365,7 @@ async fn csv_explain_verbose() {
 async fn csv_explain_verbose_plans() {
     // This test verify the look of each plan in its full cycle plan creation
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "EXPLAIN VERBOSE SELECT c1 FROM aggregate_test_100 where c2 > 10";
 
@@ -527,8 +527,8 @@ async fn csv_explain_verbose_plans() {
     //
     // Execute plan
     let msg = format!("Executing physical plan for '{}': {:?}", sql, plan);
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let results = collect(plan, runtime).await.expect(&msg);
+    let task_ctx = ctx.task_ctx();
+    let results = collect(plan, task_ctx).await.expect(&msg);
     let actual = result_vec(&results);
     // flatten to a single string
     let actual = actual.into_iter().map(|r| r.join("\t")).collect::<String>();
@@ -545,7 +545,7 @@ async fn csv_explain_verbose_plans() {
 async fn explain_analyze_runs_optimizers() {
     // repro for https://github.com/apache/arrow-datafusion/issues/917
     // where EXPLAIN ANALYZE was not correctly running optiimizer
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_parquet(&mut ctx).await;
 
     // This happens as an optimization pass where count(*) can be
@@ -553,7 +553,7 @@ async fn explain_analyze_runs_optimizers() {
     let expected = "EmptyExec: produce_one_row=true";
 
     let sql = "EXPLAIN SELECT count(*) from alltypes_plain";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let actual = arrow::util::pretty::pretty_format_batches(&actual)
         .unwrap()
         .to_string();
@@ -561,7 +561,7 @@ async fn explain_analyze_runs_optimizers() {
 
     // EXPLAIN ANALYZE should work the same
     let sql = "EXPLAIN  ANALYZE SELECT count(*) from alltypes_plain";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let actual = arrow::util::pretty::pretty_format_batches(&actual)
         .unwrap()
         .to_string();
@@ -570,7 +570,7 @@ async fn explain_analyze_runs_optimizers() {
 
 #[tokio::test]
 async fn tpch_explain_q10() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     register_tpch_csv(&mut ctx, "customer").await?;
     register_tpch_csv(&mut ctx, "orders").await?;
@@ -633,8 +633,8 @@ order by
 #[tokio::test]
 async fn test_physical_plan_display_indent() {
     // Hard code target_partitions as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_target_partitions(3);
-    let mut ctx = ExecutionContext::with_config(config);
+    let config = SessionConfig::new().with_target_partitions(3);
+    let mut ctx = SessionContext::with_config(config);
     register_aggregate_csv(&mut ctx).await.unwrap();
     let sql = "SELECT c1, MAX(c12), MIN(c12) as the_min \
                FROM aggregate_test_100 \
@@ -679,8 +679,8 @@ async fn test_physical_plan_display_indent() {
 #[tokio::test]
 async fn test_physical_plan_display_indent_multi_children() {
     // Hard code target_partitions as it appears in the RepartitionExec output
-    let config = ExecutionConfig::new().with_target_partitions(3);
-    let mut ctx = ExecutionContext::with_config(config);
+    let config = SessionConfig::new().with_target_partitions(3);
+    let mut ctx = SessionContext::with_config(config);
     // ensure indenting works for nodes with multiple children
     register_aggregate_csv(&mut ctx).await.unwrap();
     let sql = "SELECT c1 \
@@ -731,7 +731,7 @@ async fn test_physical_plan_display_indent_multi_children() {
 async fn csv_explain() {
     // This test uses the execute function that create full plan cycle: logical, optimized logical, and physical,
     // then execute the physical plan and return the final explain results
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "EXPLAIN SELECT c1 FROM aggregate_test_100 where c2 > 10";
     let actual = execute(&mut ctx, sql).await;
@@ -766,10 +766,10 @@ async fn csv_explain() {
 #[tokio::test]
 async fn csv_explain_analyze() {
     // This test uses the execute function to run an actual plan under EXPLAIN ANALYZE
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "EXPLAIN ANALYZE SELECT count(*), c1 FROM aggregate_test_100 group by c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let formatted = arrow::util::pretty::pretty_format_batches(&actual)
         .unwrap()
         .to_string();
@@ -787,11 +787,11 @@ async fn csv_explain_analyze() {
 #[tokio::test]
 async fn csv_explain_analyze_verbose() {
     // This test uses the execute function to run an actual plan under EXPLAIN VERBOSE ANALYZE
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql =
         "EXPLAIN ANALYZE VERBOSE SELECT count(*), c1 FROM aggregate_test_100 group by c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let formatted = arrow::util::pretty::pretty_format_batches(&actual)
         .unwrap()
         .to_string();

--- a/datafusion/tests/sql/expr.rs
+++ b/datafusion/tests/sql/expr.rs
@@ -19,13 +19,13 @@ use super::*;
 
 #[tokio::test]
 async fn case_when() -> Result<()> {
-    let mut ctx = create_case_context()?;
+    let ctx = create_case_context()?;
     let sql = "SELECT \
         CASE WHEN c1 = 'a' THEN 1 \
              WHEN c1 = 'b' THEN 2 \
              END \
         FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------------------------------------------------------------------------------+",
         "| CASE WHEN #t1.c1 = Utf8(\"a\") THEN Int64(1) WHEN #t1.c1 = Utf8(\"b\") THEN Int64(2) END |",
@@ -42,13 +42,13 @@ async fn case_when() -> Result<()> {
 
 #[tokio::test]
 async fn case_when_else() -> Result<()> {
-    let mut ctx = create_case_context()?;
+    let ctx = create_case_context()?;
     let sql = "SELECT \
         CASE WHEN c1 = 'a' THEN 1 \
              WHEN c1 = 'b' THEN 2 \
              ELSE 999 END \
         FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------------------------------------------------------------------------------------------------------+",
         "| CASE WHEN #t1.c1 = Utf8(\"a\") THEN Int64(1) WHEN #t1.c1 = Utf8(\"b\") THEN Int64(2) ELSE Int64(999) END |",
@@ -65,13 +65,13 @@ async fn case_when_else() -> Result<()> {
 
 #[tokio::test]
 async fn case_when_with_base_expr() -> Result<()> {
-    let mut ctx = create_case_context()?;
+    let ctx = create_case_context()?;
     let sql = "SELECT \
         CASE c1 WHEN 'a' THEN 1 \
              WHEN 'b' THEN 2 \
              END \
         FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------------------------------------------------------------+",
         "| CASE #t1.c1 WHEN Utf8(\"a\") THEN Int64(1) WHEN Utf8(\"b\") THEN Int64(2) END |",
@@ -88,13 +88,13 @@ async fn case_when_with_base_expr() -> Result<()> {
 
 #[tokio::test]
 async fn case_when_else_with_base_expr() -> Result<()> {
-    let mut ctx = create_case_context()?;
+    let ctx = create_case_context()?;
     let sql = "SELECT \
         CASE c1 WHEN 'a' THEN 1 \
              WHEN 'b' THEN 2 \
              ELSE 999 END \
         FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------------------------------------------------------------------+",
         "| CASE #t1.c1 WHEN Utf8(\"a\") THEN Int64(1) WHEN Utf8(\"b\") THEN Int64(2) ELSE Int64(999) END |",
@@ -124,10 +124,10 @@ async fn query_not() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT NOT c1 FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------+",
         "| NOT test.c1 |",
@@ -143,7 +143,7 @@ async fn query_not() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_sum_cast() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     // c8 = i32; c9 = i64
     let sql = "SELECT c8 + c9 FROM aggregate_test_100";
@@ -166,10 +166,10 @@ async fn query_is_null() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT c1 IS NULL FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",
         "| test.c1 IS NULL |",
@@ -198,10 +198,10 @@ async fn query_is_not_null() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT c1 IS NOT NULL FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------+",
         "| test.c1 IS NOT NULL |",
@@ -219,10 +219,10 @@ async fn query_is_not_null() -> Result<()> {
 async fn query_without_from() -> Result<()> {
     // Test for SELECT <expression> without FROM.
     // Should evaluate expressions in project position.
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
 
     let sql = "SELECT 1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
         "| Int64(1) |",
@@ -233,7 +233,7 @@ async fn query_without_from() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     let sql = "SELECT 1+2, 3/4, cos(0)";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------+---------------------+---------------+",
         "| Int64(1) + Int64(2) | Int64(3) / Int64(4) | cos(Int64(0)) |",
@@ -262,10 +262,10 @@ async fn query_scalar_minus_array() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT 4 - c1 FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------------------------+",
         "| Int64(4) Minus test.c1 |",
@@ -669,9 +669,9 @@ async fn test_random_expression() -> Result<()> {
 
 #[tokio::test]
 async fn case_with_bool_type_result() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "select case when 'cpu' != 'cpu' then true else false end";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------------------------------------------------------------------+",
         "| CASE WHEN Utf8(\"cpu\") != Utf8(\"cpu\") THEN Boolean(true) ELSE Boolean(false) END |",
@@ -685,7 +685,7 @@ async fn case_with_bool_type_result() -> Result<()> {
 
 #[tokio::test]
 async fn in_list_array() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;
     let sql = "SELECT
             c1 IN ('a', 'c') AS utf8_in_true
@@ -694,7 +694,7 @@ async fn in_list_array() -> Result<()> {
             ,c1 NOT IN ('a', 'c') AS utf8_not_in_false
             ,NULL IN ('a', 'c') AS utf8_in_null
         FROM aggregate_test_100 WHERE c12 < 0.05";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------+---------------+------------------+-------------------+--------------+",
         "| utf8_in_true | utf8_in_false | utf8_not_in_true | utf8_not_in_false | utf8_in_null |",
@@ -810,11 +810,11 @@ async fn test_in_list_scalar() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_boolean_eq_neq() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_boolean(&mut ctx).await.unwrap();
     // verify the plumbing is all hooked up for eq and neq
     let sql = "SELECT a, b, a = b as eq, b = true as eq_scalar, a != b as neq, a != true as neq_scalar FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------+-------+-------+-----------+-------+------------+",
@@ -836,11 +836,11 @@ async fn csv_query_boolean_eq_neq() {
 
 #[tokio::test]
 async fn csv_query_boolean_lt_lt_eq() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_boolean(&mut ctx).await.unwrap();
     // verify the plumbing is all hooked up for < and <=
     let sql = "SELECT a, b, a < b as lt, b = true as lt_scalar, a <= b as lt_eq, a <= true as lt_eq_scalar FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------+-------+-------+-----------+-------+--------------+",
@@ -862,11 +862,11 @@ async fn csv_query_boolean_lt_lt_eq() {
 
 #[tokio::test]
 async fn csv_query_boolean_gt_gt_eq() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_boolean(&mut ctx).await.unwrap();
     // verify the plumbing is all hooked up for > and >=
     let sql = "SELECT a, b, a > b as gt, b = true as gt_scalar, a >= b as gt_eq, a >= true as gt_eq_scalar FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------+-------+-------+-----------+-------+--------------+",
@@ -888,7 +888,7 @@ async fn csv_query_boolean_gt_gt_eq() {
 
 #[tokio::test]
 async fn csv_query_boolean_distinct_from() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_boolean(&mut ctx).await.unwrap();
     // verify the plumbing is all hooked up for is distinct from and is not distinct from
     let sql = "SELECT a, b, \
@@ -897,7 +897,7 @@ async fn csv_query_boolean_distinct_from() {
                a is not distinct from b as ndf, \
                a is not distinct from true as ndf_scalar \
                FROM t1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------+-------+-------+-----------+-------+------------+",
@@ -919,7 +919,7 @@ async fn csv_query_boolean_distinct_from() {
 
 #[tokio::test]
 async fn csv_query_nullif_divide_by_0() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c8/nullif(c7, 0) FROM aggregate_test_100";
     let actual = execute(&mut ctx, sql).await;
@@ -941,10 +941,10 @@ async fn csv_query_nullif_divide_by_0() -> Result<()> {
 }
 #[tokio::test]
 async fn csv_count_star() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT COUNT(*), COUNT(1) AS c, COUNT(c1) FROM aggregate_test_100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+-----+------------------------------+",
         "| COUNT(UInt8(1)) | c   | COUNT(aggregate_test_100.c1) |",

--- a/datafusion/tests/sql/functions.rs
+++ b/datafusion/tests/sql/functions.rs
@@ -37,10 +37,10 @@ async fn sqrt_f32_vs_f64() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_cast() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT CAST(c12 AS float) FROM aggregate_test_100 WHERE c12 > 0.376 AND c12 < 0.4";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----------------------------------------+",
@@ -57,11 +57,11 @@ async fn csv_query_cast() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_cast_literal() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql =
         "SELECT c12, CAST(1 AS float) FROM aggregate_test_100 WHERE c12 > CAST(0 AS float) LIMIT 2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+--------------------+---------------------------+",
@@ -93,10 +93,10 @@ async fn query_concat() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT concat(c1, '-hi-', cast(c2 as varchar)) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------------------------------+",
         "| concat(test.c1,Utf8(\"-hi-\"),CAST(test.c2 AS Utf8)) |",
@@ -129,7 +129,7 @@ async fn query_array() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT array(c1, cast(c2 as varchar)) FROM test";
     let actual = execute(&mut ctx, sql).await;
@@ -160,10 +160,10 @@ async fn query_count_distinct() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT COUNT(DISTINCT c1) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------+",
         "| COUNT(DISTINCT test.c1) |",

--- a/datafusion/tests/sql/group_by.rs
+++ b/datafusion/tests/sql/group_by.rs
@@ -19,10 +19,10 @@ use super::*;
 
 #[tokio::test]
 async fn csv_query_group_by_int_min_max() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c2, MIN(c12), MAX(c12) FROM aggregate_test_100 GROUP BY c2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-----------------------------+-----------------------------+",
         "| c2 | MIN(aggregate_test_100.c12) | MAX(aggregate_test_100.c12) |",
@@ -40,12 +40,12 @@ async fn csv_query_group_by_int_min_max() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_float32() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql =
         "SELECT COUNT(*) as cnt, c1 FROM aggregate_simple GROUP BY c1 ORDER BY cnt DESC";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----+---------+",
@@ -65,12 +65,12 @@ async fn csv_query_group_by_float32() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_float64() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql =
         "SELECT COUNT(*) as cnt, c2 FROM aggregate_simple GROUP BY c2 ORDER BY cnt DESC";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----+----------------+",
@@ -90,12 +90,12 @@ async fn csv_query_group_by_float64() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_boolean() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql =
         "SELECT COUNT(*) as cnt, c3 FROM aggregate_simple GROUP BY c3 ORDER BY cnt DESC";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----+-------+",
@@ -112,10 +112,10 @@ async fn csv_query_group_by_boolean() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_two_columns() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, c2, MIN(c3) FROM aggregate_test_100 GROUP BY c1, c2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+----------------------------+",
         "| c1 | c2 | MIN(aggregate_test_100.c3) |",
@@ -153,10 +153,10 @@ async fn csv_query_group_by_two_columns() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_and_having() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, MIN(c3) AS m FROM aggregate_test_100 GROUP BY c1 HAVING m < -100 AND MAX(c3) > 70";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+------+",
         "| c1 | m    |",
@@ -171,14 +171,14 @@ async fn csv_query_group_by_and_having() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_and_having_and_where() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, MIN(c3) AS m
                FROM aggregate_test_100
                WHERE c1 IN ('a', 'b')
                GROUP BY c1
                HAVING m < -100 AND MAX(c3) > 70";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+------+",
         "| c1 | m    |",
@@ -192,10 +192,10 @@ async fn csv_query_group_by_and_having_and_where() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_having_without_group_by() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 HAVING c2 >= 4 AND c3 > 90";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+-----+",
         "| c1 | c2 | c3  |",
@@ -213,10 +213,10 @@ async fn csv_query_having_without_group_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_avg() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, avg(c12) FROM aggregate_test_100 GROUP BY c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-----------------------------+",
         "| c1 | AVG(aggregate_test_100.c12) |",
@@ -234,10 +234,10 @@ async fn csv_query_group_by_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_int_count() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, count(c12) FROM aggregate_test_100 GROUP BY c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-------------------------------+",
         "| c1 | COUNT(aggregate_test_100.c12) |",
@@ -255,10 +255,10 @@ async fn csv_query_group_by_int_count() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_with_aliased_aggregate() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, count(c12) AS count FROM aggregate_test_100 GROUP BY c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-------+",
         "| c1 | count |",
@@ -276,10 +276,10 @@ async fn csv_query_group_with_aliased_aggregate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_string_min_max() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1, MIN(c12), MAX(c12) FROM aggregate_test_100 GROUP BY c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+-----------------------------+-----------------------------+",
         "| c1 | MIN(aggregate_test_100.c12) | MAX(aggregate_test_100.c12) |",
@@ -312,11 +312,11 @@ async fn query_group_on_null() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT COUNT(*), c1 FROM test GROUP BY c1";
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     // Note that the results also
     // include a row for NULL (c1=NULL, count = 1)
@@ -371,11 +371,11 @@ async fn query_group_on_null_multi_col() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT COUNT(*), c1, c2 FROM test GROUP BY c1, c2";
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     // Note that the results also include values for null
     // include a row for NULL (c1=NULL, count = 1)
@@ -393,14 +393,14 @@ async fn query_group_on_null_multi_col() -> Result<()> {
 
     // Also run query with group columns reversed (results should be the same)
     let sql = "SELECT COUNT(*), c1, c2 FROM test GROUP BY c2, c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_sorted_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn csv_group_by_date() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let schema = Arc::new(Schema::new(vec![
         Field::new("date", DataType::Date32, false),
         Field::new("cnt", DataType::Int32, false),
@@ -430,7 +430,7 @@ async fn csv_group_by_date() -> Result<()> {
 
     ctx.register_table("dates", Arc::new(table))?;
     let sql = "SELECT SUM(cnt) FROM dates GROUP BY date";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------+",
         "| SUM(dates.cnt) |",

--- a/datafusion/tests/sql/information_schema.rs
+++ b/datafusion/tests/sql/information_schema.rs
@@ -29,7 +29,7 @@ use super::*;
 
 #[tokio::test]
 async fn information_schema_tables_not_exist_by_default() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let err = plan_and_collect(&mut ctx, "SELECT * from information_schema.tables")
         .await
@@ -42,9 +42,8 @@ async fn information_schema_tables_not_exist_by_default() {
 
 #[tokio::test]
 async fn information_schema_tables_no_tables() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     let result = plan_and_collect(&mut ctx, "SELECT * from information_schema.tables")
         .await
@@ -63,9 +62,8 @@ async fn information_schema_tables_no_tables() {
 
 #[tokio::test]
 async fn information_schema_tables_tables_default_catalog() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     // Now, register an empty table
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
@@ -109,9 +107,8 @@ async fn information_schema_tables_tables_default_catalog() {
 
 #[tokio::test]
 async fn information_schema_tables_tables_with_multiple_catalogs() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
     schema
@@ -181,9 +178,8 @@ async fn information_schema_tables_table_types() {
         }
     }
 
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     ctx.register_table("physical", Arc::new(TestTable(TableType::Base)))
         .unwrap();
@@ -212,7 +208,7 @@ async fn information_schema_tables_table_types() {
 
 #[tokio::test]
 async fn information_schema_show_tables_no_information_schema() {
-    let mut ctx = ExecutionContext::with_config(ExecutionConfig::new());
+    let mut ctx = SessionContext::with_config(SessionConfig::new());
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -225,9 +221,8 @@ async fn information_schema_show_tables_no_information_schema() {
 
 #[tokio::test]
 async fn information_schema_show_tables() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -253,7 +248,7 @@ async fn information_schema_show_tables() {
 
 #[tokio::test]
 async fn information_schema_show_columns_no_information_schema() {
-    let mut ctx = ExecutionContext::with_config(ExecutionConfig::new());
+    let mut ctx = SessionContext::with_config(SessionConfig::new());
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -267,7 +262,7 @@ async fn information_schema_show_columns_no_information_schema() {
 
 #[tokio::test]
 async fn information_schema_show_columns_like_where() {
-    let mut ctx = ExecutionContext::with_config(ExecutionConfig::new());
+    let mut ctx = SessionContext::with_config(SessionConfig::new());
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -288,9 +283,8 @@ async fn information_schema_show_columns_like_where() {
 
 #[tokio::test]
 async fn information_schema_show_columns() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -326,9 +320,8 @@ async fn information_schema_show_columns() {
 // test errors with WHERE and LIKE
 #[tokio::test]
 async fn information_schema_show_columns_full_extended() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -353,9 +346,8 @@ async fn information_schema_show_columns_full_extended() {
 
 #[tokio::test]
 async fn information_schema_show_table_table_names() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
@@ -397,7 +389,7 @@ async fn information_schema_show_table_table_names() {
 
 #[tokio::test]
 async fn show_unsupported() {
-    let mut ctx = ExecutionContext::with_config(ExecutionConfig::new());
+    let mut ctx = SessionContext::with_config(SessionConfig::new());
 
     let err = plan_and_collect(&mut ctx, "SHOW SOMETHING_UNKNOWN")
         .await
@@ -408,7 +400,7 @@ async fn show_unsupported() {
 
 #[tokio::test]
 async fn information_schema_columns_not_exist_by_default() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let err = plan_and_collect(&mut ctx, "SELECT * from information_schema.columns")
         .await
@@ -456,9 +448,8 @@ fn table_with_many_types() -> Arc<dyn TableProvider> {
 
 #[tokio::test]
 async fn information_schema_columns() {
-    let mut ctx = ExecutionContext::with_config(
-        ExecutionConfig::new().with_information_schema(true),
-    );
+    let mut ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
 
@@ -495,7 +486,7 @@ async fn information_schema_columns() {
 
 /// Execute SQL and return results
 async fn plan_and_collect(
-    ctx: &mut ExecutionContext,
+    ctx: &mut SessionContext,
     sql: &str,
 ) -> Result<Vec<RecordBatch>> {
     ctx.sql(sql).await?.collect().await

--- a/datafusion/tests/sql/intersection.rs
+++ b/datafusion/tests/sql/intersection.rs
@@ -23,8 +23,8 @@ async fn intersect_with_null_not_equal() {
             INTERSECT SELECT * FROM (SELECT null AS id1, 2 AS id2) t2";
 
     let expected = vec!["++", "++"];
-    let mut ctx = create_join_context_qualified().unwrap();
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let ctx = create_join_context_qualified().unwrap();
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
 }
 
@@ -41,19 +41,19 @@ async fn intersect_with_null_equal() {
         "+-----+-----+",
     ];
 
-    let mut ctx = create_join_context_qualified().unwrap();
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let ctx = create_join_context_qualified().unwrap();
+    let actual = execute_to_batches(&ctx, sql).await;
 
     assert_batches_eq!(expected, &actual);
 }
 
 #[tokio::test]
 async fn test_intersect_all() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_parquet(&mut ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 INTERSECT ALL SELECT int_col, double_col FROM alltypes_plain LIMIT 4";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------+------------+",
         "| int_col | double_col |",
@@ -70,11 +70,11 @@ async fn test_intersect_all() -> Result<()> {
 
 #[tokio::test]
 async fn test_intersect_distinct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_parquet(&mut ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 INTERSECT SELECT int_col, double_col FROM alltypes_plain";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------+------------+",
         "| int_col | double_col |",

--- a/datafusion/tests/sql/joins.rs
+++ b/datafusion/tests/sql/joins.rs
@@ -20,7 +20,7 @@ use datafusion::from_slice::FromSlice;
 
 #[tokio::test]
 async fn equijoin() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
@@ -35,11 +35,11 @@ async fn equijoin() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
 
-    let mut ctx = create_join_context_qualified()?;
+    let ctx = create_join_context_qualified()?;
     let equivalent_sql = [
         "SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t1.a = t2.a ORDER BY t1.a",
         "SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t2.a = t1.a ORDER BY t1.a",
@@ -54,7 +54,7 @@ async fn equijoin() -> Result<()> {
         "+---+-----+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -62,7 +62,7 @@ async fn equijoin() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_multiple_condition_ordering() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id AND t1_name <> t2_name ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id AND t2_name <> t1_name ORDER BY t1_id",
@@ -79,7 +79,7 @@ async fn equijoin_multiple_condition_ordering() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -87,10 +87,10 @@ async fn equijoin_multiple_condition_ordering() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_and_other_condition() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1 JOIN t2 ON t1_id = t2_id AND t2_name >= 'y' ORDER BY t1_id";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -105,12 +105,12 @@ async fn equijoin_and_other_condition() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_left_and_condition_from_right() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id AND t2_name >= 'y' ORDER BY t1_id";
     let res = ctx.create_logical_plan(sql);
     assert!(res.is_ok());
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -128,12 +128,12 @@ async fn equijoin_left_and_condition_from_right() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_right_and_condition_from_left() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t1_id = t2_id AND t1_id >= 22 ORDER BY t2_name";
     let res = ctx.create_logical_plan(sql);
     assert!(res.is_ok());
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -163,7 +163,7 @@ async fn equijoin_and_unsupported_condition() -> Result<()> {
 
 #[tokio::test]
 async fn left_join() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
@@ -179,7 +179,7 @@ async fn left_join() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -188,7 +188,7 @@ async fn left_join() -> Result<()> {
 #[tokio::test]
 async fn left_join_unbalanced() -> Result<()> {
     // the t1_id is larger than t2_id so the hash_build_probe_order optimizer should kick in
-    let mut ctx = create_join_context_unbalanced("t1_id", "t2_id")?;
+    let ctx = create_join_context_unbalanced("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 LEFT JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
@@ -205,7 +205,7 @@ async fn left_join_unbalanced() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -216,7 +216,7 @@ async fn left_join_null_filter() -> Result<()> {
     // Since t2 is the non-preserved side of the join, we cannot push down a NULL filter.
     // Note that this is only true because IS NULL does not remove nulls. For filters that
     // remove nulls, we can rewrite the join as an inner join and then push down the filter.
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_name IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -229,7 +229,7 @@ async fn left_join_null_filter() -> Result<()> {
         "+-------+-------+---------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
@@ -237,7 +237,7 @@ async fn left_join_null_filter() -> Result<()> {
 #[tokio::test]
 async fn left_join_null_filter_on_join_column() -> Result<()> {
     // Again, since t2 is the non-preserved side of the join, we cannot push down a NULL filter.
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_id IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -249,14 +249,14 @@ async fn left_join_null_filter_on_join_column() -> Result<()> {
         "+-------+-------+---------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn left_join_not_null_filter() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_name IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -268,14 +268,14 @@ async fn left_join_not_null_filter() -> Result<()> {
         "+-------+-------+---------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn left_join_not_null_filter_on_join_column() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_id IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -288,14 +288,14 @@ async fn left_join_not_null_filter_on_join_column() -> Result<()> {
         "+-------+-------+---------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join_null_filter() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -306,14 +306,14 @@ async fn right_join_null_filter() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join_null_filter_on_join_column() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_id IS NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -323,14 +323,14 @@ async fn right_join_null_filter_on_join_column() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join_not_null_filter() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NOT NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -342,14 +342,14 @@ async fn right_join_not_null_filter() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join_not_null_filter_on_join_column() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_id IS NOT NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -362,14 +362,14 @@ async fn right_join_not_null_filter_on_join_column() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn full_join_null_filter() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -381,14 +381,14 @@ async fn full_join_null_filter() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn full_join_not_null_filter() -> Result<()> {
-    let mut ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id WHERE t1_name IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -402,14 +402,14 @@ async fn full_join_not_null_filter() -> Result<()> {
         "+-------+---------+-------+",
     ];
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn right_join() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 RIGHT JOIN t2 ON t2_id = t1_id ORDER BY t1_id"
@@ -425,7 +425,7 @@ async fn right_join() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -433,7 +433,7 @@ async fn right_join() -> Result<()> {
 
 #[tokio::test]
 async fn full_join() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1 FULL JOIN t2 ON t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1 FULL JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
@@ -450,7 +450,7 @@ async fn full_join() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
 
@@ -459,7 +459,7 @@ async fn full_join() -> Result<()> {
         "SELECT t1_id, t1_name, t2_name FROM t1 FULL OUTER JOIN t2 ON t2_id = t1_id ORDER BY t1_id",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
 
@@ -468,9 +468,9 @@ async fn full_join() -> Result<()> {
 
 #[tokio::test]
 async fn left_join_using() -> Result<()> {
-    let mut ctx = create_join_context("id", "id")?;
+    let ctx = create_join_context("id", "id")?;
     let sql = "SELECT id, t1_name, t2_name FROM t1 LEFT JOIN t2 USING (id) ORDER BY id";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+---------+---------+",
         "| id | t1_name | t2_name |",
@@ -487,7 +487,7 @@ async fn left_join_using() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_implicit_syntax() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let equivalent_sql = [
         "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t1_id = t2_id ORDER BY t1_id",
         "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id",
@@ -502,7 +502,7 @@ async fn equijoin_implicit_syntax() -> Result<()> {
         "+-------+---------+---------+",
     ];
     for sql in equivalent_sql.iter() {
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -510,14 +510,14 @@ async fn equijoin_implicit_syntax() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let sql = "SELECT t1_id, t1_name, t2_name \
         FROM t1, t2 \
         WHERE t1_id > 0 \
         AND t1_id = t2_id \
         AND t2_id < 99 \
         ORDER BY t1_id";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -533,10 +533,10 @@ async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
 
 #[tokio::test]
 async fn equijoin_implicit_syntax_reversed() -> Result<()> {
-    let mut ctx = create_join_context("t1_id", "t2_id")?;
+    let ctx = create_join_context("t1_id", "t2_id")?;
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -569,7 +569,7 @@ async fn cross_join() {
     let actual = execute(&mut ctx, sql).await;
     assert_eq!(4 * 4, actual.len());
 
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -611,12 +611,12 @@ async fn cross_join() {
 #[tokio::test]
 async fn cross_join_unbalanced() {
     // the t1_id is larger than t2_id so the hash_build_probe_order optimizer should kick in
-    let mut ctx = create_join_context_unbalanced("t1_id", "t2_id").unwrap();
+    let ctx = create_join_context_unbalanced("t1_id", "t2_id").unwrap();
 
     // the order of the values is not determinisitic, so we need to sort to check the values
     let sql =
         "SELECT t1_id, t1_name, t2_name FROM t1 CROSS JOIN t2 ORDER BY t1_id, t1_name, t2_name";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+---------+---------+",
         "| t1_id | t1_name | t2_name |",
@@ -648,7 +648,7 @@ async fn cross_join_unbalanced() {
 
 #[tokio::test]
 async fn test_join_timestamp() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // register time table
     let timestamp_schema = Arc::new(Schema::new(vec![Field::new(
@@ -673,7 +673,7 @@ async fn test_join_timestamp() -> Result<()> {
                      JOIN (SELECT * FROM timestamp) as b \
                      ON a.time = b.time \
                      ORDER BY a.time";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------------------------------+-------------------------------+",
@@ -691,7 +691,7 @@ async fn test_join_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn test_join_float32() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // register population table
     let population_schema = Arc::new(Schema::new(vec![
@@ -714,7 +714,7 @@ async fn test_join_float32() -> Result<()> {
                      JOIN (SELECT * FROM population) as b \
                      ON a.population = b.population \
                      ORDER BY a.population";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+------+------------+------+------------+",
@@ -732,7 +732,7 @@ async fn test_join_float32() -> Result<()> {
 
 #[tokio::test]
 async fn test_join_float64() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     // register population table
     let population_schema = Arc::new(Schema::new(vec![
@@ -755,7 +755,7 @@ async fn test_join_float64() -> Result<()> {
                      JOIN (SELECT * FROM population) as b \
                      ON a.population = b.population \
                      ORDER BY a.population";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+------+------------+------+------------+",
@@ -799,8 +799,8 @@ async fn inner_join_qualified_names() -> Result<()> {
     ];
 
     for sql in equivalent_sql.iter() {
-        let mut ctx = create_join_context_qualified()?;
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let ctx = create_join_context_qualified()?;
+        let actual = execute_to_batches(&ctx, sql).await;
         assert_batches_eq!(expected, &actual);
     }
     Ok(())
@@ -813,8 +813,8 @@ async fn inner_join_nulls() {
 
     let expected = vec!["++", "++"];
 
-    let mut ctx = create_join_context_qualified().unwrap();
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let ctx = create_join_context_qualified().unwrap();
+    let actual = execute_to_batches(&ctx, sql).await;
 
     // left and right shouldn't match anything
     assert_batches_eq!(expected, &actual);
@@ -857,14 +857,14 @@ async fn join_tables_with_duplicated_column_name_not_in_on_constraint() -> Resul
     .unwrap();
     let cities = MemTable::try_new(batch.schema(), vec![vec![batch]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("countries", Arc::new(countries))?;
     ctx.register_table("cities", Arc::new(cities))?;
 
     // city.id is not in the on constraint, but the output result will contain both city.id and
     // country.id
     let sql = "SELECT t1.id, t2.id, t1.city, t2.country FROM cities AS t1 JOIN countries AS t2 ON t1.country_id = t2.id ORDER BY t1.id";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+-----------+---------+",
         "| id | id | city      | country |",
@@ -885,7 +885,7 @@ async fn join_tables_with_duplicated_column_name_not_in_on_constraint() -> Resul
 
 #[tokio::test]
 async fn join_timestamp() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let expected = vec![
@@ -899,7 +899,7 @@ async fn join_timestamp() -> Result<()> {
     ];
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT * FROM t as t1  \
          JOIN (SELECT * FROM t) as t2 \
          ON t1.nanos = t2.nanos",
@@ -909,7 +909,7 @@ async fn join_timestamp() -> Result<()> {
     assert_batches_sorted_eq!(expected, &results);
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT * FROM t as t1  \
          JOIN (SELECT * FROM t) as t2 \
          ON t1.micros = t2.micros",
@@ -919,7 +919,7 @@ async fn join_timestamp() -> Result<()> {
     assert_batches_sorted_eq!(expected, &results);
 
     let results = execute_to_batches(
-        &mut ctx,
+        &ctx,
         "SELECT * FROM t as t1  \
          JOIN (SELECT * FROM t) as t2 \
          ON t1.millis = t2.millis",

--- a/datafusion/tests/sql/limit.rs
+++ b/datafusion/tests/sql/limit.rs
@@ -19,10 +19,10 @@ use super::*;
 
 #[tokio::test]
 async fn csv_query_limit() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+----+", "| c1 |", "+----+", "| c  |", "| d  |", "+----+"];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -30,10 +30,10 @@ async fn csv_query_limit() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_bigger_than_nbr_of_rows() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c2 FROM aggregate_test_100 LIMIT 200";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     // println!("{}", pretty_format_batches(&a).unwrap());
     let expected = vec![
         "+----+", "| c2 |", "+----+", "| 2  |", "| 5  |", "| 1  |", "| 1  |", "| 5  |",
@@ -56,10 +56,10 @@ async fn csv_query_limit_bigger_than_nbr_of_rows() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_with_same_nbr_of_rows() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c2 FROM aggregate_test_100 LIMIT 100";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+", "| c2 |", "+----+", "| 2  |", "| 5  |", "| 1  |", "| 1  |", "| 5  |",
         "| 4  |", "| 3  |", "| 3  |", "| 1  |", "| 4  |", "| 1  |", "| 4  |", "| 3  |",
@@ -81,10 +81,10 @@ async fn csv_query_limit_with_same_nbr_of_rows() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_zero() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 0";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["++", "++"];
     assert_batches_eq!(expected, &actual);
     Ok(())

--- a/datafusion/tests/sql/order.rs
+++ b/datafusion/tests/sql/order.rs
@@ -19,11 +19,11 @@ use super::*;
 
 #[tokio::test]
 async fn test_sort_unprojected_col() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_alltypes_parquet(&mut ctx).await;
     // execute the query
     let sql = "SELECT id FROM alltypes_plain ORDER BY int_col, double_col";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+", "| id |", "+----+", "| 4  |", "| 6  |", "| 2  |", "| 0  |", "| 5  |",
         "| 7  |", "| 3  |", "| 1  |", "+----+",
@@ -34,10 +34,10 @@ async fn test_sort_unprojected_col() -> Result<()> {
 
 #[tokio::test]
 async fn test_order_by_agg_expr() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT MIN(c12) FROM aggregate_test_100 ORDER BY MIN(c12)";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------------------+",
         "| MIN(aggregate_test_100.c12) |",
@@ -48,16 +48,16 @@ async fn test_order_by_agg_expr() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     let sql = "SELECT MIN(c12) FROM aggregate_test_100 ORDER BY MIN(c12) + 0.1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
 
 #[tokio::test]
 async fn test_nulls_first_asc() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----+--------+",
         "| num | letter |",
@@ -73,9 +73,9 @@ async fn test_nulls_first_asc() -> Result<()> {
 
 #[tokio::test]
 async fn test_nulls_first_desc() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num DESC";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----+--------+",
         "| num | letter |",
@@ -91,9 +91,9 @@ async fn test_nulls_first_desc() -> Result<()> {
 
 #[tokio::test]
 async fn test_specific_nulls_last_desc() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num DESC NULLS LAST";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----+--------+",
         "| num | letter |",
@@ -109,9 +109,9 @@ async fn test_specific_nulls_last_desc() -> Result<()> {
 
 #[tokio::test]
 async fn test_specific_nulls_first_asc() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num ASC NULLS FIRST";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----+--------+",
         "| num | letter |",

--- a/datafusion/tests/sql/partitioned_csv.rs
+++ b/datafusion/tests/sql/partitioned_csv.rs
@@ -25,13 +25,13 @@ use arrow::{
 };
 use datafusion::{
     error::Result,
-    prelude::{CsvReadOptions, ExecutionConfig, ExecutionContext},
+    prelude::{CsvReadOptions, SessionConfig, SessionContext},
 };
 use tempfile::TempDir;
 
 /// Execute SQL and return results
 async fn plan_and_collect(
-    ctx: &mut ExecutionContext,
+    ctx: &mut SessionContext,
     sql: &str,
 ) -> Result<Vec<RecordBatch>> {
     ctx.sql(sql).await?.collect().await
@@ -77,9 +77,9 @@ fn populate_csv_partitions(
 pub async fn create_ctx(
     tmp_dir: &TempDir,
     partition_count: usize,
-) -> Result<ExecutionContext> {
+) -> Result<SessionContext> {
     let mut ctx =
-        ExecutionContext::with_config(ExecutionConfig::new().with_target_partitions(8));
+        SessionContext::with_config(SessionConfig::new().with_target_partitions(8));
 
     let schema = populate_csv_partitions(tmp_dir, partition_count, ".csv")?;
 

--- a/datafusion/tests/sql/select.rs
+++ b/datafusion/tests/sql/select.rs
@@ -24,12 +24,12 @@ use tempfile::TempDir;
 
 #[tokio::test]
 async fn all_where_empty() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT *
                FROM aggregate_test_100
                WHERE 1=2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["++", "++"];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -37,10 +37,10 @@ async fn all_where_empty() -> Result<()> {
 
 #[tokio::test]
 async fn select_values_list() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     {
         let sql = "VALUES (1)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+",
             "| column1 |",
@@ -52,7 +52,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (-1)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+",
             "| column1 |",
@@ -64,7 +64,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (2+1,2-1,2>1)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+---------+",
             "| column1 | column2 | column3 |",
@@ -86,7 +86,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1),(2)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+",
             "| column1 |",
@@ -104,7 +104,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1,'a'),(2,'b')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -137,7 +137,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1,'a'),(NULL,'b'),(3,'c')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -151,7 +151,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (NULL,'a'),(NULL,'b'),(3,'c')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -165,7 +165,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (NULL,'a'),(NULL,'b'),(NULL,'c')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -179,7 +179,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1,'a'),(2,NULL),(3,'c')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -193,7 +193,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1,NULL),(2,NULL),(3,'c')";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+",
             "| column1 | column2 |",
@@ -207,7 +207,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "VALUES (1,2,3,4,5,6,7,8,9,10,11,12,13,NULL,'F',3.5)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------+---------+---------+---------+---------+---------+---------+---------+---------+----------+----------+----------+----------+----------+----------+----------+",
             "| column1 | column2 | column3 | column4 | column5 | column6 | column7 | column8 | column9 | column10 | column11 | column12 | column13 | column14 | column15 | column16 |",
@@ -219,7 +219,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "SELECT * FROM (VALUES (1,'a'),(2,NULL)) AS t(c1, c2)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----+----+",
             "| c1 | c2 |",
@@ -232,7 +232,7 @@ async fn select_values_list() -> Result<()> {
     }
     {
         let sql = "EXPLAIN VALUES (1, 'a', -1, 1.1),(NULL, 'b', -3, 0.5)";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------------+-----------------------------------------------------------------------------------------------------------+",
             "| plan_type     | plan                                                                                                      |",
@@ -249,14 +249,14 @@ async fn select_values_list() -> Result<()> {
 
 #[tokio::test]
 async fn select_all() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql = "SELECT c1 FROM aggregate_simple order by c1";
-    let results = execute_to_batches(&mut ctx, sql).await;
+    let results = execute_to_batches(&ctx, sql).await;
 
     let sql_all = "SELECT ALL c1 FROM aggregate_simple order by c1";
-    let results_all = execute_to_batches(&mut ctx, sql_all).await;
+    let results_all = execute_to_batches(&ctx, sql_all).await;
 
     let expected = vec![
         "+---------+",
@@ -288,7 +288,7 @@ async fn select_all() -> Result<()> {
 
 #[tokio::test]
 async fn select_distinct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await?;
 
     let sql = "SELECT DISTINCT * FROM aggregate_simple";
@@ -305,11 +305,11 @@ async fn select_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn select_distinct_simple_1() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await.unwrap();
 
     let sql = "SELECT DISTINCT c1 FROM aggregate_simple order by c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+---------+",
@@ -327,11 +327,11 @@ async fn select_distinct_simple_1() {
 
 #[tokio::test]
 async fn select_distinct_simple_2() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await.unwrap();
 
     let sql = "SELECT DISTINCT c1, c2 FROM aggregate_simple order by c1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+---------+----------------+",
@@ -349,11 +349,11 @@ async fn select_distinct_simple_2() {
 
 #[tokio::test]
 async fn select_distinct_simple_3() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await.unwrap();
 
     let sql = "SELECT distinct c3 FROM aggregate_simple order by c3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------+",
@@ -368,11 +368,11 @@ async fn select_distinct_simple_3() {
 
 #[tokio::test]
 async fn select_distinct_simple_4() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_simple_csv(&mut ctx).await.unwrap();
 
     let sql = "SELECT distinct c1+c2 as a FROM aggregate_simple";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------------------------+",
@@ -390,7 +390,7 @@ async fn select_distinct_simple_4() {
 
 #[tokio::test]
 async fn select_distinct_from() {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
 
     let sql = "select
         1 IS DISTINCT FROM CAST(NULL as INT) as a,
@@ -400,7 +400,7 @@ async fn select_distinct_from() {
         NULL IS DISTINCT FROM NULL as e,
         NULL IS NOT DISTINCT FROM NULL as f
     ";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------+-------+-------+------+-------+------+",
         "| a    | b     | c     | d    | e     | f    |",
@@ -413,7 +413,7 @@ async fn select_distinct_from() {
 
 #[tokio::test]
 async fn select_distinct_from_utf8() {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
 
     let sql = "select
         'x' IS DISTINCT FROM NULL as a,
@@ -421,7 +421,7 @@ async fn select_distinct_from_utf8() {
         'x' IS NOT DISTINCT FROM NULL as c,
         'x' IS NOT DISTINCT FROM 'x' as d
     ";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------+-------+-------+------+",
         "| a    | b     | c     | d    |",
@@ -434,10 +434,10 @@ async fn select_distinct_from_utf8() {
 
 #[tokio::test]
 async fn csv_query_with_decimal_by_sql() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_simple_aggregate_csv_with_decimal_by_sql(&mut ctx).await;
     let sql = "SELECT c1 from aggregate_simple";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
         "| c1       |",
@@ -465,10 +465,10 @@ async fn csv_query_with_decimal_by_sql() -> Result<()> {
 
 #[tokio::test]
 async fn use_between_expression_in_select_query() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let sql = "SELECT 1 NOT BETWEEN 3 AND 5";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------------------------------------+",
         "| Int64(1) NOT BETWEEN Int64(3) AND Int64(5) |",
@@ -484,7 +484,7 @@ async fn use_between_expression_in_select_query() -> Result<()> {
     ctx.register_table("test", Arc::new(table))?;
 
     let sql = "SELECT abs(c1) BETWEEN 0 AND LoG(c1 * 100 ) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     // Expect field name to be correctly converted for expr, low and high.
     let expected = vec![
         "+--------------------------------------------------------------------+",
@@ -499,7 +499,7 @@ async fn use_between_expression_in_select_query() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     let sql = "EXPLAIN SELECT c1 BETWEEN 2 AND 3 FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let formatted = arrow::util::pretty::pretty_format_batches(&actual)
         .unwrap()
         .to_string();
@@ -515,7 +515,7 @@ async fn use_between_expression_in_select_query() -> Result<()> {
 
 #[tokio::test]
 async fn query_get_indexed_field() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let schema = Arc::new(Schema::new(vec![Field::new(
         "some_list",
         DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
@@ -539,7 +539,7 @@ async fn query_get_indexed_field() -> Result<()> {
 
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT some_list[0] as i0 FROM ints LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+", "| i0 |", "+----+", "| 0  |", "| 4  |", "| 7  |", "+----+",
     ];
@@ -549,7 +549,7 @@ async fn query_get_indexed_field() -> Result<()> {
 
 #[tokio::test]
 async fn query_nested_get_indexed_field() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let nested_dt = DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
     // Nested schema of { "some_list": [[i64]] }
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -585,7 +585,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
 
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT some_list[0] as i0 FROM ints LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
         "| i0       |",
@@ -597,7 +597,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
     let sql = "SELECT some_list[0][0] as i0 FROM ints LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+", "| i0 |", "+----+", "| 0  |", "| 5  |", "| 11 |", "+----+",
     ];
@@ -607,7 +607,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
 
 #[tokio::test]
 async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let nested_dt = DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
     // Nested schema of { "some_struct": { "bar": [i64] } }
     let struct_fields = vec![Field::new("bar", nested_dt.clone(), true)];
@@ -635,7 +635,7 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
 
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT some_struct[\"bar\"] as l0 FROM structs LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------+",
         "| l0             |",
@@ -647,7 +647,7 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
     let sql = "SELECT some_struct[\"bar\"][0] as i0 FROM structs LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+", "| i0 |", "+----+", "| 0  |", "| 4  |", "| 8  |", "+----+",
     ];
@@ -676,12 +676,12 @@ async fn query_on_string_dictionary() -> Result<()> {
     .unwrap();
 
     let table = MemTable::try_new(batch.schema(), vec![vec![batch]])?;
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
 
     // Basic SELECT
     let sql = "SELECT d1 FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -695,7 +695,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // basic filtering
     let sql = "SELECT d1 FROM test WHERE d1 IS NOT NULL";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -708,7 +708,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // comparison with constant
     let sql = "SELECT d1 FROM test WHERE d1 = 'three'";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -720,7 +720,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // comparison with another dictionary column
     let sql = "SELECT d1 FROM test WHERE d1 = d2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -732,7 +732,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // order comparison with another dictionary column
     let sql = "SELECT d1 FROM test WHERE d1 <= d2";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -744,7 +744,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // comparison with a non dictionary column
     let sql = "SELECT d1 FROM test WHERE d1 = d3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -756,7 +756,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // filtering with constant
     let sql = "SELECT d1 FROM test WHERE d1 = 'three'";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+",
         "| d1    |",
@@ -768,7 +768,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // Expression evaluation
     let sql = "SELECT concat(d1, '-foo') FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------------------------------+",
         "| concat(test.d1,Utf8(\"-foo\")) |",
@@ -782,7 +782,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // Expression evaluation with two dictionaries
     let sql = "SELECT concat(d1, d2) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------+",
         "| concat(test.d1,test.d2) |",
@@ -796,7 +796,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // aggregation
     let sql = "SELECT COUNT(d1) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------+",
         "| COUNT(test.d1) |",
@@ -808,7 +808,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // aggregation min
     let sql = "SELECT MIN(d1) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------+",
         "| MIN(test.d1) |",
@@ -820,7 +820,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // aggregation max
     let sql = "SELECT MAX(d1) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------+",
         "| MAX(test.d1) |",
@@ -832,7 +832,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // grouping
     let sql = "SELECT d1, COUNT(*) FROM test group by d1";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+-----------------+",
         "| d1    | COUNT(UInt8(1)) |",
@@ -846,7 +846,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     // window functions
     let sql = "SELECT d1, row_number() OVER (partition by d1) FROM test";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------+--------------+",
         "| d1    | ROW_NUMBER() |",
@@ -865,11 +865,11 @@ async fn query_on_string_dictionary() -> Result<()> {
 async fn query_cte() -> Result<()> {
     // Test for SELECT <expression> without FROM.
     // Should evaluate expressions in project position.
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
 
     // simple with
     let sql = "WITH t AS (SELECT 1) SELECT * FROM t";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
         "| Int64(1) |",
@@ -882,19 +882,19 @@ async fn query_cte() -> Result<()> {
     // with + union
     let sql =
         "WITH t AS (SELECT 1 AS a), u AS (SELECT 2 AS a) SELECT * FROM t UNION ALL SELECT * FROM u";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+---+", "| a |", "+---+", "| 1 |", "| 2 |", "+---+"];
     assert_batches_eq!(expected, &actual);
 
     // with + join
     let sql = "WITH t AS (SELECT 1 AS id1), u AS (SELECT 1 AS id2, 5 as x) SELECT x FROM t JOIN u ON (id1 = id2)";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+---+", "| x |", "+---+", "| 5 |", "+---+"];
     assert_batches_eq!(expected, &actual);
 
     // backward reference
     let sql = "WITH t AS (SELECT 1 AS id1), u AS (SELECT * FROM t) SELECT * from u";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+-----+", "| id1 |", "+-----+", "| 1   |", "+-----+"];
     assert_batches_eq!(expected, &actual);
 
@@ -903,7 +903,7 @@ async fn query_cte() -> Result<()> {
 
 #[tokio::test]
 async fn csv_select_nested() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "SELECT o1, o2, c3
                FROM (
@@ -915,7 +915,7 @@ async fn csv_select_nested() -> Result<()> {
                    ORDER BY c2 ASC, c3 ASC
                  ) AS a
                ) AS b";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+------+",
         "| o1 | o2 | c3   |",
@@ -945,8 +945,8 @@ async fn parallel_query_with_filter() -> Result<()> {
 
     let physical_plan = ctx.create_physical_plan(&logical_plan).await?;
 
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let results = collect_partitioned(physical_plan, runtime).await?;
+    let task_ctx = ctx.task_ctx();
+    let results = collect_partitioned(physical_plan, task_ctx).await?;
 
     // note that the order of partitions is not deterministic
     let mut num_rows = 0;
@@ -991,7 +991,7 @@ async fn parallel_query_with_filter() -> Result<()> {
 
 #[tokio::test]
 async fn query_empty_table() {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let empty_table = Arc::new(EmptyTable::new(Arc::new(Schema::empty())));
     ctx.register_table("test_tbl", empty_table).unwrap();
     let sql = "SELECT * FROM test_tbl";

--- a/datafusion/tests/sql/timestamp.rs
+++ b/datafusion/tests/sql/timestamp.rs
@@ -20,7 +20,7 @@ use datafusion::from_slice::FromSlice;
 
 #[tokio::test]
 async fn query_cast_timestamp_millis() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -35,7 +35,7 @@ async fn query_cast_timestamp_millis() -> Result<()> {
     ctx.register_table("t1", Arc::new(t1_table))?;
 
     let sql = "SELECT to_timestamp_millis(ts) FROM t1 LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+--------------------------+",
@@ -52,7 +52,7 @@ async fn query_cast_timestamp_millis() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_micros() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -67,7 +67,7 @@ async fn query_cast_timestamp_micros() -> Result<()> {
     ctx.register_table("t1", Arc::new(t1_table))?;
 
     let sql = "SELECT to_timestamp_micros(ts) FROM t1 LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+--------------------------+",
@@ -85,7 +85,7 @@ async fn query_cast_timestamp_micros() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_seconds() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -98,7 +98,7 @@ async fn query_cast_timestamp_seconds() -> Result<()> {
     ctx.register_table("t1", Arc::new(t1_table))?;
 
     let sql = "SELECT to_timestamp_seconds(ts) FROM t1 LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+---------------------------+",
@@ -116,12 +116,12 @@ async fn query_cast_timestamp_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     // Original column is nanos, convert to millis and check timestamp
     let sql = "SELECT to_timestamp_millis(ts) FROM ts_data LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------------------------------+",
@@ -135,7 +135,7 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     let sql = "SELECT to_timestamp_micros(ts) FROM ts_data LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-------------------------------+",
@@ -149,7 +149,7 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     let sql = "SELECT to_timestamp_seconds(ts) FROM ts_data LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+--------------------------------+",
         "| totimestampseconds(ts_data.ts) |",
@@ -166,12 +166,12 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("ts_secs", make_timestamp_table::<TimestampSecondType>()?)?;
 
     // Original column is seconds, convert to millis and check timestamp
     let sql = "SELECT to_timestamp_millis(ts) FROM ts_secs LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------+",
         "| totimestampmillis(ts_secs.ts) |",
@@ -186,7 +186,7 @@ async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
 
     // Original column is seconds, convert to micros and check timestamp
     let sql = "SELECT to_timestamp_micros(ts) FROM ts_secs LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------------+",
         "| totimestampmicros(ts_secs.ts) |",
@@ -200,7 +200,7 @@ async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
 
     // to nanos
     let sql = "SELECT to_timestamp(ts) FROM ts_secs LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------+",
         "| totimestamp(ts_secs.ts) |",
@@ -216,7 +216,7 @@ async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_micros_to_others() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table(
         "ts_micros",
         make_timestamp_table::<TimestampMicrosecondType>()?,
@@ -224,7 +224,7 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
 
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT to_timestamp_millis(ts) FROM ts_micros LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------------------+",
         "| totimestampmillis(ts_micros.ts) |",
@@ -238,7 +238,7 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
 
     // Original column is micros, convert to seconds and check timestamp
     let sql = "SELECT to_timestamp_seconds(ts) FROM ts_micros LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------------+",
         "| totimestampseconds(ts_micros.ts) |",
@@ -252,7 +252,7 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
 
     // Original column is micros, convert to nanos and check timestamp
     let sql = "SELECT to_timestamp(ts) FROM ts_micros LIMIT 3";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------+",
         "| totimestamp(ts_micros.ts)  |",
@@ -268,11 +268,11 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp('2020-09-08T12:00:00+00:00')";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----------------+",
@@ -287,14 +287,14 @@ async fn to_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_millis() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table(
         "ts_data",
         make_timestamp_table::<TimestampMillisecondType>()?,
     )?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_millis('2020-09-08T12:00:00+00:00')";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",
         "| COUNT(UInt8(1)) |",
@@ -308,14 +308,14 @@ async fn to_timestamp_millis() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_micros() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table(
         "ts_data",
         make_timestamp_table::<TimestampMicrosecondType>()?,
     )?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_micros('2020-09-08T12:00:00+00:00')";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----------------+",
@@ -330,11 +330,11 @@ async fn to_timestamp_micros() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_seconds() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("ts_data", make_timestamp_table::<TimestampSecondType>()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_seconds('2020-09-08T12:00:00+00:00')";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+-----------------+",
@@ -349,11 +349,11 @@ async fn to_timestamp_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn count_distinct_timestamps() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     let sql = "SELECT COUNT(DISTINCT(ts)) FROM ts_data";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
         "+----------------------------+",
@@ -369,7 +369,7 @@ async fn count_distinct_timestamps() -> Result<()> {
 #[tokio::test]
 async fn test_current_timestamp_expressions() -> Result<()> {
     let t1 = chrono::Utc::now().timestamp();
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let actual = execute(&mut ctx, "SELECT NOW(), NOW() as t2").await;
     let res1 = actual[0][0].as_str();
     let res2 = actual[0][1].as_str();
@@ -387,7 +387,7 @@ async fn test_current_timestamp_expressions() -> Result<()> {
 #[tokio::test]
 async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
     let t1 = chrono::Utc::now().timestamp();
-    let ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT NOW(), NOW() as t2";
 
     let msg = format!("Creating logical plan for '{}'", sql);
@@ -397,8 +397,8 @@ async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
     let plan = ctx.create_physical_plan(&plan).await.expect(&msg);
 
     let msg = format!("Executing physical plan for '{}': {:?}", sql, plan);
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let res = collect(plan, runtime).await.expect(&msg);
+    let task_ctx = ctx.task_ctx();
+    let res = collect(plan, task_ctx).await.expect(&msg);
     let actual = result_vec(&res);
 
     let res1 = actual[0][0].as_str();
@@ -416,7 +416,7 @@ async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
 
 #[tokio::test]
 async fn timestamp_minmax() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     let table_a = make_timestamp_tz_table::<TimestampMillisecondType>(None)?;
     let table_b =
         make_timestamp_tz_table::<TimestampNanosecondType>(Some("UTC".to_owned()))?;
@@ -424,7 +424,7 @@ async fn timestamp_minmax() -> Result<()> {
     ctx.register_table("table_b", table_b)?;
 
     let sql = "SELECT MIN(table_a.ts), MAX(table_b.ts) FROM table_a, table_b";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-------------------------+----------------------------+",
         "| MIN(table_a.ts)         | MAX(table_b.ts)            |",
@@ -440,7 +440,7 @@ async fn timestamp_minmax() -> Result<()> {
 #[tokio::test]
 async fn timestamp_coercion() -> Result<()> {
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a =
             make_timestamp_tz_table::<TimestampSecondType>(Some("UTC".to_owned()))?;
         let table_b =
@@ -449,7 +449,7 @@ async fn timestamp_coercion() -> Result<()> {
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------------------+-------------------------+--------------------------+",
             "| ts                  | ts                      | table_a.ts Eq table_b.ts |",
@@ -469,14 +469,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampSecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------------------+----------------------------+--------------------------+",
             "| ts                  | ts                         | table_a.ts Eq table_b.ts |",
@@ -496,14 +496,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampSecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+---------------------+----------------------------+--------------------------+",
             "| ts                  | ts                         | table_a.ts Eq table_b.ts |",
@@ -523,14 +523,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+-------------------------+---------------------+--------------------------+",
             "| ts                      | ts                  | table_a.ts Eq table_b.ts |",
@@ -550,14 +550,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+-------------------------+----------------------------+--------------------------+",
             "| ts                      | ts                         | table_a.ts Eq table_b.ts |",
@@ -577,14 +577,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+-------------------------+----------------------------+--------------------------+",
             "| ts                      | ts                         | table_a.ts Eq table_b.ts |",
@@ -604,14 +604,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+---------------------+--------------------------+",
             "| ts                         | ts                  | table_a.ts Eq table_b.ts |",
@@ -631,14 +631,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMillisecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+-------------------------+--------------------------+",
             "| ts                         | ts                      | table_a.ts Eq table_b.ts |",
@@ -658,14 +658,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+----------------------------+--------------------------+",
             "| ts                         | ts                         | table_a.ts Eq table_b.ts |",
@@ -685,14 +685,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+---------------------+--------------------------+",
             "| ts                         | ts                  | table_a.ts Eq table_b.ts |",
@@ -712,14 +712,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMillisecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+-------------------------+--------------------------+",
             "| ts                         | ts                      | table_a.ts Eq table_b.ts |",
@@ -739,14 +739,14 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = SessionContext::new();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
         ctx.register_table("table_b", table_b)?;
 
         let sql = "SELECT table_a.ts, table_b.ts, table_a.ts = table_b.ts FROM table_a, table_b";
-        let actual = execute_to_batches(&mut ctx, sql).await;
+        let actual = execute_to_batches(&ctx, sql).await;
         let expected = vec![
             "+----------------------------+----------------------------+--------------------------+",
             "| ts                         | ts                         | table_a.ts Eq table_b.ts |",
@@ -770,7 +770,7 @@ async fn timestamp_coercion() -> Result<()> {
 
 #[tokio::test]
 async fn group_by_timestamp_millis() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new(
@@ -802,7 +802,7 @@ async fn group_by_timestamp_millis() -> Result<()> {
 
     let sql =
         "SELECT timestamp, SUM(count) FROM t1 GROUP BY timestamp ORDER BY timestamp ASC";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------+---------------+",
         "| timestamp           | SUM(t1.count) |",

--- a/datafusion/tests/sql/udf.rs
+++ b/datafusion/tests/sql/udf.rs
@@ -51,7 +51,7 @@ async fn scalar_udf() -> Result<()> {
         ],
     )?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
     ctx.register_table("t", Arc::new(provider))?;
@@ -97,8 +97,8 @@ async fn scalar_udf() -> Result<()> {
 
     let plan = ctx.optimize(&plan)?;
     let plan = ctx.create_physical_plan(&plan).await?;
-    let runtime = ctx.state.lock().runtime_env.clone();
-    let result = collect(plan, runtime).await?;
+    let task_ctx = ctx.task_ctx();
+    let result = collect(plan, task_ctx).await?;
 
     let expected = vec![
         "+-----+-----+-----------------+",
@@ -155,7 +155,7 @@ async fn simple_udaf() -> Result<()> {
         vec![Arc::new(Int32Array::from_slice(&[4, 5]))],
     )?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
 
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
     ctx.register_table("t", Arc::new(provider))?;

--- a/datafusion/tests/sql/unicode.rs
+++ b/datafusion/tests/sql/unicode.rs
@@ -116,7 +116,7 @@ async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT length(c1) FROM test";
     let actual = execute(&mut ctx, sql).await;

--- a/datafusion/tests/sql/union.rs
+++ b/datafusion/tests/sql/union.rs
@@ -19,9 +19,9 @@ use super::*;
 
 #[tokio::test]
 async fn union_all() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT 1 as x UNION ALL SELECT 2 as x";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+---+", "| x |", "+---+", "| 1 |", "| 2 |", "+---+"];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -29,7 +29,7 @@ async fn union_all() -> Result<()> {
 
 #[tokio::test]
 async fn csv_union_all() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql =
         "SELECT c1 FROM aggregate_test_100 UNION ALL SELECT c1 FROM aggregate_test_100";
@@ -40,9 +40,9 @@ async fn csv_union_all() -> Result<()> {
 
 #[tokio::test]
 async fn union_distinct() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql = "SELECT 1 as x UNION SELECT 1 as x";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec!["+---+", "| x |", "+---+", "| 1 |", "+---+"];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -50,10 +50,10 @@ async fn union_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn union_all_with_aggregate() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let ctx = SessionContext::new();
     let sql =
         "SELECT SUM(d) FROM (SELECT 1 as c, 2 as d UNION ALL SELECT 1 as c, 3 AS d) as a";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
         "| SUM(a.d) |",

--- a/datafusion/tests/sql/window.rs
+++ b/datafusion/tests/sql/window.rs
@@ -20,7 +20,7 @@ use super::*;
 /// for window functions without order by the first, last, and nth function call does not make sense
 #[tokio::test]
 async fn csv_query_window_with_empty_over() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "select \
                c9, \
@@ -30,7 +30,7 @@ async fn csv_query_window_with_empty_over() -> Result<()> {
                from aggregate_test_100 \
                order by c9 \
                limit 5";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------+------------------------------+----------------------------+----------------------------+",
         "| c9        | COUNT(aggregate_test_100.c5) | MAX(aggregate_test_100.c5) | MIN(aggregate_test_100.c5) |",
@@ -49,7 +49,7 @@ async fn csv_query_window_with_empty_over() -> Result<()> {
 /// for window functions without order by the first, last, and nth function call does not make sense
 #[tokio::test]
 async fn csv_query_window_with_partition_by() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "select \
                c9, \
@@ -61,7 +61,7 @@ async fn csv_query_window_with_partition_by() -> Result<()> {
                from aggregate_test_100 \
                order by c9 \
                limit 5";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------+-------------------------------------------+-------------------------------------------+---------------------------------------------+-------------------------------------------+-------------------------------------------+",
         "| c9        | SUM(CAST(aggregate_test_100.c4 AS Int32)) | AVG(CAST(aggregate_test_100.c4 AS Int32)) | COUNT(CAST(aggregate_test_100.c4 AS Int32)) | MAX(CAST(aggregate_test_100.c4 AS Int32)) | MIN(CAST(aggregate_test_100.c4 AS Int32)) |",
@@ -79,7 +79,7 @@ async fn csv_query_window_with_partition_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_window_with_order_by() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "select \
                c9, \
@@ -94,7 +94,7 @@ async fn csv_query_window_with_order_by() -> Result<()> {
                from aggregate_test_100 \
                order by c9 \
                limit 5";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------+----------------------------+----------------------------+------------------------------+----------------------------+----------------------------+------------------------------------+-----------------------------------+-------------------------------------------+",
         "| c9        | SUM(aggregate_test_100.c5) | AVG(aggregate_test_100.c5) | COUNT(aggregate_test_100.c5) | MAX(aggregate_test_100.c5) | MIN(aggregate_test_100.c5) | FIRST_VALUE(aggregate_test_100.c5) | LAST_VALUE(aggregate_test_100.c5) | NTH_VALUE(aggregate_test_100.c5,Int64(2)) |",
@@ -112,7 +112,7 @@ async fn csv_query_window_with_order_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_window_with_partition_by_order_by() -> Result<()> {
-    let mut ctx = ExecutionContext::new();
+    let mut ctx = SessionContext::new();
     register_aggregate_csv(&mut ctx).await?;
     let sql = "select \
                c9, \
@@ -127,7 +127,7 @@ async fn csv_query_window_with_partition_by_order_by() -> Result<()> {
                from aggregate_test_100 \
                order by c9 \
                limit 5";
-    let actual = execute_to_batches(&mut ctx, sql).await;
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------+----------------------------+----------------------------+------------------------------+----------------------------+----------------------------+------------------------------------+-----------------------------------+-------------------------------------------+",
         "| c9        | SUM(aggregate_test_100.c5) | AVG(aggregate_test_100.c5) | COUNT(aggregate_test_100.c5) | MAX(aggregate_test_100.c5) | MIN(aggregate_test_100.c5) | FIRST_VALUE(aggregate_test_100.c5) | LAST_VALUE(aggregate_test_100.c5) | NTH_VALUE(aggregate_test_100.c5,Int64(2)) |",

--- a/datafusion/tests/statistics.rs
+++ b/datafusion/tests/statistics.rs
@@ -29,12 +29,12 @@ use datafusion::{
         DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
         Statistics,
     },
-    prelude::ExecutionContext,
+    prelude::SessionContext,
     scalar::ScalarValue,
 };
 
 use async_trait::async_trait;
-use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::context::TaskContext;
 
 /// This is a testing structure for statistics
 /// It will act both as a table provider and execution plan
@@ -144,7 +144,7 @@ impl ExecutionPlan for StatisticsValidation {
     async fn execute(
         &self,
         _partition: usize,
-        _runtime: Arc<RuntimeEnv>,
+        _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         unimplemented!("This plan only serves for testing statistics")
     }
@@ -171,8 +171,8 @@ impl ExecutionPlan for StatisticsValidation {
     }
 }
 
-fn init_ctx(stats: Statistics, schema: Schema) -> Result<ExecutionContext> {
-    let mut ctx = ExecutionContext::new();
+fn init_ctx(stats: Statistics, schema: Schema) -> Result<SessionContext> {
+    let mut ctx = SessionContext::new();
     let provider: Arc<dyn TableProvider> =
         Arc::new(StatisticsValidation::new(stats, Arc::new(schema)));
     ctx.register_table("stats_table", provider)?;

--- a/docs/source/python/api/execution_context.rst
+++ b/docs/source/python/api/execution_context.rst
@@ -18,10 +18,10 @@
 .. _api.execution_context:
 .. currentmodule:: datafusion
 
-ExecutionContext
+SessionContext
 ================
 
 .. autosummary::
    :toctree: ../generated/
 
-   ExecutionContext
+   SessionContext

--- a/docs/source/python/index.rst
+++ b/docs/source/python/index.rst
@@ -44,7 +44,7 @@ Simple usage:
    import pyarrow
 
    # create a context
-   ctx = datafusion.ExecutionContext()
+   ctx = datafusion.SessionContext()
 
    # create a RecordBatch and a new DataFrame from it
    batch = pyarrow.RecordBatch.from_arrays(

--- a/docs/source/user-guide/distributed/clients/rust.md
+++ b/docs/source/user-guide/distributed/clients/rust.md
@@ -20,7 +20,7 @@
 # Ballista Rust Client
 
 Ballista usage is very similar to DataFusion. Tha main difference is that the starting point is a `BallistaContext`
-instead of the DataFusion `ExecutionContext`. Ballista uses the same DataFrame API as DataFusion.
+instead of the DataFusion `SessionContext`. Ballista uses the same DataFrame API as DataFusion.
 
 The following code sample demonstrates how to create a `BallistaContext` to connect to a Ballista scheduler process.
 

--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -36,7 +36,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {
   // register the table
-  let mut ctx = ExecutionContext::new();
+  let mut ctx = SessionContext::new();
   ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new()).await?;
 
   // create a plan to run a SQL query
@@ -56,7 +56,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {
   // create the dataframe
-  let mut ctx = ExecutionContext::new();
+  let mut ctx = SessionContext::new();
   let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
 
   let df = df.filter(col("a").lt_eq(col("b")))?

--- a/docs/source/user-guide/library.md
+++ b/docs/source/user-guide/library.md
@@ -57,7 +57,7 @@ use datafusion::prelude::*;
 #[tokio::main]
 async fn main() -> datafusion::error::Result<()> {
   // register the table
-  let mut ctx = ExecutionContext::new();
+  let mut ctx = SessionContext::new();
   ctx.register_csv("test", "<PATH_TO_YOUR_CSV_FILE>", CsvReadOptions::new()).await?;
 
   // create a plan to run a SQL query


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/1862#.

This PR covers the part 1 which are the trivial changes and UT fixes.

1. Rename from ExecutionContext to SessionContext and ExecutionContextState to SessionState,  Add TaskContext
and wrap the RuntimeEnv into TaskContext and pass down TaskContext into ExecutionPlan's execute() method, fix all the trivial UTs.


 # Rationale for this change
See #1862 as well as the discussion on a PR that includes more context for the other parts: https://github.com/apache/arrow-datafusion/pull/1924

# What changes are included in this PR?
See above

# Are there any user-facing changes?
Yes 