### PR TITLE
use cargo-tomlfmt to check Cargo.toml formatting in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -432,6 +432,72 @@ jobs:
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"
+
+  cargo-toml-formatting-checks:
+    name: Check all Cargo.toml formatting
+    needs: [linux-build-lib]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [stable]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+      - name: Install cargo-tomlfmt
+        run: |
+          which cargo-tomlfmt || cargo install cargo-tomlfmt
+        env:
+          CARGO_HOME: "/github/home/.cargo"
+          CARGO_TARGET_DIR: "/github/home/target"
+      - name: Check Cargo.toml formatting
+        run: |
+          # if you encounter error, try rerun the command below, finally run 'git diff' to
+          # check which Cargo.toml introduces formatting violation
+          cargo tomlfmt -p Cargo.toml
+          cargo tomlfmt -p datafusion-cli/Cargo.toml
+          cargo tomlfmt -p ballista/rust/core/Cargo.toml
+          cargo tomlfmt -p ballista/rust/scheduler/Cargo.toml
+          cargo tomlfmt -p ballista/rust/executor/Cargo.toml
+          cargo tomlfmt -p ballista/rust/client/Cargo.toml
+          cargo tomlfmt -p datafusion/Cargo.toml
+          cargo tomlfmt -p datafusion/fuzz-utils/Cargo.toml
+          cargo tomlfmt -p ballista-examples/Cargo.toml
+          cargo tomlfmt -p datafusion-examples/Cargo.toml
+          cargo tomlfmt -p datafusion-expr/Cargo.toml
+          cargo tomlfmt -p datafusion-physical-expr/Cargo.toml
+          cargo tomlfmt -p benchmarks/Cargo.toml
+          cargo tomlfmt -p datafusion-common/Cargo.toml
+          cargo tomlfmt -p datafusion-proto/Cargo.toml
+          cargo tomlfmt -p datafusion-jit/Cargo.toml
+          git diff --exit-code
+        env:
+          CARGO_HOME: "/github/home/.cargo"
+          CARGO_TARGET_DIR: "/github/home/target"
+
 # Coverage job was failing. https://github.com/apache/arrow-datafusion/issues/590 tracks re-instating it
 
 # coverage:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -477,22 +477,9 @@ jobs:
         run: |
           # if you encounter error, try rerun the command below, finally run 'git diff' to
           # check which Cargo.toml introduces formatting violation
-          cargo tomlfmt -p Cargo.toml
-          cargo tomlfmt -p datafusion-cli/Cargo.toml
-          cargo tomlfmt -p ballista/rust/core/Cargo.toml
-          cargo tomlfmt -p ballista/rust/scheduler/Cargo.toml
-          cargo tomlfmt -p ballista/rust/executor/Cargo.toml
-          cargo tomlfmt -p ballista/rust/client/Cargo.toml
-          cargo tomlfmt -p datafusion/Cargo.toml
-          cargo tomlfmt -p datafusion/fuzz-utils/Cargo.toml
-          cargo tomlfmt -p ballista-examples/Cargo.toml
-          cargo tomlfmt -p datafusion-examples/Cargo.toml
-          cargo tomlfmt -p datafusion-expr/Cargo.toml
-          cargo tomlfmt -p datafusion-physical-expr/Cargo.toml
-          cargo tomlfmt -p benchmarks/Cargo.toml
-          cargo tomlfmt -p datafusion-common/Cargo.toml
-          cargo tomlfmt -p datafusion-proto/Cargo.toml
-          cargo tomlfmt -p datafusion-jit/Cargo.toml
+          #
+          # ignore ./Cargo.toml because putting workspaces in multi-line lists make it easy to read
+          find . -mindepth 2 -name 'Cargo.toml' -exec cargo tomlfmt -p {} \;
           git diff --exit-code
         env:
           CARGO_HOME: "/github/home/.cargo"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -434,7 +434,7 @@ jobs:
           CARGO_TARGET_DIR: "/github/home/target"
 
   cargo-toml-formatting-checks:
-    name: Check all Cargo.toml formatting
+    name: Check Cargo.toml formatting
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,23 +16,9 @@
 # under the License.
 
 [workspace]
-members = [
-    "datafusion",
-    "datafusion-common",
-    "datafusion-expr",
-    "datafusion-jit",
-    "datafusion-physical-expr",
-    "datafusion-cli",
-    "datafusion-examples",
-    "datafusion-proto",
-    "benchmarks",
-    "ballista/rust/client",
-    "ballista/rust/core",
-    "ballista/rust/executor",
-    "ballista/rust/scheduler",
-    "ballista-examples",
+members = ["datafusion", "datafusion-common", "datafusion-expr", "datafusion-jit", "datafusion-physical-expr", "datafusion-cli", "datafusion-examples", "datafusion-proto", "benchmarks", "ballista/rust/client", "ballista/rust/core", "ballista/rust/executor", "ballista/rust/scheduler", "ballista-examples",
 ]
 
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,21 @@
 # under the License.
 
 [workspace]
-members = ["datafusion", "datafusion-common", "datafusion-expr", "datafusion-jit", "datafusion-physical-expr", "datafusion-cli", "datafusion-examples", "datafusion-proto", "benchmarks", "ballista/rust/client", "ballista/rust/core", "ballista/rust/executor", "ballista/rust/scheduler", "ballista-examples",
+members = [
+    "datafusion",
+    "datafusion-common",
+    "datafusion-expr",
+    "datafusion-jit",
+    "datafusion-physical-expr",
+    "datafusion-cli",
+    "datafusion-examples",
+    "datafusion-proto",
+    "benchmarks",
+    "ballista/rust/client",
+    "ballista/rust/core",
+    "ballista/rust/executor",
+    "ballista/rust/scheduler",
+    "ballista-examples",
 ]
 
 [profile.release]

--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -29,10 +29,10 @@ publish = false
 rust-version = "1.59"
 
 [dependencies]
+ballista = { path = "../ballista/rust/client", version = "0.6.0" }
 datafusion = { path = "../datafusion" }
-ballista = { path = "../ballista/rust/client", version = "0.6.0"}
-prost = "0.9"
-tonic = "0.6"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 futures = "0.3"
 num_cpus = "1.13.0"
+prost = "0.9"
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
+tonic = "0.6"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -30,14 +30,14 @@ rust-version = "1.59"
 ballista-core = { path = "../core", version = "0.6.0" }
 ballista-executor = { path = "../executor", version = "0.6.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.6.0", optional = true }
-futures = "0.3"
-log = "0.4"
-tokio = "1.0"
-tempfile = "3"
-sqlparser = "0.15"
-parking_lot = "0.12"
 
 datafusion = { path = "../../../datafusion", version = "7.0.0" }
+futures = "0.3"
+log = "0.4"
+parking_lot = "0.12"
+sqlparser = "0.15"
+tempfile = "3"
+tokio = "1.0"
 
 [features]
 default = []

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -37,7 +37,7 @@ hashbrown = "0.12"
 log = "0.4"
 prost = "0.9"
 prost-types = "0.9"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 sqlparser = "0.15"
 tokio = "1.0"
 tonic = "0.6"
@@ -46,7 +46,7 @@ chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 parse_arg = "0.1.3"
 
-arrow-flight = { version = "10.0"  }
+arrow-flight = { version = "10.0" }
 datafusion = { path = "../../../datafusion", version = "7.0.0" }
 datafusion-proto = { path = "../../../datafusion-proto", version = "7.0.0" }
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -31,10 +31,19 @@ simd = ["datafusion/simd"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
+
+arrow-flight = { version = "10.0" }
 async-trait = "0.1.41"
+chrono = { version = "0.4", default-features = false }
+clap = { version = "3", features = ["derive", "cargo"] }
+datafusion = { path = "../../../datafusion", version = "7.0.0" }
+datafusion-proto = { path = "../../../datafusion-proto", version = "7.0.0" }
 futures = "0.3"
 hashbrown = "0.12"
 log = "0.4"
+
+parking_lot = "0.12"
+parse_arg = "0.1.3"
 prost = "0.9"
 prost-types = "0.9"
 serde = { version = "1", features = ["derive"] }
@@ -42,15 +51,6 @@ sqlparser = "0.15"
 tokio = "1.0"
 tonic = "0.6"
 uuid = { version = "0.8", features = ["v4"] }
-chrono = { version = "0.4", default-features = false }
-clap = { version = "3", features = ["derive", "cargo"] }
-parse_arg = "0.1.3"
-
-arrow-flight = { version = "10.0" }
-datafusion = { path = "../../../datafusion", version = "7.0.0" }
-datafusion-proto = { path = "../../../datafusion-proto", version = "7.0.0" }
-
-parking_lot = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -25,37 +25,37 @@ repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2018"
 
+[package.metadata.configure_me.bin]
+executor = "executor_config_spec.toml"
+
 [features]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-arrow = { version = "10.0"  }
-arrow-flight = { version = "10.0"  }
 anyhow = "1"
+arrow = { version = "10.0" }
+arrow-flight = { version = "10.0" }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.6.0" }
+chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 datafusion = { path = "../../../datafusion", version = "7.0.0" }
 env_logger = "0.9"
 futures = "0.3"
+hyper = "0.14.4"
 log = "0.4"
-snmalloc-rs = {version = "0.2", optional = true}
+parking_lot = "0.12"
+snmalloc-rs = { version = "0.2", optional = true }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.6"
 uuid = { version = "0.8", features = ["v4"] }
-hyper = "0.14.4"
-parking_lot = "0.12"
-chrono = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 
 [build-dependencies]
 configure_me_codegen = "0.4.0"
-
-[package.metadata.configure_me.bin]
-executor = "executor_config_spec.toml"
 
 # use libc on unix like platforms to set worker priority in DedicatedExecutor
 [target."cfg(unix)".dependencies.libc]

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -46,7 +46,7 @@ log = "0.4"
 parse_arg = "0.1.3"
 prost = "0.9"
 rand = "0.8"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -25,6 +25,9 @@ repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2018"
 
+[package.metadata.configure_me.bin]
+scheduler = "scheduler_config_spec.toml"
+
 [features]
 default = ["etcd", "sled"]
 etcd = ["etcd-client"]
@@ -32,6 +35,8 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
+async-recursion = "1.0.0"
+async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.6.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
@@ -43,6 +48,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
+parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.9"
 rand = "0.8"
@@ -53,9 +59,6 @@ tokio-stream = { version = "0.1", features = ["net"], optional = true }
 tonic = "0.6"
 tower = { version = "0.4" }
 warp = "0.3"
-parking_lot = "0.12"
-async-trait = "0.1.41"
-async-recursion = "1.0.0"
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.6.0" }
@@ -64,6 +67,3 @@ uuid = { version = "0.8", features = ["v4"] }
 [build-dependencies]
 configure_me_codegen = "0.4.1"
 tonic-build = { version = "0.6" }
-
-[package.metadata.configure_me.bin]
-scheduler = "scheduler_config_spec.toml"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,18 +32,18 @@ simd = ["datafusion/simd"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client" }
-structopt = { version = "0.3", default-features = false }
-tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
-futures = "0.3"
+datafusion = { path = "../datafusion" }
 env_logger = "0.9"
+futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }
-snmalloc-rs = {version = "0.2", optional = true }
+num_cpus = "1.13.0"
 rand = "0.8.4"
 serde = "1.0.136"
 serde_json = "1.0.78"
-num_cpus = "1.13.0"
+snmalloc-rs = { version = "0.2", optional = true }
+structopt = { version = "0.3", default-features = false }
+tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 
 [dev-dependencies]
 ballista-core = { path = "../ballista/rust/core" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -28,12 +28,12 @@ repository = "https://github.com/apache/arrow-datafusion"
 rust-version = "1.59"
 
 [dependencies]
-clap = { version = "3", features = ["derive", "cargo"] }
-rustyline = "9.0"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
-datafusion = { path = "../datafusion", version = "7.0.0" }
 arrow = { version = "10.0" }
-ballista = { path = "../ballista/rust/client", version = "0.6.0", optional=true }
+ballista = { path = "../ballista/rust/client", version = "0.6.0", optional = true }
+clap = { version = "3", features = ["derive", "cargo"] }
+datafusion = { path = "../datafusion", version = "7.0.0" }
+dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "*", default-features = false }
-dirs = "4.0.0"
+rustyline = "9.0"
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }

--- a/datafusion-common/Cargo.toml
+++ b/datafusion-common/Cargo.toml
@@ -34,14 +34,14 @@ path = "src/lib.rs"
 
 [features]
 avro = ["avro-rs"]
-pyarrow = ["pyo3"]
 jit = ["cranelift-module"]
+pyarrow = ["pyo3"]
 
 [dependencies]
 arrow = { version = "10.0", features = ["prettyprint"] }
-parquet = { version = "10.0", features = ["arrow"], optional = true }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
+cranelift-module = { version = "0.82.0", optional = true }
+ordered-float = "2.10"
+parquet = { version = "10.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = "0.15"
-ordered-float = "2.10"
-cranelift-module = { version = "0.82.0", optional = true }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -35,10 +35,10 @@ required-features = ["datafusion/avro"]
 
 [dev-dependencies]
 arrow-flight = { version = "10.0" }
+async-trait = "0.1.41"
 datafusion = { path = "../datafusion" }
-prost = "0.9"
-tonic = "0.6"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 futures = "0.3"
 num_cpus = "1.13.0"
-async-trait = "0.1.41"
+prost = "0.9"
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
+tonic = "0.6"

--- a/datafusion-expr/Cargo.toml
+++ b/datafusion-expr/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 [features]
 
 [dependencies]
-datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
-arrow = { version = "10.0", features = ["prettyprint"] }
-sqlparser = "0.15"
 ahash = { version = "0.7", default-features = false }
+arrow = { version = "10.0", features = ["prettyprint"] }
+datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
+sqlparser = "0.15"

--- a/datafusion-jit/Cargo.toml
+++ b/datafusion-jit/Cargo.toml
@@ -36,9 +36,9 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-datafusion-common = { path = "../datafusion-common", version = "7.0.0", features = ["jit"] }
 cranelift = "0.82.0"
-cranelift-module = "0.82.0"
 cranelift-jit = "0.82.0"
+cranelift-module = "0.82.0"
 cranelift-native = "0.82.0"
+datafusion-common = { path = "../datafusion-common", version = "7.0.0", features = ["jit"] }
 parking_lot = "0.12"

--- a/datafusion-physical-expr/Cargo.toml
+++ b/datafusion-physical-expr/Cargo.toml
@@ -33,25 +33,25 @@ name = "datafusion_physical_expr"
 path = "src/lib.rs"
 
 [features]
-default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 crypto_expressions = ["md-5", "sha2", "blake2", "blake3"]
+default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 regex_expressions = ["regex"]
 unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
-datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
-datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
-arrow = { version = "10.0", features = ["prettyprint"] }
-paste = "^1.0"
 ahash = { version = "0.7", default-features = false }
-ordered-float = "2.10"
-lazy_static = { version = "^1.4.0" }
-md-5 = { version = "^0.10.0", optional = true }
-sha2 = { version = "^0.10.1", optional = true }
+arrow = { version = "10.0", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
-rand = "0.8"
-hashbrown = { version = "0.12", features = ["raw"] }
 chrono = { version = "0.4", default-features = false }
+datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
+datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
+hashbrown = { version = "0.12", features = ["raw"] }
+lazy_static = { version = "^1.4.0" }
+md-5 = { version = "^0.10.0", optional = true }
+ordered-float = "2.10"
+paste = "^1.0"
+rand = "0.8"
 regex = { version = "^1.4.3", optional = true }
+sha2 = { version = "^0.10.1", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -38,49 +38,49 @@ name = "datafusion"
 path = "src/lib.rs"
 
 [features]
-default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
-simd = ["arrow/simd"]
-crypto_expressions = [ "datafusion-physical-expr/crypto_expressions" ]
-unicode_expressions = ["datafusion-physical-expr/regex_expressions"]
-regex_expressions = ["datafusion-physical-expr/regex_expressions"]
-pyarrow = ["pyo3", "arrow/pyarrow", "datafusion-common/pyarrow"]
-# Used for testing ONLY: causes all values to hash to the same value (test for collisions)
-force_hash_collisions = []
 # Used to enable the avro format
 avro = ["avro-rs", "num-traits", "datafusion-common/avro"]
-# Used to enable row format experiment
-row = []
+crypto_expressions = ["datafusion-physical-expr/crypto_expressions"]
+default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
+# Used for testing ONLY: causes all values to hash to the same value (test for collisions)
+force_hash_collisions = []
 # Used to enable JIT code generation
 jit = ["datafusion-jit"]
+pyarrow = ["pyo3", "arrow/pyarrow", "datafusion-common/pyarrow"]
+regex_expressions = ["datafusion-physical-expr/regex_expressions"]
+# Used to enable row format experiment
+row = []
+simd = ["arrow/simd"]
+unicode_expressions = ["datafusion-physical-expr/regex_expressions"]
 
 [dependencies]
+ahash = { version = "0.7", default-features = false }
+arrow = { version = "10.0", features = ["prettyprint"] }
+async-trait = "0.1.41"
+avro-rs = { version = "0.13", features = ["snappy"], optional = true }
+chrono = { version = "0.4", default-features = false }
 datafusion-common = { path = "../datafusion-common", version = "7.0.0", features = ["parquet"] }
 datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
 datafusion-jit = { path = "../datafusion-jit", version = "7.0.0", optional = true }
 datafusion-physical-expr = { path = "../datafusion-physical-expr", version = "7.0.0" }
-ahash = { version = "0.7", default-features = false }
-hashbrown = { version = "0.12", features = ["raw"] }
-arrow = { version = "10.0", features = ["prettyprint"] }
-parquet = { version = "10.0", features = ["arrow"] }
-sqlparser = "0.15"
-paste = "^1.0"
-num_cpus = "1.13.0"
-chrono = { version = "0.4", default-features = false }
-async-trait = "0.1.41"
 futures = "0.3"
+hashbrown = { version = "0.12", features = ["raw"] }
+lazy_static = { version = "^1.4.0" }
+log = "^0.4"
+num-traits = { version = "0.2", optional = true }
+num_cpus = "1.13.0"
+ordered-float = "2.10"
+parking_lot = "0.12"
+parquet = { version = "10.0", features = ["arrow"] }
+paste = "^1.0"
 pin-project-lite= "^0.2.7"
+pyo3 = { version = "0.16", optional = true }
+rand = "0.8"
+smallvec = { version = "1.6", features = ["union"] }
+sqlparser = "0.15"
+tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"
-log = "^0.4"
-ordered-float = "2.10"
-lazy_static = { version = "^1.4.0" }
-smallvec = { version = "1.6", features = ["union"] }
-rand = "0.8"
-avro-rs = { version = "0.13", features = ["snappy"], optional = true }
-num-traits = { version = "0.2", optional = true }
-pyo3 = { version = "0.16", optional = true }
-tempfile = "3"
-parking_lot = "0.12"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
@@ -89,38 +89,38 @@ doc-comment = "0.3"
 fuzz-utils = { path = "fuzz-utils" }
 
 [[bench]]
+harness = false
 name = "aggregate_query_sql"
-harness = false
 
 [[bench]]
+harness = false
 name = "sort_limit_query_sql"
-harness = false
 
 [[bench]]
+harness = false
 name = "math_query_sql"
-harness = false
 
 [[bench]]
+harness = false
 name = "filter_query_sql"
-harness = false
 
 [[bench]]
+harness = false
 name = "window_query_sql"
-harness = false
 
 [[bench]]
+harness = false
 name = "scalar"
-harness = false
 
 [[bench]]
+harness = false
 name = "physical_plan"
-harness = false
 
 [[bench]]
+harness = false
 name = "parquet_query_sql"
-harness = false
 
 [[bench]]
-name = "jit"
 harness = false
+name = "jit"
 required-features = ["row", "jit"]

--- a/datafusion/fuzz-utils/Cargo.toml
+++ b/datafusion/fuzz-utils/Cargo.toml
@@ -24,5 +24,5 @@ edition = "2021"
 
 [dependencies]
 arrow = { version = "10.0", features = ["prettyprint"] }
-rand = "0.8"
 env_logger = "0.9.0"
+rand = "0.8"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Datafusion has no `Cargo.toml` formatting check yet. This pr uses `cargo-tomlfmt` tool in CI to do it

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- added the Github action in `rust` workflow
- revise existing `Cargo.toml` formatting according to `cargo-tomlfmt`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->