### PR TITLE
Handle merged schemas in parquet pruning

### DIFF
--- a/datafusion/core/src/datasource/file_format/avro.rs
+++ b/datafusion/core/src/datasource/file_format/avro.rs
@@ -57,7 +57,11 @@ impl FileFormat for AvroFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(
+        &self,
+        _reader: Arc<dyn ObjectReader>,
+        _table_schema: SchemaRef,
+    ) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 
@@ -367,7 +371,7 @@ mod tests {
             .await
             .expect("Schema inference");
         let statistics = format
-            .infer_stats(local_object_reader(filename.clone()))
+            .infer_stats(local_object_reader(filename.clone()), file_schema.clone())
             .await
             .expect("Stats inference");
         let file_groups = vec![vec![local_unpartitioned_file(filename.to_owned())]];

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -120,7 +120,11 @@ impl FileFormat for CsvFormat {
         Ok(Arc::new(merged_schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(
+        &self,
+        _reader: Arc<dyn ObjectReader>,
+        _table_schema: SchemaRef,
+    ) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 
@@ -265,7 +269,7 @@ mod tests {
             .await
             .expect("Schema inference");
         let statistics = format
-            .infer_stats(local_object_reader(filename.clone()))
+            .infer_stats(local_object_reader(filename.clone()), file_schema.clone())
             .await
             .expect("Stats inference");
         let file_groups = vec![vec![local_unpartitioned_file(filename.to_owned())]];

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -92,7 +92,11 @@ impl FileFormat for JsonFormat {
         Ok(Arc::new(schema))
     }
 
-    async fn infer_stats(&self, _reader: Arc<dyn ObjectReader>) -> Result<Statistics> {
+    async fn infer_stats(
+        &self,
+        _reader: Arc<dyn ObjectReader>,
+        _table_schema: SchemaRef,
+    ) -> Result<Statistics> {
         Ok(Statistics::default())
     }
 
@@ -219,7 +223,10 @@ mod tests {
             .await
             .expect("Schema inference");
         let statistics = format
-            .infer_stats(local_object_reader(filename.to_owned()))
+            .infer_stats(
+                local_object_reader(filename.to_owned()),
+                file_schema.clone(),
+            )
             .await
             .expect("Stats inference");
         let file_groups = vec![vec![local_unpartitioned_file(filename.to_owned())]];

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -56,7 +56,11 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
 
     /// Infer the statistics for the provided object. The cost and accuracy of the
     /// estimated statistics might vary greatly between file formats.
-    async fn infer_stats(&self, reader: Arc<dyn ObjectReader>) -> Result<Statistics>;
+    async fn infer_stats(
+        &self,
+        reader: Arc<dyn ObjectReader>,
+        table_schema: SchemaRef,
+    ) -> Result<Statistics>;
 
     /// Take a list of files and convert it to the appropriate executor
     /// according to this file format.

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -56,6 +56,11 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
 
     /// Infer the statistics for the provided object. The cost and accuracy of the
     /// estimated statistics might vary greatly between file formats.
+    /// 
+    /// `table_schema` is the (combined) schema of the overall table
+    /// and may be a superset of the schema contained in this file.
+    /// 
+    /// TODO: should the file source return statistics for only columns referred to in the table schema?
     async fn infer_stats(
         &self,
         reader: Arc<dyn ObjectReader>,

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -56,10 +56,10 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
 
     /// Infer the statistics for the provided object. The cost and accuracy of the
     /// estimated statistics might vary greatly between file formats.
-    /// 
+    ///
     /// `table_schema` is the (combined) schema of the overall table
     /// and may be a superset of the schema contained in this file.
-    /// 
+    ///
     /// TODO: should the file source return statistics for only columns referred to in the table schema?
     async fn infer_stats(
         &self,

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -376,7 +376,10 @@ impl ListingTable {
                 let statistics = if self.options.collect_stat {
                     let object_reader = object_store
                         .file_reader(part_file.file_meta.sized_file.clone())?;
-                    self.options.format.infer_stats(object_reader).await?
+                    self.options
+                        .format
+                        .infer_stats(object_reader, self.file_schema.clone())
+                        .await?
                 } else {
                     Statistics::default()
                 };

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -212,6 +212,18 @@ impl SchemaAdapter {
         Self { table_schema }
     }
 
+    /// Map a column index in the table schema to a column index in a particular
+    /// file schema
+    /// Panics if index is not in range for the table schema
+    pub(crate) fn map_column_index(
+        &self,
+        index: usize,
+        file_schema: &Schema,
+    ) -> Option<usize> {
+        let field = self.table_schema.field(index);
+        file_schema.index_of(field.name()).ok()
+    }
+
     /// Map projected column indexes to the file schema. This will fail if the table schema
     /// and the file schema contain a field with the same name and different types.
     pub fn map_projections(

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -892,7 +892,7 @@ mod tests {
         // batch1: c1(string), c3(int8)
         let batch1 = create_batch(vec![("c1", c1), ("c3", c3.clone())]);
 
-        // batch2: c3(int8), c2(int64), c1(string)
+        // batch2: c3(int8), c2(int64)
         let batch2 = create_batch(vec![("c3", c3), ("c2", c2)]);
 
         let filter = col("c2").eq(lit(0_i64));

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -889,7 +889,7 @@ mod tests {
 
         let c3: ArrayRef = Arc::new(Int8Array::from(vec![Some(10), Some(20), None]));
 
-        // batch1: c1(string), c2(int64), c3(int8)
+        // batch1: c1(string), c3(int8)
         let batch1 = create_batch(vec![("c1", c1), ("c3", c3.clone())]);
 
         // batch2: c3(int8), c2(int64), c1(string)

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1005,6 +1005,11 @@ mod tests {
             .await
             .unwrap();
 
+        // This does not look correct since the "c2" values in the result do not in fact match the predicate `c2 == 0`
+        // but parquet pruning is not exact. If the min/max values are not defined (which they are not in this case since the it is
+        // a null array, then the pruning predicate (currently) can not be applied.
+        // In a real query where this predicate was pushed down from a filter stage instead of created directly in the `ParquetExec`,
+        // the filter stage would be preserved as a separate execution plan stage so the actual query results would be as expected.
         let expected = vec![
             "+-----+----+",
             "| c1  | c2 |",

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -997,7 +997,7 @@ mod tests {
         // batch1: c1(string), c2(int64), c3(int8)
         let batch1 = create_batch(vec![("c1", c1.clone())]);
 
-        // batch2: c3(int8), c2(int64), c1(string)
+        // batch2: c2(int64)
         let batch2 = create_batch(vec![("c2", c2)]);
 
         let filter = col("c2").eq(lit(0_i64));

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -992,9 +992,7 @@ mod tests {
 
         let c2: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(2), None]));
 
-        // let c3: ArrayRef = Arc::new(Int8Array::from(vec![Some(10), Some(20), None]));
-
-        // batch1: c1(string), c2(int64), c3(int8)
+        // batch1: c1(string)
         let batch1 = create_batch(vec![("c1", c1.clone())]);
 
         // batch2: c2(int64)

--- a/datafusion/core/src/row/mod.rs
+++ b/datafusion/core/src/row/mod.rs
@@ -610,7 +610,7 @@ mod tests {
             .await
             .expect("Schema inference");
         let statistics = format
-            .infer_stats(local_object_reader(filename.clone()))
+            .infer_stats(local_object_reader(filename.clone()), file_schema.clone())
             .await
             .expect("Stats inference");
         let file_groups = vec![vec![local_unpartitioned_file(filename.clone())]];


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2161 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Adding schema merging to `ParquetFormat` broke pruning since the existing implementation assumes that each file in the `ListingTable` has the merged schema. In the best case this just prevents pruning row groups, but in certain cases (such as #2161) it can cause runtime errors and possibly incorrect query results. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Two changes:

1. When gathering column statistics during pruning, we need to find row group columns by name instead of the index in the merged schema.  2. 
2. When collecting statistics during a `ListingTable` scan, we need to map file-level statistics to the expected schema of the tables merged schema.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, in order to map the statistics to the merged schema, we need to pass the merged schema to `FileFormat::infer_stats`. 
