### PR TITLE
Chore: tune log level, lint

### DIFF
--- a/datafusion/src/dataframe.rs
+++ b/datafusion/src/dataframe.rs
@@ -352,7 +352,7 @@ impl DataFrame {
     pub async fn collect(&self) -> Result<Vec<RecordBatch>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.lock().clone()));
-        Ok(collect(plan, task_ctx).await?)
+        collect(plan, task_ctx).await
     }
 
     /// Print results.
@@ -427,7 +427,7 @@ impl DataFrame {
     pub async fn collect_partitioned(&self) -> Result<Vec<Vec<RecordBatch>>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.lock().clone()));
-        Ok(collect_partitioned(plan, task_ctx).await?)
+        collect_partitioned(plan, task_ctx).await
     }
 
     /// Executes this DataFrame and returns one stream per partition.
@@ -448,7 +448,7 @@ impl DataFrame {
     ) -> Result<Vec<SendableRecordBatchStream>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.lock().clone()));
-        Ok(execute_stream_partitioned(plan, task_ctx).await?)
+        execute_stream_partitioned(plan, task_ctx).await
     }
 
     /// Returns the schema describing the output of this DataFrame in terms of columns returned,

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -50,7 +50,7 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
-use log::{debug, info};
+use log::{debug, warn};
 use parquet::arrow::ArrowWriter;
 use parquet::file::{
     metadata::RowGroupMetaData,
@@ -249,7 +249,7 @@ impl ExecutionPlan for ParquetExec {
                 limit,
                 partition_col_proj,
             ) {
-                info!(
+                warn!(
                     "Parquet reader thread terminated due to error: {:?} for files: {:?}",
                     e, partition
                 );


### PR DESCRIPTION
 # Rationale for this change
- Tune log level as suggested in review: https://github.com/apache/arrow-datafusion/pull/2020
- Fix lint reported by rust-nightly.
