### PR TITLE
Replace usage of `println!` with logger macros

### DIFF
--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -50,7 +50,7 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
-use log::debug;
+use log::{debug, info};
 use parquet::arrow::ArrowWriter;
 use parquet::file::{
     metadata::RowGroupMetaData,
@@ -250,7 +250,7 @@ impl ExecutionPlan for ParquetExec {
                 limit,
                 partition_col_proj,
             ) {
-                println!(
+                info!(
                     "Parquet reader thread terminated due to error: {:?} for files: {:?}",
                     e, partition
                 );


### PR DESCRIPTION
The println macro used in the code is changed to the info macro.