### PR TITLE
minor: pin lock_api 0.4.6 to avoid the need for nightly

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "datafusion",
  "dirs",
  "env_logger",
+ "lock_api",
  "mimalloc",
  "rustyline",
  "tokio",
@@ -1113,11 +1114,10 @@ checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -37,3 +37,4 @@ env_logger = "0.9"
 mimalloc = { version = "*", default-features = false }
 rustyline = "9.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
+lock_api = "=0.4.6"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Encounter the need for nightly while running `datafusion-cli`, pin `lock_api` version to `0.4.6` could fix.
```
error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> /Users/shenyijie/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.7/src/mutex.rs:150:6
    |
150 | impl<R: RawMutex, T> Mutex<R, T> {
    |      ^
...
154 |     pub const fn new(val: T) -> Mutex<R, T> {
    |     --------------------------------------- function declared as const here
    |
    = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable

error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> /Users/shenyijie/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.7/src/remutex.rs:231:6
    |
231 | impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
    |      ^
...
235 |     pub const fn new(val: T) -> ReentrantMutex<R, G, T> {
    |     --------------------------------------------------- function declared as const here
    |
    = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable

error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> /Users/shenyijie/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.7/src/remutex.rs:231:19
    |
231 | impl<R: RawMutex, G: GetThreadId, T> ReentrantMutex<R, G, T> {
    |                   ^
...
235 |     pub const fn new(val: T) -> ReentrantMutex<R, G, T> {
    |     --------------------------------------------------- function declared as const here
    |
    = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable

error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> /Users/shenyijie/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.7/src/rwlock.rs:367:6
    |
367 | impl<R: RawRwLock, T> RwLock<R, T> {
    |      ^
...
371 |     pub const fn new(val: T) -> RwLock<R, T> {
    |     ---------------------------------------- function declared as const here
    |
    = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.

```
