### PR TITLE
Merge adjacent filter rule for optimizer

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -34,7 +34,7 @@ use crate::{
     logical_plan::{PlanType, ToStringifiedPlan},
     optimizer::eliminate_filter::EliminateFilter,
     optimizer::eliminate_limit::EliminateLimit,
-    optimizer::merge_adjacent_filter::MergeAdjacentFilter,
+    optimizer::combine_adjacent_filter::CombineAdjacentFilter,
     physical_optimizer::{
         aggregate_statistics::AggregateStatistics,
         hash_build_probe_order::HashBuildProbeOrder, optimizer::PhysicalOptimizerRule,
@@ -866,7 +866,7 @@ impl Default for SessionConfig {
                 Arc::new(ProjectionPushDown::new()),
                 Arc::new(FilterPushDown::new()),
                 Arc::new(LimitPushDown::new()),
-                Arc::new(MergeAdjacentFilter::new()),
+                Arc::new(CombineAdjacentFilter::new()),
                 Arc::new(SingleDistinctToGroupBy::new()),
                 // ToApproxPerc must be applied last because
                 // it rewrites only the function and may interfere with

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -34,6 +34,7 @@ use crate::{
     logical_plan::{PlanType, ToStringifiedPlan},
     optimizer::eliminate_filter::EliminateFilter,
     optimizer::eliminate_limit::EliminateLimit,
+    optimizer::merge_adjacent_filter::MergeAdjacentFilter,
     physical_optimizer::{
         aggregate_statistics::AggregateStatistics,
         hash_build_probe_order::HashBuildProbeOrder, optimizer::PhysicalOptimizerRule,
@@ -865,6 +866,7 @@ impl Default for SessionConfig {
                 Arc::new(ProjectionPushDown::new()),
                 Arc::new(FilterPushDown::new()),
                 Arc::new(LimitPushDown::new()),
+                Arc::new(MergeAdjacentFilter::new()),
                 Arc::new(SingleDistinctToGroupBy::new()),
                 // ToApproxPerc must be applied last because
                 // it rewrites only the function and may interfere with

--- a/datafusion/src/optimizer/merge_adjacent_filter.rs
+++ b/datafusion/src/optimizer/merge_adjacent_filter.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimizer rule to replace `where false` on a plan with an empty relation.
+//! This saves time in planning and executing the query.
+//! Note that this rule should be applied after simplify expressions optimizer rule.
+use datafusion_expr::{Expr, Operator};
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::logical_plan::{plan::Filter, LogicalPlan};
+use crate::optimizer::optimizer::OptimizerRule;
+
+use super::utils;
+use crate::execution::context::ExecutionProps;
+
+/// Optimization rule that merge adjacent filter
+#[derive(Default)]
+pub struct MergeAdjacentFilter;
+
+impl MergeAdjacentFilter {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+fn optimize(plan: &LogicalPlan) -> LogicalPlan {
+    match plan {
+        LogicalPlan::Filter(Filter {
+            predicate: pred,
+            input,
+        }) => {
+            let sub_plan = optimize(&**input);
+            match sub_plan {
+                LogicalPlan::Filter(Filter {
+                    predicate: sub_pred,
+                    input: sub_input,
+                }) => LogicalPlan::Filter(Filter {
+                    predicate: Expr::BinaryExpr {
+                        left: Box::new(pred.clone()),
+                        op: Operator::And,
+                        right: Box::new(sub_pred),
+                    },
+                    input: Arc::new((*sub_input).clone()),
+                }),
+                _ => plan.clone(),
+            }
+        }
+        _ => plan.clone(),
+    }
+}
+
+impl OptimizerRule for MergeAdjacentFilter {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
+        let new_plan = optimize(plan);
+
+        // Apply the optimization to all inputs of the plan
+        let inputs = &new_plan.inputs();
+        let new_inputs = inputs
+            .iter()
+            .map(|&new_plan| self.optimize(new_plan, execution_props))
+            .collect::<Result<Vec<_>>>()?;
+
+        utils::from_plan(&new_plan, &new_plan.expressions(), &new_inputs)
+    }
+
+    fn name(&self) -> &str {
+        "merge_adjacent_filter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::lit;
+
+    use super::*;
+    use crate::logical_plan::col;
+    use crate::logical_plan::LogicalPlanBuilder;
+    use crate::test::*;
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = MergeAdjacentFilter::new();
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+        assert_eq!(plan.schema(), optimized_plan.schema());
+    }
+
+    #[test]
+    fn double_filter() {
+        let table_scan = test_table_scan().unwrap();
+        let plan =
+            LogicalPlanBuilder::from(table_scan.clone())
+                .project(vec![col("a")])
+                .unwrap()
+                .filter(col("a").eq(lit(1_i32)))
+                .unwrap()
+                .filter(col("a").eq(datafusion_expr::Expr::Literal(
+                    ScalarValue::Boolean(Some(true)),
+                )))
+                .unwrap()
+                .build()
+                .unwrap();
+
+        let expected = "Filter: #test.a = Boolean(true) AND #test.a = Int32(1)\
+            \n  Projection: #test.a\
+            \n    TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+
+    #[test]
+    fn thrice_filter() {
+        let table_scan = test_table_scan().unwrap();
+        let plan =
+            LogicalPlanBuilder::from(table_scan.clone())
+                .project(vec![col("a")])
+                .unwrap()
+                .filter(col("a").eq(lit(1_i32)))
+                .unwrap()
+                .filter(col("a").eq(lit(2_i32)))
+                .unwrap()
+                .filter(col("a").eq(datafusion_expr::Expr::Literal(
+                    ScalarValue::Boolean(Some(true)),
+                )))
+                .unwrap()
+                .build()
+                .unwrap();
+
+        let expected = "Filter: #test.a = Boolean(true) AND #test.a = Int32(2) AND #test.a = Int32(1)\
+            \n  Projection: #test.a\
+            \n    TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+
+    #[test]
+    fn nested_double_filter() {
+        let table_scan = test_table_scan().unwrap();
+        let plan =
+            LogicalPlanBuilder::from(table_scan.clone())
+                .project(vec![col("a")])
+                .unwrap()
+                .filter(col("a").eq(lit(1_i32)))
+                .unwrap()
+                .filter(col("a").eq(datafusion_expr::Expr::Literal(
+                    ScalarValue::Boolean(Some(true)),
+                )))
+                .unwrap()
+                .project(vec![col("a")])
+                .unwrap()
+                .filter(col("a").eq(lit(1_i32)))
+                .unwrap()
+                .filter(col("a").eq(datafusion_expr::Expr::Literal(
+                    ScalarValue::Boolean(Some(true)),
+                )))
+                .unwrap()
+                .build()
+                .unwrap();
+
+        let expected = "Filter: #test.a = Boolean(true) AND #test.a = Int32(1)\
+        \n  Projection: #test.a\
+        \n    Filter: #test.a = Boolean(true) AND #test.a = Int32(1)\
+        \n      Projection: #test.a\
+        \n        TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+}

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -24,7 +24,7 @@ pub mod eliminate_filter;
 pub mod eliminate_limit;
 pub mod filter_push_down;
 pub mod limit_push_down;
-pub mod merge_adjacent_filter;
+pub mod combine_adjacent_filter;
 pub mod optimizer;
 pub mod projection_push_down;
 pub mod simplify_expressions;

--- a/datafusion/src/optimizer/mod.rs
+++ b/datafusion/src/optimizer/mod.rs
@@ -24,6 +24,7 @@ pub mod eliminate_filter;
 pub mod eliminate_limit;
 pub mod filter_push_down;
 pub mod limit_push_down;
+pub mod merge_adjacent_filter;
 pub mod optimizer;
 pub mod projection_push_down;
 pub mod simplify_expressions;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2016 .

```sql
explain select c1, c2 from test where c3 = true and c2 = 0.000001;
```

Before
```sql
+---------------+-------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #test.c1, #test.c2                                                                                                      |
|               |   Filter: #test.c3                                                                                                                  |
|               |     Filter: #test.c2 = Float64(0.000001)                                                                                            |
|               |       TableScan: test projection=Some([0, 1, 2]), filters=[#test.c3, #test.c2 = Float64(0.000001)]                                  |
| physical_plan | ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]                                                                                       |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                       |
|               |     FilterExec: c3@2                                                                                                                |
|               |       CoalesceBatchesExec: target_batch_size=4096                                                                                   |
|               |         FilterExec: c2@1 = 0.000001                                                                                                 |
|               |           RepartitionExec: partitioning=RoundRobinBatch(8)                                                                          |
|               |             CsvExec: files=[/home/jakevin/code/arrow-datafusion/datafusion/tests/aggregate_simple.csv], has_header=true, limit=None |
|               |                                                                                                                                     |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------+
```

After
```sql
+---------------+---------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                            |
+---------------+---------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #test.c1, #test.c2                                                                                                  |
|               |   Filter: #test.c3 AND #test.c2 = Float64(0.000001)                                                                             |
|               |     TableScan: test projection=Some([0, 1, 2]), filters=[#test.c3, #test.c2 = Float64(0.000001)]                                |
| physical_plan | ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]                                                                                   |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                   |
|               |     FilterExec: c3@2 AND c2@1 = 0.000001                                                                                        |
|               |       RepartitionExec: partitioning=RoundRobinBatch(8)                                                                          |
|               |         CsvExec: files=[/home/jakevin/code/arrow-datafusion/datafusion/tests/aggregate_simple.csv], has_header=true, limit=None |
|               |                                                                                                                                 |
+---------------+---------------------------------------------------------------------------------------------------------------------------------+

```

 # Rationale for this change

merge adjacent filter 

# Are there any user-facing changes?
None
