### PR TITLE
Change the DataFusion explain plans to make it clearer in the predicate/filter

### DIFF
--- a/datafusion/src/logical_plan/plan.rs
+++ b/datafusion/src/logical_plan/plan.rs
@@ -20,6 +20,7 @@
 use super::display::{GraphvizVisitor, IndentVisitor};
 use super::expr::{Column, Expr};
 use super::extension::UserDefinedLogicalNode;
+use crate::datasource::datasource::TableProviderFilterPushDown;
 use crate::datasource::TableProvider;
 use crate::error::DataFusionError;
 use crate::logical_plan::dfschema::DFSchemaRef;
@@ -31,7 +32,6 @@ use std::{
     fmt::{self, Display},
     sync::Arc,
 };
-use crate::datasource::datasource::TableProviderFilterPushDown;
 
 /// Join type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -384,8 +384,8 @@ impl LogicalPlan {
             LogicalPlan::EmptyRelation(EmptyRelation { schema, .. }) => schema,
             LogicalPlan::Values(Values { schema, .. }) => schema,
             LogicalPlan::TableScan(TableScan {
-                                       projected_schema, ..
-                                   }) => projected_schema,
+                projected_schema, ..
+            }) => projected_schema,
             LogicalPlan::Projection(Projection { schema, .. }) => schema,
             LogicalPlan::Filter(Filter { input, .. }) => input.schema(),
             LogicalPlan::Window(Window { schema, .. }) => schema,
@@ -416,8 +416,8 @@ impl LogicalPlan {
     pub fn all_schemas(&self) -> Vec<&DFSchemaRef> {
         match self {
             LogicalPlan::TableScan(TableScan {
-                                       projected_schema, ..
-                                   }) => vec![projected_schema],
+                projected_schema, ..
+            }) => vec![projected_schema],
             LogicalPlan::Values(Values { schema, .. }) => vec![schema],
             LogicalPlan::Window(Window { input, schema, .. })
             | LogicalPlan::Projection(Projection { input, schema, .. })
@@ -427,16 +427,16 @@ impl LogicalPlan {
                 schemas
             }
             LogicalPlan::Join(Join {
-                                  left,
-                                  right,
-                                  schema,
-                                  ..
-                              })
+                left,
+                right,
+                schema,
+                ..
+            })
             | LogicalPlan::CrossJoin(CrossJoin {
-                                         left,
-                                         right,
-                                         schema,
-                                     }) => {
+                left,
+                right,
+                schema,
+            }) => {
                 let mut schemas = left.all_schemas();
                 schemas.extend(right.all_schemas());
                 schemas.insert(0, schema);
@@ -481,18 +481,18 @@ impl LogicalPlan {
             }
             LogicalPlan::Filter(Filter { predicate, .. }) => vec![predicate.clone()],
             LogicalPlan::Repartition(Repartition {
-                                         partitioning_scheme,
-                                         ..
-                                     }) => match partitioning_scheme {
+                partitioning_scheme,
+                ..
+            }) => match partitioning_scheme {
                 Partitioning::Hash(expr, _) => expr.clone(),
                 _ => vec![],
             },
             LogicalPlan::Window(Window { window_expr, .. }) => window_expr.clone(),
             LogicalPlan::Aggregate(Aggregate {
-                                       group_expr,
-                                       aggr_expr,
-                                       ..
-                                   }) => group_expr.iter().chain(aggr_expr.iter()).cloned().collect(),
+                group_expr,
+                aggr_expr,
+                ..
+            }) => group_expr.iter().chain(aggr_expr.iter()).cloned().collect(),
             LogicalPlan::Join(Join { on, .. }) => on
                 .iter()
                 .flat_map(|(l, r)| vec![Expr::Column(l.clone()), Expr::Column(r.clone())])
@@ -557,10 +557,10 @@ impl LogicalPlan {
 
             fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
                 if let LogicalPlan::Join(Join {
-                                             join_constraint: JoinConstraint::Using,
-                                             on,
-                                             ..
-                                         }) = plan
+                    join_constraint: JoinConstraint::Using,
+                    on,
+                    ..
+                }) = plan
                 {
                     self.using_columns.push(
                         on.iter()
@@ -627,7 +627,7 @@ pub trait PlanVisitor {
     /// Err(..) or Ok(false) are returned, the recursion stops
     /// immediately and the error, if any, is returned to `accept`
     fn pre_visit(&mut self, plan: &LogicalPlan)
-                 -> std::result::Result<bool, Self::Error>;
+        -> std::result::Result<bool, Self::Error>;
 
     /// Invoked on a logical plan after all of its child inputs have
     /// been visited. The return value is handled the same as the
@@ -647,8 +647,8 @@ impl LogicalPlan {
     /// `pre_visit` or `post_visit` returned Ok(false) and may have
     /// cut short the recursion
     pub fn accept<V>(&self, visitor: &mut V) -> std::result::Result<bool, V::Error>
-        where
-            V: PlanVisitor,
+    where
+        V: PlanVisitor,
     {
         if !visitor.pre_visit(self)? {
             return Ok(false);
@@ -902,13 +902,13 @@ impl LogicalPlan {
                     }
 
                     LogicalPlan::TableScan(TableScan {
-                                               ref source,
-                                               ref table_name,
-                                               ref projection,
-                                               ref filters,
-                                               ref limit,
-                                               ..
-                                           }) => {
+                        ref source,
+                        ref table_name,
+                        ref projection,
+                        ref filters,
+                        ref limit,
+                        ..
+                    }) => {
                         write!(
                             f,
                             "TableScan: {} projection={:?}",
@@ -920,11 +920,19 @@ impl LogicalPlan {
                             let mut partial_filter = vec![];
                             let mut unsupported_filters = vec![];
 
-                            filters.iter().for_each(|x| if let Ok(t) = source.supports_filter_pushdown(x) {
-                                match t {
-                                    TableProviderFilterPushDown::Exact => full_filter.push(x),
-                                    TableProviderFilterPushDown::Inexact => partial_filter.push(x),
-                                    TableProviderFilterPushDown::Unsupported => unsupported_filters.push(x),
+                            filters.iter().for_each(|x| {
+                                if let Ok(t) = source.supports_filter_pushdown(x) {
+                                    match t {
+                                        TableProviderFilterPushDown::Exact => {
+                                            full_filter.push(x)
+                                        }
+                                        TableProviderFilterPushDown::Inexact => {
+                                            partial_filter.push(x)
+                                        }
+                                        TableProviderFilterPushDown::Unsupported => {
+                                            unsupported_filters.push(x)
+                                        }
+                                    }
                                 }
                             });
 
@@ -935,7 +943,11 @@ impl LogicalPlan {
                                 write!(f, ", partial_filters={:?}", partial_filter)?;
                             }
                             if !unsupported_filters.is_empty() {
-                                write!(f, ", unsupported_filters={:?}", unsupported_filters)?;
+                                write!(
+                                    f,
+                                    ", unsupported_filters={:?}",
+                                    unsupported_filters
+                                )?;
                             }
                         }
 
@@ -946,8 +958,8 @@ impl LogicalPlan {
                         Ok(())
                     }
                     LogicalPlan::Projection(Projection {
-                                                ref expr, alias, ..
-                                            }) => {
+                        ref expr, alias, ..
+                    }) => {
                         write!(f, "Projection: ")?;
                         for (i, expr_item) in expr.iter().enumerate() {
                             if i > 0 {
@@ -961,19 +973,19 @@ impl LogicalPlan {
                         Ok(())
                     }
                     LogicalPlan::Filter(Filter {
-                                            predicate: ref expr,
-                                            ..
-                                        }) => write!(f, "Filter: {:?}", expr),
+                        predicate: ref expr,
+                        ..
+                    }) => write!(f, "Filter: {:?}", expr),
                     LogicalPlan::Window(Window {
-                                            ref window_expr, ..
-                                        }) => {
+                        ref window_expr, ..
+                    }) => {
                         write!(f, "WindowAggr: windowExpr=[{:?}]", window_expr)
                     }
                     LogicalPlan::Aggregate(Aggregate {
-                                               ref group_expr,
-                                               ref aggr_expr,
-                                               ..
-                                           }) => write!(
+                        ref group_expr,
+                        ref aggr_expr,
+                        ..
+                    }) => write!(
                         f,
                         "Aggregate: groupBy=[{:?}], aggr=[{:?}]",
                         group_expr, aggr_expr
@@ -989,11 +1001,11 @@ impl LogicalPlan {
                         Ok(())
                     }
                     LogicalPlan::Join(Join {
-                                          on: ref keys,
-                                          join_constraint,
-                                          join_type,
-                                          ..
-                                      }) => {
+                        on: ref keys,
+                        join_constraint,
+                        join_type,
+                        ..
+                    }) => {
                         let join_expr: Vec<String> =
                             keys.iter().map(|(l, r)| format!("{} = {}", l, r)).collect();
                         match join_constraint {
@@ -1014,9 +1026,9 @@ impl LogicalPlan {
                         write!(f, "CrossJoin:")
                     }
                     LogicalPlan::Repartition(Repartition {
-                                                 partitioning_scheme,
-                                                 ..
-                                             }) => match partitioning_scheme {
+                        partitioning_scheme,
+                        ..
+                    }) => match partitioning_scheme {
                         Partitioning::RoundRobinBatch(n) => write!(
                             f,
                             "Repartition: RoundRobinBatch partition_count={}",
@@ -1035,25 +1047,25 @@ impl LogicalPlan {
                     },
                     LogicalPlan::Limit(Limit { ref n, .. }) => write!(f, "Limit: {}", n),
                     LogicalPlan::CreateExternalTable(CreateExternalTable {
-                                                         ref name,
-                                                         ..
-                                                     }) => {
+                        ref name,
+                        ..
+                    }) => {
                         write!(f, "CreateExternalTable: {:?}", name)
                     }
                     LogicalPlan::CreateMemoryTable(CreateMemoryTable {
-                                                       name, ..
-                                                   }) => {
+                        name, ..
+                    }) => {
                         write!(f, "CreateMemoryTable: {:?}", name)
                     }
                     LogicalPlan::CreateCatalogSchema(CreateCatalogSchema {
-                                                         schema_name,
-                                                         ..
-                                                     }) => {
+                        schema_name,
+                        ..
+                    }) => {
                         write!(f, "CreateCatalogSchema: {:?}", schema_name)
                     }
                     LogicalPlan::DropTable(DropTable {
-                                               name, if_exists, ..
-                                           }) => {
+                        name, if_exists, ..
+                    }) => {
                         write!(f, "DropTable: {:?} if not exist:={}", name, if_exists)
                     }
                     LogicalPlan::Explain { .. } => write!(f, "Explain"),
@@ -1177,13 +1189,13 @@ mod tests {
             &employee_schema(),
             Some(vec![0, 3]),
         )
-            .unwrap()
-            .filter(col("state").eq(lit("CO")))
-            .unwrap()
-            .project(vec![col("id")])
-            .unwrap()
-            .build()
-            .unwrap()
+        .unwrap()
+        .filter(col("state").eq(lit("CO")))
+        .unwrap()
+        .project(vec![col("id")])
+        .unwrap()
+        .build()
+        .unwrap()
     }
 
     #[test]

--- a/datafusion/src/optimizer/filter_push_down.rs
+++ b/datafusion/src/optimizer/filter_push_down.rs
@@ -1431,7 +1431,7 @@ mod tests {
         let plan = table_scan_with_pushdown_provider(TableProviderFilterPushDown::Exact)?;
 
         let expected = "\
-        TableScan: test projection=None, filters=[#a = Int64(1)]";
+        TableScan: test projection=None, full_filters=[#a = Int64(1)]";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1443,7 +1443,7 @@ mod tests {
 
         let expected = "\
         Filter: #a = Int64(1)\
-        \n  TableScan: test projection=None, filters=[#a = Int64(1)]";
+        \n  TableScan: test projection=None, partial_filters=[#a = Int64(1)]";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1457,7 +1457,7 @@ mod tests {
 
         let expected = "\
         Filter: #a = Int64(1)\
-        \n  TableScan: test projection=None, filters=[#a = Int64(1)]";
+        \n  TableScan: test projection=None, partial_filters=[#a = Int64(1)]";
 
         // Optimizing the same plan multiple times should produce the same plan
         // each time.
@@ -1501,7 +1501,7 @@ mod tests {
 
         let expected ="Projection: #a, #b\
             \n  Filter: #a = Int64(10) AND #b > Int64(11)\
-            \n    TableScan: test projection=Some([0]), filters=[#a = Int64(10), #b > Int64(11)]";
+            \n    TableScan: test projection=Some([0]), partial_filters=[#a = Int64(10), #b > Int64(11)]";
 
         assert_optimized_plan_eq(&plan, expected);
 

--- a/datafusion/tests/sql/explain_analyze.rs
+++ b/datafusion/tests/sql/explain_analyze.rs
@@ -260,7 +260,7 @@ async fn csv_explain_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32]",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
+        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -275,7 +275,7 @@ async fn csv_explain_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]",
+        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -297,7 +297,7 @@ async fn csv_explain_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -308,7 +308,7 @@ async fn csv_explain_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -458,7 +458,7 @@ async fn csv_explain_verbose_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32]",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
+        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -473,7 +473,7 @@ async fn csv_explain_verbose_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]",
+        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -495,7 +495,7 @@ async fn csv_explain_verbose_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -506,7 +506,7 @@ async fn csv_explain_verbose_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -621,9 +621,9 @@ order by
     \n          Inner Join: #customer.c_custkey = #orders.o_custkey\
     \n            TableScan: customer projection=Some([0, 1, 2, 3, 4, 5, 7])\
     \n            Filter: #orders.o_orderdate >= Date32(\"8674\") AND #orders.o_orderdate < Date32(\"8766\")\
-    \n              TableScan: orders projection=Some([0, 1, 4]), filters=[#orders.o_orderdate >= Date32(\"8674\"), #orders.o_orderdate < Date32(\"8766\")]\
+    \n              TableScan: orders projection=Some([0, 1, 4]), partial_filters=[#orders.o_orderdate >= Date32(\"8674\"), #orders.o_orderdate < Date32(\"8766\")]\
     \n          Filter: #lineitem.l_returnflag = Utf8(\"R\")\
-    \n            TableScan: lineitem projection=Some([0, 5, 6, 8]), filters=[#lineitem.l_returnflag = Utf8(\"R\")]\
+    \n            TableScan: lineitem projection=Some([0, 5, 6, 8]), partial_filters=[#lineitem.l_returnflag = Utf8(\"R\")]\
     \n        TableScan: nation projection=Some([0, 1])";
     assert_eq!(format!("{:?}", plan.unwrap()), expected);
 
@@ -744,7 +744,7 @@ async fn csv_explain() {
             "logical_plan",
             "Projection: #aggregate_test_100.c1\
              \n  Filter: #aggregate_test_100.c2 > Int64(10)\
-             \n    TableScan: aggregate_test_100 projection=Some([0, 1]), filters=[#aggregate_test_100.c2 > Int64(10)]"
+             \n    TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]"
         ],
         vec!["physical_plan",
              "ProjectionExec: expr=[c1@0 as c1]\


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2021.

 # Rationale for this change
Thanks @alamb 's desgin to decouple between explain  and planNode, No need to change `tableScan` struct.
Now 
```
❯  explain select c1, c2 from test where  c2 = 0.000001;
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                 |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #test.c1, #test.c2                                                                                                                       |
|               |   Filter: #test.c2 = Float64(0.000001)                                                                                                               |
|               |     TableScan: test projection=Some([0, 1]), partial_filters=[#test.c2 = Float64(0.000001)]                                                          |
| physical_plan | ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]                                                                                                        |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                                        |
|               |     FilterExec: CAST(c2@1 AS Float64) = 0.000001                                                                                                     |
|               |       RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                              |
|               |         CsvExec: files=[/Users/yangjiang/CLionProjects/github/arrow-datafusion/testing/data/csv/aggregate_test_100.csv], has_header=true, limit=None |
|               |                                                                                                                                                      |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.004 seconds.
``` 

# What changes are included in this PR?
plan tree node `TableScan`

# Are there any user-facing changes?

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
