### PR TITLE
Fix join without constraints

### DIFF
--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -189,6 +189,12 @@ impl HashJoinExec {
     ) -> Result<Self> {
         let left_schema = left.schema();
         let right_schema = right.schema();
+        if on.is_empty() {
+            return Err(DataFusionError::Plan(
+                "On constraints in HashJoinExec should be non-empty".to_string(),
+            ));
+        }
+
         check_join_is_valid(&left_schema, &right_schema, &on)?;
 
         let (schema, column_indices) =

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -528,13 +528,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // When we don't have join keys, use cross join
                     let join = LogicalPlanBuilder::from(left).cross_join(&right)?;
 
-                    let join_filter_init = filter.remove(0);
-                    join.filter(
-                        filter
-                            .into_iter()
-                            .fold(join_filter_init, |acc, e| acc.and(e)),
-                    )?
-                    .build()
+                    join.filter(filter.into_iter().reduce(|acc, e| acc.and(e)).unwrap())?
+                        .build()
                 } else if filter.is_empty() {
                     let join = LogicalPlanBuilder::from(left).join(
                         &right,
@@ -548,13 +543,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         join_type,
                         (left_keys, right_keys),
                     )?;
-                    let join_filter_init = filter.remove(0);
-                    join.filter(
-                        filter
-                            .into_iter()
-                            .fold(join_filter_init, |acc, e| acc.and(e)),
-                    )?
-                    .build()
+                    join.filter(filter.into_iter().reduce(|acc, e| acc.and(e)).unwrap())?
+                        .build()
                 }
                 // Left join with all non-equijoin expressions from the right
                 // l left join r

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -528,7 +528,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // When we don't have join keys, use cross join
                     let join = LogicalPlanBuilder::from(left).cross_join(&right)?;
 
-                    join.filter(filter.into_iter().reduce(|acc, e| acc.and(e)).unwrap())?
+                    join.filter(filter.into_iter().reduce(Expr::and).unwrap())?
                         .build()
                 } else if filter.is_empty() {
                     let join = LogicalPlanBuilder::from(left).join(
@@ -543,7 +543,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         join_type,
                         (left_keys, right_keys),
                     )?;
-                    join.filter(filter.into_iter().reduce(|acc, e| acc.and(e)).unwrap())?
+                    join.filter(filter.into_iter().reduce(Expr::and).unwrap())?
                         .build()
                 }
                 // Left join with all non-equijoin expressions from the right

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -294,6 +294,24 @@ async fn left_join_not_null_filter_on_join_column() -> Result<()> {
 }
 
 #[tokio::test]
+async fn self_join_non_equijoin() -> Result<()> {
+    let ctx = create_join_context_with_nulls()?;
+    let sql =
+        "SELECT x.t1_id, y.t1_id FROM t1 x JOIN t1 y ON x.t1_id = 11 AND y.t1_id = 44";
+    let expected = vec![
+        "+-------+-------+",
+        "| t1_id | t1_id |",
+        "+-------+-------+",
+        "| 11    | 44    |",
+        "+-------+-------+",
+    ];
+
+    let actual = execute_to_batches(&ctx, sql).await;
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn right_join_null_filter() -> Result<()> {
     let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t2_id";


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2230

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Allows to use join syntax, even if no actual join constraint can be used to use an equi-join. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fixes join without on constraint.
Also adds explicit check for non-empty constraint list in HashJoinExec

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
