### PR TITLE
fix `not(null)` with constant `null`

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1014,10 +1014,12 @@ pub fn create_physical_expr(
             input_schema,
             data_type.clone(),
         ),
-        Expr::Not(expr) => expressions::not(
-            create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
+        Expr::Not(expr) => expressions::not(create_physical_expr(
+            expr,
+            input_dfschema,
             input_schema,
-        ),
+            execution_props,
+        )?),
         Expr::Negative(expr) => expressions::negative(
             create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
             input_schema,
@@ -1096,7 +1098,7 @@ pub fn create_physical_expr(
             );
 
             if *negated {
-                expressions::not(binary_expr?, input_schema)
+                expressions::not(binary_expr?)
             } else {
                 binary_expr
             }
@@ -1535,7 +1537,7 @@ mod tests {
             &schema,
             &make_session_state(),
         )?;
-        let expected = expressions::not(expressions::col("a", &schema)?, &schema)?;
+        let expected = expressions::not(expressions::col("a", &schema)?)?;
 
         assert_eq!(format!("{:?}", expr), format!("{:?}", expected));
 

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -334,6 +334,45 @@ async fn test_string_concat_operator() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_not_expressions() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "SELECT not(true), not(false)";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-------------------+--------------------+",
+        "| NOT Boolean(true) | NOT Boolean(false) |",
+        "+-------------------+--------------------+",
+        "| false             | true               |",
+        "+-------------------+--------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "SELECT null, not(null)";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+------------+----------------+",
+        "| Utf8(NULL) | NOT Utf8(NULL) |",
+        "+------------+----------------+",
+        "|            |                |",
+        "+------------+----------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "SELECT NOT('hi')";
+    let result = plan_and_collect(&ctx, sql).await;
+    match result {
+        Ok(_) => panic!("expected error"),
+        Err(e) => {
+            assert_contains!(e.to_string(),
+                             "NOT 'Literal { value: Utf8(\"hi\") }' can't be evaluated because the expression's type is Utf8, not boolean or NULL"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_boolean_expressions() -> Result<()> {
     test_expression!("true", "true");
     test_expression!("false", "false");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1191.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
df `not` expression can not take `NULL` like
```
> select not(null);
Internal("NOT 'Literal { value: Utf8(NULL) }' can't be evaluated because the expression's type is Utf8, not boolean")
```
the correct output should be `NULL`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
`NotExpr` accepts  `NULL` input presented as `ScalarValue::Utf8(None)` 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
NO.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
