### PR TITLE
Fix minor clippy issue

### DIFF
--- a/ballista/rust/core/src/event_loop.rs
+++ b/ballista/rust/core/src/event_loop.rs
@@ -134,8 +134,8 @@ pub struct EventSender<E> {
 
 impl<E> EventSender<E> {
     pub async fn post_event(&self, event: E) -> Result<()> {
-        Ok(self.tx_event.send(event).await.map_err(|e| {
+        self.tx_event.send(event).await.map_err(|e| {
             BallistaError::General(format!("Fail to send event due to {}", e))
-        })?)
+        })
     }
 }


### PR DESCRIPTION
Due to "reasons" I have to run nightly clippy and it flags some new lints that I also think make Datafusion / Ballista code nicer

Here is a tiny change that makes clippy run cleanly under nightly rust