### PR TITLE
fix df union all bug

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use crate::error::{DataFusionError, Result};
 use crate::Column;
 
+use arrow::compute::can_cast_types;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use std::fmt::{Display, Formatter};
 
@@ -279,6 +280,18 @@ impl DFSchema {
             .iter()
             .zip(arrow_schema.fields().iter())
             .all(|(dffield, arrowfield)| dffield.name() == arrowfield.name())
+    }
+
+    /// Check to see if fields in 2 Arrow schemas are compatible
+    pub fn check_arrow_schema_type_compatible(&self, arrow_schema: &Schema) -> bool {
+        let self_arrow_schema: Schema = self.into();
+        self_arrow_schema
+            .fields()
+            .iter()
+            .zip(arrow_schema.fields().iter())
+            .all(|(l_field, r_field)| {
+                can_cast_types(r_field.data_type(), l_field.data_type())
+            })
     }
 
     /// Strip all field qualifier in schema

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -1021,6 +1021,29 @@ fn validate_unique_names<'a>(
     })
 }
 
+pub fn project_with_column_index_alias(
+    expr: Vec<Expr>,
+    input: Arc<LogicalPlan>,
+    schema: DFSchemaRef,
+    alias: Option<String>,
+) -> Result<LogicalPlan> {
+    let alias_expr = expr
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| match e {
+            ignore_alias @ Expr::Alias { .. } => ignore_alias,
+            ignore_col @ Expr::Column { .. } => ignore_col,
+            x => x.alias(format!("column{}", i).as_str()),
+        })
+        .collect::<Vec<_>>();
+    Ok(LogicalPlan::Projection(Projection {
+        expr: alias_expr,
+        input,
+        schema,
+        alias,
+    }))
+}
+
 /// Union two logical plans with an optional alias.
 pub fn union_with_alias(
     left_plan: LogicalPlan,
@@ -1033,6 +1056,15 @@ pub fn union_with_alias(
             LogicalPlan::Union(Union { inputs, .. }) => inputs,
             x => vec![x],
         })
+        .map(|p| match p {
+            LogicalPlan::Projection(Projection {
+                expr,
+                input,
+                schema,
+                alias,
+            }) => project_with_column_index_alias(expr, input, schema, alias).unwrap(),
+            x => x,
+        })
         .collect::<Vec<_>>();
     if inputs.is_empty() {
         return Err(DataFusionError::Plan("Empty UNION".to_string()));
@@ -1043,19 +1075,20 @@ pub fn union_with_alias(
         Some(ref alias) => union_schema.replace_qualifier(alias.as_str()),
         None => union_schema.strip_qualifiers(),
     });
+
     if !inputs.iter().skip(1).all(|input_plan| {
-        // union changes all qualifers in resulting schema, so we only need to
-        // match against arrow schema here, which doesn't include qualifiers
-        union_schema.matches_arrow_schema(&((**input_plan.schema()).clone().into()))
+        // we need to check arrow field types cast compatible here
+        union_schema
+            .check_arrow_schema_type_compatible(&((**input_plan.schema()).clone().into()))
     }) {
         return Err(DataFusionError::Plan(
-            "UNION ALL schemas are expected to be the same".to_string(),
+            "UNION ALL schemas are expected to be arrow type compatible".to_string(),
         ));
     }
 
     Ok(LogicalPlan::Union(Union {
-        schema: union_schema,
         inputs,
+        schema: union_schema,
         alias,
     }))
 }

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -1076,15 +1076,14 @@ pub fn union_with_alias(
         None => union_schema.strip_qualifiers(),
     });
 
-    if !inputs.iter().skip(1).all(|input_plan| {
-        // we need to check arrow field types cast compatible here
-        union_schema
-            .check_arrow_schema_type_compatible(&((**input_plan.schema()).clone().into()))
-    }) {
-        return Err(DataFusionError::Plan(
-            "UNION ALL schemas are expected to be arrow type compatible".to_string(),
-        ));
-    }
+    inputs
+        .iter()
+        .skip(1)
+        .try_for_each(|input_plan| -> Result<()> {
+            union_schema.check_arrow_schema_type_compatible(
+                &((**input_plan.schema()).clone().into()),
+            )
+        })?;
 
     Ok(LogicalPlan::Union(Union {
         inputs,

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -3514,13 +3514,25 @@ mod tests {
     }
 
     #[test]
-    fn union_schemas_should_be_same() {
+    fn union_with_different_column_names() {
         let sql = "SELECT order_id from orders UNION ALL SELECT customer_id FROM orders";
-        let err = logical_plan(sql).expect_err("query should have failed");
-        assert_eq!(
-            "Plan(\"UNION ALL schemas are expected to be the same\")",
-            format!("{:?}", err)
-        );
+        let expected = "Union\
+            \n  Projection: #orders.order_id\
+            \n    TableScan: orders projection=None\
+            \n  Projection: #orders.customer_id\
+            \n    TableScan: orders projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn union_values_with_no_alias() {
+        let sql = "SELECT 1, 2 UNION ALL SELECT 3, 4";
+        let expected = "Union\
+            \n  Projection: Int64(1) AS column0, Int64(2) AS column1\
+            \n    EmptyRelation\
+            \n  Projection: Int64(3) AS column0, Int64(4) AS column1\
+            \n    EmptyRelation";
+        quick_test(sql, expected);
     }
 
     #[test]

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -3536,6 +3536,19 @@ mod tests {
     }
 
     #[test]
+    fn union_with_incompatible_data_type() {
+        let sql = "SELECT interval '1 year 1 day' UNION ALL SELECT 1";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert_eq!(
+            "Plan(\"Column Int64(1) (type: Int64) is \
+            not compatible wiht column IntervalMonthDayNano\
+            (\\\"950737950189618795196236955648\\\") \
+            (type: Interval(MonthDayNano))\")",
+            format!("{:?}", err)
+        );
+    }
+
+    #[test]
     fn empty_over() {
         let sql = "SELECT order_id, MAX(order_id) OVER () from orders";
         let expected = "\


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1818.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
when union different some constants, `UNION ALL schemas are expected to be the same` would raise, like
```
❯ select 1,2
union all
select 3,4;
Plan("UNION ALL schemas are expected to be the same")
```
This pr fix it.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. except for expression `Alias` and `Column` in `Projection` under `Union`, other expressions should be aliased with column index like `column0`
2. change field names match check to field type compatible check.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
