### PR TITLE
Short-circuit evaluation for `CaseWhen`

### DIFF
--- a/datafusion-physical-expr/src/expressions/case.rs
+++ b/datafusion-physical-expr/src/expressions/case.rs
@@ -379,8 +379,6 @@ impl CaseExpr {
         let mut current_value = new_null_array(&return_type, batch.num_rows());
         let mut remainder = BooleanArray::from(vec![true; batch.num_rows()]);
         for i in 0..self.when_then_expr.len() {
-            let i = i as usize;
-
             let when_value = self.when_then_expr[i]
                 .0
                 .evaluate_selection(batch, &remainder)?;

--- a/datafusion-physical-expr/src/expressions/case.rs
+++ b/datafusion-physical-expr/src/expressions/case.rs
@@ -330,8 +330,6 @@ impl CaseExpr {
         // We only consider non-null values while comparing with whens
         let mut remainder = not(&base_nulls)?;
         for i in 0..self.when_then_expr.len() {
-            let i = i as usize;
-
             let when_value = self.when_then_expr[i]
                 .0
                 .evaluate_selection(batch, &remainder)?;

--- a/datafusion-physical-expr/src/expressions/case.rs
+++ b/datafusion-physical-expr/src/expressions/case.rs
@@ -354,10 +354,11 @@ impl CaseExpr {
             // keep `else_expr`'s data type and return type consistent
             let expr = try_cast(e.clone(), &*batch.schema(), return_type.clone())
                 .unwrap_or_else(|_| e.clone());
+            // null and unmatched tuples should be assigned else value
+            remainder = or(&base_nulls, &remainder)?;
             let else_ = expr
                 .evaluate_selection(batch, &remainder)?
                 .into_array(batch.num_rows());
-            remainder = or(&base_nulls, &remainder)?;
             current_value = if_then_else(&remainder, else_, current_value, &return_type)?;
         }
 
@@ -413,7 +414,6 @@ impl CaseExpr {
             let else_ = expr
                 .evaluate_selection(batch, &remainder)?
                 .into_array(batch.num_rows());
-            remainder = or(&is_null(&remainder)?, &remainder)?;
             current_value = if_then_else(&remainder, else_, current_value, &return_type)?;
         }
 

--- a/datafusion-physical-expr/src/physical_expr.rs
+++ b/datafusion-physical-expr/src/physical_expr.rs
@@ -43,7 +43,8 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
     fn nullable(&self, input_schema: &Schema) -> Result<bool>;
     /// Evaluate an expression against a RecordBatch
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue>;
-    /// Evaluate an expression against a RecordBatch with validity array
+    /// Evaluate an expression against a RecordBatch after first applying a
+    /// validity array
     fn evaluate_selection(
         &self,
         batch: &RecordBatch,

--- a/datafusion-physical-expr/src/physical_expr.rs
+++ b/datafusion-physical-expr/src/physical_expr.rs
@@ -19,12 +19,17 @@ use arrow::datatypes::{DataType, Schema};
 
 use arrow::record_batch::RecordBatch;
 
-use datafusion_common::Result;
+use datafusion_common::{DataFusionError, Result};
 
 use datafusion_expr::ColumnarValue;
 use std::fmt::{Debug, Display};
 
+use arrow::array::{
+    make_array, Array, ArrayRef, BooleanArray, MutableArrayData, UInt64Array,
+};
+use arrow::compute::{take, SlicesIterator};
 use std::any::Any;
+use std::sync::Arc;
 
 /// Expression that can be evaluated against a RecordBatch
 /// A Physical expression knows its type, nullability and how to evaluate itself.
@@ -38,4 +43,74 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
     fn nullable(&self, input_schema: &Schema) -> Result<bool>;
     /// Evaluate an expression against a RecordBatch
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue>;
+    /// Evaluate an expression against a RecordBatch with validity array
+    fn evaluate_selection(
+        &self,
+        batch: &RecordBatch,
+        selection: &BooleanArray,
+    ) -> Result<ColumnarValue> {
+        let mut indices = vec![];
+        for (i, b) in selection.iter().enumerate() {
+            if let Some(true) = b {
+                indices.push(i as u64);
+            }
+        }
+        let indices = UInt64Array::from_iter_values(indices);
+        let tmp_columns = batch
+            .columns()
+            .iter()
+            .map(|c| {
+                take(c.as_ref(), &indices, None)
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))
+            })
+            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+
+        let tmp_batch = RecordBatch::try_new(batch.schema(), tmp_columns)?;
+        let tmp_result = self.evaluate(&tmp_batch)?;
+        if let ColumnarValue::Array(a) = tmp_result {
+            let result = scatter(selection, a.as_ref())?;
+            Ok(ColumnarValue::Array(result))
+        } else {
+            Ok(tmp_result)
+        }
+    }
+}
+
+/// Scatter `truthy` array by boolean mask. When the mask evaluates `true`, next values of `truthy`
+/// are taken, when the mask evaluates `false` values null values are filled.
+///
+/// # Arguments
+/// * `mask` - Boolean values used to determine where to put the `truthy` values
+/// * `truthy` - All values of this array are to scatter according to `mask` into final result.
+fn scatter(mask: &BooleanArray, truthy: &dyn Array) -> Result<ArrayRef> {
+    let truthy = truthy.data();
+
+    let mut mutable = MutableArrayData::new(vec![&*truthy], true, mask.len());
+
+    // the SlicesIterator slices only the true values. So the gaps left by this iterator we need to
+    // fill with falsy values
+
+    // keep track of how much is filled
+    let mut filled = 0;
+    // keep track of current position we have in truthy array
+    let mut true_pos = 0;
+
+    SlicesIterator::new(mask).for_each(|(start, end)| {
+        // the gap needs to be filled with nulls
+        if start > filled {
+            mutable.extend_nulls(start - filled);
+        }
+        // fill with truthy values
+        let len = end - start;
+        mutable.extend(0, true_pos, true_pos + len);
+        true_pos += len;
+        filled = end;
+    });
+    // the remaining part is falsy
+    if filled < truthy.len() {
+        mutable.extend_nulls(truthy.len() - filled);
+    }
+
+    let data = mutable.freeze();
+    Ok(make_array(data))
 }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #2064.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As reported by #2064, we are currently evaluating `then expr` and `else expr` for all tuples, regardless a tuple might already fail the `when expr` already.


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Evaluate expressions sequentially as they appear in CaseWhen, short-circuit when possible.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.
