### PR TITLE
Change log level for noisy logs

### DIFF
--- a/ballista/rust/scheduler/src/state/stage_manager.rs
+++ b/ballista/rust/scheduler/src/state/stage_manager.rs
@@ -18,7 +18,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use log::{error, info, warn};
+use log::{debug, error, warn};
 use parking_lot::RwLock;
 use rand::Rng;
 
@@ -305,7 +305,7 @@ impl StageScheduler for StageManager {
         let stage_distribution = self.stage_distribution.read();
         let stages_running = &stage_distribution.stages_running;
         if stages_running.is_empty() {
-            info!("There's no running stages");
+            debug!("There's no running stages");
             return None;
         }
         let stages = stages_running

--- a/ballista/rust/scheduler/src/state/task_scheduler.rs
+++ b/ballista/rust/scheduler/src/state/task_scheduler.rs
@@ -182,7 +182,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskScheduler
         }
 
         let total_task_num = tasks_status.len();
-        info!("{} tasks to be scheduled", total_task_num);
+        debug!("{} tasks to be scheduled", total_task_num);
 
         // No need to deal with the stage event, since the task status is changing from pending to running
         self.stage_manager.update_tasks_status(tasks_status);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

These two logs statements were creating a lot of noise. They can be valuable for debugging but think they should be debug logs instead of info logs. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
