### PR TITLE
Update to arrow `11.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,9 @@ members = [
 [profile.release]
 codegen-units = 1
 lto = true
+
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev="0575a94528db631caae490143b5c9ad74edd9aa6" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev="0575a94528db631caae490143b5c9ad74edd9aa6" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev="0575a94528db631caae490143b5c9ad74edd9aa6" }


### PR DESCRIPTION
Draft until arrow 11.1.0 is actually released 

https://github.com/apache/arrow-rs/pull/1514 and https://github.com/apache/arrow-rs/issues/1513

This is part of my verification that arrow 11.1.0 is actually semantically compatible with 11.0.0