### PR TITLE
Eliminate the scalar value filter

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -32,6 +32,7 @@ use crate::{
         MemTable,
     },
     logical_plan::{PlanType, ToStringifiedPlan},
+    optimizer::eliminate_filter::EliminateFilter,
     optimizer::eliminate_limit::EliminateLimit,
     physical_optimizer::{
         aggregate_statistics::AggregateStatistics,
@@ -847,6 +848,7 @@ impl Default for ExecutionConfig {
                 // Simplify expressions first to maximize the chance
                 // of applying other optimizations
                 Arc::new(SimplifyExpressions::new()),
+                Arc::new(EliminateFilter::new()),
                 Arc::new(CommonSubexprEliminate::new()),
                 Arc::new(EliminateLimit::new()),
                 Arc::new(ProjectionPushDown::new()),

--- a/datafusion/src/optimizer/eliminate_filter.rs
+++ b/datafusion/src/optimizer/eliminate_filter.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimizer rule to replace `where false` on a plan with an empty relation.
+//! This saves time in planning and executing the query.
+//! Note that this rule should be applied after simplify expressions optimizer rule.
+use datafusion_common::ScalarValue;
+use datafusion_expr::Expr;
+
+use crate::error::Result;
+use crate::logical_plan::plan::Filter;
+use crate::logical_plan::{EmptyRelation, LogicalPlan};
+use crate::optimizer::optimizer::OptimizerRule;
+
+use super::utils;
+use crate::execution::context::ExecutionProps;
+
+/// Optimization rule that elimanate the scalar value filter with an [LogicalPlan::EmptyRelation]
+#[derive(Default)]
+pub struct EliminateFilter;
+
+impl EliminateFilter {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for EliminateFilter {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
+        match plan {
+            LogicalPlan::Filter(Filter {
+                predicate: Expr::Literal(ScalarValue::Boolean(Some(v))),
+                input,
+            }) if !*v => {
+                return Ok(LogicalPlan::EmptyRelation(EmptyRelation {
+                    produce_one_row: false,
+                    schema: input.schema().clone(),
+                }));
+            }
+            _ => {
+                // apply the optimization to all inputs of the plan
+                let inputs = plan.inputs();
+                let new_inputs = inputs
+                    .iter()
+                    .map(|plan| self.optimize(plan, execution_props))
+                    .collect::<Result<Vec<_>>>()?;
+
+                utils::from_plan(plan, &plan.expressions(), &new_inputs)
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "eliminate_filter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical_plan::LogicalPlanBuilder;
+    use crate::logical_plan::{col, sum};
+    use crate::test::*;
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = EliminateFilter::new();
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+        assert_eq!(plan.schema(), optimized_plan.schema());
+    }
+
+    #[test]
+    fn fliter_false() {
+        let filter_expr = Expr::Literal(ScalarValue::Boolean(Some(false)));
+
+        let table_scan = test_table_scan().unwrap();
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .filter(filter_expr)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        // No aggregate / scan / limit
+        let expected = "EmptyRelation";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+
+    #[test]
+    fn fliter_false_nested() {
+        let filter_expr = Expr::Literal(ScalarValue::Boolean(Some(false)));
+
+        let table_scan = test_table_scan().unwrap();
+        let plan1 = LogicalPlanBuilder::from(table_scan.clone())
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .build()
+            .unwrap();
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .filter(filter_expr)
+            .unwrap()
+            .union(plan1)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        // Left side is removed
+        let expected = "Union\
+            \n  EmptyRelation\
+            \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
+            \n    TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+}

--- a/datafusion/src/optimizer/eliminate_filter.rs
+++ b/datafusion/src/optimizer/eliminate_filter.rs
@@ -50,11 +50,15 @@ impl OptimizerRule for EliminateFilter {
             LogicalPlan::Filter(Filter {
                 predicate: Expr::Literal(ScalarValue::Boolean(Some(v))),
                 input,
-            }) if !*v => {
-                return Ok(LogicalPlan::EmptyRelation(EmptyRelation {
-                    produce_one_row: false,
-                    schema: input.schema().clone(),
-                }));
+            }) => {
+                if !*v {
+                    return Ok(LogicalPlan::EmptyRelation(EmptyRelation {
+                        produce_one_row: false,
+                        schema: input.schema().clone(),
+                    }));
+                } else {
+                    return Ok((**input).clone());
+                }
             }
             _ => {
                 // apply the optimization to all inputs of the plan

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -20,6 +20,7 @@
 
 #![allow(clippy::module_inception)]
 pub mod common_subexpr_eliminate;
+pub mod eliminate_filter;
 pub mod eliminate_limit;
 pub mod filter_push_down;
 pub mod limit_push_down;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1724.

# What changes are included in this PR?

Add rule `eliminate_filter`, which can eliminate the filter using scalar and add unit test.

# Are there any user-facing changes?

None.
