### PR TITLE
Add type coercion rule for date + interval

### DIFF
--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -48,6 +48,15 @@ pub(crate) fn coerce_types(
         }
         // "like" operators operate on strings and always return a boolean
         Operator::Like | Operator::NotLike => like_coercion(lhs_type, rhs_type),
+        // date +/- interval returns date
+        Operator::Plus | Operator::Minus
+            if (*lhs_type == DataType::Date32 || *lhs_type == DataType::Date64) =>
+        {
+            match rhs_type {
+                DataType::Interval(_) => Some(lhs_type.clone()),
+                _ => None,
+            }
+        }
         // for math expressions, the final value of the coercion is also the return type
         // because coercion favours higher information types
         Operator::Plus


### PR DESCRIPTION
Signed-off-by: Andy Grove <agrove@apache.org>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #https://github.com/apache/arrow-datafusion/issues/2229.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Attempting to create a query plan from SQL using date + interval expressions was failing with a type-coercion error because no type coercion rule had been implemented for this operation.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR implements the type coercion rule for date +/ interval, allowing the SQL query to be converted to a valid logical plan. This is sufficient for the use case of using DataFusion as SQL query planner.

A follow-on issue has been filed for implementing support for this expression in the physical planner:

- https://github.com/apache/arrow-datafusion/issues/2236

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No