### PR TITLE
2078 docs for approx functions

### DIFF
--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -13,7 +13,7 @@ Aggregate functions operate on a set of values to compute a single result.
 ### count
 `count(1) -> uint64` returns the number of input values.
 
-`count(*) -> uint64` returns the number of input values.
+`count(*) -> uint64` returns the number of input values. it is an alias of `count(1)`.
 
 `count(x) -> uint64` returns the number of non-null input values.
 
@@ -23,7 +23,7 @@ Aggregate functions operate on a set of values to compute a single result.
 `avg(x) -> float64` returns the average (arithmetic mean) of input values.
 
 ### sum
-`sum(x) -> same as x` returns the sum of all input values.
+`sum(x) -> x` returns the sum of all input values.
 
 ### array_agg
 `array_agg(x) -> array<x>` returns an array created from the input values.
@@ -34,36 +34,44 @@ Aggregate functions operate on a set of values to compute a single result.
 `approx_distinct(x) -> uint64` returns the approximate number (HyperLogLog) of distinct input values
 
 ### approx_median
-`approx_median(x) -> x` returns the approximate median of input values.
-
-it is same as `approx_percentile_cont(x, 0.5)`.
+`approx_median(x) -> x` returns the approximate median of input values. it is an alias of `approx_percentile_cont(x, 0.5)`.
 
 ### approx_percentile_cont
 `approx_percentile_cont(x, p) -> x` return the approximate percentile (TDigest) of input values, where `p` is a float64 between 0 and 1 (inclusive).
 
 it supports raw data as input and build Tdigest sketches during query time.
 
+it is approximately equal to `approx_percentile_cont_with_weight(x, 1, p)`.
+
 ### approx_percentile_cont_with_weight
 `approx_percentile_cont_with_weight(x, w, p) -> x` return the approximate percentile (TDigest) of input values with weight, where `w` is weight column expression and `p` is a float64 between 0 and 1 (inclusive).
 
-it supports raw data as input or pre-aggregated TDigest sketches (mean and weight), then build and merge Tdigest sketches during query time.
-it is suitable for low latency query OLAP system where `Spark Streaming/Flink` pre-aggregate data to a data store, then query by Datafusion.
+it supports raw data as input or pre-aggregated TDigest sketches, then build or merge Tdigest sketches during query time. TDigest sketches are a list of centroid `(x, w)`, where `x` stands for mean and `w` stands for weight.
+
+it is suitable for low latency OLAP system where streaming compute engine (e.g. Spark Streaming/Flink) pre-aggregate data to a data store, then query by Datafusion.
 
 ## Statistical
 
 ### var
-var
-var_samp
-var_pop
+`var(x) -> float64` returns the sample variance of all input values. it is an alias of `var_samp(x)`.
+
+`var_samp(x) -> float64` returns the sample variance of all input values.
+
+`var_pop(x) -> float64` returns the population variance of all input values.
 
 ### stddev
-stddev
-stddev_samp
-stddev_pop
+`stddev(x) -> float64` returns the sample standard deviation of all input values it is an alias of `stddev_samp(x)`.
+
+`stddev_samp(x) -> float64` returns the sample standard deviation of all input values
+
+`stddev_pop(x) -> float64` returns the population standard deviation of all input values
 
 ### covar
-covar
-covar_samp
-covar_pop
+`covar(x, y) -> float64` returns the sample covariance of input values. it is an alias of `covar_samp(x)`.
+
+`covar_samp(x, y) -> float64` returns the sample covariance of input values.
+
+`covar_pop(x, y) -> float64` returns the population covariance of input values.
 
 ### corr
+`corr(x, y) -> float64` returns correlation coefficient of input values

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -1,42 +1,54 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
 # Aggregate Functions
 
-Aggregate functions operate on a set of values to compute a single result.
+Aggregate functions operate on a set of values to compute a single result. Please refer to [PostgreSQL](https://www.postgresql.org/docs/current/functions-aggregate.html) for usage of standard SQL functions.
 
 ## General
 
-### min
-`min(x) -> x` returns the minimum value of all input values.
+- min
+- max
+- count
+- avg
+- sum
+- array_agg
 
-### max
-`max(x) -> x` returns the maximum value of all input values.
+## Statistical
 
-### count
-`count(1) -> uint64` returns the number of input values.
-
-`count(*) -> uint64` returns the number of input values. it is an alias of `count(1)`.
-
-`count(x) -> uint64` returns the number of non-null input values.
-
-`count(distinct x) -> uint64` returns the number of non-null distinct input values.
-
-### avg
-`avg(x) -> float64` returns the average (arithmetic mean) of input values.
-
-### sum
-`sum(x) -> x` returns the sum of all input values.
-
-### array_agg
-`array_agg(x) -> array<x>` returns an array created from the input values.
+- var / var_samp / var_pop
+- stddev / stddev_samp / stddev_pop
+- covar / covar_samp / covar_pop
+- corr
 
 ## Approximate
 
 ### approx_distinct
+
 `approx_distinct(x) -> uint64` returns the approximate number (HyperLogLog) of distinct input values
 
 ### approx_median
+
 `approx_median(x) -> x` returns the approximate median of input values. it is an alias of `approx_percentile_cont(x, 0.5)`.
 
 ### approx_percentile_cont
+
 `approx_percentile_cont(x, p) -> x` return the approximate percentile (TDigest) of input values, where `p` is a float64 between 0 and 1 (inclusive).
 
 it supports raw data as input and build Tdigest sketches during query time.
@@ -44,34 +56,9 @@ it supports raw data as input and build Tdigest sketches during query time.
 it is approximately equal to `approx_percentile_cont_with_weight(x, 1, p)`.
 
 ### approx_percentile_cont_with_weight
+
 `approx_percentile_cont_with_weight(x, w, p) -> x` return the approximate percentile (TDigest) of input values with weight, where `w` is weight column expression and `p` is a float64 between 0 and 1 (inclusive).
 
 it supports raw data as input or pre-aggregated TDigest sketches, then build or merge Tdigest sketches during query time. TDigest sketches are a list of centroid `(x, w)`, where `x` stands for mean and `w` stands for weight.
 
 it is suitable for low latency OLAP system where streaming compute engine (e.g. Spark Streaming/Flink) pre-aggregate data to a data store, then query by Datafusion.
-
-## Statistical
-
-### var
-`var(x) -> float64` returns the sample variance of all input values. it is an alias of `var_samp(x)`.
-
-`var_samp(x) -> float64` returns the sample variance of all input values.
-
-`var_pop(x) -> float64` returns the population variance of all input values.
-
-### stddev
-`stddev(x) -> float64` returns the sample standard deviation of all input values it is an alias of `stddev_samp(x)`.
-
-`stddev_samp(x) -> float64` returns the sample standard deviation of all input values
-
-`stddev_pop(x) -> float64` returns the population standard deviation of all input values
-
-### covar
-`covar(x, y) -> float64` returns the sample covariance of input values. it is an alias of `covar_samp(x)`.
-
-`covar_samp(x, y) -> float64` returns the sample covariance of input values.
-
-`covar_pop(x, y) -> float64` returns the population covariance of input values.
-
-### corr
-`corr(x, y) -> float64` returns correlation coefficient of input values

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -51,14 +51,12 @@ Aggregate functions operate on a set of values to compute a single result. Pleas
 
 `approx_percentile_cont(x, p) -> x` return the approximate percentile (TDigest) of input values, where `p` is a float64 between 0 and 1 (inclusive).
 
-it supports raw data as input and build Tdigest sketches during query time.
-
-it is approximately equal to `approx_percentile_cont_with_weight(x, 1, p)`.
+It supports raw data as input and build Tdigest sketches during query time, and is approximately equal to `approx_percentile_cont_with_weight(x, 1, p)`.
 
 ### approx_percentile_cont_with_weight
 
-`approx_percentile_cont_with_weight(x, w, p) -> x` return the approximate percentile (TDigest) of input values with weight, where `w` is weight column expression and `p` is a float64 between 0 and 1 (inclusive).
+`approx_percentile_cont_with_weight(x, w, p) -> x` returns the approximate percentile (TDigest) of input values with weight, where `w` is weight column expression and `p` is a float64 between 0 and 1 (inclusive).
 
-it supports raw data as input or pre-aggregated TDigest sketches, then build or merge Tdigest sketches during query time. TDigest sketches are a list of centroid `(x, w)`, where `x` stands for mean and `w` stands for weight.
+It supports raw data as input or pre-aggregated TDigest sketches, then builds or merges Tdigest sketches during query time. TDigest sketches are a list of centroid `(x, w)`, where `x` stands for mean and `w` stands for weight.
 
-it is suitable for low latency OLAP system where streaming compute engine (e.g. Spark Streaming/Flink) pre-aggregate data to a data store, then query by Datafusion.
+It is suitable for low latency OLAP system where a streaming compute engine (e.g. Spark Streaming/Flink) pre-aggregates data to a data store, then queries using Datafusion.

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -1,0 +1,69 @@
+# Aggregate Functions
+
+Aggregate functions operate on a set of values to compute a single result.
+
+## General
+
+### min
+`min(x) -> x` returns the minimum value of all input values.
+
+### max
+`max(x) -> x` returns the maximum value of all input values.
+
+### count
+`count(1) -> uint64` returns the number of input values.
+
+`count(*) -> uint64` returns the number of input values.
+
+`count(x) -> uint64` returns the number of non-null input values.
+
+`count(distinct x) -> uint64` returns the number of non-null distinct input values.
+
+### avg
+`avg(x) -> float64` returns the average (arithmetic mean) of input values.
+
+### sum
+`sum(x) -> same as x` returns the sum of all input values.
+
+### array_agg
+`array_agg(x) -> array<x>` returns an array created from the input values.
+
+## Approximate
+
+### approx_distinct
+`approx_distinct(x) -> uint64` returns the approximate number (HyperLogLog) of distinct input values
+
+### approx_median
+`approx_median(x) -> x` returns the approximate median of input values.
+
+it is same as `approx_percentile_cont(x, 0.5)`.
+
+### approx_percentile_cont
+`approx_percentile_cont(x, p) -> x` return the approximate percentile (TDigest) of input values, where `p` is a float64 between 0 and 1 (inclusive).
+
+it supports raw data as input and build Tdigest sketches during query time.
+
+### approx_percentile_cont_with_weight
+`approx_percentile_cont_with_weight(x, w, p) -> x` return the approximate percentile (TDigest) of input values with weight, where `w` is weight column expression and `p` is a float64 between 0 and 1 (inclusive).
+
+it supports raw data as input or pre-aggregated TDigest sketches (mean and weight), then build and merge Tdigest sketches during query time.
+it is suitable for low latency query OLAP system where `Spark Streaming/Flink` pre-aggregate data to a data store, then query by Datafusion.
+
+## Statistical
+
+### var
+var
+var_samp
+var_pop
+
+### stddev
+stddev
+stddev_samp
+stddev_pop
+
+### covar
+covar
+covar_samp
+covar_pop
+
+### corr

--- a/docs/source/user-guide/sql/index.rst
+++ b/docs/source/user-guide/sql/index.rst
@@ -24,4 +24,5 @@ SQL Reference
    sql_status
    select
    ddl
+   aggregate_functions
    DataFusion Functions <datafusion-functions>

--- a/docs/source/user-guide/sql/sql_status.md
+++ b/docs/source/user-guide/sql/sql_status.md
@@ -76,6 +76,9 @@
   - [x] nullif
 - Approximation functions
   - [x] approx_distinct
+  - [x] approx_median
+  - [x] approx_percentile_cont
+  - [x] approx_percentile_cont_with_weight
 - Common date/time functions
   - [ ] Basic date functions
   - [ ] Basic time functions


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-datafusion/issues/2078

 # Rationale for this change

Add user guide for aggregate functions, similar to https://trino.io/docs/current/functions/aggregate.html

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

only Documentation
