### PR TITLE
WIP: `LogicalPlan::TableScan` now refers to table provider by name

### DIFF
--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -269,10 +269,7 @@ impl BallistaContext {
         options: CsvReadOptions<'_>,
     ) -> Result<()> {
         match self.read_csv(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan {
-                table_provider_name,
-                ..
-            }) => {
+            LogicalPlan::TableScan(TableScan { table_name, .. }) => {
                 todo!("ballista context")
                 //self.register_table(name, source)
             }
@@ -287,10 +284,7 @@ impl BallistaContext {
         options: ParquetReadOptions<'_>,
     ) -> Result<()> {
         match self.read_parquet(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan {
-                table_provider_name,
-                ..
-            }) => {
+            LogicalPlan::TableScan(TableScan { table_name, .. }) => {
                 todo!("ballista context")
                 // self.register_table(name, source)
             }
@@ -305,10 +299,7 @@ impl BallistaContext {
         options: AvroReadOptions<'_>,
     ) -> Result<()> {
         match self.read_avro(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan {
-                table_provider_name,
-                ..
-            }) => {
+            LogicalPlan::TableScan(TableScan { table_name, .. }) => {
                 todo!("ballista context")
                 // self.register_table(name, source)
             }

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -269,8 +269,12 @@ impl BallistaContext {
         options: CsvReadOptions<'_>,
     ) -> Result<()> {
         match self.read_csv(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan { source, .. }) => {
-                self.register_table(name, source)
+            LogicalPlan::TableScan(TableScan {
+                table_provider_name,
+                ..
+            }) => {
+                todo!("ballista context")
+                //self.register_table(name, source)
             }
             _ => Err(DataFusionError::Internal("Expected tables scan".to_owned())),
         }
@@ -283,8 +287,12 @@ impl BallistaContext {
         options: ParquetReadOptions<'_>,
     ) -> Result<()> {
         match self.read_parquet(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan { source, .. }) => {
-                self.register_table(name, source)
+            LogicalPlan::TableScan(TableScan {
+                table_provider_name,
+                ..
+            }) => {
+                todo!("ballista context")
+                // self.register_table(name, source)
             }
             _ => Err(DataFusionError::Internal("Expected tables scan".to_owned())),
         }
@@ -297,8 +305,12 @@ impl BallistaContext {
         options: AvroReadOptions<'_>,
     ) -> Result<()> {
         match self.read_avro(path, options).await?.to_logical_plan() {
-            LogicalPlan::TableScan(TableScan { source, .. }) => {
-                self.register_table(name, source)
+            LogicalPlan::TableScan(TableScan {
+                table_provider_name,
+                ..
+            }) => {
+                todo!("ballista context")
+                // self.register_table(name, source)
             }
             _ => Err(DataFusionError::Internal("Expected tables scan".to_owned())),
         }

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -177,7 +177,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
 
         let schema: Schema = self.plan.schema().as_ref().clone().into();
-        let mut catalog_list: Arc<dyn CatalogList> = Arc::new(MemoryCatalogList::new());
+        let catalog_list: Arc<dyn CatalogList> = Arc::new(MemoryCatalogList::new());
         println!(
             "ballista catalogs BEFORE decoding logical plan: {:?}",
             catalog_list.catalog_names()

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -165,7 +165,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     async fn execute(
         &self,
         partition: usize,
-        task_context: Arc<TaskContext>,
+        _task_context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
 

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -1197,7 +1197,7 @@ mod roundtrip_tests {
                 4,
             )
             .await
-            .and_then(|plan| plan.sort(vec![col("salary")]))
+            .and_then(|plan| plan.builder.sort(vec![col("salary")]))
             .and_then(|plan| plan.build())
             .map_err(BallistaError::DataFusionError)?,
         );
@@ -1290,7 +1290,7 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.builder.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(true, true))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -1303,7 +1303,7 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.builder.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(false, true))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -1333,7 +1333,7 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.builder.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(true, false))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -1346,7 +1346,7 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.builder.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(false, false))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -1387,7 +1387,10 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.join(&scan_plan, JoinType::Inner, (vec!["id"], vec!["id"])))
+        .and_then(|plan| {
+            plan.builder
+                .join(&scan_plan, JoinType::Inner, (vec!["id"], vec!["id"]))
+        })
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
 
@@ -1413,7 +1416,7 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.builder.sort(vec![col("salary")]))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
 
@@ -1457,7 +1460,10 @@ mod roundtrip_tests {
             4,
         )
         .await
-        .and_then(|plan| plan.aggregate(vec![col("state")], vec![max(col("salary"))]))
+        .and_then(|plan| {
+            plan.builder
+                .aggregate(vec![col("state")], vec![max(col("salary"))])
+        })
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
 

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -730,7 +730,7 @@ mod tests {
 
         let proto = LogicalPlanNode::try_from_logical_plan(
             &topk_plan,
-            ctx.state.read().execution_props.catalog_list.as_ref(),
+            ctx.state.read().catalog_list.as_ref(),
             &extension_codec,
         )?;
         let logical_round_trip = proto.try_into_logical_plan(&ctx, &extension_codec)?;

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -165,7 +165,7 @@ pub(crate) fn parse_physical_expr(
                 .collect::<Result<Vec<_>, _>>()?;
 
             // TODO Do not create new the ExecutionProps
-            let execution_props = ExecutionProps::new();
+            let execution_props = ExecutionProps::default();
 
             let fun_expr = functions::create_physical_fun(
                 &(&scalar_function).into(),

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -1334,7 +1334,7 @@ mod roundtrip_tests {
 
         let input = Arc::new(EmptyExec::new(false, schema.clone()));
 
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
 
         let fun_expr = functions::create_physical_fun(
             &BuiltinScalarFunction::Abs,

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -38,7 +38,7 @@ use datafusion::arrow::{
 };
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::{
-    QueryPlanner, SessionConfig, SessionContext, SessionState,
+    ExecutionProps, QueryPlanner, SessionConfig, SessionContext, SessionState,
 };
 use datafusion::logical_plan::LogicalPlan;
 

--- a/ballista/rust/core/src/utils.rs
+++ b/ballista/rust/core/src/utils.rs
@@ -38,7 +38,7 @@ use datafusion::arrow::{
 };
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::{
-    ExecutionProps, QueryPlanner, SessionConfig, SessionContext, SessionState,
+    QueryPlanner, SessionConfig, SessionContext, SessionState,
 };
 use datafusion::logical_plan::LogicalPlan;
 

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -144,8 +144,6 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
     for agg_func in executor.aggregate_functions.clone() {
         task_aggregate_functions.insert(agg_func.0, agg_func.1);
     }
-    // TODO need to build a catalog list from the task definition
-    let catalog_list = Arc::new(MemoryCatalogList::default());
     let task_context = Arc::new(TaskContext::new(
         task_id_log.clone(),
         session_id,
@@ -153,7 +151,6 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
         task_scalar_functions,
         task_aggregate_functions,
         runtime.clone(),
-        // catalog_list,
     ));
 
     let plan: Arc<dyn ExecutionPlan> =

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -153,7 +153,7 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
         task_scalar_functions,
         task_aggregate_functions,
         runtime.clone(),
-        catalog_list,
+        // catalog_list,
     ));
 
     let plan: Arc<dyn ExecutionPlan> =

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -36,6 +36,7 @@ use ballista_core::error::BallistaError;
 use ballista_core::serde::physical_plan::from_proto::parse_protobuf_hash_partitioning;
 use ballista_core::serde::scheduler::ExecutorSpecification;
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan, BallistaCodec};
+use datafusion::catalog::catalog::MemoryCatalogList;
 use datafusion::execution::context::TaskContext;
 
 pub async fn poll_loop<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
@@ -143,6 +144,8 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
     for agg_func in executor.aggregate_functions.clone() {
         task_aggregate_functions.insert(agg_func.0, agg_func.1);
     }
+    // TODO need to build a catalog list from the task definition
+    let catalog_list = Arc::new(MemoryCatalogList::default());
     let task_context = Arc::new(TaskContext::new(
         task_id_log.clone(),
         session_id,
@@ -150,6 +153,7 @@ async fn run_received_tasks<T: 'static + AsLogicalPlan, U: 'static + AsExecution
         task_scalar_functions,
         task_aggregate_functions,
         runtime.clone(),
+        catalog_list,
     ));
 
     let plan: Arc<dyn ExecutionPlan> =

--- a/ballista/rust/executor/src/executor.rs
+++ b/ballista/rust/executor/src/executor.rs
@@ -25,6 +25,7 @@ use ballista_core::error::BallistaError;
 use ballista_core::execution_plans::ShuffleWriterExec;
 use ballista_core::serde::protobuf;
 use ballista_core::serde::protobuf::ExecutorRegistration;
+use datafusion::catalog::catalog::CatalogList;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -38,6 +38,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::scheduler::ExecutorState;
 use ballista_core::serde::{AsExecutionPlan, AsLogicalPlan, BallistaCodec};
+use datafusion::catalog::catalog::MemoryCatalogList;
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 
@@ -196,6 +197,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
         for agg_func in self.executor.aggregate_functions.clone() {
             task_aggregate_functions.insert(agg_func.0, agg_func.1);
         }
+        // TODO need to build a catalog list from the task definition
+        let catalog_list = Arc::new(MemoryCatalogList::default());
         let task_context = Arc::new(TaskContext::new(
             task_id_log.clone(),
             session_id,
@@ -203,6 +206,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             task_scalar_functions,
             task_aggregate_functions,
             runtime.clone(),
+            catalog_list,
         ));
 
         let encoded_plan = &task.plan.as_slice();

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -206,7 +206,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             task_scalar_functions,
             task_aggregate_functions,
             runtime.clone(),
-            catalog_list,
+            // catalog_list,
         ));
 
         let encoded_plan = &task.plan.as_slice();

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -197,8 +197,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
         for agg_func in self.executor.aggregate_functions.clone() {
             task_aggregate_functions.insert(agg_func.0, agg_func.1);
         }
-        // TODO need to build a catalog list from the task definition
-        let catalog_list = Arc::new(MemoryCatalogList::default());
         let task_context = Arc::new(TaskContext::new(
             task_id_log.clone(),
             session_id,
@@ -206,7 +204,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             task_scalar_functions,
             task_aggregate_functions,
             runtime.clone(),
-            // catalog_list,
         ));
 
         let encoded_plan = &task.plan.as_slice();

--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -603,6 +603,7 @@ mod test {
 
         LogicalPlanBuilder::scan_empty(None, &schema, Some(vec![0, 1]))
             .unwrap()
+            .builder
             .aggregate(vec![col("id")], vec![sum(col("gmv"))])
             .unwrap()
             .build()

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1428,6 +1428,7 @@ mod tests {
             let proto: protobuf::LogicalPlanNode =
                 protobuf::LogicalPlanNode::try_from_logical_plan(
                     &plan,
+                    ctx.state.read().execution_props.catalog_list.as_ref(),
                     codec.logical_extension_codec(),
                 )
                 .unwrap();
@@ -1445,6 +1446,7 @@ mod tests {
             let proto: protobuf::LogicalPlanNode =
                 protobuf::LogicalPlanNode::try_from_logical_plan(
                     &plan,
+                    ctx.state.read().execution_props.catalog_list.as_ref(),
                     codec.logical_extension_codec(),
                 )
                 .unwrap();

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1394,7 +1394,7 @@ mod tests {
             let config = SessionConfig::new()
                 .with_target_partitions(1)
                 .with_batch_size(10);
-            let ctx = SessionContext::with_config(config);
+            let ctx = SessionContext::with_config(config.clone());
             let codec: BallistaCodec<
                 protobuf::LogicalPlanNode,
                 protobuf::PhysicalPlanNode,
@@ -1432,8 +1432,10 @@ mod tests {
                     codec.logical_extension_codec(),
                 )
                 .unwrap();
+
+            let round_trip_ctx = SessionContext::with_config(config.clone());
             let round_trip: LogicalPlan = (&proto)
-                .try_into_logical_plan(&ctx, codec.logical_extension_codec())
+                .try_into_logical_plan(&round_trip_ctx, codec.logical_extension_codec())
                 .unwrap();
             assert_eq!(
                 format!("{:?}", plan),
@@ -1450,8 +1452,10 @@ mod tests {
                     codec.logical_extension_codec(),
                 )
                 .unwrap();
+
+            let round_trip_ctx = SessionContext::with_config(config.clone());
             let round_trip: LogicalPlan = (&proto)
-                .try_into_logical_plan(&ctx, codec.logical_extension_codec())
+                .try_into_logical_plan(&round_trip_ctx, codec.logical_extension_codec())
                 .unwrap();
             assert_eq!(
                 format!("{:?}", plan),
@@ -1495,16 +1499,15 @@ mod tests {
             };
         }
 
-        //TODO
-        // test_round_trip!(q1, 1);
-        // test_round_trip!(q3, 3);
-        // test_round_trip!(q5, 5);
-        // test_round_trip!(q6, 6);
-        // test_round_trip!(q7, 7);
-        // test_round_trip!(q8, 8);
-        // test_round_trip!(q9, 9);
-        // test_round_trip!(q10, 10);
-        // test_round_trip!(q12, 12);
-        // test_round_trip!(q13, 13);
+        test_round_trip!(q1, 1);
+        test_round_trip!(q3, 3);
+        test_round_trip!(q5, 5);
+        test_round_trip!(q6, 6);
+        test_round_trip!(q7, 7);
+        test_round_trip!(q8, 8);
+        test_round_trip!(q9, 9);
+        test_round_trip!(q10, 10);
+        test_round_trip!(q12, 12);
+        test_round_trip!(q13, 13);
     }
 }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1493,15 +1493,16 @@ mod tests {
             };
         }
 
-        test_round_trip!(q1, 1);
-        test_round_trip!(q3, 3);
-        test_round_trip!(q5, 5);
-        test_round_trip!(q6, 6);
-        test_round_trip!(q7, 7);
-        test_round_trip!(q8, 8);
-        test_round_trip!(q9, 9);
-        test_round_trip!(q10, 10);
-        test_round_trip!(q12, 12);
-        test_round_trip!(q13, 13);
+        //TODO
+        // test_round_trip!(q1, 1);
+        // test_round_trip!(q3, 3);
+        // test_round_trip!(q5, 5);
+        // test_round_trip!(q6, 6);
+        // test_round_trip!(q7, 7);
+        // test_round_trip!(q8, 8);
+        // test_round_trip!(q9, 9);
+        // test_round_trip!(q10, 10);
+        // test_round_trip!(q12, 12);
+        // test_round_trip!(q13, 13);
     }
 }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1308,15 +1308,6 @@ mod tests {
         }
 
         let plan = create_logical_plan(&ctx, n)?;
-        println!("state: {:?}", ctx.state.read().catalog_list.catalog_names());
-        println!(
-            "props: {:?}",
-            ctx.state
-                .read()
-                .execution_props
-                .catalog_list
-                .catalog_names()
-        );
         execute_query(&ctx, &plan, false).await?;
 
         Ok(())
@@ -1437,7 +1428,7 @@ mod tests {
             let proto: protobuf::LogicalPlanNode =
                 protobuf::LogicalPlanNode::try_from_logical_plan(
                     &plan,
-                    ctx.state.read().execution_props.catalog_list.as_ref(),
+                    ctx.state.read().catalog_list.as_ref(),
                     codec.logical_extension_codec(),
                 )
                 .unwrap();
@@ -1455,7 +1446,7 @@ mod tests {
             let proto: protobuf::LogicalPlanNode =
                 protobuf::LogicalPlanNode::try_from_logical_plan(
                     &plan,
-                    ctx.state.read().execution_props.catalog_list.as_ref(),
+                    ctx.state.read().catalog_list.as_ref(),
                     codec.logical_extension_codec(),
                 )
                 .unwrap();

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1308,6 +1308,15 @@ mod tests {
         }
 
         let plan = create_logical_plan(&ctx, n)?;
+        println!("state: {:?}", ctx.state.read().catalog_list.catalog_names());
+        println!(
+            "props: {:?}",
+            ctx.state
+                .read()
+                .execution_props
+                .catalog_list
+                .catalog_names()
+        );
         execute_query(&ctx, &plan, false).await?;
 
         Ok(())

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -100,9 +100,9 @@ use super::options::{
 };
 
 /// The default catalog name - this impacts what SQL queries use if not specified
-const DEFAULT_CATALOG: &str = "datafusion";
+pub const DEFAULT_CATALOG: &str = "datafusion";
 /// The default schema name - this impacts what SQL queries use if not specified
-const DEFAULT_SCHEMA: &str = "public";
+pub const DEFAULT_SCHEMA: &str = "public";
 
 /// SessionContext is the main interface for executing queries with DataFusion. It stands for
 /// the connection between user and DataFusion/Ballista cluster.
@@ -1456,8 +1456,6 @@ pub struct TaskContext {
     aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     /// Runtime environment associated with this task context
     runtime: Arc<RuntimeEnv>,
-    /// Catalog for table provider discovery
-    pub catalog_list: Arc<dyn CatalogList>,
 }
 
 impl TaskContext {
@@ -1469,7 +1467,7 @@ impl TaskContext {
         scalar_functions: HashMap<String, Arc<ScalarUDF>>,
         aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
         runtime: Arc<RuntimeEnv>,
-        catalog_list: Arc<dyn CatalogList>,
+        // catalog_list: Arc<dyn CatalogList>,
     ) -> Self {
         Self {
             task_id: Some(task_id),
@@ -1478,7 +1476,7 @@ impl TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
-            catalog_list,
+            // catalog_list,
         }
     }
 
@@ -1555,7 +1553,6 @@ impl From<&SessionContext> for TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
-            catalog_list,
         }
     }
 }
@@ -1576,7 +1573,6 @@ impl From<&SessionState> for TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
-            catalog_list,
         }
     }
 }

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -810,6 +810,7 @@ impl SessionContext {
         let state_cloned = {
             let mut state = self.state.write();
             state.execution_props.start_execution();
+            state.execution_props.catalog_list = state.catalog_list.clone();
 
             // We need to clone `state` to release the lock that is not `Send`. We could
             // make the lock `Send` by using `tokio::sync::Mutex`, but that would require to
@@ -1345,7 +1346,13 @@ impl SessionState {
     where
         F: FnMut(&LogicalPlan, &dyn OptimizerRule),
     {
-        let execution_props = &mut self.execution_props.clone();
+        let mut execution_props = &mut self.execution_props.clone();
+        execution_props.catalog_list = self.catalog_list.clone(); // TODO hacky ?
+
+        println!(
+            "optimize_internal = {:?}",
+            execution_props.catalog_list.catalog_names()
+        );
         let optimizers = &self.optimizers;
 
         let execution_props = execution_props.start_execution();

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1076,20 +1076,22 @@ pub struct ExecutionProps {
     pub(crate) query_execution_start_time: DateTime<Utc>,
     /// providers for scalar variables
     pub var_providers: Option<HashMap<VarType, Arc<dyn VarProvider + Send + Sync>>>,
+    pub table_providers: HashMap<String, Arc<dyn TableProvider>>,
 }
 
 impl Default for ExecutionProps {
     fn default() -> Self {
-        Self::new()
+        Self::new(HashMap::new())
     }
 }
 
 impl ExecutionProps {
     /// Creates a new execution props
-    pub fn new() -> Self {
+    pub fn new(table_providers: HashMap<String, Arc<dyn TableProvider>>) -> Self {
         ExecutionProps {
             query_execution_start_time: chrono::Utc::now(),
             var_providers: None,
+            table_providers,
         }
     }
 
@@ -1226,7 +1228,7 @@ impl SessionState {
             scalar_functions: HashMap::new(),
             aggregate_functions: HashMap::new(),
             config,
-            execution_props: ExecutionProps::new(),
+            execution_props: ExecutionProps::default(),
             runtime_env: runtime,
         }
     }

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1536,13 +1536,12 @@ impl TaskContext {
 impl From<&SessionContext> for TaskContext {
     fn from(session: &SessionContext) -> Self {
         let session_id = session.session_id.clone();
-        let (config, scalar_functions, aggregate_functions, catalog_list) = {
+        let (config, scalar_functions, aggregate_functions) = {
             let session_state = session.state.read();
             (
                 session_state.config.clone(),
                 session_state.scalar_functions.clone(),
                 session_state.aggregate_functions.clone(),
-                session_state.catalog_list.clone(),
             )
         };
         let runtime = session.runtime_env();
@@ -1565,7 +1564,6 @@ impl From<&SessionState> for TaskContext {
         let scalar_functions = state.scalar_functions.clone();
         let aggregate_functions = state.aggregate_functions.clone();
         let runtime = state.runtime_env.clone();
-        let catalog_list = state.catalog_list.clone();
         Self {
             task_id: None,
             session_id,

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -17,7 +17,6 @@
 
 //! This module provides a builder for creating LogicalPlans
 
-use crate::datasource::datasource::TableProviderFilterPushDown;
 use crate::datasource::{
     empty::EmptyTable,
     listing::{ListingTable, ListingTableConfig},

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -95,18 +95,12 @@ pub const UNNAMED_TABLE: &str = "?table?";
 pub struct LogicalPlanBuilder {
     /// The plan that is being built
     plan: LogicalPlan,
-    /// Map of table_provider_name to TableProvider. TableScan structs refer to
-    /// table providers by name
-    pub table_providers: HashMap<String, Arc<dyn TableProvider>>,
 }
 
 impl LogicalPlanBuilder {
     /// Create a builder from an existing plan
     pub fn from(plan: LogicalPlan) -> Self {
-        Self {
-            plan,
-            table_providers: HashMap::new(),
-        }
+        Self { plan }
     }
 
     /// Return the output schema of the plan build so far
@@ -454,23 +448,14 @@ impl LogicalPlanBuilder {
                 DFSchema::try_from_qualified_schema(&table_name, &schema)
             })?;
 
-        // TODO generate unique name instead of using table name (which can appear
-        // more than once in the same query)
-        let table_provider_name = format!("_provider_{}", table_name);
-
         let table_scan = LogicalPlan::TableScan(TableScan {
             table_name,
-            table_provider_name: table_provider_name.clone(),
             projected_schema: Arc::new(projected_schema),
             projection,
             filters,
             limit: None,
         });
-        let mut builder = Self::from(table_scan);
-        builder
-            .table_providers
-            .insert(table_provider_name.to_owned(), provider);
-        Ok(builder)
+        Ok(Self::from(table_scan))
     }
     /// Wrap a plan in a window
     pub(crate) fn window_plan(

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -457,6 +457,10 @@ impl LogicalPlanBuilder {
             ));
         }
 
+        //TODO hack so we don't register "employee.csv" as schema "employee" table "csv"
+        // this did not come up before because we accessed TableProvider directly
+        let table_name = table_name.replace(".", "_");
+
         let schema = provider.schema();
 
         let projected_schema = projection

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -17,6 +17,7 @@
 
 //! This module provides a builder for creating LogicalPlans
 
+use crate::datasource::datasource::TableProviderFilterPushDown;
 use crate::datasource::{
     empty::EmptyTable,
     listing::{ListingTable, ListingTableConfig},
@@ -453,6 +454,9 @@ impl LogicalPlanBuilder {
             projected_schema: Arc::new(projected_schema),
             projection,
             filters,
+            full_filters: vec![],
+            partial_filters: vec![],
+            unsupported_filters: vec![],
             limit: None,
         });
         Ok(Self::from(table_scan))

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -130,8 +130,6 @@ pub struct Window {
 pub struct TableScan {
     /// The name of the table
     pub table_name: String,
-    /// The name of the table provider
-    pub table_provider_name: String,
     /// Optional column indices to use as a projection
     pub projection: Option<Vec<usize>>,
     /// The schema description of the output
@@ -950,7 +948,6 @@ impl LogicalPlan {
                     }
 
                     LogicalPlan::TableScan(TableScan {
-                        ref table_provider_name,
                         ref table_name,
                         ref projection,
                         ref filters,

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -776,7 +776,8 @@ impl LogicalPlan {
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap()
+    /// let (plan, _, _) = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap();
+    /// plan
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -817,7 +818,8 @@ impl LogicalPlan {
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap()
+    /// let (plan, _, _) = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap();
+    /// plan
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -857,7 +859,8 @@ impl LogicalPlan {
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo.csv"), &schema, None).unwrap()
+    /// let (plan, _, _) = LogicalPlanBuilder::scan_empty(Some("foo.csv"), &schema, None).unwrap();
+    /// plan
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -1224,18 +1227,19 @@ mod tests {
     }
 
     fn display_plan() -> LogicalPlan {
-        LogicalPlanBuilder::scan_empty(
+        let scan = LogicalPlanBuilder::scan_empty(
             Some("employee_csv"),
             &employee_schema(),
             Some(vec![0, 3]),
         )
-        .unwrap()
-        .filter(col("state").eq(lit("CO")))
-        .unwrap()
-        .project(vec![col("id")])
-        .unwrap()
-        .build()
-        .unwrap()
+        .unwrap();
+        scan.builder
+            .filter(col("state").eq(lit("CO")))
+            .unwrap()
+            .project(vec![col("id")])
+            .unwrap()
+            .build()
+            .unwrap()
     }
 
     #[test]
@@ -1535,6 +1539,7 @@ mod tests {
 
         LogicalPlanBuilder::scan_empty(None, &schema, Some(vec![0, 1]))
             .unwrap()
+            .builder
             .filter(col("state").eq(lit("CO")))
             .unwrap()
             .project(vec![col("id")])

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -130,8 +130,8 @@ pub struct Window {
 pub struct TableScan {
     /// The name of the table
     pub table_name: String,
-    /// The source of the table
-    pub source: Arc<dyn TableProvider>,
+    /// The name of the table provider
+    pub table_provider_name: String,
     /// Optional column indices to use as a projection
     pub projection: Option<Vec<usize>>,
     /// The schema description of the output
@@ -950,7 +950,7 @@ impl LogicalPlan {
                     }
 
                     LogicalPlan::TableScan(TableScan {
-                        ref source,
+                        ref table_provider_name,
                         ref table_name,
                         ref projection,
                         ref filters,
@@ -963,41 +963,43 @@ impl LogicalPlan {
                             table_name, projection
                         )?;
 
-                        if !filters.is_empty() {
-                            let mut full_filter = vec![];
-                            let mut partial_filter = vec![];
-                            let mut unsupported_filters = vec![];
-
-                            filters.iter().for_each(|x| {
-                                if let Ok(t) = source.supports_filter_pushdown(x) {
-                                    match t {
-                                        TableProviderFilterPushDown::Exact => {
-                                            full_filter.push(x)
-                                        }
-                                        TableProviderFilterPushDown::Inexact => {
-                                            partial_filter.push(x)
-                                        }
-                                        TableProviderFilterPushDown::Unsupported => {
-                                            unsupported_filters.push(x)
-                                        }
-                                    }
-                                }
-                            });
-
-                            if !full_filter.is_empty() {
-                                write!(f, ", full_filters={:?}", full_filter)?;
-                            };
-                            if !partial_filter.is_empty() {
-                                write!(f, ", partial_filters={:?}", partial_filter)?;
-                            }
-                            if !unsupported_filters.is_empty() {
-                                write!(
-                                    f,
-                                    ", unsupported_filters={:?}",
-                                    unsupported_filters
-                                )?;
-                            }
-                        }
+                        // if !filters.is_empty() {
+                        //     let mut full_filter: Vec<Expr> = vec![];
+                        //     let mut partial_filter: Vec<Expr> = vec![];
+                        //     let mut unsupported_filters: Vec<Expr> = vec![];
+                        //
+                        //     filters.iter().for_each(|x| {
+                        //         // TODO need access to table provider map to do this, or we
+                        //         // need to copy more info into TableScan struct
+                        //         // if let Ok(t) = source.supports_filter_pushdown(x) {
+                        //         //     match t {
+                        //         //         TableProviderFilterPushDown::Exact => {
+                        //         //             full_filter.push(x)
+                        //         //         }
+                        //         //         TableProviderFilterPushDown::Inexact => {
+                        //         //             partial_filter.push(x)
+                        //         //         }
+                        //         //         TableProviderFilterPushDown::Unsupported => {
+                        //         //             unsupported_filters.push(x)
+                        //         //         }
+                        //         //     }
+                        //         // }
+                        //     });
+                        //
+                        //     if !full_filter.is_empty() {
+                        //         write!(f, ", full_filters={:?}", full_filter)?;
+                        //     };
+                        //     if !partial_filter.is_empty() {
+                        //         write!(f, ", partial_filters={:?}", partial_filter)?;
+                        //     }
+                        //     if !unsupported_filters.is_empty() {
+                        //         write!(
+                        //             f,
+                        //             ", unsupported_filters={:?}",
+                        //             unsupported_filters
+                        //         )?;
+                        //     }
+                        // }
 
                         if let Some(n) = limit {
                             write!(f, ", limit={}", n)?;

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -20,8 +20,6 @@
 use super::display::{GraphvizVisitor, IndentVisitor};
 use super::expr::{Column, Expr};
 use super::extension::UserDefinedLogicalNode;
-use crate::datasource::datasource::TableProviderFilterPushDown;
-use crate::datasource::TableProvider;
 use crate::error::DataFusionError;
 use crate::logical_plan::dfschema::DFSchemaRef;
 use crate::sql::parser::FileType;

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -663,17 +663,11 @@ fn replace_common_expr(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{
         avg, binary_expr, col, lit, sum, LogicalPlanBuilder, Operator,
     };
     use crate::test::*;
     use std::iter;
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let optimizer = CommonSubexprEliminate {};
@@ -681,7 +675,7 @@ mod test {
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -660,7 +660,7 @@ mod test {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let optimizer = CommonSubexprEliminate {};
         let optimized_plan = optimizer
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/eliminate_filter.rs
+++ b/datafusion/core/src/optimizer/eliminate_filter.rs
@@ -83,16 +83,9 @@ impl OptimizerRule for EliminateFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::LogicalPlanBuilder;
     use crate::logical_plan::{col, sum};
     use crate::test::*;
-    use std::sync::Arc;
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = EliminateFilter::new();
@@ -100,7 +93,7 @@ mod tests {
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);

--- a/datafusion/core/src/optimizer/eliminate_filter.rs
+++ b/datafusion/core/src/optimizer/eliminate_filter.rs
@@ -88,7 +88,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = EliminateFilter::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/eliminate_limit.rs
+++ b/datafusion/core/src/optimizer/eliminate_limit.rs
@@ -74,16 +74,9 @@ impl OptimizerRule for EliminateLimit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::LogicalPlanBuilder;
     use crate::logical_plan::{col, sum};
     use crate::test::*;
-    use std::sync::Arc;
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = EliminateLimit::new();
@@ -91,7 +84,7 @@ mod tests {
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);

--- a/datafusion/core/src/optimizer/eliminate_limit.rs
+++ b/datafusion/core/src/optimizer/eliminate_limit.rs
@@ -79,7 +79,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = EliminateLimit::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -521,7 +521,7 @@ fn optimize(
             let mut used_columns = HashSet::new();
             let mut new_filters = filters.clone();
 
-            match execution_props.table_providers.get(table_name) {
+            match execution_props.get_table_provider(table_name) {
                 Some(source) => {
                     // TODO consolidate this logic and remove duplication
 
@@ -646,7 +646,6 @@ fn rewrite(expr: &Expr, projection: &HashMap<String, Expr>) -> Result<Expr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datasource::empty::EmptyTable;
     use crate::datasource::TableProvider;
     use crate::logical_plan::{
         lit, sum, union_with_alias, DFSchema, Expr, LogicalPlanBuilder, Operator,
@@ -659,11 +658,7 @@ mod tests {
 
     fn optimize_plan(plan: &LogicalPlan) -> LogicalPlan {
         let rule = FilterPushDown::new();
-        let mut table_providers = HashMap::new();
-        let table_provider: Arc<dyn TableProvider> =
-            Arc::new(EmptyTable::new(SchemaRef::new(test_table_schema())));
-        table_providers.insert("test".to_owned(), table_provider);
-        rule.optimize(plan, &ExecutionProps::new(table_providers))
+        rule.optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan")
     }
 

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -511,7 +511,6 @@ fn optimize(
             optimize_join(state, execution_props, plan, left, right)
         }
         LogicalPlan::TableScan(TableScan {
-            table_provider_name,
             projected_schema,
             filters,
             projection,
@@ -521,7 +520,7 @@ fn optimize(
             let mut used_columns = HashSet::new();
             let mut new_filters = filters.clone();
 
-            match execution_props.table_providers.get(table_provider_name) {
+            match execution_props.table_providers.get(table_name) {
                 Some(source) => {
                     for (filter_expr, cols) in &state.filters {
                         let (preserve_filter_node, add_to_provider) =
@@ -550,7 +549,6 @@ fn optimize(
                         execution_props,
                         used_columns,
                         &LogicalPlan::TableScan(TableScan {
-                            table_provider_name: table_provider_name.clone(),
                             projection: projection.clone(),
                             projected_schema: projected_schema.clone(),
                             table_name: table_name.clone(),
@@ -561,7 +559,7 @@ fn optimize(
                 }
                 _ => Err(DataFusionError::Plan(format!(
                     "No table provider named {}",
-                    table_provider_name
+                    table_name
                 ))),
             }
         }
@@ -1439,7 +1437,6 @@ mod tests {
 
         let table_scan = LogicalPlan::TableScan(TableScan {
             table_name: "test".to_string(),
-            table_provider_name: "test".to_string(),
             filters: vec![],
             projected_schema: Arc::new(DFSchema::try_from(
                 (*test_provider.schema()).clone(),
@@ -1516,7 +1513,6 @@ mod tests {
 
         let table_scan = LogicalPlan::TableScan(TableScan {
             table_name: "test".to_string(),
-            table_provider_name: "test".to_string(),
             filters: vec![col("a").eq(lit(10i64)), col("b").gt(lit(11i64))],
             projected_schema: Arc::new(DFSchema::try_from(
                 (*test_provider.schema()).clone(),

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -654,7 +654,6 @@ fn rewrite(expr: &Expr, projection: &HashMap<String, Expr>) -> Result<Expr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::datasource::TableProvider;
     use crate::logical_plan::{
         lit, sum, union_with_alias, DFSchema, Expr, LogicalPlanBuilder, Operator,
@@ -665,17 +664,12 @@ mod tests {
     use arrow::datatypes::SchemaRef;
     use async_trait::async_trait;
 
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
-
     fn optimize_plan(plan: &LogicalPlan) -> LogicalPlan {
         let rule = FilterPushDown::new();
         rule.optimize(
             plan,
             &ExecutionProps::default(),
-            create_catalog_list().as_ref(),
+            create_test_table_catalog_list().as_ref(),
         )
         .expect("failed to optimize plan")
     }

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -61,7 +61,6 @@ fn limit_push_down(
         (
             LogicalPlan::TableScan(TableScan {
                 table_name,
-                table_provider_name,
                 projection,
                 filters,
                 limit,
@@ -70,7 +69,6 @@ fn limit_push_down(
             Some(upper_limit),
         ) => Ok(LogicalPlan::TableScan(TableScan {
             table_name: table_name.clone(),
-            table_provider_name: table_provider_name.clone(),
             projection: projection.clone(),
             filters: filters.clone(),
             limit: limit

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -169,16 +169,10 @@ impl OptimizerRule for LimitPushDown {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::{
         logical_plan::{col, max, LogicalPlan, LogicalPlanBuilder},
         test::*,
     };
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = LimitPushDown::new();
@@ -186,7 +180,7 @@ mod test {
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -63,6 +63,9 @@ fn limit_push_down(
                 table_name,
                 projection,
                 filters,
+                full_filters,
+                partial_filters,
+                unsupported_filters,
                 limit,
                 projected_schema,
             }),
@@ -71,6 +74,9 @@ fn limit_push_down(
             table_name: table_name.clone(),
             projection: projection.clone(),
             filters: filters.clone(),
+            full_filters: full_filters.clone(),
+            partial_filters: partial_filters.clone(),
+            unsupported_filters: unsupported_filters.clone(),
             limit: limit
                 .map(|x| std::cmp::min(x, upper_limit))
                 .or(Some(upper_limit)),

--- a/datafusion/core/src/optimizer/optimizer.rs
+++ b/datafusion/core/src/optimizer/optimizer.rs
@@ -17,6 +17,7 @@
 
 //! Query optimizer traits
 
+use crate::catalog::catalog::CatalogList;
 use crate::error::Result;
 use crate::execution::context::ExecutionProps;
 use crate::logical_plan::LogicalPlan;
@@ -30,6 +31,7 @@ pub trait OptimizerRule {
         &self,
         plan: &LogicalPlan,
         execution_props: &ExecutionProps,
+        catalog_list: &dyn CatalogList,
     ) -> Result<LogicalPlan>;
 
     /// A human readable name for this optimizer rule

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -345,6 +345,11 @@ fn optimize_plan(
             limit,
             ..
         }) => {
+            println!(
+                "proj push down: {:?}",
+                _execution_props.catalog_list.catalog_names()
+            );
+
             if let Some(source) =
                 get_table_provider(_execution_props.catalog_list.as_ref(), table_name)
             {

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -535,7 +535,6 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{
         col, exprlist_to_fields, lit, max, min, Expr, JoinType, LogicalPlanBuilder,
     };
@@ -1015,12 +1014,7 @@ mod tests {
         rule.optimize(
             plan,
             &ExecutionProps::default(),
-            create_catalog_list().as_ref(),
+            create_test_table_catalog_list().as_ref(),
         )
-    }
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
     }
 }

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -344,7 +344,7 @@ fn optimize_plan(
             limit,
             ..
         }) => {
-            match _execution_props.table_providers.get(table_name) {
+            match _execution_props.get_table_provider(table_name) {
                 Some(source) => {
                     let (projection, projected_schema) = get_projected_schema(
                         Some(table_name),

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -337,12 +337,11 @@ fn optimize_plan(
         // * remove un-used columns from the scan projection
         LogicalPlan::TableScan(TableScan {
             table_name,
-            table_provider_name,
             filters,
             limit,
             ..
         }) => {
-            match _execution_props.table_providers.get(table_provider_name) {
+            match _execution_props.table_providers.get(table_name) {
                 Some(source) => {
                     let (projection, projected_schema) = get_projected_schema(
                         Some(table_name),
@@ -353,7 +352,6 @@ fn optimize_plan(
                     // return the table scan with projection
                     Ok(LogicalPlan::TableScan(TableScan {
                         table_name: table_name.clone(),
-                        table_provider_name: table_provider_name.clone(),
                         projection: Some(projection),
                         projected_schema,
                         filters: filters.clone(),
@@ -362,7 +360,7 @@ fn optimize_plan(
                 }
                 _ => Err(DataFusionError::Execution(format!(
                     "Could not resolve table provider named {}",
-                    table_provider_name
+                    table_name
                 ))),
             }
         }

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -338,6 +338,9 @@ fn optimize_plan(
         LogicalPlan::TableScan(TableScan {
             table_name,
             filters,
+            full_filters,
+            partial_filters,
+            unsupported_filters,
             limit,
             ..
         }) => {
@@ -355,6 +358,9 @@ fn optimize_plan(
                         projection: Some(projection),
                         projected_schema,
                         filters: filters.clone(),
+                        full_filters: full_filters.clone(),
+                        partial_filters: partial_filters.clone(),
+                        unsupported_filters: unsupported_filters.clone(),
                         limit: *limit,
                     }))
                 }

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -740,13 +740,13 @@ mod tests {
 
     use super::*;
     use crate::assert_contains;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{
         and, binary_expr, call_fn, col, create_udf, lit, lit_timestamp_nano, DFField,
         Expr, LogicalPlanBuilder,
     };
     use crate::physical_plan::functions::{make_scalar_function, BuiltinScalarFunction};
     use crate::physical_plan::udf::ScalarUDF;
+    use crate::test::create_test_table_catalog_list;
 
     #[test]
     fn test_simplify_or_true() {
@@ -1512,18 +1512,13 @@ mod tests {
             .expect("building plan")
     }
 
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
-
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SimplifyExpressions::new();
         let optimized_plan = rule
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
@@ -1749,7 +1744,11 @@ mod tests {
         };
 
         let err = rule
-            .optimize(plan, &execution_props, create_catalog_list().as_ref())
+            .optimize(
+                plan,
+                &execution_props,
+                create_test_table_catalog_list().as_ref(),
+            )
             .expect_err("expected optimization to fail");
 
         err.to_string()
@@ -1766,7 +1765,11 @@ mod tests {
         };
 
         let optimized_plan = rule
-            .optimize(plan, &execution_props, create_catalog_list().as_ref())
+            .optimize(
+                plan,
+                &execution_props,
+                create_test_table_catalog_list().as_ref(),
+            )
             .expect("failed to optimize plan");
         return format!("{:?}", optimized_plan);
     }

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -257,7 +257,7 @@ impl SimplifyExpressions {
 /// # use datafusion::optimizer::simplify_expressions::ConstEvaluator;
 /// # use datafusion::execution::context::ExecutionProps;
 ///
-/// let execution_props = ExecutionProps::new();
+/// let execution_props = ExecutionProps::default();
 /// let mut const_evaluator = ConstEvaluator::new(&execution_props);
 ///
 /// // (1 + 2) + a
@@ -1176,6 +1176,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
+            table_providers: HashMap::new(),
         };
 
         let mut const_evaluator = ConstEvaluator::new(&execution_props);
@@ -1201,7 +1202,7 @@ mod tests {
 
     fn simplify(expr: Expr) -> Expr {
         let schema = expr_test_schema();
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
         let info = SimplifyContext::new(vec![&schema], &execution_props);
         expr.simplify(&info).unwrap()
     }
@@ -1512,7 +1513,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SimplifyExpressions::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);
@@ -1734,6 +1735,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
+            table_providers: HashMap::new(),
         };
 
         let err = rule
@@ -1751,6 +1753,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
+            table_providers: HashMap::new(),
         };
 
         let optimized_plan = rule

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -738,6 +738,7 @@ mod tests {
 
     use super::*;
     use crate::assert_contains;
+    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{
         and, binary_expr, call_fn, col, create_udf, lit, lit_timestamp_nano, DFField,
         Expr, LogicalPlanBuilder,
@@ -1176,7 +1177,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
-            table_providers: HashMap::new(),
+            catalog_list: Arc::new(MemoryCatalogList::default()),
         };
 
         let mut const_evaluator = ConstEvaluator::new(&execution_props);
@@ -1735,7 +1736,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
-            table_providers: HashMap::new(),
+            catalog_list: Arc::new(MemoryCatalogList::default()),
         };
 
         let err = rule
@@ -1753,7 +1754,7 @@ mod tests {
         let execution_props = ExecutionProps {
             query_execution_start_time: *date_time,
             var_providers: None,
-            table_providers: HashMap::new(),
+            catalog_list: Arc::new(MemoryCatalogList::default()),
         };
 
         let optimized_plan = rule

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -1508,6 +1508,7 @@ mod tests {
         ]);
         LogicalPlanBuilder::scan_empty(Some("test"), &schema, None)
             .expect("creating scan")
+            .builder
             .build()
             .expect("building plan")
     }

--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -17,6 +17,7 @@
 
 //! single distinct to group by optimizer rule
 
+use crate::catalog::catalog::CatalogList;
 use crate::error::Result;
 use crate::execution::context::ExecutionProps;
 use crate::logical_plan::plan::{Aggregate, Projection};
@@ -189,6 +190,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
         &self,
         plan: &LogicalPlan,
         _execution_props: &ExecutionProps,
+        _catalog_list: &dyn CatalogList,
     ) -> Result<LogicalPlan> {
         optimize(plan)
     }
@@ -200,14 +202,24 @@ impl OptimizerRule for SingleDistinctToGroupBy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{col, count, count_distinct, lit, max, LogicalPlanBuilder};
     use crate::physical_plan::aggregates;
     use crate::test::*;
 
+    fn create_catalog_list() -> Arc<dyn CatalogList> {
+        // TODO populate
+        Arc::new(MemoryCatalogList::default())
+    }
+
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SingleDistinctToGroupBy::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::default())
+            .optimize(
+                plan,
+                &ExecutionProps::default(),
+                create_catalog_list().as_ref(),
+            )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -207,7 +207,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SingleDistinctToGroupBy::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -202,15 +202,9 @@ impl OptimizerRule for SingleDistinctToGroupBy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{col, count, count_distinct, lit, max, LogicalPlanBuilder};
     use crate::physical_plan::aggregates;
     use crate::test::*;
-
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SingleDistinctToGroupBy::new();
@@ -218,7 +212,7 @@ mod tests {
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());

--- a/datafusion/core/src/optimizer/to_approx_perc.rs
+++ b/datafusion/core/src/optimizer/to_approx_perc.rs
@@ -132,7 +132,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = ToApproxPerc::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &ExecutionProps::default())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/to_approx_perc.rs
+++ b/datafusion/core/src/optimizer/to_approx_perc.rs
@@ -17,6 +17,7 @@
 
 //! espression/function to approx_percentile optimizer rule
 
+use crate::catalog::catalog::CatalogList;
 use crate::error::Result;
 use crate::execution::context::ExecutionProps;
 use crate::logical_plan::plan::Aggregate;
@@ -114,6 +115,7 @@ impl OptimizerRule for ToApproxPerc {
         &self,
         plan: &LogicalPlan,
         _execution_props: &ExecutionProps,
+        _catalog_list: &dyn CatalogList,
     ) -> Result<LogicalPlan> {
         optimize(plan)
     }
@@ -125,14 +127,24 @@ impl OptimizerRule for ToApproxPerc {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{col, LogicalPlanBuilder};
     use crate::physical_plan::aggregates;
     use crate::test::*;
+    use std::sync::Arc;
 
+    fn create_catalog_list() -> Arc<dyn CatalogList> {
+        // TODO populate
+        Arc::new(MemoryCatalogList::default())
+    }
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = ToApproxPerc::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::default())
+            .optimize(
+                plan,
+                &ExecutionProps::default(),
+                create_catalog_list().as_ref(),
+            )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/to_approx_perc.rs
+++ b/datafusion/core/src/optimizer/to_approx_perc.rs
@@ -127,23 +127,17 @@ impl OptimizerRule for ToApproxPerc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::catalog::MemoryCatalogList;
     use crate::logical_plan::{col, LogicalPlanBuilder};
     use crate::physical_plan::aggregates;
     use crate::test::*;
-    use std::sync::Arc;
 
-    fn create_catalog_list() -> Arc<dyn CatalogList> {
-        // TODO populate
-        Arc::new(MemoryCatalogList::default())
-    }
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = ToApproxPerc::new();
         let optimized_plan = rule
             .optimize(
                 plan,
                 &ExecutionProps::default(),
-                create_catalog_list().as_ref(),
+                create_test_table_catalog_list().as_ref(),
             )
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -23,6 +23,7 @@ use crate::logical_plan::plan::{
     Aggregate, Analyze, Extension, Filter, Join, Projection, Sort, SubqueryAlias, Window,
 };
 
+use crate::catalog::catalog::CatalogList;
 use crate::logical_plan::{
     build_join_schema, Column, CreateMemoryTable, DFSchemaRef, Expr, ExprVisitable,
     Limit, LogicalPlan, LogicalPlanBuilder, Operator, Partitioning, Recursion,
@@ -108,12 +109,13 @@ pub fn optimize_children(
     optimizer: &impl OptimizerRule,
     plan: &LogicalPlan,
     execution_props: &ExecutionProps,
+    catalog_list: &dyn CatalogList,
 ) -> Result<LogicalPlan> {
     let new_exprs = plan.expressions();
     let new_inputs = plan
         .inputs()
         .into_iter()
-        .map(|plan| optimizer.optimize(plan, execution_props))
+        .map(|plan| optimizer.optimize(plan, execution_props, catalog_list))
         .collect::<Result<Vec<_>>>()?;
 
     from_plan(plan, &new_exprs, &new_inputs)

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -134,7 +134,7 @@ impl PruningPredicate {
         let stat_dfschema = DFSchema::try_from(stat_schema.clone())?;
 
         // TODO allow these properties to be passed in
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
         let predicate_expr = create_physical_expr(
             &logical_predicate_expr,
             &stat_dfschema,

--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -1196,7 +1196,7 @@ mod tests {
         ($FUNC:ident, $ARGS:expr, $EXPECTED:expr, $EXPECTED_TYPE:ty, $DATA_TYPE: ident, $ARRAY_TYPE:ident) => {
             // used to provide type annotation
             let expected: Result<Option<$EXPECTED_TYPE>> = $EXPECTED;
-            let execution_props = ExecutionProps::new();
+            let execution_props = ExecutionProps::default();
 
             // any type works here: we evaluate against a literal of `value`
             let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
@@ -3431,7 +3431,7 @@ mod tests {
 
     #[test]
     fn test_empty_arguments_error() -> Result<()> {
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
         // pick some arbitrary functions to test
@@ -3474,7 +3474,7 @@ mod tests {
 
     #[test]
     fn test_empty_arguments() -> Result<()> {
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
         let funs = [BuiltinScalarFunction::Now, BuiltinScalarFunction::Random];
@@ -3497,7 +3497,7 @@ mod tests {
             Field::new("b", value2.data_type().clone(), false),
         ]);
         let columns: Vec<ArrayRef> = vec![value1, value2];
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
 
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Array,
@@ -3560,7 +3560,7 @@ mod tests {
     fn test_regexp_match() -> Result<()> {
         use arrow::array::ListArray;
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
 
         let col_value: ArrayRef = Arc::new(StringArray::from_slice(&["aaa-555"]));
         let pattern = lit(ScalarValue::Utf8(Some(r".*-(\d*)".to_string())));
@@ -3599,7 +3599,7 @@ mod tests {
     fn test_regexp_match_all_literals() -> Result<()> {
         use arrow::array::ListArray;
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
-        let execution_props = ExecutionProps::new();
+        let execution_props = ExecutionProps::default();
 
         let col_value = lit(ScalarValue::Utf8(Some("aaa-555".to_string())));
         let pattern = lit(ScalarValue::Utf8(Some(r".*-(\d*)".to_string())));

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -22,8 +22,6 @@ use super::{
     aggregates, empty::EmptyExec, expressions::binary, functions,
     hash_join::PartitionMode, udaf, union::UnionExec, values::ValuesExec, windows,
 };
-use crate::catalog::TableReference;
-use crate::datasource::TableProvider;
 use crate::execution::context::{ExecutionProps, SessionState};
 use crate::logical_plan::plan::{
     Aggregate, EmptyRelation, Filter, Join, Projection, Sort, SubqueryAlias, TableScan,
@@ -340,43 +338,16 @@ impl DefaultPhysicalPlanner {
                     filters,
                     limit,
                     ..
-                }) => {
-
-                    // TODO do we have these defined as defaults somewhere?
-                    let mut catalog_name = "datafusion".to_owned();
-                    let mut schema_name = "public".to_owned();
-                    let mut table_ref_name = "".to_owned();
-
-                    let table_ref: TableReference = table_name.as_str().into();
-                    match table_ref {
-                        TableReference::Bare { table } => {
-                            table_ref_name = table.to_string()
-                        }
-                        _ => unimplemented!()
+                }) => match session_state.execution_props.get_table_provider(&table_name) {
+                    Some(t) => {
+                        // Remove all qualifiers from the scan as the provider
+                        // doesn't know (nor should care) how the relation was
+                        // referred to in the query
+                        let filters = unnormalize_cols(filters.iter().cloned());
+                        let unaliased: Vec<Expr> = filters.into_iter().map(unalias).collect();
+                        t.scan(projection, &unaliased, *limit).await
                     }
-
-                    let table_provider: Option<Arc<dyn TableProvider>> = match session_state.catalog_list.catalog(&catalog_name) {
-                         Some(catalog) => match catalog.schema(&schema_name) {
-                            Some(schema) => match schema.table(&table_ref_name) {
-                                Some(table) => Some(table.clone()),
-                                _ => None
-                            }
-                             _ => None
-                         }
-                        _ => None
-                    };
-
-                    match table_provider {
-                        Some(t) => {
-                            // Remove all qualifiers from the scan as the provider
-                            // doesn't know (nor should care) how the relation was
-                            // referred to in the query
-                            let filters = unnormalize_cols(filters.iter().cloned());
-                            let unaliased: Vec<Expr> = filters.into_iter().map(unalias).collect();
-                            t.scan(projection, &unaliased, *limit).await
-                        }
-                        _ => Err(DataFusionError::Plan(format!("No table provider named {}", table_name)))
-                    }
+                    _ => Err(DataFusionError::Plan(format!("No table provider named {}", table_name)))
                 }
                 LogicalPlan::Values(Values {
                     values,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -333,12 +333,13 @@ impl DefaultPhysicalPlanner {
         async move {
             let exec_plan: Result<Arc<dyn ExecutionPlan>> = match logical_plan {
                 LogicalPlan::TableScan (TableScan {
-                    source,
+                    table_provider_name,
                     projection,
                     filters,
                     limit,
                     ..
                 }) => {
+                    let source = session_state.execution_props.table_providers.get(table_provider_name).expect("table provider found"); // TODO error handling
                     // Remove all qualifiers from the scan as the provider
                     // doesn't know (nor should care) how the relation was
                     // referred to in the query

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -22,6 +22,7 @@ use super::{
     aggregates, empty::EmptyExec, expressions::binary, functions,
     hash_join::PartitionMode, udaf, union::UnionExec, values::ValuesExec, windows,
 };
+use crate::catalog::catalog::get_table_provider;
 use crate::execution::context::{ExecutionProps, SessionState};
 use crate::logical_plan::plan::{
     Aggregate, EmptyRelation, Filter, Join, Projection, Sort, SubqueryAlias, TableScan,
@@ -338,7 +339,7 @@ impl DefaultPhysicalPlanner {
                     filters,
                     limit,
                     ..
-                }) => match session_state.execution_props.get_table_provider(&table_name) {
+                }) => match get_table_provider(session_state.execution_props.catalog_list.as_ref(), &table_name) {
                     Some(t) => {
                         // Remove all qualifiers from the scan as the provider
                         // doesn't know (nor should care) how the relation was

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1523,6 +1523,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         // filter clause needs the type coercion rule applied
         .filter(col("c7").lt(lit(5_u8)))?
         .project(vec![col("c1"), col("c2")])?
@@ -1575,6 +1576,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         .filter(col("c7").lt(col("c12")))?
         .build()?;
 
@@ -1619,6 +1621,7 @@ mod tests {
                 1,
             )
             .await?
+            .builder
             .project(vec![case.clone()]);
             let message = format!(
                 "Expression {:?} expected to error due to impossible coercion",
@@ -1719,6 +1722,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         // filter clause needs the type coercion rule applied
         .filter(col("c12").lt(lit(0.05)))?
         .project(vec![col("c1").in_list(list, false)])?
@@ -1741,6 +1745,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         // filter clause needs the type coercion rule applied
         .filter(col("c12").lt(lit(0.05)))?
         .project(vec![col("c12").lt_eq(lit(0.025)).in_list(list, false)])?
@@ -1782,6 +1787,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         .filter(col("c12").lt(lit(0.05)))?
         .project(vec![col("c1").in_list(list, false)])?
         .build()?;
@@ -1810,6 +1816,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         .filter(col("c12").lt(lit(0.05)))?
         .project(vec![col("c1").in_list(list, false)])?
         .build()?;
@@ -1834,6 +1841,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
         .build()?;
 
@@ -1867,6 +1875,7 @@ mod tests {
             1,
         )
         .await?
+        .builder
         .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
         .build()?;
 
@@ -1887,6 +1896,7 @@ mod tests {
         let logical_plan =
             LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
                 .unwrap()
+                .builder
                 .explain(true, false)
                 .unwrap()
                 .build()

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -333,13 +333,13 @@ impl DefaultPhysicalPlanner {
         async move {
             let exec_plan: Result<Arc<dyn ExecutionPlan>> = match logical_plan {
                 LogicalPlan::TableScan (TableScan {
-                    table_provider_name,
+                    table_name,
                     projection,
                     filters,
                     limit,
                     ..
                 }) => {
-                    match session_state.execution_props.table_providers.get(table_provider_name) {
+                    match session_state.execution_props.table_providers.get(table_name) {
                         Some(source) => {
                             // Remove all qualifiers from the scan as the provider
                             // doesn't know (nor should care) how the relation was
@@ -348,7 +348,7 @@ impl DefaultPhysicalPlanner {
                             let unaliased: Vec<Expr> = filters.into_iter().map(unalias).collect();
                             source.scan(projection, &unaliased, *limit).await
                         }
-                        _ => Err(DataFusionError::Plan(format!("No table provider named {}", table_provider_name)))
+                        _ => Err(DataFusionError::Plan(format!("No table provider named {}", table_name)))
                     }
                 }
                 LogicalPlan::Values(Values {

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -345,19 +345,19 @@ impl DefaultPhysicalPlanner {
                     // TODO do we have these defined as defaults somewhere?
                     let mut catalog_name = "datafusion".to_owned();
                     let mut schema_name = "public".to_owned();
-                    let mut table_name = "".to_owned();
+                    let mut table_ref_name = "".to_owned();
 
                     let table_ref: TableReference = table_name.as_str().into();
                     match table_ref {
                         TableReference::Bare { table } => {
-                            table_name = table.to_string()
+                            table_ref_name = table.to_string()
                         }
                         _ => unimplemented!()
                     }
 
                     let table_provider: Option<Arc<dyn TableProvider>> = match session_state.catalog_list.catalog(&catalog_name) {
                          Some(catalog) => match catalog.schema(&schema_name) {
-                            Some(schema) => match schema.table(&table_name) {
+                            Some(schema) => match schema.table(&table_ref_name) {
                                 Some(table) => Some(table.clone()),
                                 _ => None
                             }

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -648,10 +648,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         (Some(cte_plan), _) => Ok(cte_plan.clone()),
                         (_, Some(provider)) => {
                             let scan =
-                                LogicalPlanBuilder::scan(&table_name, provider, None);
+                                LogicalPlanBuilder::scan(&table_name, provider, None)?;
                             let scan = match alias {
-                                Some(ref name) => scan?.alias(name.name.value.as_str()),
-                                _ => scan,
+                                Some(ref name) => {
+                                    scan.builder.alias(name.name.value.as_str())
+                                }
+                                _ => Ok(scan.builder),
                             };
                             scan?.build()
                         }

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -105,13 +105,17 @@ pub fn create_partitioned_csv(
     Ok((tmp_dir.into_path().to_str().unwrap().to_string(), groups))
 }
 
-/// some tests share a common table with different names
-pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
-    let schema = Schema::new(vec![
+pub fn test_table_schema() -> Schema {
+    Schema::new(vec![
         Field::new("a", DataType::UInt32, false),
         Field::new("b", DataType::UInt32, false),
         Field::new("c", DataType::UInt32, false),
-    ]);
+    ])
+}
+
+/// some tests share a common table with different names
+pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
+    let schema = test_table_schema();
     LogicalPlanBuilder::scan_empty(Some(name), &schema, None)?.build()
 }
 

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -213,14 +213,9 @@ async fn custom_source_dataframe() -> Result<()> {
     match &optimized_plan {
         LogicalPlan::Projection(Projection { input, .. }) => match &**input {
             LogicalPlan::TableScan(TableScan {
-                table_provider_name,
-                projected_schema,
-                ..
+                projected_schema, ..
             }) => {
-                let source = builder
-                    .table_providers
-                    .get(table_provider_name)
-                    .expect("table provider found");
+                let source = provider;
                 assert_eq!(source.schema().fields().len(), 2);
                 assert_eq!(projected_schema.fields().len(), 1);
             }

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -501,6 +501,7 @@ impl ContextWithParquet {
         let sql = format!("EXPR only: {:?}", expr);
         let logical_plan = LogicalPlanBuilder::scan("t", self.provider.clone(), None)
             .unwrap()
+            .builder
             .filter(expr)
             .unwrap()
             .build()

--- a/datafusion/core/tests/simplification.rs
+++ b/datafusion/core/tests/simplification.rs
@@ -59,7 +59,7 @@ impl From<DFSchema> for MyInfo {
     fn from(schema: DFSchema) -> Self {
         Self {
             schema,
-            execution_props: ExecutionProps::new(),
+            execution_props: ExecutionProps::default(),
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2247.

**Note that this is an early WIP and not functional yet.**

I am putting up this PR in an early state to get feedback on the general approach.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The logical plan currently depends on the physical plan, which prevents us from moving the logical plan into its own crate alongside the logical expressions (which is needed in order to support subqueries, and also to better support the use case where DataFusion is being used just for SQL query planning and then using a different execution engine).

The reason that the logical plan depends on the physical plan is that LogicalPlan::TableScan has a reference to a TableProvider which has a scan method that returns ExecutionPlan.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] `TableScan` struct no longer has a direct reference to a `TableProvider` instance. The `TableProvider` is looked up when needed, based on `table_name`.
- [x] `CatalogList` is now passed to optimizer rules, allowing tables to be resolved during optimization
- [x] `TableScan` now contains `full_filters`, `partial_filters` and `unsupported_filters` so that we can still show them in `fmt::Display` without having access to the `TableProvider`
- [ ] Fix Ballista serde
- [ ] Update many tests to provide a valid `CatalogList`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this is an API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
