### PR TITLE
minor: fix some clippy warnings from nightly rust

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -351,7 +351,7 @@ impl DataFrame {
     pub async fn collect(&self) -> Result<Vec<RecordBatch>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.read().clone()));
-        Ok(collect(plan, task_ctx).await?)
+        collect(plan, task_ctx).await
     }
 
     /// Print results.
@@ -426,7 +426,7 @@ impl DataFrame {
     pub async fn collect_partitioned(&self) -> Result<Vec<Vec<RecordBatch>>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.read().clone()));
-        Ok(collect_partitioned(plan, task_ctx).await?)
+        collect_partitioned(plan, task_ctx).await
     }
 
     /// Executes this DataFrame and returns one stream per partition.
@@ -447,7 +447,7 @@ impl DataFrame {
     ) -> Result<Vec<SendableRecordBatchStream>> {
         let plan = self.create_physical_plan().await?;
         let task_ctx = Arc::new(TaskContext::from(&self.session_state.read().clone()));
-        Ok(execute_stream_partitioned(plan, task_ctx).await?)
+        execute_stream_partitioned(plan, task_ctx).await
     }
 
     /// Returns the schema describing the output of this DataFrame in terms of columns returned,


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change
On occasion, I run `cargo +nightly clippy` which flags a few issues that looks legit

# What changes are included in this PR?
Fix clippy warnings

# Are there any user-facing changes?
No