### PR TITLE
minor: move field_util from `physical-expr` crate to `expr` crate

### DIFF
--- a/datafusion/core/src/logical_plan/expr_schema.rs
+++ b/datafusion/core/src/logical_plan/expr_schema.rs
@@ -22,7 +22,7 @@ use crate::physical_plan::{
 use arrow::compute::can_cast_types;
 use arrow::datatypes::DataType;
 use datafusion_common::{DFField, DFSchema, DataFusionError, ExprSchema, Result};
-use datafusion_physical_expr::field_util::get_indexed_field;
+use datafusion_expr::field_util::get_indexed_field;
 
 /// trait to allow expr to typable with respect to a schema
 pub trait ExprSchemable {

--- a/datafusion/expr/src/field_util.rs
+++ b/datafusion/expr/src/field_util.rs
@@ -18,8 +18,7 @@
 //! Utility functions for complex field access
 
 use arrow::datatypes::{DataType, Field};
-use datafusion_common::ScalarValue;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, ScalarValue};
 
 /// Returns the field access indexed by `key` from a [`DataType::List`] or [`DataType::Struct`]
 /// # Error

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -21,6 +21,7 @@ mod built_in_function;
 mod columnar_value;
 pub mod expr;
 pub mod expr_fn;
+pub mod field_util;
 mod function;
 mod literal;
 mod operator;

--- a/datafusion/physical-expr/src/expressions/get_indexed_field.rs
+++ b/datafusion/physical-expr/src/expressions/get_indexed_field.rs
@@ -17,7 +17,7 @@
 
 //! get field of a `ListArray`
 
-use crate::{field_util::get_indexed_field as get_data_type_field, PhysicalExpr};
+use crate::PhysicalExpr;
 use arrow::array::Array;
 use arrow::array::{ListArray, StructArray};
 use arrow::compute::concat;
@@ -28,7 +28,9 @@ use arrow::{
 use datafusion_common::DataFusionError;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
-use datafusion_expr::ColumnarValue;
+use datafusion_expr::{
+    field_util::get_indexed_field as get_data_type_field, ColumnarValue,
+};
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::{any::Any, sync::Arc};

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -23,7 +23,6 @@ pub mod conditional_expressions;
 pub mod crypto_expressions;
 pub mod datetime_expressions;
 pub mod expressions;
-pub mod field_util;
 mod functions;
 mod hyperloglog;
 pub mod math_expressions;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/issues/2247

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

field_utils does not refer to physical expressions so there is no need for it to be in the `physical-expr` crate. Moving this to the `expr` crate removes one LogicalPlan dependency on the physical-expr crate.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Move field_utils.rs from `physical-expr` crate to `expr` crate.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
