### PR TITLE
Add write and delete operations to ObjectStore

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -966,7 +966,7 @@ mod roundtrip_tests {
             self,
             object_store::{
                 local::LocalFileSystem, FileMetaStream, ListEntryStream, ObjectReader,
-                ObjectStore,
+                ObjectStore, ObjectWriter,
             },
             SizedFile,
         },
@@ -1015,6 +1015,55 @@ mod roundtrip_tests {
                 io::ErrorKind::Unsupported,
                 "this is only a test object store".to_string(),
             ))
+        }
+
+        fn file_writer(
+            &self,
+            _path: &str,
+        ) -> datafusion_data_access::Result<Arc<dyn ObjectWriter>> {
+            unimplemented!();
+        }
+
+        async fn create_dir(
+            &self,
+            _path: &str,
+            _recursive: bool,
+        ) -> datafusion_data_access::Result<()> {
+            unimplemented!();
+        }
+
+        async fn remove_dir_all(
+            &self,
+            _path: &str,
+        ) -> datafusion_data_access::Result<()> {
+            unimplemented!();
+        }
+
+        async fn remove_dir_contents(
+            &self,
+            _path: &str,
+        ) -> datafusion_data_access::Result<()> {
+            unimplemented!();
+        }
+
+        async fn remove_file(&self, _path: &str) -> datafusion_data_access::Result<()> {
+            unimplemented!();
+        }
+
+        async fn rename(
+            &self,
+            _source: &str,
+            _dest: &str,
+        ) -> datafusion_data_access::Result<()> {
+            unimplemented!();
+        }
+
+        async fn copy(
+            &self,
+            _source: &str,
+            _dest: &str,
+        ) -> datafusion_data_access::Result<()> {
+            unimplemented!();
         }
     }
 

--- a/data-access/Cargo.toml
+++ b/data-access/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.41"
-chrono = { version = "0.4"}
+chrono = { version = "0.4", features = ["std"] }
 futures = "0.3"
 parking_lot = "0.12"
 tempfile = "3"

--- a/data-access/Cargo.toml
+++ b/data-access/Cargo.toml
@@ -38,4 +38,4 @@ chrono = { version = "0.4", features = ["std"] }
 futures = "0.3"
 parking_lot = "0.12"
 tempfile = "3"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot", "io-util"] }

--- a/data-access/Cargo.toml
+++ b/data-access/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.41"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4"}
 futures = "0.3"
 parking_lot = "0.12"
 tempfile = "3"

--- a/data-access/src/lib.rs
+++ b/data-access/src/lib.rs
@@ -15,6 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Datafusion Data Access provides general traits and structs
+//! for data access abstractions. The main trait is the 
+//! [object_store::ObjectStore] traits, which defines a filesystem-like
+//! interfaces that can be implemented by a variety of systems. This 
+//! create provides local filesystem implementation for ObjectStore 
+//! as [object_store::local::LocalFileSystem].
+//! 
+//! Alternative object stores are provided by separate crates, including:
+//!  * [S3FileSystem](https://docs.rs/datafusion-objectstore-s3/latest/datafusion_objectstore_s3/)
+
 pub mod object_store;
 
 use chrono::{DateTime, Utc};

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -32,17 +32,10 @@ use crate::{FileMeta, Result, SizedFile};
 
 use super::{
     FileMetaStream, ListEntryStream, ObjectReader, ObjectWriter, ObjectReaderStream, ObjectStore,
+    path_without_scheme
 };
 
 pub static LOCAL_SCHEME: &str = "file";
-
-fn path_without_scheme(full_path: &str) -> &str {
-    if let Some((_scheme, path)) = full_path.split_once("://") {
-        path
-    } else {
-        full_path
-    }
-}
 
 #[derive(Debug)]
 /// Local File System as Object Store.

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -69,12 +69,12 @@ use crate::{FileMeta, Result, SizedFile};
 
 use super::{
     path_without_scheme, FileMetaStream, ListEntryStream, ObjectReader,
-    ObjectReaderStream, ObjectStore, ObjectWriter,
+    ObjectReaderStream, ObjectStore, ObjectWriter
 };
 
 pub static LOCAL_SCHEME: &str = "file";
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 /// Local File System as Object Store.
 pub struct LocalFileSystem;
 
@@ -326,6 +326,7 @@ pub fn local_object_reader(file: String) -> Arc<dyn ObjectReader> {
         .expect("File not found")
 }
 
+// TODO: Why would a user want this function that unwraps? unless we said it's unsafe?
 /// Helper method to fetch the file size and date at given path and create a `FileMeta`
 pub fn local_unpartitioned_file(file: String) -> FileMeta {
     let metadata = fs::metadata(&file).expect("Local file metadata");
@@ -364,6 +365,7 @@ impl ObjectWriter for LocalFileWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_object_store;
     use futures::StreamExt;
     use std::collections::HashSet;
     use std::fs::File;
@@ -638,4 +640,6 @@ mod tests {
 
         Ok(())
     }
+
+    test_object_store!(LocalFileSystem::default, tempdir);
 }

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -20,6 +20,7 @@
 use std::fs::{self, File, Metadata};
 use std::io::{self, Write};
 use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -212,9 +213,9 @@ impl LocalFileWriter {
 
 #[async_trait]
 impl ObjectWriter for LocalFileWriter {
-    async fn writer(&self) -> Result<Box<dyn AsyncWrite>> {
+    async fn writer(&self) -> Result<Pin<Box<dyn AsyncWrite>>> {
         let file = AsyncFile::open(&self.path).await?;
-        Ok(Box::new(file))
+        Ok(Box::pin(file))
     }
 
     fn sync_writer(&self) -> Result<Box<dyn Write + Send + Sync>> {

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -490,7 +490,7 @@ mod tests {
         // rename replaces files
         let test_content = b"test";
         let mut f = File::create(&a_path)?;
-        f.write(test_content)?;
+        f.write_all(test_content)?;
         f.flush()?;
         fs.rename(a_path.to_str().unwrap(), b_path.to_str().unwrap())
             .await?;
@@ -565,7 +565,7 @@ mod tests {
         // Copy replaces files
         let test_content = b"test";
         let mut f = File::create(&a_path)?;
-        f.write(test_content)?;
+        f.write_all(test_content)?;
         f.flush()?;
         fs.copy(a_path.to_str().unwrap(), b_path.to_str().unwrap())
             .await?;

--- a/data-access/src/object_store/mod.rs
+++ b/data-access/src/object_store/mod.rs
@@ -114,3 +114,20 @@ pub trait ObjectStore: Sync + Send + Debug {
     /// Get object writer for one file
     fn file_writer(&self, path: String) -> Result<Arc<dyn ObjectWriter>>;
 }
+
+// TODO: Document below when we do and do not expect a scheme
+/// Return path without scheme
+/// 
+/// # Examples
+/// 
+/// ```
+/// let path = "file://path/to/object";
+/// assert_eq(path_without_scheme(path), "path/to/object");
+/// ```
+pub fn path_without_scheme(full_path: &str) -> &str {
+    if let Some((_scheme, path)) = full_path.split_once("://") {
+        path
+    } else {
+        full_path
+    }
+}

--- a/data-access/src/object_store/mod.rs
+++ b/data-access/src/object_store/mod.rs
@@ -71,7 +71,7 @@ pub trait ObjectReader: Send + Sync {
 /// Object Writer for one file in an object store.
 #[async_trait]
 pub trait ObjectWriter: Send + Sync {
-    async fn writer(&self) -> Result<Box<dyn AsyncWrite>>;
+    async fn writer(&self) -> Result<Pin<Box<dyn AsyncWrite>>>;
 
     fn sync_writer(&self) -> Result<Box<dyn Write + Send + Sync>>;
 }

--- a/data-access/src/object_store/mod.rs
+++ b/data-access/src/object_store/mod.rs
@@ -101,7 +101,15 @@ pub trait ObjectStore: Sync + Send + Debug {
     }
 
     /// Returns all the files in `prefix` if the `prefix` is already a leaf dir,
-    /// or all paths between the `prefix` and the first occurrence of the `delimiter` if it is provided.
+    /// or all paths between the `prefix` and the first occurrence of the `delimiter`
+    /// if it is provided.
+    ///
+    /// # Arguments
+    ///
+    ///  * `prefix` -
+    ///  * `delimiter` -
+    ///
+    /// # Example
     async fn list_dir(
         &self,
         prefix: &str,
@@ -116,7 +124,10 @@ pub trait ObjectStore: Sync + Send + Debug {
 
     /// Create directory, recursively if requested
     ///
-    /// If directory already exists, will return Ok
+    /// If directory already exists, will return Ok.
+    /// In many cases, object stores don't have a notion of directories, so this
+    /// might do nothing except check that a file with the same path doesn't
+    /// already exist.
     async fn create_dir(&self, path: &str, recursive: bool) -> Result<()>;
 
     /// Delete directory and its contents, recursively
@@ -138,7 +149,18 @@ pub trait ObjectStore: Sync + Send + Debug {
     /// If dest exists, source will replace it unless dest is a non-empty directory,
     /// in which case an [std::io::ErrorKind::AlreadyExists] or
     /// [std::io::ErrorKind::DirectoryNotEmpty] error will be returned
-    async fn rename(&self, source: &str, dest: &str) -> Result<()>;
+    ///
+    /// In many implementations, this will simply perform a copy and then delete
+    /// source.
+    async fn rename(&self, source: &str, dest: &str) -> Result<()> {
+        self.copy(source, dest).await?;
+        // if is_file {
+        //     self.remove_file(source).await
+        // } else {
+        //     self.remove_dir_all(source).await
+        // }
+        todo!();
+    }
 
     /// Copy a file or directory
     ///

--- a/data-access/src/object_store/mod.rs
+++ b/data-access/src/object_store/mod.rs
@@ -153,8 +153,9 @@ pub trait ObjectStore: Sync + Send + Debug {
 /// # Examples
 ///
 /// ```
+/// use datafusion_data_access::object_store::path_without_scheme;
 /// let path = "file://path/to/object";
-/// assert_eq(path_without_scheme(path), "path/to/object");
+/// assert_eq!(path_without_scheme(path), "path/to/object");
 /// ```
 pub fn path_without_scheme(full_path: &str) -> &str {
     if let Some((_scheme, path)) = full_path.split_once("://") {

--- a/data-access/src/object_store/mod.rs
+++ b/data-access/src/object_store/mod.rs
@@ -112,5 +112,5 @@ pub trait ObjectStore: Sync + Send + Debug {
     fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>>;
 
     /// Get object writer for one file
-    fn file_writer(&self, file: SizedFile) -> Result<Arc<dyn ObjectWriter>>;
+    fn file_writer(&self, path: String) -> Result<Arc<dyn ObjectWriter>>;
 }

--- a/datafusion/core/src/test/object_store.rs
+++ b/datafusion/core/src/test/object_store.rs
@@ -23,7 +23,9 @@ use std::{
 };
 
 use crate::datafusion_data_access::{
-    object_store::{FileMetaStream, ListEntryStream, ObjectReader, ObjectStore},
+    object_store::{
+        FileMetaStream, ListEntryStream, ObjectReader, ObjectStore, ObjectWriter,
+    },
     FileMeta, Result, SizedFile,
 };
 use async_trait::async_trait;
@@ -90,6 +92,34 @@ impl ObjectStore for TestObjectStore {
                 "not in provided test list",
             )),
         }
+    }
+
+    fn file_writer(&self, _path: &str) -> Result<Arc<dyn ObjectWriter>> {
+        unimplemented!();
+    }
+
+    async fn create_dir(&self, _path: &str, _recursive: bool) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_dir_all(&self, _path: &str) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_dir_contents(&self, _path: &str) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_file(&self, _path: &str) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn rename(&self, _source: &str, _dest: &str) -> Result<()> {
+        unimplemented!();
+    }
+
+    async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
+        unimplemented!();
     }
 }
 

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -533,11 +533,18 @@ impl ObjectStore for MirroringObjectStore {
         }
     }
 
-    fn file_writer(&self, _path: &str) -> datafusion_data_access::Result<Arc<dyn ObjectWriter>> {
+    fn file_writer(
+        &self,
+        _path: &str,
+    ) -> datafusion_data_access::Result<Arc<dyn ObjectWriter>> {
         unimplemented!();
     }
 
-    async fn create_dir(&self, _path: &str, _recursive: bool) -> datafusion_data_access::Result<()> {
+    async fn create_dir(
+        &self,
+        _path: &str,
+        _recursive: bool,
+    ) -> datafusion_data_access::Result<()> {
         unimplemented!();
     }
 
@@ -545,7 +552,10 @@ impl ObjectStore for MirroringObjectStore {
         unimplemented!();
     }
 
-    async fn remove_dir_contents(&self, _path: &str) -> datafusion_data_access::Result<()> {
+    async fn remove_dir_contents(
+        &self,
+        _path: &str,
+    ) -> datafusion_data_access::Result<()> {
         unimplemented!();
     }
 
@@ -553,11 +563,19 @@ impl ObjectStore for MirroringObjectStore {
         unimplemented!();
     }
 
-    async fn rename(&self, _source: &str, _dest: &str) -> datafusion_data_access::Result<()> {
+    async fn rename(
+        &self,
+        _source: &str,
+        _dest: &str,
+    ) -> datafusion_data_access::Result<()> {
         unimplemented!();
     }
 
-    async fn copy(&self, _source: &str, _dest: &str) -> datafusion_data_access::Result<()> {
+    async fn copy(
+        &self,
+        _source: &str,
+        _dest: &str,
+    ) -> datafusion_data_access::Result<()> {
         unimplemented!();
     }
 }

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -25,7 +25,7 @@ use datafusion::{
     datafusion_data_access::{
         object_store::{
             local::LocalFileSystem, FileMetaStream, ListEntryStream, ObjectReader,
-            ObjectStore,
+            ObjectStore, ObjectWriter,
         },
         FileMeta, SizedFile,
     },
@@ -531,5 +531,33 @@ impl ObjectStore for MirroringObjectStore {
                 "not in provided test list",
             )),
         }
+    }
+
+    fn file_writer(&self, _path: &str) -> datafusion_data_access::Result<Arc<dyn ObjectWriter>> {
+        unimplemented!();
+    }
+
+    async fn create_dir(&self, _path: &str, _recursive: bool) -> datafusion_data_access::Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_dir_all(&self, _path: &str) -> datafusion_data_access::Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_dir_contents(&self, _path: &str) -> datafusion_data_access::Result<()> {
+        unimplemented!();
+    }
+
+    async fn remove_file(&self, _path: &str) -> datafusion_data_access::Result<()> {
+        unimplemented!();
+    }
+
+    async fn rename(&self, _source: &str, _dest: &str) -> datafusion_data_access::Result<()> {
+        unimplemented!();
+    }
+
+    async fn copy(&self, _source: &str, _dest: &str) -> datafusion_data_access::Result<()> {
+        unimplemented!();
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2185.

 # Rationale for this change

This PR adds other filesystem operations so we can build writers without each writer having to re-implement details of each filesystem. The API design was based on the [C++ Arrow filesystem](https://github.com/apache/arrow/blob/master/cpp/src/arrow/filesystem/filesystem.h) with the method names altered to match canonical Rust names from `std::fs`.

# What changes are included in this PR?

 * [x] Add writer to `ObjectStore` trait
 * [x] Implement writer for local filesystem
 * [x] Add delete functions to `ObjectStore` trait
 * [x] Implement delete functions for local filesystem

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
