### PR TITLE
Minor: make disk_manager public

### DIFF
--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -18,7 +18,7 @@
 //! DataFusion query execution
 
 pub mod context;
-pub(crate) mod disk_manager;
+pub mod disk_manager;
 pub mod memory_manager;
 pub mod options;
 pub mod runtime_env;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

To enable setting sort/shuffle spill dirs in downstream projects.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make `disk_manager` pub so that we could create `DiskManagerConfig` and specify temp dirs used in `DiskManager`.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
