### PR TITLE
fix string coercion missing in Eq/NotEq operator

### DIFF
--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -959,6 +959,30 @@ async fn parallel_query_with_filter() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_with_filter_string_type_coercion() {
+    let large_string_array = LargeStringArray::from(vec!["1", "2", "3", "4", "5"]);
+    let schema =
+        Schema::new(vec![Field::new("large_string", DataType::LargeUtf8, false)]);
+    let batch =
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(large_string_array)])
+            .unwrap();
+
+    let ctx = SessionContext::new();
+    let table = MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap();
+    ctx.register_table("t", Arc::new(table)).unwrap();
+    let sql = "select * from t where large_string = '1'";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+--------------+",
+        "| large_string |",
+        "+--------------+",
+        "| 1            |",
+        "+--------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+}
+
+#[tokio::test]
 async fn query_empty_table() {
     let ctx = SessionContext::new();
     let empty_table = Arc::new(EmptyTable::new(Arc::new(Schema::empty())));

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -980,6 +980,20 @@ async fn query_with_filter_string_type_coercion() {
         "+--------------+",
     ];
     assert_batches_eq!(expected, &actual);
+
+    let sql = "select * from t where large_string != '1'";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+--------------+",
+        "| large_string |",
+        "+--------------+",
+        "| 2            |",
+        "| 3            |",
+        "| 4            |",
+        "| 5            |",
+        "+--------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
 }
 
 #[tokio::test]

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -116,6 +116,7 @@ fn comparison_eq_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
     comparison_binary_numeric_coercion(lhs_type, rhs_type)
         .or_else(|| dictionary_coercion(lhs_type, rhs_type))
         .or_else(|| temporal_coercion(lhs_type, rhs_type))
+        .or_else(|| string_coercion(lhs_type, rhs_type))
 }
 
 fn comparison_order_coercion(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2225.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Suppose `large_string` is a `DataType::LargeUtf8` column in table `t`, sql like
```
select * from t where large_string = '1'
```
will throw an error: `Plan("'LargeUtf8 = Utf8' can't be evaluated because there isn't a common type to coerce the types to")`
This pr fix it.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Introduce `string_coercion` to `comparison_eq_coercion`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
