### PR TITLE
fix: Use PostgreSQL dialect for parsing

### DIFF
--- a/datafusion/core/src/sql/parser.rs
+++ b/datafusion/core/src/sql/parser.rs
@@ -21,7 +21,7 @@
 
 use sqlparser::{
     ast::{ColumnDef, ColumnOptionDef, Statement as SQLStatement, TableConstraint},
-    dialect::{keywords::Keyword, Dialect, GenericDialect},
+    dialect::{keywords::Keyword, Dialect, PostgreSqlDialect},
     parser::{Parser, ParserError},
     tokenizer::{Token, Tokenizer},
 };
@@ -105,7 +105,7 @@ pub struct DFParser<'a> {
 impl<'a> DFParser<'a> {
     /// Parse the specified tokens
     pub fn new(sql: &str) -> Result<Self, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::new_with_dialect(sql, dialect)
     }
 
@@ -124,7 +124,7 @@ impl<'a> DFParser<'a> {
 
     /// Parse a SQL statement and produce a set of statements with dialect
     pub fn parse_sql(sql: &str) -> Result<VecDeque<Statement>, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::parse_sql_with_dialect(sql, dialect)
     }
 


### PR DESCRIPTION
Related: https://github.com/apache/arrow-datafusion/issues/2207

Hello!

I am working on implementing support for `ArrayIndex` (`SELECT (ARRAY[1,2,3])[1])`, but it's not possible with `GenericDialect`, because SQLParser library which is used for parsing has hacks for dialect:

https://github.com/sqlparser-rs/sqlparser-rs/blob/bfd416d9785acc5d75f811cf0240c18d999a1d38/src/parser.rs#L647

DF uses PostgresSQL as a base for implementing functions/information_schema/etc. I would like to propose using the PostgreSQL dialect for parsing instead of implementing our own dialect and changing SQLParser.

Thanks