### PR TITLE
JIT-compille DataFusion expression with column name

### DIFF
--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -42,5 +42,6 @@ cranelift-module = "0.82.0"
 cranelift-native = "0.82.0"
 datafusion-common = { path = "../common", version = "7.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "7.0.0" }
+arrow = {version = "11"}
 
 parking_lot = "0.12"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -42,6 +42,6 @@ cranelift-module = "0.82.0"
 cranelift-native = "0.82.0"
 datafusion-common = { path = "../common", version = "7.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "7.0.0" }
-arrow = {version = "11"}
+arrow = { version = "11" }
 
 parking_lot = "0.12"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,12 +36,12 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
+arrow = { version = "11" }
 cranelift = "0.82.0"
 cranelift-jit = "0.82.0"
 cranelift-module = "0.82.0"
 cranelift-native = "0.82.0"
 datafusion-common = { path = "../common", version = "7.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "7.0.0" }
-arrow = { version = "11" }
 
 parking_lot = "0.12"

--- a/datafusion/jit/src/ast.rs
+++ b/datafusion/jit/src/ast.rs
@@ -166,8 +166,8 @@ impl TryFrom<(datafusion_expr::Expr, DFSchemaRef)> for Expr {
                     }
                 };
                 Ok(Expr::Binary(op(
-                    Box::new(((*left.clone(), schema.clone())).try_into()?),
-                    Box::new(((*right.clone(), schema)).try_into()?),
+                    Box::new((*left.clone(), schema.clone()).try_into()?),
+                    Box::new((*right.clone(), schema).try_into()?),
                 )))
             }
             datafusion_expr::Expr::Column(col) => {

--- a/datafusion/jit/src/ast.rs
+++ b/datafusion/jit/src/ast.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use cranelift::codegen::ir;
-use datafusion_common::{DataFusionError, ScalarValue};
+use datafusion_common::{DFSchemaRef, DataFusionError, ScalarValue};
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug)]
@@ -138,11 +138,13 @@ pub enum Literal {
     Typed(TypedLit),
 }
 
-impl TryFrom<datafusion_expr::Expr> for Expr {
+impl TryFrom<(datafusion_expr::Expr, DFSchemaRef)> for Expr {
     type Error = DataFusionError;
 
     // Try to JIT compile the Expr for faster evaluation
-    fn try_from(value: datafusion_expr::Expr) -> Result<Self, Self::Error> {
+    fn try_from(
+        (value, schema): (datafusion_expr::Expr, DFSchemaRef),
+    ) -> Result<Self, Self::Error> {
         match &value {
             datafusion_expr::Expr::BinaryExpr { left, op, right } => {
                 let op = match op {
@@ -164,9 +166,29 @@ impl TryFrom<datafusion_expr::Expr> for Expr {
                     }
                 };
                 Ok(Expr::Binary(op(
-                    Box::new((*left.clone()).try_into()?),
-                    Box::new((*right.clone()).try_into()?),
+                    Box::new(((*left.clone(), schema.clone())).try_into()?),
+                    Box::new(((*right.clone(), schema)).try_into()?),
                 )))
+            }
+            datafusion_expr::Expr::Column(col) => {
+                let field = schema.field_from_column(col)?;
+                let ty = field.data_type();
+
+                let jit_type = match ty {
+                    arrow::datatypes::DataType::Int64 => I64,
+                    arrow::datatypes::DataType::Float32 => F32,
+                    arrow::datatypes::DataType::Float64 => F64,
+                    arrow::datatypes::DataType::Boolean => BOOL,
+
+                    _ => {
+                        return Err(DataFusionError::NotImplemented(format!(
+                        "Compiling Expression with type {} not yet supported in JIT mode",
+                        ty
+                    )))
+                    }
+                };
+
+                Ok(Expr::Identifier(field.qualified_name(), jit_type))
             }
             datafusion_expr::Expr::Literal(s) => {
                 let lit = match s {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/2123

 # Rationale for this change
 Allowing to compile more realistic expressions, like (a+1) as a step towards generating code to run on Arrays.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
