### PR TITLE
fix: ‘Invalid identifier #xxx’ caused by Case-to-case conversion in SQL

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -179,11 +179,14 @@ impl DFSchema {
                 // field to lookup is qualified.
                 // current field is qualified and not shared between relations, compare both
                 // qualifier and name.
-                (Some(q), Some(field_q)) => q == field_q && field.name() == name,
+                (Some(q), Some(field_q)) => {
+                    q.eq_ignore_ascii_case(field_q)
+                        && field.name().eq_ignore_ascii_case(name)
+                }
                 // field to lookup is qualified but current field is unqualified.
                 (Some(_), None) => false,
                 // field to lookup is unqualified, no need to compare qualifier
-                (None, Some(_)) | (None, None) => field.name() == name,
+                (None, Some(_)) | (None, None) => field.name().eq_ignore_ascii_case(name),
             })
             .map(|(idx, _)| idx);
         match matches.next() {
@@ -227,7 +230,12 @@ impl DFSchema {
     pub fn fields_with_qualified(&self, qualifier: &str) -> Vec<&DFField> {
         self.fields
             .iter()
-            .filter(|field| field.qualifier().map(|q| q.eq(qualifier)).unwrap_or(false))
+            .filter(|field| {
+                field
+                    .qualifier()
+                    .map(|q| q.eq_ignore_ascii_case(qualifier))
+                    .unwrap_or(false)
+            })
             .collect()
     }
 
@@ -235,7 +243,7 @@ impl DFSchema {
     pub fn fields_with_unqualified_name(&self, name: &str) -> Vec<&DFField> {
         self.fields
             .iter()
-            .filter(|field| field.name() == name)
+            .filter(|field| field.name().eq_ignore_ascii_case(name))
             .collect()
     }
 

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -1026,7 +1026,7 @@ async fn case_insensitive_in_sql() -> Result<()> {
     ctx.register_table("test", Arc::new(table))?;
 
     // Select with lower and upper case
-    let sql = "SELECT COLumn1,colUMN2,column3 FROM test where TEst.COLUMN1='content1' and column2='content2' and COLumn3='content3'";
+    let sql = "SELECT COLumn1, colUMN2, column3 FROM test WHERE TEst.COLUMN1='content1' and column2='content2' and COLumn3='content3'";
     let actual = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![


### PR DESCRIPTION
# Which issue does this PR close?
Closes #2210

 # Rationale for this change
fix: ‘Invalid identifier #xxx’ caused by Case-to-case conversion in SQL

# What changes are included in this PR?
Make the tablename and filed name case-insensitive in SQL. 

# Are there any user-facing changes?
Field name with uppercase letters can be used in SQL correctly and SQL statement will be case-insensitive. 