### PR TITLE
fix: replace `ExecutionContex` and `ExecutionConfig` with `SessionContext` and `SessionConfig`

### DIFF
--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -3036,8 +3036,8 @@ mod tests {
     #[tokio::test]
     async fn sql_create_schema() -> Result<()> {
         // the information schema used to introduce cyclic Arcs
-        let mut ctx = ExecutionContext::with_config(
-            ExecutionConfig::new().with_information_schema(true),
+        let mut ctx = SessionContext::with_config(
+            SessionConfig::new().with_information_schema(true),
         );
 
         // Create schema


### PR DESCRIPTION
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/41979257/158816838-680eeb6d-2bf4-4466-ab55-28e5c6f5d37f.png">

<img width="963" alt="image" src="https://user-images.githubusercontent.com/41979257/158816873-bfb3deed-bde4-4f06-8f47-287f285acea9.png">

Introduced by #1959
cc @matthewmturner 