### PR TITLE
MINOR: fix concat_ws corner bug

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -555,6 +555,7 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("concat_ws('|',NULL)", "");
     test_expression!("concat_ws(NULL,'a',NULL,'b','c')", "NULL");
     test_expression!("concat_ws('|','a',NULL)", "a");
+    test_expression!("concat_ws('|','a',NULL,NULL)", "a");
     test_expression!("initcap('')", "");
     test_expression!("initcap('hi THOMAS')", "Hi Thomas");
     test_expression!("initcap(NULL)", "NULL");

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -554,6 +554,7 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("concat_ws('|','a','b','c')", "a|b|c");
     test_expression!("concat_ws('|',NULL)", "");
     test_expression!("concat_ws(NULL,'a',NULL,'b','c')", "NULL");
+    test_expression!("concat_ws('|','a',NULL)", "a");
     test_expression!("initcap('')", "");
     test_expression!("initcap('hi THOMAS')", "Hi Thomas");
     test_expression!("initcap(NULL)", "NULL");

--- a/datafusion/physical-expr/src/string_expressions.rs
+++ b/datafusion/physical-expr/src/string_expressions.rs
@@ -337,6 +337,8 @@ pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
         )));
     }
 
+    let last_arg_null = (&args[args.len() - 1]).is_null(0);
+
     // first map is the iterator, second is for the `Option<_>`
     let result = args[0]
         .iter()
@@ -349,7 +351,9 @@ pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
                     if !arg.is_null(index) {
                         owned_string.push_str(arg.value(index));
                         // if not last push separator
-                        if arg_index != args.len() - 1 {
+                        if arg_index != args.len() - 1
+                            && !(arg_index == args.len() - 2 && last_arg_null)
+                        {
                             owned_string.push_str(sep);
                         }
                     }

--- a/datafusion/physical-expr/src/string_expressions.rs
+++ b/datafusion/physical-expr/src/string_expressions.rs
@@ -347,9 +347,9 @@ pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
                     .iter()
                     .flat_map(|arg| {
                         if !arg.is_null(index) {
-                            vec![arg.value(index)]
+                            Some(arg.value(index))
                         } else {
-                            vec![]
+                            None
                         }
                     })
                     .collect::<Vec<&str>>();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2100.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Function concat_ws is not ignoring NULL in last argument and seperator text is added at the end of the result.
To Reproduce
```
SELECT concat_ws('|', 'a', NULL);
-- Result: a|
```
Expected behavior
```
SELECT concat_ws('|', 'a', NULL);
-- Result: a
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
skip adding separator when NULL in last argument.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
