### PR TITLE
Fix stuck issue for the load testing of Push-based task scheduling

### DIFF
--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -147,6 +147,11 @@ pub struct ExecutorData {
     pub available_task_slots: u32,
 }
 
+pub struct ExecutorDeltaData {
+    pub executor_id: String,
+    pub task_slots: i32,
+}
+
 struct ExecutorResourcePair {
     total: protobuf::executor_resource::Resource,
     available: protobuf::executor_resource::Resource,

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -147,7 +147,7 @@ pub struct ExecutorData {
     pub available_task_slots: u32,
 }
 
-pub struct ExecutorDeltaData {
+pub struct ExecutorDataChange {
     pub executor_id: String,
     pub task_slots: i32,
 }

--- a/ballista/rust/scheduler/src/scheduler_server/event_loop.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/event_loop.rs
@@ -24,7 +24,7 @@ use log::{debug, warn};
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::EventAction;
 use ballista_core::serde::protobuf::{LaunchTaskParams, TaskDefinition};
-use ballista_core::serde::scheduler::ExecutorData;
+use ballista_core::serde::scheduler::ExecutorDeltaData;
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan};
 
 use crate::scheduler_server::ExecutorsClient;
@@ -70,12 +70,28 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             return Ok(Some(SchedulerServerEvent::JobSubmitted(job_id)));
         }
 
+        let mut executors_delta_data: Vec<ExecutorDeltaData> = available_executors
+            .iter()
+            .map(|executor_data| ExecutorDeltaData {
+                executor_id: executor_data.executor_id.clone(),
+                task_slots: executor_data.available_task_slots as i32,
+            })
+            .collect();
+
         let (tasks_assigment, num_tasks) = self
             .state
             .fetch_tasks(&mut available_executors, &job_id)
             .await?;
+        for (delta_data, data) in executors_delta_data
+            .iter_mut()
+            .zip(available_executors.iter())
+        {
+            delta_data.task_slots =
+                data.available_task_slots as i32 - delta_data.task_slots;
+        }
+
         if num_tasks > 0 {
-            self.launch_tasks(&available_executors, tasks_assigment)
+            self.launch_tasks(&executors_delta_data, tasks_assigment)
                 .await?;
         }
 
@@ -84,12 +100,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
 
     async fn launch_tasks(
         &self,
-        executors: &[ExecutorData],
+        executors: &[ExecutorDeltaData],
         tasks_assigment: Vec<Vec<TaskDefinition>>,
     ) -> Result<()> {
         for (idx_executor, tasks) in tasks_assigment.into_iter().enumerate() {
             if !tasks.is_empty() {
-                let executor_data = &executors[idx_executor];
+                let executor_delta_data = &executors[idx_executor];
                 debug!(
                     "Start to launch tasks {:?} to executor {:?}",
                     tasks
@@ -107,14 +123,17 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                             }
                         })
                         .collect::<Vec<String>>(),
-                    executor_data.executor_id
+                    executor_delta_data.executor_id
                 );
                 let mut client = {
                     let clients = self.executors_client.read().await;
-                    clients.get(&executor_data.executor_id).unwrap().clone()
+                    clients
+                        .get(&executor_delta_data.executor_id)
+                        .unwrap()
+                        .clone()
                 };
                 // Update the resources first
-                self.state.save_executor_data(executor_data.clone());
+                self.state.update_executor_data(executor_delta_data);
                 // TODO check whether launching task is successful or not
                 client.launch_task(LaunchTaskParams { task: tasks }).await?;
             } else {

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -31,7 +31,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::scheduler::to_proto::hash_partitioning_to_proto;
 use ballista_core::serde::scheduler::{
-    ExecutorData, ExecutorDeltaData, ExecutorMetadata,
+    ExecutorData, ExecutorDataChange, ExecutorMetadata,
 };
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
@@ -294,7 +294,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             }
 
             if let Some(executor_data) = self.state.get_executor_data(&executor_id) {
-                self.state.update_executor_data(&ExecutorDeltaData {
+                self.state.update_executor_data(&ExecutorDataChange {
                     executor_id: executor_data.executor_id,
                     task_slots: num_tasks as i32,
                 });

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -30,7 +30,9 @@ use ballista_core::serde::protobuf::{
     TaskDefinition, UpdateTaskStatusParams, UpdateTaskStatusResult,
 };
 use ballista_core::serde::scheduler::to_proto::hash_partitioning_to_proto;
-use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
+use ballista_core::serde::scheduler::{
+    ExecutorData, ExecutorDeltaData, ExecutorMetadata,
+};
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
@@ -290,9 +292,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                     jobs.insert(task_id.job_id.clone());
                 }
             }
-            if let Some(mut executor_data) = self.state.get_executor_data(&executor_id) {
-                executor_data.available_task_slots += num_tasks as u32;
-                self.state.save_executor_data(executor_data);
+
+            if let Some(executor_data) = self.state.get_executor_data(&executor_id) {
+                self.state.update_executor_data(&ExecutorDeltaData {
+                    executor_id: executor_data.executor_id,
+                    task_slots: num_tasks as i32,
+                });
             } else {
                 error!("Fail to get executor data for {:?}", &executor_id);
             }

--- a/ballista/rust/scheduler/src/state/in_memory_state.rs
+++ b/ballista/rust/scheduler/src/state/in_memory_state.rs
@@ -128,7 +128,8 @@ impl InMemorySchedulerState {
             executors_data
                 .iter()
                 .filter_map(|(exec, data)| {
-                    alive_executors.contains(exec).then(|| data.clone())
+                    (data.available_task_slots > 0 && alive_executors.contains(exec))
+                        .then(|| data.clone())
                 })
                 .collect::<Vec<ExecutorData>>()
         };

--- a/ballista/rust/scheduler/src/state/in_memory_state.rs
+++ b/ballista/rust/scheduler/src/state/in_memory_state.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use ballista_core::serde::protobuf::{ExecutorHeartbeat, TaskStatus};
-use ballista_core::serde::scheduler::{ExecutorData, ExecutorDeltaData};
+use ballista_core::serde::scheduler::{ExecutorData, ExecutorDataChange};
 use log::{error, info, warn};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -86,13 +86,13 @@ impl InMemorySchedulerState {
         executors_data.insert(executor_data.executor_id.clone(), executor_data);
     }
 
-    pub(crate) fn update_executor_data(&self, executor_delta_data: &ExecutorDeltaData) {
+    pub(crate) fn update_executor_data(&self, executor_data_change: &ExecutorDataChange) {
         let mut executors_data = self.executors_data.write();
         if let Some(executor_data) =
-            executors_data.get_mut(&executor_delta_data.executor_id)
+            executors_data.get_mut(&executor_data_change.executor_id)
         {
             let available_task_slots = executor_data.available_task_slots as i32
-                + executor_delta_data.task_slots;
+                + executor_data_change.task_slots;
             if available_task_slots < 0 {
                 error!(
                     "Available task slots {} for executor {} is less than 0",
@@ -108,7 +108,7 @@ impl InMemorySchedulerState {
         } else {
             warn!(
                 "Could not find executor data for {}",
-                executor_delta_data.executor_id
+                executor_data_change.executor_id
             );
         }
     }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -32,7 +32,7 @@ use ballista_core::serde::protobuf::{
     FailedTask, JobStatus, RunningJob, RunningTask, TaskStatus,
 };
 use ballista_core::serde::scheduler::{
-    ExecutorData, ExecutorMetadata, PartitionId, PartitionStats,
+    ExecutorData, ExecutorDeltaData, ExecutorMetadata, PartitionId, PartitionStats,
 };
 use ballista_core::serde::{protobuf, AsExecutionPlan, AsLogicalPlan, BallistaCodec};
 use datafusion::prelude::ExecutionContext;
@@ -225,6 +225,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
 
     pub fn save_executor_data(&self, executor_data: ExecutorData) {
         self.in_memory_state.save_executor_data(executor_data);
+    }
+
+    pub fn update_executor_data(&self, executor_delta_data: &ExecutorDeltaData) {
+        self.in_memory_state
+            .update_executor_data(executor_delta_data);
     }
 
     pub fn get_available_executors_data(&self) -> Vec<ExecutorData> {

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -32,7 +32,7 @@ use ballista_core::serde::protobuf::{
     FailedTask, JobStatus, RunningJob, RunningTask, TaskStatus,
 };
 use ballista_core::serde::scheduler::{
-    ExecutorData, ExecutorDeltaData, ExecutorMetadata, PartitionId, PartitionStats,
+    ExecutorData, ExecutorDataChange, ExecutorMetadata, PartitionId, PartitionStats,
 };
 use ballista_core::serde::{protobuf, AsExecutionPlan, AsLogicalPlan, BallistaCodec};
 use datafusion::prelude::ExecutionContext;
@@ -227,9 +227,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         self.in_memory_state.save_executor_data(executor_data);
     }
 
-    pub fn update_executor_data(&self, executor_delta_data: &ExecutorDeltaData) {
+    pub fn update_executor_data(&self, executor_data_change: &ExecutorDataChange) {
         self.in_memory_state
-            .update_executor_data(executor_delta_data);
+            .update_executor_data(executor_data_change);
     }
 
     pub fn get_available_executors_data(&self) -> Vec<ExecutorData> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2005 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. For the first bug:
We should make sure the returned available_executors should be all with available_task_slots > 0.

2. For the second bug:
We should use update_executor_data rather than save_executor_data to update executors' available_task_slots.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
