### PR TITLE
Support GetIndexedFieldExpr for ScalarValue

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -519,6 +519,21 @@ async fn test_crypto_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_array_index() -> Result<()> {
+    // By default PostgreSQL uses a one-based numbering convention for arrays, that is, an array of n elements starts with array[1] and ends with array[n
+    test_expression!("([5,4,3,2,1])[1]", "5");
+    test_expression!("([5,4,3,2,1])[2]", "4");
+    test_expression!("([5,4,3,2,1])[5]", "1");
+    // out of bounds
+    test_expression!("([5,4,3,2,1])[0]", "NULL");
+    test_expression!("([5,4,3,2,1])[6]", "NULL");
+    // test_expression!("([5,4,3,2,1])[-1]", "NULL");
+    test_expression!("([5,4,3,2,1])[100]", "NULL");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_array_literals() -> Result<()> {
     // Named, just another syntax
     test_expression!("ARRAY[1,2,3,4,5]", "[1, 2, 3, 4, 5]");

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -520,10 +520,15 @@ async fn test_crypto_expressions() -> Result<()> {
 
 #[tokio::test]
 async fn test_array_index() -> Result<()> {
-    // By default PostgreSQL uses a one-based numbering convention for arrays, that is, an array of n elements starts with array[1] and ends with array[n
+    // By default PostgreSQL uses a one-based numbering convention for arrays, that is, an array of n elements starts with array[1] and ends with array[n]
     test_expression!("([5,4,3,2,1])[1]", "5");
     test_expression!("([5,4,3,2,1])[2]", "4");
     test_expression!("([5,4,3,2,1])[5]", "1");
+    test_expression!("([[1, 2], [2, 3], [3,4]])[1]", "[1, 2]");
+    test_expression!("([[1, 2], [2, 3], [3,4]])[3]", "[3, 4]");
+    test_expression!("([[1, 2], [2, 3], [3,4]])[1][1]", "1");
+    test_expression!("([[1, 2], [2, 3], [3,4]])[2][2]", "3");
+    test_expression!("([[1, 2], [2, 3], [3,4]])[3][2]", "4");
     // out of bounds
     test_expression!("([5,4,3,2,1])[0]", "NULL");
     test_expression!("([5,4,3,2,1])[6]", "NULL");

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -529,7 +529,7 @@ async fn query_get_indexed_field() -> Result<()> {
     ctx.register_table("ints", table_a)?;
 
     // Original column is micros, convert to millis and check timestamp
-    let sql = "SELECT some_list[0] as i0 FROM ints LIMIT 3";
+    let sql = "SELECT some_list[1] as i0 FROM ints LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]
     let expected = vec![
@@ -582,7 +582,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
     ctx.register_table("ints", table_a)?;
 
     // Original column is micros, convert to millis and check timestamp
-    let sql = "SELECT some_list[0] as i0 FROM ints LIMIT 3";
+    let sql = "SELECT some_list[1] as i0 FROM ints LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----------+",
@@ -594,7 +594,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
         "+----------+",
     ];
     assert_batches_eq!(expected, &actual);
-    let sql = "SELECT some_list[0][0] as i0 FROM ints LIMIT 3";
+    let sql = "SELECT some_list[1][1] as i0 FROM ints LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]
     let expected = vec![
@@ -666,7 +666,7 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
-    let sql = "SELECT some_struct['bar'][0] as i0 FROM structs LIMIT 3";
+    let sql = "SELECT some_struct['bar'][1] as i0 FROM structs LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]
     let expected = vec![

--- a/datafusion/expr/src/field_util.rs
+++ b/datafusion/expr/src/field_util.rs
@@ -28,14 +28,7 @@ use datafusion_common::{DataFusionError, Result, ScalarValue};
 pub fn get_indexed_field(data_type: &DataType, key: &ScalarValue) -> Result<Field> {
     match (data_type, key) {
         (DataType::List(lt), ScalarValue::Int64(Some(i))) => {
-            if *i < 0 {
-                Err(DataFusionError::Plan(format!(
-                    "List based indexed access requires a positive int, was {0}",
-                    i
-                )))
-            } else {
-                Ok(Field::new(&i.to_string(), lt.data_type().clone(), false))
-            }
+            Ok(Field::new(&i.to_string(), lt.data_type().clone(), true))
         }
         (DataType::Struct(fields), ScalarValue::Utf8(Some(s))) => {
             if s.is_empty() {


### PR DESCRIPTION
Closes: https://github.com/apache/arrow-datafusion/issues/2207

Hello!

I've opened a PR as a Draft to indicate that I am working on the task of supporting the array index operator in DF. 

## Breaking changes

- It's started to allow using negative number indexes as PostgreSQL does.
- Use 1-based indexes as PostgreSQL does.

<img width="718" alt="image" src="https://user-images.githubusercontent.com/572096/171681707-e1084021-5932-4082-af32-998bf3033e72.png">


Thanks