### PR TITLE
Add ExecutorMetricsCollector interface

### DIFF
--- a/ballista/rust/executor/src/lib.rs
+++ b/ballista/rust/executor/src/lib.rs
@@ -22,6 +22,7 @@ pub mod execution_loop;
 pub mod executor;
 pub mod executor_server;
 pub mod flight_service;
+pub mod metrics;
 
 mod cpu_bound_executor;
 mod standalone;

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -42,6 +42,7 @@ use ballista_core::serde::BallistaCodec;
 use ballista_core::{print_version, BALLISTA_VERSION};
 use ballista_executor::executor::Executor;
 use ballista_executor::flight_service::BallistaFlightService;
+use ballista_executor::metrics::LoggingMetricsCollector;
 use config::prelude::*;
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 
@@ -118,7 +119,14 @@ async fn main() -> Result<()> {
         BallistaError::Internal("Failed to init Executor RuntimeEnv".to_owned())
     })?);
 
-    let executor = Arc::new(Executor::new(executor_meta, &work_dir, runtime));
+    let metrics_collector = Arc::new(LoggingMetricsCollector::default());
+
+    let executor = Arc::new(Executor::new(
+        executor_meta,
+        &work_dir,
+        runtime,
+        metrics_collector,
+    ));
 
     let scheduler = SchedulerGrpcClient::connect(scheduler_url)
         .await

--- a/ballista/rust/executor/src/metrics/mod.rs
+++ b/ballista/rust/executor/src/metrics/mod.rs
@@ -1,7 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use ballista_core::execution_plans::ShuffleWriterExec;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 
+/// `ExecutorMetricsCollector` records metrics for `ShuffleWriteExec`
+/// after they are executed.
+///
+/// After each stage completes, `ShuffleWriteExec::record_stage` will be
+/// called.
 pub trait ExecutorMetricsCollector: Send + Sync {
+    /// Record metrics for stage after it is executed
     fn record_stage(
         &self,
         job_id: &str,
@@ -11,6 +34,8 @@ pub trait ExecutorMetricsCollector: Send + Sync {
     );
 }
 
+/// Implementation of `ExecutorMetricsCollector` which logs the completed
+/// plan to stdout.
 #[derive(Default)]
 pub struct LoggingMetricsCollector {}
 

--- a/ballista/rust/executor/src/metrics/mod.rs
+++ b/ballista/rust/executor/src/metrics/mod.rs
@@ -1,0 +1,33 @@
+use ballista_core::execution_plans::ShuffleWriterExec;
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
+
+pub trait ExecutorMetricsCollector: Send + Sync {
+    fn record_stage(
+        &self,
+        job_id: &str,
+        stage_id: usize,
+        partition: usize,
+        plan: ShuffleWriterExec,
+    );
+}
+
+#[derive(Default)]
+pub struct LoggingMetricsCollector {}
+
+impl ExecutorMetricsCollector for LoggingMetricsCollector {
+    fn record_stage(
+        &self,
+        job_id: &str,
+        stage_id: usize,
+        partition: usize,
+        plan: ShuffleWriterExec,
+    ) {
+        println!(
+            "=== [{}/{}/{}] Physical plan with metrics ===\n{}\n",
+            job_id,
+            stage_id,
+            partition,
+            DisplayableExecutionPlan::with_metrics(&plan).indent()
+        );
+    }
+}

--- a/ballista/rust/executor/src/standalone.rs
+++ b/ballista/rust/executor/src/standalone.rs
@@ -34,6 +34,7 @@ use tokio::net::TcpListener;
 use tonic::transport::{Channel, Server};
 use uuid::Uuid;
 
+use crate::metrics::LoggingMetricsCollector;
 use crate::{execution_loop, executor::Executor, flight_service::BallistaFlightService};
 
 pub async fn new_standalone_executor<
@@ -78,6 +79,7 @@ pub async fn new_standalone_executor<
         executor_meta,
         &work_dir,
         Arc::new(RuntimeEnv::new(config).unwrap()),
+        Arc::new(LoggingMetricsCollector::default()),
     ));
 
     let service = BallistaFlightService::new(executor.clone());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2204 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently there is no way of getting execution metrics from Ballista executors (aside from parsing log messages). This adds a trait `ExecutorMetricsCollector` which can record stage execution metrics. Currently it just defaults to `LoggingMetricsCollector` which just logs the plan (same as before). 

I'm also working on a prometheus metrics collector which we can upstream (under a feature flag) when it's ready. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Add `ExecutorMetricsCollector` trait 
2. Created default `LoggingMetricsCollector` implementation
3. `Executor` needs to own an `Arc<dyn ExecutorMetricsCollector>` and call `record_stage` after executing a shuffle write. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
