### PR TITLE
fix bug the optimizer rule filter push down

### DIFF
--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -523,7 +523,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                     // Don't add expression again if it's already present in
                     // pushed down filters.
                     if new_filters.contains(filter_expr) {
-                        break;
+                        continue;
                     }
                     new_filters.push(filter_expr.clone());
                 }

--- a/datafusion/src/test/mod.rs
+++ b/datafusion/src/test/mod.rs
@@ -105,12 +105,20 @@ pub fn create_partitioned_csv(
 
 /// some tests share a common table with different names
 pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
+    test_table_scan_with_name_projection(name, None)
+}
+
+/// some tests share a common table with different names and specifiy projections
+pub fn test_table_scan_with_name_projection(
+    name: &str,
+    projection: Option<Vec<usize>>,
+) -> Result<LogicalPlan> {
     let schema = Schema::new(vec![
         Field::new("a", DataType::UInt32, false),
         Field::new("b", DataType::UInt32, false),
         Field::new("c", DataType::UInt32, false),
     ]);
-    LogicalPlanBuilder::scan_empty(Some(name), &schema, None)?.build()
+    LogicalPlanBuilder::scan_empty(Some(name), &schema, projection)?.build()
 }
 
 /// some tests share a common table

--- a/datafusion/src/test/mod.rs
+++ b/datafusion/src/test/mod.rs
@@ -105,20 +105,12 @@ pub fn create_partitioned_csv(
 
 /// some tests share a common table with different names
 pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
-    test_table_scan_with_name_projection(name, None)
-}
-
-/// some tests share a common table with different names and specifiy projections
-pub fn test_table_scan_with_name_projection(
-    name: &str,
-    projection: Option<Vec<usize>>,
-) -> Result<LogicalPlan> {
     let schema = Schema::new(vec![
         Field::new("a", DataType::UInt32, false),
         Field::new("b", DataType::UInt32, false),
         Field::new("c", DataType::UInt32, false),
     ]);
-    LogicalPlanBuilder::scan_empty(Some(name), &schema, projection)?.build()
+    LogicalPlanBuilder::scan_empty(Some(name), &schema, None)?.build()
 }
 
 /// some tests share a common table


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2038.

# What changes are included in this PR?

Fix the bug due to break loop cause `used_columns` is wrong.

It will cause the `issue_filters` get wrong `used_columns` param

# Are there any user-facing changes?
None

