### PR TITLE
MINOR: handle `NULL` in advance to avoid value copy in `string_concat`

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -50,14 +50,12 @@ use arrow::compute::kernels::comparison::{
     regexp_is_match_utf8_scalar,
 };
 use arrow::compute::kernels::comparison::{like_utf8, nlike_utf8, regexp_is_match_utf8};
-use arrow::compute::kernels::take::take;
 use arrow::datatypes::{ArrowNumericType, DataType, Schema, TimeUnit};
 use arrow::error::ArrowError::DivideByZero;
 use arrow::record_batch::RecordBatch;
 
 use crate::coercion_rule::binary_rule::coerce_types;
 use crate::expressions::try_cast;
-use crate::string_expressions;
 use crate::PhysicalExpr;
 use datafusion_common::ScalarValue;
 use datafusion_common::{DataFusionError, Result};
@@ -418,30 +416,25 @@ fn bitwise_or(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
     }
 }
 
-/// Use datafusion build-in expression `concat` to evaluate `StringConcat` operator.
-/// Besides, any `NULL` exists on lhs or rhs will come out result `NULL`
+/// Concat lhs and rhs String Array, any `NULL` exists on lhs or rhs will come out result `NULL`
 /// 1. 'a' || 'b' || 32 = 'ab32'
 /// 2. 'a' || NULL = NULL
 fn string_concat(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
-    let ignore_null = match string_expressions::concat(&[
-        ColumnarValue::Array(left.clone()),
-        ColumnarValue::Array(right.clone()),
-    ])? {
-        ColumnarValue::Array(array_ref) => array_ref,
-        scalar_value => scalar_value.into_array(left.clone().len()),
-    };
-    let ignore_null_array = ignore_null.as_any().downcast_ref::<StringArray>().unwrap();
-    let index_array = (0..ignore_null_array.len())
+    let left_array = left.as_any().downcast_ref::<StringArray>().unwrap();
+    let right_array = right.as_any().downcast_ref::<StringArray>().unwrap();
+    let result = (0..left.len())
         .into_iter()
-        .map(|index| {
-            if left.is_null(index) || right.is_null(index) {
+        .map(|i| {
+            if left.is_null(i) || right.is_null(i) {
                 None
             } else {
-                Some(index as u32)
+                let mut owned_string: String = "".to_owned();
+                owned_string.push_str(left_array.value(i));
+                owned_string.push_str(right_array.value(i));
+                Some(owned_string)
             }
         })
-        .collect::<UInt32Array>();
-    let result = take(ignore_null_array, &index_array, None)?;
+        .collect::<StringArray>();
     Ok(Arc::new(result) as ArrayRef)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- When `StringConcat` operator runs `evaluate`, it eliminates `NULL` from output array of build-in `concat` expression. Current `collect` after `Some(array.value(index))` logic will trigger value copying.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Handle `NULL` in advance without using build-in `concat` operation.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.