### PR TITLE
doc: separate and fix link for `extract` and `date_part`

### DIFF
--- a/docs/source/user-guide/sql/datafusion-functions.md
+++ b/docs/source/user-guide/sql/datafusion-functions.md
@@ -85,20 +85,22 @@ Note that `CAST(.. AS Timestamp)` converts to Timestamps with Nanosecond resolut
 
 Note that `CAST(.. AS Timestamp)` converts to Timestamps with Nanosecond resolution; this function is the only way to convert/cast to seconds resolution.
 
-## `EXTRACT, date_part`
+## `extract`
 
-`EXTRACT(field FROM source)`
+`extract(field FROM source)`
 
 - The `extract` function retrieves subfields such as year or hour from date/time values.
   `source` must be a value expression of type timestamp, Data32, or Data64. `field` is an identifier that selects what field to extract from the source value.
   The `extract` function returns values of type u32.
-  - `year` :`EXTRACT(year FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 2020`
-  - `month`:`EXTRACT(month FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 9`
-  - `week` :`EXTRACT(week FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 37`
-  - `day`: `EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 8`
-  - `hour`: `EXTRACT(hour FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 12`
-  - `minute`: `EXTRACT(minute FROM to_timestamp('2020-09-08T12:01:00+00:00')) -> 1`
-  - `second`: `EXTRACT(second FROM to_timestamp('2020-09-08T12:00:03+00:00')) -> 3`
+  - `year` :`extract(year FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 2020`
+  - `month`:`extract(month FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 9`
+  - `week` :`extract(week FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 37`
+  - `day`: `extract(day FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 8`
+  - `hour`: `extract(hour FROM to_timestamp('2020-09-08T12:00:00+00:00')) -> 12`
+  - `minute`: `extract(minute FROM to_timestamp('2020-09-08T12:01:00+00:00')) -> 1`
+  - `second`: `extract(second FROM to_timestamp('2020-09-08T12:00:03+00:00')) -> 3`
+
+## `date_part`
 
 `date_part('field', source)`
 

--- a/docs/source/user-guide/sql/sql_status.md
+++ b/docs/source/user-guide/sql/sql_status.md
@@ -87,7 +87,8 @@
     - [x] [to_timestamp_millis](docs/user-guide/book/sql/datafusion-functions.html#to_timestamp_millis)
     - [x] [to_timestamp_micros](docs/user-guide/book/sql/datafusion-functions.html#to_timestamp_micros)
     - [x] [to_timestamp_seconds](docs/user-guide/book/sql/datafusion-functions.html#to_timestamp_seconds)
-    - [x] [extract, date_part](docs/user-guide/book/sql/datafusion-functions.html#`EXTRACT, date_part`)
+    - [x] [extract](docs/user-guide/book/sql/datafusion-functions.html#extract)
+    - [x] [date_part](docs/user-guide/book/sql/datafusion-functions.html#date_part)
 - nested functions
   - [x] Array of columns
 - [x] Schema Queries


### PR DESCRIPTION
# Which issue does this PR close?

NA

# Rationale for this change

original link for `extract, date_part` seems broken. And given they are two functions, we should probably given different headers

before
<img width="918" alt="Screen Shot 2022-03-27 at 6 54 21 PM" src="https://user-images.githubusercontent.com/663949/160304642-1d34b90a-4c1b-41bd-832e-ba2aafa9d081.png">

after
<img width="918" alt="image" src="https://user-images.githubusercontent.com/663949/160304694-2e4dfe8b-143a-46a5-bd56-548b099473d7.png">


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
