### PR TITLE
feat: Support simple Arrays with Literals

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 use arrow::datatypes::*;
 use hashbrown::HashMap;
+
 use sqlparser::ast::{
     BinaryOperator, DataType as SQLDataType, DateTimeField, Expr as SQLExpr, FunctionArg,
     FunctionArgExpr, Ident, Join, JoinConstraint, JoinOperator, ObjectName, Query,
@@ -1438,6 +1439,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 fractional_seconds_precision,
             ),
 
+            SQLExpr::Array(arr) => self.sql_array_literal(arr.elem, schema),
+
             SQLExpr::Identifier(id) => {
                 if id.value.starts_with('@') {
                     // TODO: figure out if ScalarVariables should be insensitive.
@@ -2118,6 +2121,51 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .get_table_provider(tables_reference)
             .is_some()
     }
+
+    fn sql_array_literal(
+        &self,
+        elements: Vec<SQLExpr>,
+        schema: &DFSchema,
+    ) -> Result<Expr> {
+        let mut values = Vec::with_capacity(elements.len());
+
+        for element in elements {
+            let value = self.sql_expr_to_logical_expr(element, schema)?;
+            match value {
+                Expr::Literal(scalar) => {
+                    values.push(scalar);
+                }
+                _ => {
+                    return Err(DataFusionError::NotImplemented(format!(
+                        "Arrays with elements other than literal are not supported: {}",
+                        value
+                    )));
+                }
+            }
+        }
+
+        let data_types: HashSet<DataType> =
+            values.iter().map(|e| e.get_datatype()).collect();
+
+        if data_types.is_empty() {
+            Ok(Expr::Literal(ScalarValue::List(
+                None,
+                Box::new(DataType::Utf8),
+            )))
+        } else if data_types.len() > 1 {
+            Err(DataFusionError::NotImplemented(format!(
+                "Arrays with different types are not supported: {:?}",
+                data_types,
+            )))
+        } else {
+            let data_type = values[0].get_datatype();
+
+            Ok(Expr::Literal(ScalarValue::List(
+                Some(Box::new(values)),
+                Box::new(data_type),
+            )))
+        }
+    }
 }
 
 /// Remove join expressions from a filter expression
@@ -2261,7 +2309,7 @@ fn parse_sql_number(n: &str) -> Result<Expr> {
 mod tests {
     use crate::datasource::empty::EmptyTable;
     use crate::physical_plan::functions::Volatility;
-    use crate::{logical_plan::create_udf, sql::parser::DFParser};
+    use crate::{assert_contains, logical_plan::create_udf, sql::parser::DFParser};
     use datafusion_expr::ScalarFunctionImplementation;
 
     use super::*;
@@ -2964,6 +3012,28 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!(
             r#"NotImplemented("Interval field value out of range: \"100000000000000000 day\"")"#,
+            format!("{:?}", err)
+        );
+    }
+
+    #[test]
+    fn select_array_no_common_type() {
+        let sql = "SELECT [1, true, null]";
+        let err = logical_plan(sql).expect_err("query should have failed");
+
+        // HashSet doesnt guaranty order
+        assert_contains!(
+            format!("{:?}", err),
+            r#"NotImplemented("Arrays with different types are not supported: "#
+        );
+    }
+
+    #[test]
+    fn select_array_non_literal_type() {
+        let sql = "SELECT [now()]";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert_eq!(
+            r#"NotImplemented("Arrays with elements other than literal are not supported: now()")"#,
             format!("{:?}", err)
         );
     }

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -3021,10 +3021,10 @@ mod tests {
         let sql = "SELECT [1, true, null]";
         let err = logical_plan(sql).expect_err("query should have failed");
 
-        // HashSet doesnt guaranty order
+        // HashSet doesn't guarantee order
         assert_contains!(
-            format!("{:?}", err),
-            r#"NotImplemented("Arrays with different types are not supported: "#
+            err.to_string(),
+            r#"Arrays with different types are not supported: "#
         );
     }
 

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -458,6 +458,25 @@ async fn test_crypto_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_array_literals() -> Result<()> {
+    // Named, just another syntax
+    test_expression!("ARRAY[1,2,3,4,5]", "[1, 2, 3, 4, 5]");
+    // Unnamed variant
+    test_expression!("[1,2,3,4,5]", "[1, 2, 3, 4, 5]");
+    test_expression!("[true, false]", "[true, false]");
+    test_expression!("['str1', 'str2']", "[str1, str2]");
+    test_expression!("[[1,2], [3,4]]", "[[1, 2], [3, 4]]");
+
+    // TODO: Not supported in parser, uncomment when it will be available
+    // test_expression!(
+    //     "[]",
+    //     "[]"
+    // );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_interval_expressions() -> Result<()> {
     // day nano intervals
     test_expression!(


### PR DESCRIPTION
Related: https://github.com/apache/arrow-datafusion/issues/2207

Hello!

This PR introduces support for simple arrays with literal. For example it can support `[1,2,3]` or nested: `[[1,2], [3,4]]`, but it doesn't support array with expressions for example: [now()].

It's first iteration, I will send later another PR with implementing the new expression node which can holds expressions and optimizer to simplify it.

Thanks