### PR TITLE
[Ballista] Support Union in ballista.

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -569,6 +569,7 @@ mod tests {
         use ballista_core::config::{
             BallistaConfigBuilder, BALLISTA_WITH_INFORMATION_SCHEMA,
         };
+        use datafusion::arrow::util::pretty::pretty_format_batches;
         use datafusion::assert_batches_eq;
         let config = BallistaConfigBuilder::default()
             .set(BALLISTA_WITH_INFORMATION_SCHEMA, "true")

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -365,8 +365,6 @@ impl BallistaContext {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::util::pretty::pretty_format_batches;
-    use std::io::BufRead;
 
     #[tokio::test]
     #[cfg(feature = "standalone")]

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -365,6 +365,8 @@ impl BallistaContext {
 
 #[cfg(test)]
 mod tests {
+    use datafusion::arrow::util::pretty::pretty_format_batches;
+    use std::io::BufRead;
 
     #[tokio::test]
     #[cfg(feature = "standalone")]
@@ -560,5 +562,64 @@ mod tests {
 
         let df = context.sql(sql).await.unwrap();
         assert!(!df.collect().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "standalone")]
+    async fn test_union_and_union_all() {
+        use super::*;
+        use ballista_core::config::{
+            BallistaConfigBuilder, BALLISTA_WITH_INFORMATION_SCHEMA,
+        };
+        use datafusion::assert_batches_eq;
+        let config = BallistaConfigBuilder::default()
+            .set(BALLISTA_WITH_INFORMATION_SCHEMA, "true")
+            .build()
+            .unwrap();
+        let context = BallistaContext::standalone(&config, 1).await.unwrap();
+
+        let df = context
+            .sql("SELECT 1 as NUMBER union SELECT 1 as NUMBER;")
+            .await
+            .unwrap();
+        let res1 = df.collect().await.unwrap();
+        let expected1 = vec![
+            "+--------+",
+            "| number |",
+            "+--------+",
+            "| 1      |",
+            "+--------+",
+        ];
+        assert_eq!(
+            expected1,
+            pretty_format_batches(&*res1)
+                .unwrap()
+                .to_string()
+                .trim()
+                .lines()
+                .collect::<Vec<&str>>()
+        );
+        let expected2 = vec![
+            "+--------+",
+            "| number |",
+            "+--------+",
+            "| 1      |",
+            "| 1      |",
+            "+--------+",
+        ];
+        let df = context
+            .sql("SELECT 1 as NUMBER union all SELECT 1 as NUMBER;")
+            .await
+            .unwrap();
+        let res2 = df.collect().await.unwrap();
+        assert_eq!(
+            expected2,
+            pretty_format_batches(&*res2)
+                .unwrap()
+                .to_string()
+                .trim()
+                .lines()
+                .collect::<Vec<&str>>()
+        );
     }
 }

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -50,6 +50,7 @@ message LogicalPlanNode {
     ValuesNode values = 16;
     LogicalExtensionNode extension = 17;
     CreateCatalogSchemaNode create_catalog_schema = 18;
+    UnionNode union = 19;
   }
 }
 
@@ -210,6 +211,11 @@ message JoinNode {
   repeated datafusion.Column left_join_column = 5;
   repeated datafusion.Column right_join_column = 6;
   bool null_equals_null = 7;
+}
+
+message UnionNode {
+  repeated LogicalPlanNode inputs = 1;
+  datafusion.DfSchema schema = 2;
 }
 
 message CrossJoinNode {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -215,7 +215,6 @@ message JoinNode {
 
 message UnionNode {
   repeated LogicalPlanNode inputs = 1;
-  datafusion.DfSchema schema = 2;
 }
 
 message CrossJoinNode {
@@ -259,6 +258,7 @@ message PhysicalPlanNode {
     CrossJoinExecNode cross_join = 19;
     AvroScanExecNode avro_scan = 20;
     PhysicalExtensionNode extension = 21;
+    UnionExecNode union = 22;
   }
 }
 
@@ -437,6 +437,10 @@ message HashJoinExecNode {
   JoinType join_type = 4;
   PartitionMode partition_mode = 6;
   bool null_equals_null = 7;
+}
+
+message UnionExecNode {
+  repeated PhysicalPlanNode inputs = 1;
 }
 
 message CrossJoinExecNode {

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -423,8 +423,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 for plan in input_plans {
                     builder = builder.union(plan)?;
                 }
-                let result = builder.build().map_err(|e| e.into());
-                result
+                builder.build().map_err(|e| e.into())
             }
             LogicalPlanType::CrossJoin(crossjoin) => {
                 let left = into_logical_plan!(crossjoin.left, &ctx, extension_codec)?;

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -419,11 +419,12 @@ impl AsLogicalPlan for LogicalPlanNode {
                    )));
                 }
 
-                let builder = LogicalPlanBuilder::from(input_plans.pop().unwrap());
+                let mut builder = LogicalPlanBuilder::from(input_plans.pop().unwrap());
                 for plan in input_plans {
-                    builder.union(plan)?;
+                    builder = builder.union(plan)?;
                 }
-                builder.build().map_err(|e| e.into())
+                let result = builder.build().map_err(|e| e.into());
+                result
             }
             LogicalPlanType::CrossJoin(crossjoin) => {
                 let left = into_logical_plan!(crossjoin.left, &ctx, extension_codec)?;
@@ -849,7 +850,6 @@ impl AsLogicalPlan for LogicalPlanNode {
                     logical_plan_type: Some(LogicalPlanType::Union(
                         protobuf::UnionNode {
                             inputs,
-                            schema: None,
                         },
                     ))
                 })

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -847,10 +847,8 @@ impl AsLogicalPlan for LogicalPlanNode {
                     .collect::<Result<_, BallistaError>>()?;
                 Ok(protobuf::LogicalPlanNode {
                     logical_plan_type: Some(LogicalPlanType::Union(
-                        protobuf::UnionNode {
-                            inputs,
-                        },
-                    ))
+                        protobuf::UnionNode { inputs },
+                    )),
                 })
             }
             LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -406,6 +406,25 @@ impl AsLogicalPlan for LogicalPlanNode {
 
                 builder.build().map_err(|e| e.into())
             }
+            LogicalPlanType::Union(union) => {
+                let mut input_plans: Vec<LogicalPlan> = union
+                    .inputs
+                    .iter()
+                    .map(|i| i.try_into_logical_plan(ctx, extension_codec))
+                    .collect::<Result<_, BallistaError>>()?;
+
+                if input_plans.len() < 2 {
+                    return  Err( BallistaError::General(String::from(
+                       "Protobuf deserialization error, Union was require at least two input.",
+                   )));
+                }
+
+                let builder = LogicalPlanBuilder::from(input_plans.pop().unwrap());
+                for plan in input_plans {
+                    builder.union(plan)?;
+                }
+                builder.build().map_err(|e| e.into())
+            }
             LogicalPlanType::CrossJoin(crossjoin) => {
                 let left = into_logical_plan!(crossjoin.left, &ctx, extension_codec)?;
                 let right = into_logical_plan!(crossjoin.right, &ctx, extension_codec)?;
@@ -815,7 +834,26 @@ impl AsLogicalPlan for LogicalPlanNode {
                     ))),
                 })
             }
-            LogicalPlan::Union(_) => unimplemented!(),
+            LogicalPlan::Union(union) => {
+                let inputs: Vec<LogicalPlanNode> = union
+                    .inputs
+                    .iter()
+                    .map(|i| {
+                        protobuf::LogicalPlanNode::try_from_logical_plan(
+                            i,
+                            extension_codec,
+                        )
+                    })
+                    .collect::<Result<_, BallistaError>>()?;
+                Ok(protobuf::LogicalPlanNode {
+                    logical_plan_type: Some(LogicalPlanType::Union(
+                        protobuf::UnionNode {
+                            inputs,
+                            schema: None,
+                        },
+                    ))
+                })
+            }
             LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
                 let left = protobuf::LogicalPlanNode::try_from_logical_plan(
                     left.as_ref(),

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -876,7 +876,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
             })
         } else if let Some(union) = plan.downcast_ref::<UnionExec>() {
             let mut inputs: Vec<PhysicalPlanNode> = vec![];
-            for input in &union.inputs {
+            for input in union.inputs() {
                 inputs.push(protobuf::PhysicalPlanNode::try_from_physical_plan(
                     input.to_owned(),
                     extension_codec,

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -52,6 +52,7 @@ use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
     AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr, WindowExpr,
@@ -381,6 +382,13 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     partition_mode,
                     &hashjoin.null_equals_null,
                 )?))
+            }
+            PhysicalPlanType::Union(union) => {
+                let mut inputs: Vec<Arc<dyn ExecutionPlan>> = vec![];
+                for input in &union.inputs {
+                    inputs.push(input.try_into_physical_plan(ctx, extension_codec)?);
+                }
+                Ok(Arc::new(UnionExec::new(inputs)))
             }
             PhysicalPlanType::CrossJoin(crossjoin) => {
                 let left: Arc<dyn ExecutionPlan> =
@@ -864,6 +872,19 @@ impl AsExecutionPlan for PhysicalPlanNode {
                         input_partition_count: exec.input_partition_count as u32,
                         output_partition_count: exec.output_partition_count as u32,
                     },
+                )),
+            })
+        } else if let Some(union) = plan.downcast_ref::<UnionExec>() {
+            let mut inputs: Vec<PhysicalPlanNode> = vec![];
+            for input in &union.inputs {
+                inputs.push(protobuf::PhysicalPlanNode::try_from_physical_plan(
+                    input.to_owned(),
+                    extension_codec,
+                )?);
+            }
+            Ok(protobuf::PhysicalPlanNode {
+                physical_plan_type: Some(PhysicalPlanType::Union(
+                    protobuf::UnionExecNode { inputs },
                 )),
             })
         } else {

--- a/datafusion/src/physical_plan/union.rs
+++ b/datafusion/src/physical_plan/union.rs
@@ -43,7 +43,7 @@ use async_trait::async_trait;
 #[derive(Debug)]
 pub struct UnionExec {
     /// Input execution plan
-    pub inputs: Vec<Arc<dyn ExecutionPlan>>,
+    inputs: Vec<Arc<dyn ExecutionPlan>>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
 }
@@ -55,6 +55,11 @@ impl UnionExec {
             inputs,
             metrics: ExecutionPlanMetricsSet::new(),
         }
+    }
+
+    /// Get inputs of the execution plan
+    pub fn inputs(&self) -> &Vec<Arc<dyn ExecutionPlan>> {
+        &self.inputs
     }
 }
 

--- a/datafusion/src/physical_plan/union.rs
+++ b/datafusion/src/physical_plan/union.rs
@@ -43,7 +43,7 @@ use async_trait::async_trait;
 #[derive(Debug)]
 pub struct UnionExec {
     /// Input execution plan
-    inputs: Vec<Arc<dyn ExecutionPlan>>,
+    pub inputs: Vec<Arc<dyn ExecutionPlan>>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2032 .

 # Rationale for this change
Use `cargo run --bin datafusion-cli --features ballista -- --host localhost --port 50050`
Before 
```
 SELECT 1 as NUMBER union SELECT 1 as NUMBER;
thread 'main' panicked at 'not implemented', ballista/rust/core/src/serde/logical_plan/mod.rs:818:38
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now
```
❯ SELECT 1 as NUMBER union SELECT 1 as NUMBER;
+--------+
| number |
+--------+
| 1      |
+--------+
1 row in set. Query took 1.085 seconds.
❯ SELECT 1 as NUMBER union all SELECT 1 as NUMBER;
+--------+
| number |
+--------+
| 1      |
| 1      |
+--------+
2 rows in set. Query took 0.225 seconds.
```


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
