### PR TITLE
update cli readme

### DIFF
--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -65,17 +65,21 @@ DataFusion CLI v4.0.0-SNAPSHOT
 1 row in set. Query took 0.017 seconds.
 ```
 
+## DataFusion-Cli
+
+Build the `datafusion-cli` without the feature of ballista.
+
+```bash
+cd arrow-datafusion/datafusion-cli
+cargo build
+```
+
 ## Ballista
 If you want to execute the SQL in ballista by `datafusion-cli`, you must build/compile the `datafusion-cli` with features of "ballista" first.
 
 ```bash
+cd arrow-datafusion/datafusion-cli
 cargo build --features ballista
-```
-
-or
-
-```bash
-cargo build -p datafusion-cli --features ballista
 ```
 
 The DataFusion CLI can connect to a Ballista scheduler for query execution.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -65,6 +65,15 @@ DataFusion CLI v5.1.0-SNAPSHOT
 1 row in set. Query took 0.017 seconds.
 ```
 
+## DataFusion-Cli
+
+Build the `datafusion-cli` without the feature of ballista.
+
+```bash
+cd arrow-datafusion/datafusion-cli
+cargo build
+```
+
 ## Ballista
 
 The DataFusion CLI can also connect to a Ballista scheduler for query execution.
@@ -73,14 +82,8 @@ Before you use the `datafusion-cli` to connect the Ballista scheduler, you shoul
 the `datafusion-cli` with feature of "ballista" first.
 
 ```bash
+cd arrow-datafusion/datafusion-cli
 cargo build --features ballista
-```
-
-or
-
-```bash
-cargo build -p datafusion-cli --features ballista
-
 ```
 
 Then, you can connect the Ballista by below command.


### PR DESCRIPTION
# Which issue does this PR close?

related https://github.com/apache/arrow-datafusion/pull/2112

after this https://github.com/apache/arrow-datafusion/pull/2112 which add  `exclude = ["datafusion-cli"]`, we couldn't build `cli` from root dir by `cargo build` or `cargo build -p datafusion-cli`.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
