### PR TITLE
Serialize scalar UDFs in physical plan

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -296,7 +296,15 @@ message PhysicalExprNode {
 
     // window expressions
     PhysicalWindowExprNode window_expr = 15;
+
+    PhysicalScalarUdfNode scalar_udf = 16;
   }
+}
+
+message PhysicalScalarUdfNode {
+  string name = 1;
+  repeated PhysicalExprNode args = 2;
+  datafusion.ArrowType return_type = 4;
 }
 
 message PhysicalAggregateExprNode {

--- a/ballista/rust/core/proto/datafusion.proto
+++ b/ballista/rust/core/proto/datafusion.proto
@@ -176,6 +176,7 @@ enum ScalarFunction {
   Translate=60;
   Trim=61;
   Upper=62;
+  UserDefined = 63;
 }
 
 message ScalarFunctionNode {

--- a/ballista/rust/core/proto/datafusion.proto
+++ b/ballista/rust/core/proto/datafusion.proto
@@ -176,7 +176,6 @@ enum ScalarFunction {
   Translate=60;
   Trim=61;
   Upper=62;
-  UserDefined = 63;
 }
 
 message ScalarFunctionNode {

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -161,8 +161,10 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
             )
         })?;
 
-    let shuffle_output_partitioning =
-        parse_protobuf_hash_partitioning(task.output_partitioning.as_ref())?;
+    let shuffle_output_partitioning = parse_protobuf_hash_partitioning(
+        task.output_partitioning.as_ref(),
+        task_context.as_ref(),
+    )?;
 
     tokio::spawn(async move {
         let execution_result = executor

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -216,8 +216,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
                 )
             })?;
 
-        let shuffle_output_partitioning =
-            parse_protobuf_hash_partitioning(task.output_partitioning.as_ref())?;
+        let shuffle_output_partitioning = parse_protobuf_hash_partitioning(
+            task.output_partitioning.as_ref(),
+            task_context.as_ref(),
+        )?;
 
         let execution_result = self
             .executor


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently in Ballista scalar UDFs are only getting serialized in the logical plan. The job would fail on execution because the scalar UDF could not be deserialized by the executor. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add protobuf message and serde logic for Scalar UDFs in Ballista. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
