### PR TITLE
fix: find the right wider decimal datatype for comparison operation

### DIFF
--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -185,7 +185,7 @@ fn get_comparison_common_decimal_type(
     }
 }
 
-// Returns a `DataType::Decimal` that can store any value from either 
+// Returns a `DataType::Decimal` that can store any value from either
 // `lhs_decimal_type` and `rhs_decimal_type`
 // The result decimal type is (max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)).
 fn get_wider_decimal_type(

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -185,7 +185,8 @@ fn get_comparison_common_decimal_type(
     }
 }
 
-// Find the winder decimal type when both types are decimal.
+// Returns a `DataType::Decimal` that can store any value from either 
+// `lhs_decimal_type` and `rhs_decimal_type`
 // The result decimal type is (max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)).
 fn get_wider_decimal_type(
     lhs_decimal_type: &DataType,

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -143,7 +143,7 @@ fn comparison_binary_numeric_coercion(
     // that the coercion removes the least amount of information
     match (lhs_type, rhs_type) {
         // support decimal data type for comparison operation
-        (Decimal(p1, s1), Decimal(p2, s2)) => Some(Decimal(*p1.max(p2), *s1.max(s2))),
+        (d1 @ Decimal(_, _), d2 @ Decimal(_, _)) => get_wider_decimal_type(d1, d2),
         (Decimal(_, _), _) => get_comparison_common_decimal_type(lhs_type, rhs_type),
         (_, Decimal(_, _)) => get_comparison_common_decimal_type(rhs_type, lhs_type),
         (Float64, _) | (_, Float64) => Some(Float64),
@@ -178,12 +178,23 @@ fn get_comparison_common_decimal_type(
         }
     };
     match (decimal_type, &other_decimal_type) {
-        (DataType::Decimal(p1, s1), DataType::Decimal(p2, s2)) => {
-            let new_precision = p1.max(p2);
-            let new_scale = s1.max(s2);
-            Some(DataType::Decimal(*new_precision, *new_scale))
-        }
+        (d1 @ DataType::Decimal(_, _), d2 @ DataType::Decimal(_, _)) =>
+            get_wider_decimal_type(d1, d2),
         _ => None,
+    }
+}
+
+// Find the winder type when both types are decimal.
+// The result decimal type is (max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)).
+fn get_wider_decimal_type(lhs_decimal_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
+    match (lhs_decimal_type, rhs_type) {
+        (DataType::Decimal(p1, s1), DataType::Decimal(p2, s2)) => {
+            // max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)
+            let s = *s1.max(s2);
+            let range = (p1 - s1).max(p2 - s2);
+            Some(create_decimal_type(range + s, s))
+        }
+        (_, _) => None
     }
 }
 
@@ -333,11 +344,11 @@ pub fn is_signed_numeric(dt: &DataType) -> bool {
 pub fn is_numeric(dt: &DataType) -> bool {
     is_signed_numeric(dt)
         || match dt {
-            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
-                true
-            }
-            _ => false,
+        DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+            true
         }
+        _ => false,
+    }
 }
 
 /// Coercion rules for dictionary values (aka the type of the  dictionary itself)
@@ -531,7 +542,6 @@ mod tests {
     use datafusion_expr::Operator;
 
     #[test]
-
     fn test_coercion_error() -> Result<()> {
         let result_type =
             coerce_types(&DataType::Float32, &Operator::Plus, &DataType::Utf8);
@@ -557,15 +567,17 @@ mod tests {
             DataType::Float32,
             DataType::Float64,
             DataType::Decimal(38, 10),
+            DataType::Decimal(20, 8),
         ];
         let result_types = [
             DataType::Decimal(20, 3),
             DataType::Decimal(20, 3),
             DataType::Decimal(20, 3),
-            DataType::Decimal(20, 3),
-            DataType::Decimal(20, 7),
-            DataType::Decimal(30, 15),
+            DataType::Decimal(23, 3),
+            DataType::Decimal(24, 7),
+            DataType::Decimal(32, 15),
             DataType::Decimal(38, 10),
+            DataType::Decimal(25, 8),
         ];
         let comparison_op_types = [
             Operator::NotEq,

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -185,7 +185,7 @@ fn get_comparison_common_decimal_type(
     }
 }
 
-// Find the winder type when both types are decimal.
+// Find the winder decimal type when both types are decimal.
 // The result decimal type is (max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)).
 fn get_wider_decimal_type(
     lhs_decimal_type: &DataType,

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -178,15 +178,19 @@ fn get_comparison_common_decimal_type(
         }
     };
     match (decimal_type, &other_decimal_type) {
-        (d1 @ DataType::Decimal(_, _), d2 @ DataType::Decimal(_, _)) =>
-            get_wider_decimal_type(d1, d2),
+        (d1 @ DataType::Decimal(_, _), d2 @ DataType::Decimal(_, _)) => {
+            get_wider_decimal_type(d1, d2)
+        }
         _ => None,
     }
 }
 
 // Find the winder type when both types are decimal.
 // The result decimal type is (max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)).
-fn get_wider_decimal_type(lhs_decimal_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
+fn get_wider_decimal_type(
+    lhs_decimal_type: &DataType,
+    rhs_type: &DataType,
+) -> Option<DataType> {
     match (lhs_decimal_type, rhs_type) {
         (DataType::Decimal(p1, s1), DataType::Decimal(p2, s2)) => {
             // max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)
@@ -194,7 +198,7 @@ fn get_wider_decimal_type(lhs_decimal_type: &DataType, rhs_type: &DataType) -> O
             let range = (p1 - s1).max(p2 - s2);
             Some(create_decimal_type(range + s, s))
         }
-        (_, _) => None
+        (_, _) => None,
     }
 }
 
@@ -344,11 +348,11 @@ pub fn is_signed_numeric(dt: &DataType) -> bool {
 pub fn is_numeric(dt: &DataType) -> bool {
     is_signed_numeric(dt)
         || match dt {
-        DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
-            true
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+                true
+            }
+            _ => false,
         }
-        _ => false,
-    }
 }
 
 /// Coercion rules for dictionary values (aka the type of the  dictionary itself)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2232 

For decimal with the comparison operation, we use the error algorithm to calculate the precision/scale.

Before: max(p1,p2),max(s1,s2)

Now: max(38,max(s1, s2) + max(p1-s1, p2-s2)), max(s1, s2, 38)



 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

schema
```
CREATE EXTERNAL TABLE food (a DECIMAL(10,6), b double, c boolean) STORED AS CSV LOCATION 'aggregate_simple.csv';
```
Before this fix, we got the plan https://github.com/apache/arrow-datafusion/pull/2200#discussion_r850030108

After this fix, we got the right converted type in the filter expr
```
❯ explain select * from food where a >= CAST(0.00002 as Decimal(10,8));
+---------------+----------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                     |
+---------------+----------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #food.a, #food.b, #food.c                                                                    |
|               |   Filter: #food.a >= Decimal128(Some(2000),10,8)                                                         |
|               |     TableScan: food projection=Some([0, 1, 2]), partial_filters=[#food.a >= Decimal128(Some(2000),10,8)] |
| physical_plan | ProjectionExec: expr=[a@0 as a, b@1 as b, c@2 as c]                                                      |
|               |   CoalesceBatchesExec: target_batch_size=4096                                                            |
|               |     FilterExec: CAST(a@0 AS Decimal(12, 8)) >= CAST(Some(2000),10,8 AS Decimal(12, 8))                   |
|               |       RepartitionExec: partitioning=RoundRobinBatch(16)                                                  |
|               |         CsvExec: files=[aggregate_simple.csv], has_header=false, limit=None, projection=[a, b, c]        |
|               |                                                                                                          |
+---------------+----------------------------------------------------------------------------------------------------------+

```


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

cc @alamb 
