### PR TITLE
Minor add clarifying comment in parquet

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -515,7 +515,8 @@ fn read_partition(
                 Some(Err(e)) => {
                     let err_msg =
                         format!("Error reading batch from {}: {}", partitioned_file, e);
-                    // send error to operator
+                    // send_result error, if any, should not overwrite
+                    // the original ArrowError, so ignore it
                     let _ = send_result(
                         &response_tx,
                         Err(ArrowError::ParquetError(err_msg.clone())),


### PR DESCRIPTION
Clarify behavior, as suggested in https://github.com/apache/arrow-datafusion/pull/2113#discussion_r837300387