### PR TITLE
`case when` supports `NULL`  constant

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -110,6 +110,40 @@ async fn case_when_else_with_base_expr() -> Result<()> {
 }
 
 #[tokio::test]
+async fn case_when_else_with_null_literal() -> Result<()> {
+    let ctx = create_case_context()?;
+    let sql = "SELECT \
+        CASE WHEN c1 = 'a' THEN 1 \
+             WHEN NULL THEN 2 \
+             ELSE 999 END \
+        FROM t1";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+----------------------------------------------------------------------------------------------+",
+        "| CASE WHEN #t1.c1 = Utf8(\"a\") THEN Int64(1) WHEN Utf8(NULL) THEN Int64(2) ELSE Int64(999) END |",
+        "+----------------------------------------------------------------------------------------------+",
+        "| 1                                                                                            |",
+        "| 999                                                                                          |",
+        "| 999                                                                                          |",
+        "| 999                                                                                          |",
+        "+----------------------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "SELECT CASE WHEN NULL THEN 'foo' ELSE 'bar' END";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+------------------------------------------------------------+",
+        "| CASE WHEN Utf8(NULL) THEN Utf8(\"foo\") ELSE Utf8(\"bar\") END |",
+        "+------------------------------------------------------------+",
+        "| bar                                                        |",
+        "+------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_not() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
 

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -110,7 +110,7 @@ async fn case_when_else_with_base_expr() -> Result<()> {
 }
 
 #[tokio::test]
-async fn case_when_else_with_null_literal() -> Result<()> {
+async fn case_when_else_with_null_contant() -> Result<()> {
     let ctx = create_case_context()?;
     let sql = "SELECT \
         CASE WHEN c1 = 'a' THEN 1 \

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -178,14 +178,16 @@ impl CaseExpr {
             let when_value = self.when_then_expr[i]
                 .0
                 .evaluate_selection(batch, &remainder)?;
+            // Treat 'NULL' as false value
             let when_value = match when_value {
-                ColumnarValue::Scalar(value) =>
+                ColumnarValue::Scalar(value) => {
                     if value.is_null() {
                         ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))
                     } else {
                         ColumnarValue::Scalar(value)
                     }
-                _ => when_value
+                }
+                _ => when_value,
             };
             let when_value = when_value.into_array(batch.num_rows());
             let when_value = when_value

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -24,7 +24,7 @@ use arrow::compute::kernels::zip::zip;
 use arrow::compute::{and, eq_dyn, is_null, not, or, or_kleene};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{DataFusionError, Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 
 type WhenThen = (Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>);
@@ -180,12 +180,8 @@ impl CaseExpr {
                 .evaluate_selection(batch, &remainder)?;
             // Treat 'NULL' as false value
             let when_value = match when_value {
-                ColumnarValue::Scalar(value) => {
-                    if value.is_null() {
-                        ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))
-                    } else {
-                        ColumnarValue::Scalar(value)
-                    }
+                ColumnarValue::Scalar(value) if value.is_null() => {
+                    continue;
                 }
                 _ => when_value,
             };


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1189.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
df `case when` expression cannot take `NULL` constant, like
```
> select CASE WHEN NULL THEN 'foo' ELSE 'bar' END;
thread 'main' panicked at 'WHEN expression did not return a BooleanArray', datafusion/src/physical_plan/expressions/case.rs:381:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Postgres:
```
# select case null when null then 'foo' else 'bar' end;
 case 
------
 bar
(1 row)
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
For `when expression` without `case expression`, treat `NULL` as `false` before down cast to `BooleanArray`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
