### PR TITLE
(NOT FOR MERGING) Patch datafusion to use preview of arrow-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ exclude = ["datafusion-cli"]
 [profile.release]
 codegen-units = 1
 lto = true
+
+
+
+[patch.crates-io]
+arrow = { git = "https://github.com/alamb/arrow-rs.git", branch="alamb/test_null_cast" }


### PR DESCRIPTION
This PR is assist @WinkerDu in https://github.com/apache/arrow-datafusion/issues/1184

Specifically, it patches datafusion to use a version of arrow-rs that is the same as 11.1.0 but contains the code in https://github.com/apache/arrow-rs/pull/1572 

The branch is https://github.com/alamb/arrow-rs/tree/alamb/test_null_cast

I created it by cherry-picking https://github.com/apache/arrow-rs/commit/8bed7ea9d7c7f16cf9987a7150b4b4ec614ae723 to a branch based on 11.1.0 tag:


```shell
git checkout 11.1.0
git checkout -b alamb/test_null_cast
git cherry-pick 8bed7ea 
```