### PR TITLE
[MINOR] fix doc in `EXTRACT(field FROM source)

### DIFF
--- a/docs/source/user-guide/sql/datafusion-functions.md
+++ b/docs/source/user-guide/sql/datafusion-functions.md
@@ -94,7 +94,7 @@ Note that `CAST(.. AS Timestamp)` converts to Timestamps with Nanosecond resolut
   The `extract` function returns values of type u32.
   - `year` :`EXTRACT(year FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 2020`
   - `month`:`EXTRACT(month FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 9`
-  - `week` :`EXTRACT(week FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 23`
+  - `week` :`EXTRACT(week FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 37`
   - `day`: `EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 8`
   - `hour`: `EXTRACT(hour FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 12`
   - `minute`: `EXTRACT(minute FROM to_timestamp('2020-09-08T12:01:00+00:00')) -> 1`


### PR DESCRIPTION


Closes #.

 # Rationale for this change
Sorry for my carelessness.
```
❯ select date_part('week', to_timestamp('2020-09-08T12:00:12+00:00'))
;
+-----------------------------------------------------------------------+
| datepart(Utf8("week"),totimestamp(Utf8("2020-09-08T12:00:12+00:00"))) |
+-----------------------------------------------------------------------+
| 37                                                                    |
+-----------------------------------------------------------------------+
1 row in set. Query took 0.005 seconds.
❯
```
week result should be 37.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
