### PR TITLE
Add single line description of ExecutionPlan (#2216)

### DIFF
--- a/datafusion/core/src/physical_plan/display.rs
+++ b/datafusion/core/src/physical_plan/display.rs
@@ -101,6 +101,32 @@ impl<'a> DisplayableExecutionPlan<'a> {
             show_metrics: self.show_metrics,
         }
     }
+
+    /// Return a single-line summary of the root of the plan
+    pub fn one_line(&self) -> impl fmt::Display + 'a {
+        struct Wrapper<'a> {
+            plan: &'a dyn ExecutionPlan,
+            show_metrics: ShowMetrics,
+        }
+
+        impl<'a> fmt::Display for Wrapper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                let mut visitor = IndentVisitor {
+                    f,
+                    t: DisplayFormatType::Default,
+                    indent: 0,
+                    show_metrics: self.show_metrics,
+                };
+                visitor.pre_visit(self.plan)?;
+                Ok(())
+            }
+        }
+
+        Wrapper {
+            plan: self.inner,
+            show_metrics: self.show_metrics,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/datafusion/core/src/physical_plan/display.rs
+++ b/datafusion/core/src/physical_plan/display.rs
@@ -103,7 +103,7 @@ impl<'a> DisplayableExecutionPlan<'a> {
     }
 
     /// Return a single-line summary of the root of the plan
-    // Example: `ProjectionExec: expr=[a@0 as a]`.
+    /// Example: `ProjectionExec: expr=[a@0 as a]`.
     pub fn one_line(&self) -> impl fmt::Display + 'a {
         struct Wrapper<'a> {
             plan: &'a dyn ExecutionPlan,

--- a/datafusion/core/src/physical_plan/display.rs
+++ b/datafusion/core/src/physical_plan/display.rs
@@ -103,6 +103,7 @@ impl<'a> DisplayableExecutionPlan<'a> {
     }
 
     /// Return a single-line summary of the root of the plan
+    // Example: `ProjectionExec: expr=[a@0 as a]`.
     pub fn one_line(&self) -> impl fmt::Display + 'a {
         struct Wrapper<'a> {
             plan: &'a dyn ExecutionPlan,

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -318,6 +318,9 @@ pub fn with_new_children_if_necessary(
 ///              \n      RepartitionExec: partitioning=RoundRobinBatch(3)\
 ///              \n        CsvExec: files=[tests/example.csv], has_header=true, limit=None, projection=[a]",
 ///               plan_string.trim());
+///
+///   let one_line = format!("{}", displayable_plan.one_line());
+///   assert_eq!("ProjectionExec: expr=[a@0 as a]", one_line.trim());
 /// }
 /// ```
 ///


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2216

 # Rationale for this change

See ticket

# What changes are included in this PR?

Adds the ability to get a single-line summary of the root of an ExecutionPlan

# Are there any user-facing changes?

No