### PR TITLE
Introduce RowLayout to represent rows for different purposes

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -41,7 +41,7 @@ path = "src/lib.rs"
 # Used to enable the avro format
 avro = ["avro-rs", "num-traits", "datafusion-common/avro"]
 crypto_expressions = ["datafusion-physical-expr/crypto_expressions"]
-default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
+default = ["crypto_expressions", "regex_expressions", "unicode_expressions", "row"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = []
 # Used to enable JIT code generation

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -41,7 +41,7 @@ path = "src/lib.rs"
 # Used to enable the avro format
 avro = ["avro-rs", "num-traits", "datafusion-common/avro"]
 crypto_expressions = ["datafusion-physical-expr/crypto_expressions"]
-default = ["crypto_expressions", "regex_expressions", "unicode_expressions", "row"]
+default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = []
 # Used to enable JIT code generation

--- a/datafusion/core/benches/jit.rs
+++ b/datafusion/core/benches/jit.rs
@@ -23,7 +23,8 @@ extern crate datafusion;
 mod data_utils;
 use crate::criterion::Criterion;
 use crate::data_utils::{create_record_batches, create_schema};
-use datafusion::row::writer::{bench_write_batch, bench_write_batch_jit};
+use datafusion::row::jit::writer::bench_write_compact_batch_jit;
+use datafusion::row::writer::bench_write_compact_batch;
 use std::sync::Arc;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -37,13 +38,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("row serializer", |b| {
         b.iter(|| {
-            criterion::black_box(bench_write_batch(&batches, schema.clone()).unwrap())
+            criterion::black_box(
+                bench_write_compact_batch(&batches, schema.clone()).unwrap(),
+            )
         })
     });
 
     c.bench_function("row serializer jit", |b| {
         b.iter(|| {
-            criterion::black_box(bench_write_batch_jit(&batches, schema.clone()).unwrap())
+            criterion::black_box(
+                bench_write_compact_batch_jit(&batches, schema.clone()).unwrap(),
+            )
         })
     });
 }

--- a/datafusion/core/src/row/jit/mod.rs
+++ b/datafusion/core/src/row/jit/mod.rs
@@ -17,8 +17,8 @@
 
 //! Just-In-Time(JIT) version for row reader and writers
 
-mod reader;
-mod writer;
+pub mod reader;
+pub mod writer;
 
 #[macro_export]
 /// register external functions to the assembler
@@ -44,8 +44,8 @@ fn fn_name<T>(f: T) -> &'static str {
 #[cfg(test)]
 mod tests {
     use crate::error::Result;
-    use crate::row::jit::reader::read_as_batch_jit;
-    use crate::row::jit::writer::write_batch_unchecked_jit;
+    use crate::row::jit::reader::read_compact_rows_as_batch_jit;
+    use crate::row::jit::writer::write_compact_batch_unchecked_jit;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
     use datafusion_jit::api::Assembler;
@@ -64,8 +64,8 @@ mod tests {
                     let mut vector = vec![0; 1024];
                     let assembler = Assembler::default();
                     let row_offsets =
-                        { write_batch_unchecked_jit(&mut vector, 0, &batch, 0, schema.clone(), &assembler)? };
-                    let output_batch = { read_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
+                        { write_compact_batch_unchecked_jit(&mut vector, 0, &batch, 0, schema.clone(), &assembler)? };
+                    let output_batch = { read_compact_rows_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
                     assert_eq!(batch, output_batch);
                     Ok(())
                 }
@@ -80,8 +80,8 @@ mod tests {
                     let mut vector = vec![0; 1024];
                     let assembler = Assembler::default();
                     let row_offsets =
-                        { write_batch_unchecked_jit(&mut vector, 0, &batch, 0, schema.clone(), &assembler)? };
-                    let output_batch = { read_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
+                        { write_compact_batch_unchecked_jit(&mut vector, 0, &batch, 0, schema.clone(), &assembler)? };
+                    let output_batch = { read_compact_rows_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
                     assert_eq!(batch, output_batch);
                     Ok(())
                 }
@@ -183,7 +183,7 @@ mod tests {
         let mut vector = vec![0; 8192];
         let assembler = Assembler::default();
         let row_offsets = {
-            write_batch_unchecked_jit(
+            write_compact_batch_unchecked_jit(
                 &mut vector,
                 0,
                 &batch,
@@ -192,8 +192,9 @@ mod tests {
                 &assembler,
             )?
         };
-        let output_batch =
-            { read_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
+        let output_batch = {
+            read_compact_rows_as_batch_jit(&vector, schema, &row_offsets, &assembler)?
+        };
         assert_eq!(batch, output_batch);
         Ok(())
     }
@@ -207,7 +208,7 @@ mod tests {
         let mut vector = vec![0; 8192];
         let assembler = Assembler::default();
         let row_offsets = {
-            write_batch_unchecked_jit(
+            write_compact_batch_unchecked_jit(
                 &mut vector,
                 0,
                 &batch,
@@ -216,8 +217,9 @@ mod tests {
                 &assembler,
             )?
         };
-        let output_batch =
-            { read_as_batch_jit(&vector, schema, &row_offsets, &assembler)? };
+        let output_batch = {
+            read_compact_rows_as_batch_jit(&vector, schema, &row_offsets, &assembler)?
+        };
         assert_eq!(batch, output_batch);
         Ok(())
     }

--- a/datafusion/core/src/row/jit/reader.rs
+++ b/datafusion/core/src/row/jit/reader.rs
@@ -20,6 +20,7 @@
 use crate::error::{DataFusionError, Result};
 use crate::reg_fn;
 use crate::row::jit::fn_name;
+use crate::row::layout::RowType;
 use crate::row::reader::RowReader;
 use crate::row::reader::*;
 use crate::row::MutableRecordBatch;
@@ -33,7 +34,7 @@ use std::sync::Arc;
 
 /// Read `data` of raw-bytes rows starting at `offsets` out to a record batch
 
-pub fn read_as_batch_jit(
+pub fn read_compact_rows_as_batch_jit(
     data: &[u8],
     schema: Arc<Schema>,
     offsets: &[usize],
@@ -41,7 +42,7 @@ pub fn read_as_batch_jit(
 ) -> Result<RecordBatch> {
     let row_num = offsets.len();
     let mut output = MutableRecordBatch::new(row_num, schema.clone());
-    let mut row = RowReader::new(&schema);
+    let mut row = RowReader::new(&schema, RowType::Compact);
     register_read_functions(assembler)?;
     let gen_func = gen_read_row(&schema, assembler)?;
     let mut jit = assembler.create_jit();

--- a/datafusion/core/src/row/jit/writer.rs
+++ b/datafusion/core/src/row/jit/writer.rs
@@ -20,6 +20,7 @@
 use crate::error::Result;
 use crate::reg_fn;
 use crate::row::jit::fn_name;
+use crate::row::layout::RowType;
 use crate::row::schema_null_free;
 use crate::row::writer::RowWriter;
 use crate::row::writer::*;
@@ -36,7 +37,7 @@ use std::sync::Arc;
 /// # Panics
 ///
 /// This function will panic if the output buffer doesn't have enough space to hold all the rows
-pub fn write_batch_unchecked_jit(
+pub fn write_compact_batch_unchecked_jit(
     output: &mut [u8],
     offset: usize,
     batch: &RecordBatch,
@@ -44,7 +45,7 @@ pub fn write_batch_unchecked_jit(
     schema: Arc<Schema>,
     assembler: &Assembler,
 ) -> Result<Vec<usize>> {
-    let mut writer = RowWriter::new(&schema);
+    let mut writer = RowWriter::new(&schema, RowType::Compact);
     let mut current_offset = offset;
     let mut offsets = vec![];
     register_write_functions(assembler)?;
@@ -71,12 +72,12 @@ pub fn write_batch_unchecked_jit(
 
 /// bench jit version write
 #[inline(never)]
-pub fn bench_write_batch_jit(
+pub fn bench_write_compact_batch_jit(
     batches: &[Vec<RecordBatch>],
     schema: Arc<Schema>,
 ) -> Result<Vec<usize>> {
     let assembler = Assembler::default();
-    let mut writer = RowWriter::new(&schema);
+    let mut writer = RowWriter::new(&schema, RowType::Compact);
     let mut lengths = vec![];
     register_write_functions(&assembler)?;
     let gen_func = gen_write_row(&schema, &assembler)?;

--- a/datafusion/core/src/row/layout.rs
+++ b/datafusion/core/src/row/layout.rs
@@ -17,26 +17,94 @@
 
 //! Various row layout for different use case
 
-use crate::row::{schema_null_free, var_length};
+use crate::row::{row_supported, schema_null_free, var_length};
 use arrow::datatypes::{DataType, Schema};
 use arrow::util::bit_util::{ceil, round_upto_power_of_2};
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 const UTF8_DEFAULT_SIZE: usize = 20;
 const BINARY_DEFAULT_SIZE: usize = 100;
 
+#[derive(Copy, Clone, Debug)]
+/// Type of a RowLayout
+pub enum RowType {
+    /// This type of layout will store each field with minimum bytes for space efficiency.
+    /// Its typical use case represents a sorting payload that accesses all row fields as a unit.
+    Compact,
+    /// This type of layout will store one 8-byte word per field for CPU-friendly,
+    /// It is mainly used to represent the rows with frequently updated content,
+    /// for example, grouping state for hash aggregation.
+    WordAligned,
+    // RawComparable,
+}
+
+/// Reveals how the fields of a record are stored in the raw-bytes format
+pub(crate) struct RowLayout {
+    /// Type of the layout
+    type_: RowType,
+    /// If a row is null free according to its schema
+    pub(crate) null_free: bool,
+    /// The number of bytes used to store null bits for each field.
+    pub(crate) null_width: usize,
+    /// Length in bytes for `values` part of the current tuple.
+    pub(crate) values_width: usize,
+    /// Total number of fields for each tuple.
+    pub(crate) field_count: usize,
+    /// Starting offset for each fields in the raw bytes.
+    pub(crate) field_offsets: Vec<usize>,
+}
+
+impl RowLayout {
+    pub(crate) fn new(schema: &Arc<Schema>, type_: RowType) -> Self {
+        assert!(row_supported(schema));
+        let null_free = schema_null_free(schema);
+        let field_count = schema.fields().len();
+        let null_width = if null_free { 0 } else { ceil(field_count, 8) };
+        let (field_offsets, values_width) = match type_ {
+            RowType::Compact => compact_offsets(null_width, schema),
+            RowType::WordAligned => word_aligned_offsets(null_width, schema),
+        };
+        Self {
+            type_,
+            null_free,
+            null_width,
+            values_width,
+            field_count,
+            field_offsets,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn init_varlena_offset(&self) -> usize {
+        self.null_width + self.values_width
+    }
+}
+
+impl Debug for RowLayout {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RowLayout")
+            .field("type", &self.type_)
+            .field("null_width", &self.null_width)
+            .field("values_width", &self.values_width)
+            .field("field_count", &self.field_count)
+            .field("offsets", &self.field_offsets)
+            .finish()
+    }
+}
+
 /// Get relative offsets for each field and total width for values
-pub fn get_offsets(null_width: usize, schema: &Arc<Schema>) -> (Vec<usize>, usize) {
+fn compact_offsets(null_width: usize, schema: &Arc<Schema>) -> (Vec<usize>, usize) {
     let mut offsets = vec![];
     let mut offset = null_width;
     for f in schema.fields() {
         offsets.push(offset);
-        offset += type_width(f.data_type());
+        offset += compact_type_width(f.data_type());
     }
     (offsets, offset - null_width)
 }
 
-fn type_width(dt: &DataType) -> usize {
+fn compact_type_width(dt: &DataType) -> usize {
     use DataType::*;
     if var_length(dt) {
         return std::mem::size_of::<u64>();
@@ -50,13 +118,23 @@ fn type_width(dt: &DataType) -> usize {
     }
 }
 
+fn word_aligned_offsets(null_width: usize, schema: &Arc<Schema>) -> (Vec<usize>, usize) {
+    let mut offsets = vec![];
+    let mut offset = null_width;
+    for _ in schema.fields() {
+        offsets.push(offset);
+        offset += 8; // a 8-bytes word for each field
+    }
+    (offsets, offset - null_width)
+}
+
 /// Estimate row width based on schema
 pub fn estimate_row_width(schema: &Arc<Schema>) -> usize {
     let null_free = schema_null_free(schema);
     let field_count = schema.fields().len();
     let mut width = if null_free { 0 } else { ceil(field_count, 8) };
     for f in schema.fields() {
-        width += type_width(f.data_type());
+        width += compact_type_width(f.data_type());
         match f.data_type() {
             DataType::Utf8 => width += UTF8_DEFAULT_SIZE,
             DataType::Binary => width += BINARY_DEFAULT_SIZE,

--- a/datafusion/core/src/row/reader.rs
+++ b/datafusion/core/src/row/reader.rs
@@ -18,24 +18,24 @@
 //! Accessing row from raw bytes
 
 use crate::error::{DataFusionError, Result};
-use crate::row::layout::get_offsets;
+use crate::row::layout::{RowLayout, RowType};
 use crate::row::validity::{all_valid, NullBitsFormatter};
-use crate::row::{row_supported, schema_null_free, MutableRecordBatch};
+use crate::row::MutableRecordBatch;
 use arrow::array::*;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use arrow::util::bit_util::{ceil, get_bit_raw};
+use arrow::util::bit_util::get_bit_raw;
 use std::sync::Arc;
 
 /// Read `data` of raw-bytes rows starting at `offsets` out to a record batch
-pub fn read_as_batch(
+pub fn read_compact_rows_as_batch(
     data: &[u8],
     schema: Arc<Schema>,
     offsets: &[usize],
 ) -> Result<RecordBatch> {
     let row_num = offsets.len();
     let mut output = MutableRecordBatch::new(row_num, schema.clone());
-    let mut row = RowReader::new(&schema);
+    let mut row = RowReader::new(&schema, RowType::Compact);
 
     for offset in offsets.iter().take(row_num) {
         row.point_to(*offset, data);
@@ -48,7 +48,7 @@ pub fn read_as_batch(
 macro_rules! get_idx {
     ($NATIVE: ident, $SELF: ident, $IDX: ident, $WIDTH: literal) => {{
         $SELF.assert_index_valid($IDX);
-        let offset = $SELF.field_offsets[$IDX];
+        let offset = $SELF.field_offsets()[$IDX];
         let start = $SELF.base_offset + offset;
         let end = start + $WIDTH;
         $NATIVE::from_le_bytes($SELF.data[start..end].try_into().unwrap())
@@ -60,7 +60,7 @@ macro_rules! fn_get_idx {
         paste::item! {
             fn [<get_ $NATIVE>](&self, idx: usize) -> $NATIVE {
                 self.assert_index_valid(idx);
-                let offset = self.field_offsets[idx];
+                let offset = self.field_offsets()[idx];
                 let start = self.base_offset + offset;
                 let end = start + $WIDTH;
                 $NATIVE::from_le_bytes(self.data[start..end].try_into().unwrap())
@@ -85,32 +85,24 @@ macro_rules! fn_get_idx_opt {
 
 /// Read the tuple `data[base_offset..]` we are currently pointing to
 pub struct RowReader<'a> {
+    /// Layout on how to read each field
+    layout: RowLayout,
     /// Raw bytes slice where the tuple stores
     data: &'a [u8],
     /// Start position for the current tuple in the raw bytes slice.
     base_offset: usize,
-    /// Total number of fields for each tuple.
-    field_count: usize,
-    /// The number of bytes used to store null bits for each field.
-    null_width: usize,
-    /// Starting offset for each fields in the raw bytes.
-    /// For fixed length fields, it's where the actual data stores.
-    /// For variable length fields, it's a pack of (offset << 32 | length) if we use u64.
-    field_offsets: Vec<usize>,
-    /// If a row is null free according to its schema
-    null_free: bool,
 }
 
 impl<'a> std::fmt::Debug for RowReader<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.null_free {
+        if self.null_free() {
             write!(f, "null_free")
         } else {
             let null_bits = self.null_bits();
             write!(
                 f,
                 "{:?}",
-                NullBitsFormatter::new(null_bits, self.field_count)
+                NullBitsFormatter::new(null_bits, self.layout.field_count)
             )
         }
     }
@@ -118,19 +110,11 @@ impl<'a> std::fmt::Debug for RowReader<'a> {
 
 impl<'a> RowReader<'a> {
     /// new
-    pub fn new(schema: &Arc<Schema>) -> Self {
-        assert!(row_supported(schema));
-        let null_free = schema_null_free(schema);
-        let field_count = schema.fields().len();
-        let null_width = if null_free { 0 } else { ceil(field_count, 8) };
-        let (field_offsets, _) = get_offsets(null_width, schema);
+    pub fn new(schema: &Arc<Schema>, type_: RowType) -> Self {
         Self {
+            layout: RowLayout::new(schema, type_),
             data: &[],
             base_offset: 0,
-            field_count,
-            null_width,
-            field_offsets,
-            null_free,
         }
     }
 
@@ -142,26 +126,36 @@ impl<'a> RowReader<'a> {
 
     #[inline]
     fn assert_index_valid(&self, idx: usize) {
-        assert!(idx < self.field_count);
+        assert!(idx < self.layout.field_count);
+    }
+
+    #[inline(always)]
+    fn field_offsets(&self) -> &[usize] {
+        &self.layout.field_offsets
+    }
+
+    #[inline(always)]
+    fn null_free(&self) -> bool {
+        self.layout.null_free
     }
 
     #[inline(always)]
     fn null_bits(&self) -> &[u8] {
-        if self.null_free {
+        if self.null_free() {
             &[]
         } else {
             let start = self.base_offset;
-            &self.data[start..start + self.null_width]
+            &self.data[start..start + self.layout.null_width]
         }
     }
 
     #[inline(always)]
     fn all_valid(&self) -> bool {
-        if self.null_free {
+        if self.null_free() {
             true
         } else {
             let null_bits = self.null_bits();
-            all_valid(null_bits, self.field_count)
+            all_valid(null_bits, self.layout.field_count)
         }
     }
 
@@ -171,14 +165,14 @@ impl<'a> RowReader<'a> {
 
     fn get_bool(&self, idx: usize) -> bool {
         self.assert_index_valid(idx);
-        let offset = self.field_offsets[idx];
+        let offset = self.field_offsets()[idx];
         let value = &self.data[self.base_offset + offset..];
         value[0] != 0
     }
 
     fn get_u8(&self, idx: usize) -> u8 {
         self.assert_index_valid(idx);
-        let offset = self.field_offsets[idx];
+        let offset = self.field_offsets()[idx];
         self.data[self.base_offset + offset]
     }
 
@@ -258,7 +252,7 @@ impl<'a> RowReader<'a> {
 
 /// Read the row currently pointed by RowWriter to the output columnar batch buffer
 pub fn read_row(row: &RowReader, batch: &mut MutableRecordBatch, schema: &Arc<Schema>) {
-    if row.null_free || row.all_valid() {
+    if row.all_valid() {
         for ((col_idx, to), field) in batch
             .arrays
             .iter_mut()

--- a/datafusion/core/src/row/writer.rs
+++ b/datafusion/core/src/row/writer.rs
@@ -18,12 +18,12 @@
 //! Reusable row writer backed by Vec<u8> to stitch attributes together
 
 use crate::error::Result;
-use crate::row::layout::{estimate_row_width, get_offsets};
-use crate::row::{fixed_size, row_supported, schema_null_free};
+use crate::row::fixed_size;
+use crate::row::layout::{estimate_row_width, RowLayout, RowType};
 use arrow::array::*;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use arrow::util::bit_util::{ceil, round_upto_power_of_2, set_bit_raw, unset_bit_raw};
+use arrow::util::bit_util::{round_upto_power_of_2, set_bit_raw, unset_bit_raw};
 use std::cmp::max;
 use std::sync::Arc;
 
@@ -31,14 +31,14 @@ use std::sync::Arc;
 /// # Panics
 ///
 /// This function will panic if the output buffer doesn't have enough space to hold all the rows
-pub fn write_batch_unchecked(
+pub fn write_compact_batch_unchecked(
     output: &mut [u8],
     offset: usize,
     batch: &RecordBatch,
     row_idx: usize,
     schema: Arc<Schema>,
 ) -> Vec<usize> {
-    let mut writer = RowWriter::new(&schema);
+    let mut writer = RowWriter::new(&schema, RowType::Compact);
     let mut current_offset = offset;
     let mut offsets = vec![];
     let columns = batch.columns();
@@ -55,11 +55,11 @@ pub fn write_batch_unchecked(
 
 /// bench interpreted version write
 #[inline(never)]
-pub fn bench_write_batch(
+pub fn bench_write_compact_batch(
     batches: &[Vec<RecordBatch>],
     schema: Arc<Schema>,
 ) -> Result<Vec<usize>> {
-    let mut writer = RowWriter::new(&schema);
+    let mut writer = RowWriter::new(&schema, RowType::Compact);
     let mut lengths = vec![];
 
     for batch in batches.iter().flatten() {
@@ -77,7 +77,7 @@ pub fn bench_write_batch(
 macro_rules! set_idx {
     ($WIDTH: literal, $SELF: ident, $IDX: ident, $VALUE: ident) => {{
         $SELF.assert_index_valid($IDX);
-        let offset = $SELF.field_offsets[$IDX];
+        let offset = $SELF.field_offsets()[$IDX];
         $SELF.data[offset..offset + $WIDTH].copy_from_slice(&$VALUE.to_le_bytes());
     }};
 }
@@ -87,7 +87,7 @@ macro_rules! fn_set_idx {
         paste::item! {
             fn [<set_ $NATIVE>](&mut self, idx: usize, value: $NATIVE) {
                 self.assert_index_valid(idx);
-                let offset = self.field_offsets[idx];
+                let offset = self.field_offsets()[idx];
                 self.data[offset..offset + $WIDTH].copy_from_slice(&value.to_le_bytes());
             }
         }
@@ -96,51 +96,34 @@ macro_rules! fn_set_idx {
 
 /// Reusable row writer backed by Vec<u8>
 pub struct RowWriter {
+    /// Layout on how to write each field
+    layout: RowLayout,
     /// buffer for the current tuple been written.
     data: Vec<u8>,
-    /// Total number of fields for each tuple.
-    field_count: usize,
     /// Length in bytes for the current tuple, 8-bytes word aligned.
     pub(crate) row_width: usize,
-    /// The number of bytes used to store null bits for each field.
-    null_width: usize,
-    /// Length in bytes for `values` part of the current tuple.
-    values_width: usize,
     /// Length in bytes for `variable length data` part of the current tuple.
     varlena_width: usize,
     /// Current offset for the next variable length field to write to.
     varlena_offset: usize,
-    /// Starting offset for each fields in the raw bytes.
-    /// For fixed length fields, it's where the actual data stores.
-    /// For variable length fields, it's a pack of (offset << 32 | length) if we use u64.
-    field_offsets: Vec<usize>,
-    /// If a row is null free according to its schema
-    null_free: bool,
 }
 
 impl RowWriter {
     /// new
-    pub fn new(schema: &Arc<Schema>) -> Self {
-        assert!(row_supported(schema));
-        let null_free = schema_null_free(schema);
-        let field_count = schema.fields().len();
-        let null_width = if null_free { 0 } else { ceil(field_count, 8) };
-        let (field_offsets, values_width) = get_offsets(null_width, schema);
+    pub fn new(schema: &Arc<Schema>, type_: RowType) -> Self {
+        let layout = RowLayout::new(schema, type_);
         let mut init_capacity = estimate_row_width(schema);
         if !fixed_size(schema) {
             // double the capacity to avoid repeated resize
             init_capacity *= 2;
         }
+        let varlena_offset = layout.init_varlena_offset();
         Self {
+            layout,
             data: vec![0; init_capacity],
-            field_count,
             row_width: 0,
-            null_width,
-            values_width,
             varlena_width: 0,
-            varlena_offset: null_width + values_width,
-            field_offsets,
-            null_free,
+            varlena_offset,
         }
     }
 
@@ -149,20 +132,30 @@ impl RowWriter {
         self.data.fill(0);
         self.row_width = 0;
         self.varlena_width = 0;
-        self.varlena_offset = self.null_width + self.values_width;
+        self.varlena_offset = self.layout.init_varlena_offset();
     }
 
     #[inline]
     fn assert_index_valid(&self, idx: usize) {
-        assert!(idx < self.field_count);
+        assert!(idx < self.layout.field_count);
+    }
+
+    #[inline(always)]
+    fn field_offsets(&self) -> &[usize] {
+        &self.layout.field_offsets
+    }
+
+    #[inline(always)]
+    fn null_free(&self) -> bool {
+        self.layout.null_free
     }
 
     pub(crate) fn set_null_at(&mut self, idx: usize) {
         assert!(
-            !self.null_free,
+            !self.null_free(),
             "Unexpected call to set_null_at on null-free row writer"
         );
-        let null_bits = &mut self.data[0..self.null_width];
+        let null_bits = &mut self.data[0..self.layout.null_width];
         unsafe {
             unset_bit_raw(null_bits.as_mut_ptr(), idx);
         }
@@ -170,10 +163,10 @@ impl RowWriter {
 
     pub(crate) fn set_non_null_at(&mut self, idx: usize) {
         assert!(
-            !self.null_free,
+            !self.null_free(),
             "Unexpected call to set_non_null_at on null-free row writer"
         );
-        let null_bits = &mut self.data[0..self.null_width];
+        let null_bits = &mut self.data[0..self.layout.null_width];
         unsafe {
             set_bit_raw(null_bits.as_mut_ptr(), idx);
         }
@@ -181,13 +174,13 @@ impl RowWriter {
 
     fn set_bool(&mut self, idx: usize, value: bool) {
         self.assert_index_valid(idx);
-        let offset = self.field_offsets[idx];
+        let offset = self.field_offsets()[idx];
         self.data[offset] = if value { 1 } else { 0 };
     }
 
     fn set_u8(&mut self, idx: usize, value: u8) {
         self.assert_index_valid(idx);
-        let offset = self.field_offsets[idx];
+        let offset = self.field_offsets()[idx];
         self.data[offset] = value;
     }
 
@@ -202,7 +195,7 @@ impl RowWriter {
 
     fn set_i8(&mut self, idx: usize, value: i8) {
         self.assert_index_valid(idx);
-        let offset = self.field_offsets[idx];
+        let offset = self.field_offsets()[idx];
         self.data[offset] = value.to_le_bytes()[0];
     }
 
@@ -241,7 +234,7 @@ impl RowWriter {
     }
 
     fn current_width(&self) -> usize {
-        self.null_width + self.values_width + self.varlena_width
+        self.layout.init_varlena_offset() + self.varlena_width
     }
 
     /// End each row at 8-byte word boundary.
@@ -267,7 +260,7 @@ pub fn write_row(
     columns: &[ArrayRef],
 ) -> usize {
     // Get the row from the batch denoted by row_idx
-    if row.null_free {
+    if row.null_free() {
         for ((i, f), col) in schema.fields().iter().enumerate().zip(columns.iter()) {
             write_field(i, row_idx, col, f.data_type(), row);
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

The second part of #2189.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To support an 8-byte aligned row layout for grouping states of hash aggregation.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Enable the reading and writing raw-bytes rows with two possible layouts.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
An API change might have no effects since it's on the optional feature `row`.