### PR TITLE
trim quoted table name in `FROM` clause when creating relation

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -638,7 +638,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             TableFactor::Table {
                 ref name, alias, ..
             } => {
-                let table_name = name.to_string();
+                // Trim quoted table name: "db_name" -> db_name
+                let table_name = name.to_string().trim_matches('\"').to_string();
                 let cte = ctes.get(&table_name);
                 (
                     match (


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2147. 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Suppose table `t1` has a int-typed column named `id_field`, sql like
```
select * from "t1" where "t1"."id_field" > 1
```
will throw error `thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Plan("No field named 't1.id_field'. Valid fields are '\"t1\".id_field'.")'`
This pr fix it.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Trim quoted table name in `FROM` clause when creating relation, like `"tb_name"` -> `tb_name`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
