### PR TITLE
implement 'StringConcat' operator to support sql like "select 'aa' || 'b' "

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1311,6 +1311,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             BinaryOperator::PGRegexNotIMatch => Ok(Operator::RegexNotIMatch),
             BinaryOperator::BitwiseAnd => Ok(Operator::BitwiseAnd),
             BinaryOperator::BitwiseOr => Ok(Operator::BitwiseOr),
+            BinaryOperator::StringConcat => Ok(Operator::StringConcat),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported SQL binary operator {:?}",
                 op

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -297,6 +297,7 @@ async fn test_string_concat_operator() -> Result<()> {
 
     // concat 4 strings as a string concat pipe.
     let sql = "SELECT 'aa' || 'b' || 'cc' || 'd'";
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------------------------------------------------+",
         "| Utf8(\"aa\") || Utf8(\"b\") || Utf8(\"cc\") || Utf8(\"d\") |",
@@ -304,19 +305,30 @@ async fn test_string_concat_operator() -> Result<()> {
         "| aabccd                                             |",
         "+----------------------------------------------------+",
     ];
-    let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
 
-    // concat 3 strings with one is NULL
+    // concat 2 strings and NULL, output should be NULL
     let sql = "SELECT 'aa' || NULL || 'd'";
+    let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+---------------------------------------+",
         "| Utf8(\"aa\") || Utf8(NULL) || Utf8(\"d\") |",
         "+---------------------------------------+",
-        "| aad                                   |",
+        "|                                       |",
         "+---------------------------------------+",
     ];
+    assert_batches_eq!(expected, &actual);
+
+    // concat 1 strings and 2 numeric
+    let sql = "SELECT 'a' || 42 || 23.3";
     let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-----------------------------------------+",
+        "| Utf8(\"a\") || Int64(42) || Float64(23.3) |",
+        "+-----------------------------------------+",
+        "| a4223.3                                 |",
+        "+-----------------------------------------+",
+    ];
     assert_batches_eq!(expected, &actual);
     Ok(())
 }

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -71,6 +71,8 @@ pub enum Operator {
     BitwiseAnd,
     /// Bitwise or, like `|`
     BitwiseOr,
+    /// String concat
+    StringConcat,
 }
 
 impl fmt::Display for Operator {
@@ -99,6 +101,7 @@ impl fmt::Display for Operator {
             Operator::IsNotDistinctFrom => "IS NOT DISTINCT FROM",
             Operator::BitwiseAnd => "&",
             Operator::BitwiseOr => "|",
+            Operator::StringConcat => "||",
         };
         write!(f, "{}", display)
     }

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -57,7 +57,8 @@ pub(crate) fn coerce_types(
         Operator::RegexMatch
         | Operator::RegexIMatch
         | Operator::RegexNotMatch
-        | Operator::RegexNotIMatch => string_coercion(lhs_type, rhs_type),
+        | Operator::RegexNotIMatch
+        | Operator::StringConcat => string_coercion(lhs_type, rhs_type),
         Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
             eq_coercion(lhs_type, rhs_type)
         }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -499,9 +499,7 @@ fn string_concat(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
     ])?;
     match result {
         ColumnarValue::Array(array_ref) => Ok(array_ref),
-        _ => Err(DataFusionError::Execution(
-            "string_concat return type should be Array, but Scalar found".to_string(),
-        )),
+        scalar_value => Ok(scalar_value.into_array(1)),
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -487,6 +487,12 @@ fn bitwise_or(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
 
 /// Use datafusion build-in expression `concat` to evaluate `StringConcat` operator
 fn string_concat(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
+    // return NULL if left or right is NULL
+    for i in 0..left.len() {
+        if left.is_null(i) || right.is_null(i) {
+            return Ok(new_null_array(&DataType::Utf8, left.len()));
+        }
+    }
     let result = string_expressions::concat(&[
         ColumnarValue::Array(left),
         ColumnarValue::Array(right),

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -492,7 +492,7 @@ fn string_concat(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
         ColumnarValue::Array(right),
     ])?;
     match result {
-        ColumnarValue::Array(arrayRef) => Ok(arrayRef),
+        ColumnarValue::Array(array_ref) => Ok(array_ref),
         _ => Err(DataFusionError::Execution(
             "string_concat return type should be Array, but Scalar found".to_string(),
         )),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2141 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
df now has not implemented `StringConcat` operator, like

```
❯ select 'aa' || 'b';
NotImplemented("Unsupported SQL binary operator StringConcat")
```
But Postgres SQL will come out results like

```
select 'aa' || 'b';
 ?column? 
----------
 aab
(1 row)
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Reuse df build-in `concat` string expression to do it.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
