### PR TITLE
Add bytes scanned metric to ParquetExec

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -88,6 +88,8 @@ struct ParquetFileMetrics {
     pub predicate_evaluation_errors: metrics::Count,
     /// Number of row groups pruned using
     pub row_groups_pruned: metrics::Count,
+    /// Total number of bytes scanned
+    pub bytes_scanned: metrics::Count,
 }
 
 impl ParquetExec {
@@ -152,9 +154,14 @@ impl ParquetFileMetrics {
             .with_new_label("filename", filename.to_string())
             .counter("row_groups_pruned", partition);
 
+        let bytes_scanned = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .counter("bytes_scanned", partition);
+
         Self {
             predicate_evaluation_errors,
             row_groups_pruned,
+            bytes_scanned,
         }
     }
 }
@@ -326,6 +333,7 @@ impl ParquetExecStream {
             file.file_meta.path(),
             &self.metrics,
         );
+        let bytes_scanned = file_metrics.bytes_scanned.clone();
         let object_reader = self
             .object_store
             .file_reader(file.file_meta.sized_file.clone())?;
@@ -347,7 +355,10 @@ impl ParquetExecStream {
         }
 
         let file_reader = SerializedFileReader::new_with_options(
-            ChunkObjectReader(object_reader),
+            ChunkObjectReader {
+                object_reader,
+                bytes_scanned: Some(bytes_scanned),
+            },
             opt.build(),
         )?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Tracking total number of bytes read from storage is an important metric for query execution (especially for use cases where data is read from object storage or NAS rather than a local SSD). It's especially important for Parquet data sources where we have many levers we can pull to reduce the amount of data read. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a `bytes_scanned` counter to `ParquetFileMetrics` and track total number of bytes read through `ChunkObjectReader`.  This should be quite cheap since we pass the number of bytes to read as an argument. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

`ParquetExec` will have a `bytes_scanned` metric. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
