### PR TITLE
fix:  incorrect memory usage track for sort

### DIFF
--- a/datafusion/core/src/execution/memory_manager.rs
+++ b/datafusion/core/src/execution/memory_manager.rs
@@ -309,7 +309,8 @@ impl MemoryManager {
         ));
     }
 
-    fn get_requester_total(&self) -> usize {
+    /// Return the total memory usage for all requesters
+    pub fn get_requester_total(&self) -> usize {
         *self.requesters_total.lock()
     }
 

--- a/datafusion/core/src/execution/memory_manager.rs
+++ b/datafusion/core/src/execution/memory_manager.rs
@@ -195,6 +195,12 @@ pub trait MemoryConsumer: Send + Sync {
         Ok(())
     }
 
+    /// Return `freed` memory to the memory manager,
+    /// may wake up other requesters waiting for their minimum memory quota.
+    fn shrink(&self, freed: usize) {
+        self.memory_manager().record_free(freed);
+    }
+
     /// Spill in-memory buffers to disk, free memory, return the previous used
     async fn spill(&self) -> Result<usize>;
 
@@ -342,8 +348,8 @@ impl MemoryManager {
                 // if we cannot acquire at lease 1/2n memory, just wait for others
                 // to spill instead spill self frequently with limited total mem
                 debug!(
-                    "Cannot acquire minimum amount of memory {} on memory manager {}, waiting for others to spill ...",
-                    human_readable_size(min_per_rqt), self);
+                    "Cannot acquire a minimum amount of {} memory from the manager of total {}, waiting for others to spill ...",
+                    human_readable_size(min_per_rqt), human_readable_size(self.pool_size));
                 let now = Instant::now();
                 self.cv.wait(&mut rqt_current_used);
                 let elapsed = now.elapsed();
@@ -361,12 +367,30 @@ impl MemoryManager {
         granted
     }
 
-    fn record_free_then_acquire(&self, freed: usize, acquired: usize) -> usize {
+    fn record_free_then_acquire(&self, freed: usize, acquired: usize) {
         let mut requesters_total = self.requesters_total.lock();
+        debug!(
+            "free_then_acquire: total {}, freed {}, acquired {}",
+            human_readable_size(*requesters_total),
+            human_readable_size(freed),
+            human_readable_size(acquired)
+        );
         assert!(*requesters_total >= freed);
         *requesters_total -= freed;
         *requesters_total += acquired;
-        self.cv.notify_all()
+        self.cv.notify_all();
+    }
+
+    fn record_free(&self, freed: usize) {
+        let mut requesters_total = self.requesters_total.lock();
+        debug!(
+            "free: total {}, freed {}",
+            human_readable_size(*requesters_total),
+            human_readable_size(freed)
+        );
+        assert!(*requesters_total >= freed);
+        *requesters_total -= freed;
+        self.cv.notify_all();
     }
 
     /// Drop a memory consumer and reclaim the memory
@@ -378,6 +402,8 @@ impl MemoryManager {
                 let mut total = self.requesters_total.lock();
                 assert!(*total >= mem_used);
                 *total -= mem_used;
+                self.cv.notify_all();
+                return;
             }
         }
         self.shrink_tracker_usage(mem_used);

--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -684,6 +684,15 @@ mod tests {
         assert_eq!(c7.value(0), 15);
         assert_eq!(c7.value(c7.len() - 1), 254,);
 
+        assert_eq!(
+            session_ctx
+                .runtime_env()
+                .memory_manager
+                .get_requester_total(),
+            0,
+            "The sort should have returned all memory used back to the memory manager"
+        );
+
         Ok(())
     }
 
@@ -760,6 +769,15 @@ mod tests {
         let c7 = as_primitive_array::<UInt8Type>(&columns[6]);
         assert_eq!(c7.value(0), 15);
         assert_eq!(c7.value(c7.len() - 1), 254,);
+
+        assert_eq!(
+            session_ctx
+                .runtime_env()
+                .memory_manager
+                .get_requester_total(),
+            0,
+            "The sort should have returned all memory used back to the memory manager"
+        );
 
         Ok(())
     }
@@ -946,6 +964,15 @@ mod tests {
         assert_is_pending(&mut fut);
         drop(fut);
         assert_strong_count_converges_to_zero(refs).await;
+
+        assert_eq!(
+            session_ctx
+                .runtime_env()
+                .memory_manager
+                .get_requester_total(),
+            0,
+            "The sort should have returned all memory used back to the memory manager"
+        );
 
         Ok(())
     }

--- a/datafusion/core/tests/order_spill_fuzz.rs
+++ b/datafusion/core/tests/order_spill_fuzz.rs
@@ -93,6 +93,14 @@ async fn run_sort(pool_size: usize, size_spill: Vec<(usize, bool)>) {
             assert_eq!(sort.metrics().unwrap().spill_count().unwrap(), 0);
         }
 
+        assert_eq!(
+            session_ctx
+                .runtime_env()
+                .memory_manager
+                .get_requester_total(),
+            0,
+            "The sort should have returned all memory used back to the memory manager"
+        );
         assert_eq!(expected, actual, "failure in @ pool_size {}", pool_size);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2155.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

1. Since we've changed Memory Requesters' memory tracking behavior in https://github.com/apache/arrow-datafusion/pull/1691:
  > Consumers push their memory usage to MemoryManager. No more pull from MemoryManagers for usage updates.
 
The sort memory is not correctly tracked anymore.

2. The debug log for "sleep on memory insufficient" introduced a deadlock by holding a lock and asking for the lock again.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Correct sort memory track by manually update usage after sort.
- Stop trying to acquire the lock while already holding it.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
