### PR TITLE
Use `filter` (filter_record_batch) instead of `take` to avoid using indices

### DIFF
--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -47,7 +47,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
         batch: &RecordBatch,
         selection: &BooleanArray,
     ) -> Result<ColumnarValue> {
-        let tmp_batch = filter_record_batch(batch, &selection)?;
+        let tmp_batch = filter_record_batch(batch, selection)?;
 
         let tmp_result = self.evaluate(&tmp_batch)?;
         // All values from the `selection` filter are true.

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -47,9 +47,8 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
         batch: &RecordBatch,
         selection: &BooleanArray,
     ) -> Result<ColumnarValue> {
-        let tmp_columns = filter_record_batch(batch, &selection);
+        let tmp_batch = filter_record_batch(batch, &selection)?;
 
-        let tmp_batch = RecordBatch::try_new(batch.schema(), tmp_columns)?;
         let tmp_result = self.evaluate(&tmp_batch)?;
         if let ColumnarValue::Array(a) = tmp_result {
             let result = scatter(selection, a.as_ref())?;

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -49,16 +49,11 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
         batch: &RecordBatch,
         selection: &BooleanArray,
     ) -> Result<ColumnarValue> {
-        let filter = match selection.null_count() {
-            0 => BooleanArray::from(selection.data().clone()),
-            _ => prep_null_mask_filter(selection),
-        };
-
-        let filter_count = filter
+        let filter_count = selection
             .values()
             .count_set_bits_offset(selection.offset(), selection.len());
 
-        if filter_count == selection.len() {
+        if selection.null_count() == 0 && filter_count == selection.len() {
             return self.evaluate(batch);
         }
 

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -47,6 +47,13 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
         batch: &RecordBatch,
         selection: &BooleanArray,
     ) -> Result<ColumnarValue> {
+        let filter_count = selection
+            .values()
+            .count_set_bits_offset(selection.offset(), selection.len());
+        if filter_count == selection.len() {
+            return self.evaluate(batch);
+        }
+
         let tmp_batch = filter_record_batch(batch, &selection)?;
 
         let tmp_result = self.evaluate(&tmp_batch)?;

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -53,9 +53,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
 
         let tmp_result = self.evaluate(&tmp_batch)?;
         // All values from the `selection` filter are true.
-        if batch.columns().first().map(|x| x.len())
-            == tmp_batch.columns().first().map(|x| x.len())
-        {
+        if batch.num_rows() == tmp_batch.num_rows() {
             return Ok(tmp_result);
         }
         if let ColumnarValue::Array(a) = tmp_result {

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -25,9 +25,7 @@ use datafusion_expr::ColumnarValue;
 use std::fmt::{Debug, Display};
 
 use arrow::array::{make_array, Array, ArrayRef, BooleanArray, MutableArrayData};
-use arrow::compute::{
-    and_kleene, filter_record_batch, is_not_null, prep_null_mask_filter, SlicesIterator,
-};
+use arrow::compute::{and_kleene, filter_record_batch, is_not_null, SlicesIterator};
 use std::any::Any;
 
 /// Expression that can be evaluated against a RecordBatch
@@ -110,6 +108,8 @@ fn scatter(mask: &BooleanArray, truthy: &dyn Array) -> Result<ArrayRef> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use arrow::array::Int32Array;
     use datafusion_common::Result;


### PR DESCRIPTION
# Which issue does this PR close?
n/a

 # Rationale for this change
We can use the more efficient `filter` kernel than building an indices array and using `take`.
Referenced by @alamb in https://github.com/apache/arrow-rs/issues/1542

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use filter instead of take. 

This has the following benefits (besides removing some code)
* This also uses the faster counting, and has some extra fast paths.
* Avoids materializing the indices both in `Vec` and `UInt64Array`
* The `filter` kernel itself is faster / than `take`.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No