### PR TITLE
Fix lost filters and projections in ParquetExec, CSVExec etc

### DIFF
--- a/datafusion/src/physical_optimizer/pruning.rs
+++ b/datafusion/src/physical_optimizer/pruning.rs
@@ -210,6 +210,11 @@ impl PruningPredicate {
     pub fn logical_expr(&self) -> &Expr {
         &self.logical_expr
     }
+
+    /// Returns a reference to the predicate expr
+    pub fn predicate_expr(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.predicate_expr
+    }
 }
 
 /// Handles creating references to the min/max statistics

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -365,7 +365,7 @@ mod tests {
             "HashAggregateExec: mode=Final, gby=[], aggr=[]",
             "HashAggregateExec: mode=Partial, gby=[], aggr=[]",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -381,7 +381,7 @@ mod tests {
             "HashAggregateExec: mode=Partial, gby=[], aggr=[]",
             "FilterExec: c1@0",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -398,7 +398,7 @@ mod tests {
             "FilterExec: c1@0",
             // nothing sorts the data, so the local limit doesn't require sorted data either
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -414,7 +414,7 @@ mod tests {
             "LocalLimitExec: limit=100",
             // data is sorted so can't repartition here
             "SortExec: [c1@0 ASC]",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -432,7 +432,7 @@ mod tests {
             // data is sorted so can't repartition here even though
             // filter would benefit from parallelism, the answers might be wrong
             "SortExec: [c1@0 ASC]",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -455,7 +455,7 @@ mod tests {
             "GlobalLimitExec: limit=100",
             "LocalLimitExec: limit=100",
             // Expect no repartition to happen for local limit
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -471,11 +471,11 @@ mod tests {
         let expected = &[
             "UnionExec",
             // Expect no repartition of ParquetExec
-            "ParquetExec: limit=None, partitions=[x]",
-            "ParquetExec: limit=None, partitions=[x]",
-            "ParquetExec: limit=None, partitions=[x]",
-            "ParquetExec: limit=None, partitions=[x]",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -489,7 +489,7 @@ mod tests {
         let expected = &[
             "SortPreservingMergeExec: [c1@0 ASC]",
             // Expect no repartition of SortPreservingMergeExec
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -505,7 +505,7 @@ mod tests {
             // Expect no repartition of SortPreservingMergeExec
             // even though there is a projection exec between it
             "ProjectionExec: expr=[c1@0 as c1]",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -522,7 +522,7 @@ mod tests {
             "SortExec: [c1@0 ASC]",
             "ProjectionExec: expr=[c1@0 as c1]",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -539,7 +539,7 @@ mod tests {
             "SortExec: [c1@0 ASC]",
             "FilterExec: c1@0",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -560,7 +560,7 @@ mod tests {
             "FilterExec: c1@0",
             // repartition is lowest down
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x]",
+            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
         ];
 
         assert_optimized!(expected, plan);

--- a/datafusion/src/physical_optimizer/repartition.rs
+++ b/datafusion/src/physical_optimizer/repartition.rs
@@ -365,7 +365,7 @@ mod tests {
             "HashAggregateExec: mode=Final, gby=[], aggr=[]",
             "HashAggregateExec: mode=Partial, gby=[], aggr=[]",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -381,7 +381,7 @@ mod tests {
             "HashAggregateExec: mode=Partial, gby=[], aggr=[]",
             "FilterExec: c1@0",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -398,7 +398,7 @@ mod tests {
             "FilterExec: c1@0",
             // nothing sorts the data, so the local limit doesn't require sorted data either
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -414,7 +414,7 @@ mod tests {
             "LocalLimitExec: limit=100",
             // data is sorted so can't repartition here
             "SortExec: [c1@0 ASC]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -432,7 +432,7 @@ mod tests {
             // data is sorted so can't repartition here even though
             // filter would benefit from parallelism, the answers might be wrong
             "SortExec: [c1@0 ASC]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -455,7 +455,7 @@ mod tests {
             "GlobalLimitExec: limit=100",
             "LocalLimitExec: limit=100",
             // Expect no repartition to happen for local limit
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -471,11 +471,11 @@ mod tests {
         let expected = &[
             "UnionExec",
             // Expect no repartition of ParquetExec
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -489,7 +489,7 @@ mod tests {
         let expected = &[
             "SortPreservingMergeExec: [c1@0 ASC]",
             // Expect no repartition of SortPreservingMergeExec
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -505,7 +505,7 @@ mod tests {
             // Expect no repartition of SortPreservingMergeExec
             // even though there is a projection exec between it
             "ProjectionExec: expr=[c1@0 as c1]",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -522,7 +522,7 @@ mod tests {
             "SortExec: [c1@0 ASC]",
             "ProjectionExec: expr=[c1@0 as c1]",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -539,7 +539,7 @@ mod tests {
             "SortExec: [c1@0 ASC]",
             "FilterExec: c1@0",
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);
@@ -560,7 +560,7 @@ mod tests {
             "FilterExec: c1@0",
             // repartition is lowest down
             "RepartitionExec: partitioning=RoundRobinBatch(10)",
-            "ParquetExec: limit=None, partitions=[x], projected_col=[c1]",
+            "ParquetExec: limit=None, partitions=[x], projection=[c1]",
         ];
 
         assert_optimized!(expected, plan);

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -165,10 +165,11 @@ impl ExecutionPlan for CsvExec {
             DisplayFormatType::Default => {
                 write!(
                     f,
-                    "CsvExec: files={}, has_header={}, limit={:?}",
+                    "CsvExec: files={}, has_header={}, limit={:?}, projected_col={}",
                     super::FileGroupsDisplay(&self.base_config.file_groups),
                     self.has_header,
                     self.base_config.limit,
+                    super::ProjectSchemaDisplay(&self.projected_schema),
                 )
             }
         }

--- a/datafusion/src/physical_plan/file_format/csv.rs
+++ b/datafusion/src/physical_plan/file_format/csv.rs
@@ -165,7 +165,7 @@ impl ExecutionPlan for CsvExec {
             DisplayFormatType::Default => {
                 write!(
                     f,
-                    "CsvExec: files={}, has_header={}, limit={:?}, projected_col={}",
+                    "CsvExec: files={}, has_header={}, limit={:?}, projection={}",
                     super::FileGroupsDisplay(&self.base_config.file_groups),
                     self.has_header,
                     self.base_config.limit,

--- a/datafusion/src/physical_plan/file_format/mod.rs
+++ b/datafusion/src/physical_plan/file_format/mod.rs
@@ -171,6 +171,22 @@ impl<'a> Display for FileGroupsDisplay<'a> {
     }
 }
 
+/// A wrapper to customize partitioned file display
+#[derive(Debug)]
+struct ProjectSchemaDisplay<'a>(&'a SchemaRef);
+
+impl<'a> Display for ProjectSchemaDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let parts: Vec<_> = self
+            .0
+            .fields()
+            .iter()
+            .map(|x| x.name().to_owned())
+            .collect::<Vec<String>>();
+        write!(f, "[{}]", parts.join(", "))
+    }
+}
+
 /// A utility which can adapt file-level record batches to a table schema which may have a schema
 /// obtained from merging multiple file-level schemas.
 ///

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -277,7 +277,7 @@ impl ExecutionPlan for ParquetExec {
                 if let Some(pre) = &self.pruning_predicate {
                     write!(
                         f,
-                        "ParquetExec: limit={:?}, partitions={}, pruning_predicate={}, projected_col={}",
+                        "ParquetExec: limit={:?}, partitions={}, predicate={}, projection={}",
                         self.base_config.limit,
                         super::FileGroupsDisplay(&self.base_config.file_groups),
                         pre.predicate_expr(),
@@ -286,7 +286,7 @@ impl ExecutionPlan for ParquetExec {
                 } else {
                     write!(
                         f,
-                        "ParquetExec: limit={:?}, partitions={}, projected_col={}",
+                        "ParquetExec: limit={:?}, partitions={}, projection={}",
                         self.base_config.limit,
                         super::FileGroupsDisplay(&self.base_config.file_groups),
                         super::ProjectSchemaDisplay(&self.projected_schema),

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -274,12 +274,24 @@ impl ExecutionPlan for ParquetExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                write!(
-                    f,
-                    "ParquetExec: limit={:?}, partitions={}",
-                    self.base_config.limit,
-                    super::FileGroupsDisplay(&self.base_config.file_groups)
-                )
+                if let Some(pre) = &self.pruning_predicate {
+                    write!(
+                        f,
+                        "ParquetExec: limit={:?}, partitions={}, pruning_predicate={}, projected_col={}",
+                        self.base_config.limit,
+                        super::FileGroupsDisplay(&self.base_config.file_groups),
+                        pre.predicate_expr(),
+                        super::ProjectSchemaDisplay(&self.projected_schema),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "ParquetExec: limit={:?}, partitions={}, projected_col={}",
+                        self.base_config.limit,
+                        super::FileGroupsDisplay(&self.base_config.file_groups),
+                        super::ProjectSchemaDisplay(&self.projected_schema),
+                    )
+                }
             }
         }
     }

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -291,7 +291,7 @@ pub trait ExecutionPlan: Debug + Send + Sync {
 ///              \n  CoalesceBatchesExec: target_batch_size=4096\
 ///              \n    FilterExec: a@0 < 5\
 ///              \n      RepartitionExec: partitioning=RoundRobinBatch(3)\
-///              \n        CsvExec: files=[tests/example.csv], has_header=true, limit=None",
+///              \n        CsvExec: files=[tests/example.csv], has_header=true, limit=None, projected_col=[a]",
 ///               plan_string.trim());
 /// }
 /// ```

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -291,7 +291,7 @@ pub trait ExecutionPlan: Debug + Send + Sync {
 ///              \n  CoalesceBatchesExec: target_batch_size=4096\
 ///              \n    FilterExec: a@0 < 5\
 ///              \n      RepartitionExec: partitioning=RoundRobinBatch(3)\
-///              \n        CsvExec: files=[tests/example.csv], has_header=true, limit=None, projected_col=[a]",
+///              \n        CsvExec: files=[tests/example.csv], has_header=true, limit=None, projection=[a]",
 ///               plan_string.trim());
 /// }
 /// ```

--- a/datafusion/tests/sql/explain_analyze.rs
+++ b/datafusion/tests/sql/explain_analyze.rs
@@ -658,7 +658,7 @@ async fn test_physical_plan_display_indent() {
         "                CoalesceBatchesExec: target_batch_size=4096",
         "                  FilterExec: c12@1 < CAST(10 AS Float64)",
         "                    RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                      CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1, c12]",
+        "                      CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projection=[c1, c12]",
     ];
 
     let data_path = datafusion::test_util::arrow_test_data();
@@ -703,13 +703,13 @@ async fn test_physical_plan_display_indent_multi_children() {
         "          ProjectionExec: expr=[c1@0 as c1]",
         "            ProjectionExec: expr=[c1@0 as c1]",
         "              RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1]",
+        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projection=[c1]",
         "      CoalesceBatchesExec: target_batch_size=4096",
         "        RepartitionExec: partitioning=Hash([Column { name: \"c2\", index: 0 }], 3)",
         "          ProjectionExec: expr=[c2@0 as c2]",
         "            ProjectionExec: expr=[c1@0 as c2]",
         "              RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1]",
+        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projection=[c1]",
     ];
 
     let data_path = datafusion::test_util::arrow_test_data();
@@ -751,7 +751,7 @@ async fn csv_explain() {
               \n  CoalesceBatchesExec: target_batch_size=4096\
               \n    FilterExec: CAST(c2@1 AS Int64) > 10\
               \n      RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES)\
-              \n        CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1, c2]\
+              \n        CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projection=[c1, c2]\
               \n"
         ]];
     assert_eq!(expected, actual);

--- a/datafusion/tests/sql/explain_analyze.rs
+++ b/datafusion/tests/sql/explain_analyze.rs
@@ -658,7 +658,7 @@ async fn test_physical_plan_display_indent() {
         "                CoalesceBatchesExec: target_batch_size=4096",
         "                  FilterExec: c12@1 < CAST(10 AS Float64)",
         "                    RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                      CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None",
+        "                      CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1, c12]",
     ];
 
     let data_path = datafusion::test_util::arrow_test_data();
@@ -703,13 +703,13 @@ async fn test_physical_plan_display_indent_multi_children() {
         "          ProjectionExec: expr=[c1@0 as c1]",
         "            ProjectionExec: expr=[c1@0 as c1]",
         "              RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None",
+        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1]",
         "      CoalesceBatchesExec: target_batch_size=4096",
         "        RepartitionExec: partitioning=Hash([Column { name: \"c2\", index: 0 }], 3)",
         "          ProjectionExec: expr=[c2@0 as c2]",
         "            ProjectionExec: expr=[c1@0 as c2]",
         "              RepartitionExec: partitioning=RoundRobinBatch(3)",
-        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None",
+        "                CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1]",
     ];
 
     let data_path = datafusion::test_util::arrow_test_data();
@@ -751,7 +751,7 @@ async fn csv_explain() {
               \n  CoalesceBatchesExec: target_batch_size=4096\
               \n    FilterExec: CAST(c2@1 AS Int64) > 10\
               \n      RepartitionExec: partitioning=RoundRobinBatch(NUM_CORES)\
-              \n        CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None\
+              \n        CsvExec: files=[ARROW_TEST_DATA/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1, c2]\
               \n"
         ]];
     assert_eq!(expected, actual);

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -215,7 +215,7 @@ async fn topk_query() -> Result<()> {
 async fn topk_plan() -> Result<()> {
     let mut ctx = setup_table(make_topk_context()).await?;
 
-    let expected = vec![
+    let mut expected = vec![
         "| logical_plan after topk                               | TopK: k=3                                                                     |",
         "|                                                       |   Projection: #sales.customer_id, #sales.revenue                              |",
         "|                                                       |     TableScan: sales projection=Some([0, 1])                                  |",
@@ -225,7 +225,9 @@ async fn topk_plan() -> Result<()> {
     let actual_output = exec_sql(&mut ctx, &explain_query).await?;
 
     // normalize newlines (output on windows uses \r\n)
-    let actual_output = actual_output.replace("\r\n", "\n");
+    let mut actual_output = actual_output.replace("\r\n", "\n");
+    actual_output.retain(|x| !x.is_ascii_whitespace());
+    expected.retain(|x| !x.is_ascii_whitespace());
 
     assert!(
         actual_output.contains(&expected),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Thanks for @yjshen give this advice ❤️. 
Closes #2073.

 # Rationale for this change

Before:
```
❯  explain select c1, c2 from test where  c2 = 0.000001;
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                 |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #test.c1, #test.c2                                                                                                                       |
|               |   Filter: #test.c2 = Float64(0.000001)                                                                                                               |
|               |     TableScan: test projection=Some([0, 1]), partial_filters=[#test.c2 = Float64(0.000001)]                                                          |
| physical_plan | ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]                                                                                                        |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                                        |
|               |     FilterExec: CAST(c2@1 AS Float64) = 0.000001                                                                                                     |
|               |       RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                              |
|               |         CsvExec: files=[/Users/yangjiang/CLionProjects/github/arrow-datafusion/testing/data/csv/aggregate_test_100.csv], has_header=true, limit=None |
|               |                                                                                                                                                      |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.004 seconds.
```

Now:
```
explain select l_orderkey, l_shipdate from parquet where l_shipdate < '1996-05-20';
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                           |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #parquet.l_orderkey, #parquet.l_shipdate                                                                                                                                                                                                                           |
|               |   Filter: #parquet.l_shipdate < Utf8("1996-05-20")                                                                                                                                                                                                                             |
|               |     TableScan: parquet projection=Some([0, 10]), partial_filters=[#parquet.l_shipdate < Utf8("1996-05-20")]                                                                                                                                                                    |
| physical_plan | ProjectionExec: expr=[l_orderkey@0 as l_orderkey, l_shipdate@1 as l_shipdate]                                                                                                                                                                                                  |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                                                                                                                                                                  |
|               |     FilterExec: l_shipdate@1 < CAST(1996-05-20 AS Date32)                                                                                                                                                                                                                      |
|               |       RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                                                                                                                                                        |
|               |         ParquetExec: limit=None, partitions=[/Users/yangjiang/test-data/tpch-1g-oneFile/lineitem/part-00000-41937a05-669a-4bfc-abbd-b4cdf90557f1-c000.snappy.parquet], pruning_predicate=l_shipdate_min@0 < CAST(1996-05-20 AS Date32), projected_col=[l_orderkey, l_shipdate] |
|               |                                                                                                                                                                                                                                                                                |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.008 seconds.



explain select c1,c2 from csv where c2 < 10;
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                         |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #csv.c1, #csv.c2                                                                                                                                                 |
|               |   Filter: #csv.c2 < Int64(10)                                                                                                                                                |
|               |     TableScan: csv projection=Some([0, 1]), partial_filters=[#csv.c2 < Int64(10)]                                                                                            |
| physical_plan | ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]                                                                                                                                |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                                                                                                |
|               |     FilterExec: CAST(c2@1 AS Int64) < 10                                                                                                                                     |
|               |       RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                                                      |
|               |         CsvExec: files=[/Users/yangjiang/CLionProjects/github/arrow-datafusion/testing/data/csv/aggregate_test_100.csv], has_header=true, limit=None, projected_col=[c1, c2] |
|               |                                                                                                                                                                              |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.005 seconds.









```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
