### PR TITLE
Refactor SessionContext, SessionState add SessionConfig to support multi-tenancy configurations - Part 2

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -224,6 +224,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 };
 
                 let object_store = ctx
+                    .runtime_env()
                     .object_store(scan.path.as_str())
                     .map_err(|e| {
                         BallistaError::NotImplemented(format!(
@@ -1256,9 +1257,10 @@ mod roundtrip_tests {
         let codec: BallistaCodec<protobuf::LogicalPlanNode, protobuf::PhysicalPlanNode> =
             BallistaCodec::default();
         let custom_object_store = Arc::new(TestObjectStore {});
-        ctx.register_object_store("test", custom_object_store.clone());
+        ctx.runtime_env()
+            .register_object_store("test", custom_object_store.clone());
 
-        let (os, _) = ctx.object_store("test://foo.csv")?;
+        let (os, _) = ctx.runtime_env().object_store("test://foo.csv")?;
 
         println!("Object Store {:?}", os);
 

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -360,6 +360,7 @@ mod tests {
     use prost::Message;
     use std::any::Any;
 
+    use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use std::convert::TryInto;
     use std::fmt;
     use std::fmt::{Debug, Formatter};
@@ -692,10 +693,11 @@ mod tests {
     #[tokio::test]
     async fn test_extension_plan() -> crate::error::Result<()> {
         let store = Arc::new(LocalFileSystem {});
-        let config =
-            SessionConfig::new().with_query_planner(Arc::new(TopKQueryPlanner {}));
+        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::default()).unwrap());
+        let session_state = SessionState::with_config(SessionConfig::new(), runtime)
+            .with_query_planner(Arc::new(TopKQueryPlanner {}));
 
-        let ctx = SessionContext::with_config(config);
+        let ctx = SessionContext::with_state(session_state);
 
         let scan = LogicalPlanBuilder::scan_csv(
             store,

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -29,7 +29,7 @@ use chrono::{TimeZone, Utc};
 use datafusion::datasource::object_store::local::LocalFileSystem;
 use datafusion::datasource::object_store::{FileMeta, SizedFile};
 use datafusion::datasource::PartitionedFile;
-use datafusion::execution::context::SessionState;
+use datafusion::execution::context::ExecutionProps;
 
 use datafusion::physical_plan::file_format::FileScanConfig;
 
@@ -153,12 +153,12 @@ impl TryFrom<&protobuf::PhysicalExprNode> for Arc<dyn PhysicalExpr> {
                     .map(|x| x.try_into())
                     .collect::<Result<Vec<_>, _>>()?;
 
-                // TODO Do not create new the SessionState
-                let session_state = SessionState::new();
+                // TODO Do not create new the ExecutionProps
+                let execution_props = ExecutionProps::new();
 
                 let fun_expr = functions::create_physical_fun(
                     &(&scalar_function).into(),
-                    &session_state.execution_props,
+                    &execution_props,
                 )?;
 
                 Arc::new(ScalarFunctionExpr::new(

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -905,7 +905,7 @@ fn decode_scan_config(
         .collect::<Result<Vec<_>, _>>()?;
 
     let object_store = if let Some(file) = file_groups.get(0).and_then(|h| h.get(0)) {
-        ctx.object_store(file.file_meta.path())?.0
+        ctx.runtime_env().object_store(file.file_meta.path())?.0
     } else {
         Arc::new(LocalFileSystem {})
     };

--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -160,9 +160,19 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
     }
 }
 
-/// Create a DataFusion context that is compatible with Ballista
+/// Create a DataFusion session context that is compatible with Ballista Configuration
 pub fn create_datafusion_context(config: &BallistaConfig) -> SessionContext {
     let config =
         SessionConfig::new().with_target_partitions(config.default_shuffle_partitions());
     SessionContext::with_config(config)
+}
+
+/// Update the existing DataFusion session context with Ballista Configuration
+pub fn update_datafusion_context(
+    session_ctx: Arc<SessionContext>,
+    config: &BallistaConfig,
+) -> Arc<SessionContext> {
+    session_ctx.state.lock().config.target_partitions =
+        config.default_shuffle_partitions();
+    session_ctx
 }

--- a/datafusion/src/datasource/object_store/mod.rs
+++ b/datafusion/src/datasource/object_store/mod.rs
@@ -163,7 +163,7 @@ pub trait ObjectStore: Sync + Send + Debug {
 
 static LOCAL_SCHEME: &str = "file";
 
-/// A Registry holds all the object stores at runtime with a scheme for each store.
+/// A Registry holds all the object stores at Runtime with a scheme for each store.
 /// This allows the user to extend DataFusion with different storage systems such as S3 or HDFS
 /// and query data inside these systems.
 pub struct ObjectStoreRegistry {

--- a/datafusion/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/src/physical_optimizer/aggregate_statistics.rs
@@ -297,7 +297,7 @@ mod tests {
     ) -> Result<()> {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
-        let conf = session_ctx.state.lock().clone().config;
+        let conf = session_ctx.copied_config();
         let optimized = AggregateStatistics::new().optimize(Arc::new(plan), &conf)?;
 
         let (col, count) = match nulls {

--- a/datafusion/src/physical_optimizer/coalesce_batches.rs
+++ b/datafusion/src/physical_optimizer/coalesce_batches.rs
@@ -75,7 +75,7 @@ impl PhysicalOptimizerRule for CoalesceBatches {
                 // we should do that once https://issues.apache.org/jira/browse/ARROW-11059 is
                 // implemented. For now, we choose half the configured batch size to avoid copies
                 // when a small number of rows are removed from a batch
-                let target_batch_size = config.runtime.batch_size / 2;
+                let target_batch_size = config.batch_size / 2;
                 Arc::new(CoalesceBatchesExec::new(plan.clone(), target_batch_size))
             } else {
                 plan.clone()

--- a/datafusion/src/physical_plan/file_format/json.rs
+++ b/datafusion/src/physical_plan/file_format/json.rs
@@ -99,7 +99,7 @@ impl ExecutionPlan for NdJsonExec {
     ) -> Result<SendableRecordBatchStream> {
         let proj = self.base_config.projected_file_column_names();
 
-        let batch_size = context.runtime.batch_size();
+        let batch_size = context.session_config().batch_size;
         let file_schema = Arc::clone(&self.base_config.file_schema);
 
         // The json reader cannot limit the number of records, so `remaining` is ignored.

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1399,7 +1399,7 @@ impl DefaultPhysicalPlanner {
     where
         F: FnMut(&dyn ExecutionPlan, &dyn PhysicalOptimizerRule),
     {
-        let optimizers = &session_state.config.physical_optimizers;
+        let optimizers = &session_state.physical_optimizers;
         debug!(
             "Input physical plan:\n{}\n",
             displayable(plan.as_ref()).indent()
@@ -1435,10 +1435,12 @@ mod tests {
     use crate::datasource::object_store::local::LocalFileSystem;
     use crate::execution::context::TaskContext;
     use crate::execution::options::CsvReadOptions;
+    use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use crate::logical_plan::plan::Extension;
     use crate::physical_plan::{
         expressions, DisplayFormatType, Partitioning, Statistics,
     };
+    use crate::prelude::SessionConfig;
     use crate::scalar::ScalarValue;
     use crate::{
         logical_plan::LogicalPlanBuilder, physical_plan::SendableRecordBatchStream,
@@ -1454,7 +1456,8 @@ mod tests {
     use std::{any::Any, fmt};
 
     fn make_session_state() -> SessionState {
-        SessionState::new()
+        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::default()).unwrap());
+        SessionState::with_config(SessionConfig::new(), runtime)
     }
 
     async fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/tests/order_spill_fuzz.rs
+++ b/datafusion/tests/order_spill_fuzz.rs
@@ -23,7 +23,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion::execution::memory_manager::MemoryManagerConfig;
-use datafusion::execution::runtime_env::RuntimeConfig;
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::physical_plan::expressions::{col, PhysicalSortExpr};
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -78,8 +78,8 @@ async fn run_sort(pool_size: usize, size_spill: Vec<(usize, bool)>) {
         let runtime_config = RuntimeConfig::new().with_memory_manager(
             MemoryManagerConfig::try_new_limit(pool_size, 1.0).unwrap(),
         );
-        let session_config = SessionConfig::new().with_runtime_config(runtime_config);
-        let session_ctx = SessionContext::with_config(session_config);
+        let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+        let session_ctx = SessionContext::with_config_rt(SessionConfig::new(), runtime);
 
         let task_ctx = session_ctx.task_ctx();
         let collected = collect(sort.clone(), task_ctx).await.unwrap();

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -87,6 +87,7 @@ use std::{any::Any, collections::BTreeMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use datafusion::execution::context::{ExecutionProps, TaskContext};
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::logical_plan::plan::{Extension, Sort};
 use datafusion::logical_plan::{DFSchemaRef, Limit};
 
@@ -242,12 +243,12 @@ async fn topk_plan() -> Result<()> {
 }
 
 fn make_topk_context() -> SessionContext {
-    let config = SessionConfig::new()
+    let config = SessionConfig::new().with_target_partitions(48);
+    let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::default()).unwrap());
+    let state = SessionState::with_config(config, runtime)
         .with_query_planner(Arc::new(TopKQueryPlanner {}))
-        .with_target_partitions(48)
         .add_optimizer_rule(Arc::new(TopKOptimizerRule {}));
-
-    SessionContext::with_config(config)
+    SessionContext::with_state(state)
 }
 
 // ------ The implementation of the TopK code follows -----


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partially Closes #1862.

This PR covers the part 2:

1. Make SessionConfig just hold all the configuration property entries, move batch_size from RunTimeEnv to SessionConfig
2. Move optimizers/physical_optimizers/planners to SessionState, move object_store_registry to RuntimeEnv.
3. Avoid creating SessionContext again and again in DataFrame

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
