### PR TITLE
Enable filter pushdown when using In_list on parquet

### DIFF
--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -688,6 +688,29 @@ fn build_predicate_expression(
                 return Ok(unhandled);
             }
         }
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            if !list.is_empty() {
+                let mut or_expr = if *negated {
+                    Expr::not_eq(*expr.clone(), list[0].clone())
+                } else {
+                    Expr::eq(*expr.clone(), list[0].clone())
+                };
+
+                for e in list.iter().skip(1) {
+                    if *negated {
+                        or_expr = or_expr.or(Expr::not_eq(*expr.clone(), e.clone()));
+                    } else {
+                        or_expr = or_expr.or(Expr::eq(*expr.clone(), e.clone()));
+                    }
+                }
+                return build_predicate_expression(&or_expr, schema, required_columns);
+            }
+            return Ok(unhandled);
+        }
         _ => {
             return Ok(unhandled);
         }
@@ -1336,6 +1359,26 @@ mod tests {
         );
         // c2 = 3 shouldn't add any new statistics fields
         assert_eq!(required_columns.columns.len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn row_group_predicate_in_list() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("c1", DataType::Int32, false),
+            Field::new("c2", DataType::Int32, false),
+        ]);
+        // test c1 in(1, 2, 3)
+        let expr = Expr::InList {
+            expr: Box::new(col("c1")),
+            list: vec![lit(1), lit(2), lit(3)],
+            negated: false,
+        };
+        let expected_expr = "#c1_min <= Int32(1) AND Int32(1) <= #c1_max OR #c1_min <= Int32(2) AND Int32(2) <= #c1_max OR #c1_min <= Int32(3) AND Int32(3) <= #c1_max";
+        let predicate_expr =
+            build_predicate_expression(&expr, &schema, &mut RequiredStatColumns::new())?;
+        assert_eq!(format!("{:?}", predicate_expr), expected_expr);
 
         Ok(())
     }

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -696,7 +696,7 @@ fn build_predicate_expression(
             let eq_fun = if *negated { Expr::not_eq } else { Expr::eq };
             let re_fun = if *negated { Expr::and } else { Expr::or };
             let change_expr = list
-                .into_iter()
+                .iter()
                 .map(|e| eq_fun(*expr.clone(), e.clone()))
                 .reduce(re_fun)
                 .unwrap();

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -403,6 +403,21 @@ async fn prune_f64_complex_expr_subtract() {
     assert_eq!(output.result_rows, 9, "{}", output.description());
 }
 
+#[tokio::test]
+async fn prune_int32_eq_in_list() {
+    // resulrt of sql "SELECT * FROM t where in (1)"
+    let output = ContextWithParquet::new(Scenario::Int32)
+        .await
+        .query("SELECT * FROM t where i in (1)")
+        .await;
+
+    println!("{}", output.description());
+    // This should prune out groups without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(3));
+    assert_eq!(output.result_rows, 1, "{}", output.description());
+}
+
 // ----------------------
 // Begin test fixture
 // ----------------------

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -185,7 +185,7 @@ async fn prune_int32_lt() {
     let (expected_errors, expected_row_group_pruned, expected_results) =
         (Some(0), Some(1), 11);
 
-    // resulrt of sql "SELECT * FROM t where i < 1" is same as
+    // result of sql "SELECT * FROM t where i < 1" is same as
     // "SELECT * FROM t where -i > -1"
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
@@ -222,7 +222,7 @@ async fn prune_int32_lt() {
 
 #[tokio::test]
 async fn prune_int32_eq() {
-    // resulrt of sql "SELECT * FROM t where i = 1"
+    // result of sql "SELECT * FROM t where i = 1"
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
         .query("SELECT * FROM t where i = 1")
@@ -237,7 +237,7 @@ async fn prune_int32_eq() {
 
 #[tokio::test]
 async fn prune_int32_scalar_fun_and_eq() {
-    // resulrt of sql "SELECT * FROM t where abs(i) = 1 and i = 1"
+    // result of sql "SELECT * FROM t where abs(i) = 1 and i = 1"
     // only use "i = 1" to prune
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
@@ -253,7 +253,7 @@ async fn prune_int32_scalar_fun_and_eq() {
 
 #[tokio::test]
 async fn prune_int32_scalar_fun() {
-    // resulrt of sql "SELECT * FROM t where abs(i) = 1" is not supported
+    // result of sql "SELECT * FROM t where abs(i) = 1" is not supported
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
         .query("SELECT * FROM t where abs(i) = 1")
@@ -269,7 +269,7 @@ async fn prune_int32_scalar_fun() {
 
 #[tokio::test]
 async fn prune_int32_complex_expr() {
-    // resulrt of sql "SELECT * FROM t where i+1 = 1" is not supported
+    // result of sql "SELECT * FROM t where i+1 = 1" is not supported
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
         .query("SELECT * FROM t where i+1 = 1")
@@ -285,7 +285,7 @@ async fn prune_int32_complex_expr() {
 
 #[tokio::test]
 async fn prune_int32_complex_expr_subtract() {
-    // resulrt of sql "SELECT * FROM t where 1-i > 1" is not supported
+    // result of sql "SELECT * FROM t where 1-i > 1" is not supported
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
         .query("SELECT * FROM t where 1-i > 1")
@@ -304,7 +304,7 @@ async fn prune_f64_lt() {
     let (expected_errors, expected_row_group_pruned, expected_results) =
         (Some(0), Some(1), 11);
 
-    // resulrt of sql "SELECT * FROM t where i < 1" is same as
+    // result of sql "SELECT * FROM t where i < 1" is same as
     // "SELECT * FROM t where -i > -1"
     let output = ContextWithParquet::new(Scenario::Float64)
         .await
@@ -341,7 +341,7 @@ async fn prune_f64_lt() {
 
 #[tokio::test]
 async fn prune_f64_scalar_fun_and_gt() {
-    // resulrt of sql "SELECT * FROM t where abs(f - 1) <= 0.000001  and f >= 0.1"
+    // result of sql "SELECT * FROM t where abs(f - 1) <= 0.000001  and f >= 0.1"
     // only use "f >= 0" to prune
     let output = ContextWithParquet::new(Scenario::Float64)
         .await
@@ -357,7 +357,7 @@ async fn prune_f64_scalar_fun_and_gt() {
 
 #[tokio::test]
 async fn prune_f64_scalar_fun() {
-    // resulrt of sql "SELECT * FROM t where abs(f-1) <= 0.000001" is not supported
+    // result of sql "SELECT * FROM t where abs(f-1) <= 0.000001" is not supported
     let output = ContextWithParquet::new(Scenario::Float64)
         .await
         .query("SELECT * FROM t where abs(f-1) <= 0.000001")
@@ -373,7 +373,7 @@ async fn prune_f64_scalar_fun() {
 
 #[tokio::test]
 async fn prune_f64_complex_expr() {
-    // resulrt of sql "SELECT * FROM t where f+1 > 1.1"" is not supported
+    // result of sql "SELECT * FROM t where f+1 > 1.1"" is not supported
     let output = ContextWithParquet::new(Scenario::Float64)
         .await
         .query("SELECT * FROM t where f+1 > 1.1")
@@ -389,7 +389,7 @@ async fn prune_f64_complex_expr() {
 
 #[tokio::test]
 async fn prune_f64_complex_expr_subtract() {
-    // resulrt of sql "SELECT * FROM t where 1-f > 1" is not supported
+    // result of sql "SELECT * FROM t where 1-f > 1" is not supported
     let output = ContextWithParquet::new(Scenario::Float64)
         .await
         .query("SELECT * FROM t where 1-f > 1")
@@ -405,7 +405,7 @@ async fn prune_f64_complex_expr_subtract() {
 
 #[tokio::test]
 async fn prune_int32_eq_in_list() {
-    // resulrt of sql "SELECT * FROM t where in (1)"
+    // result of sql "SELECT * FROM t where in (1)"
     let output = ContextWithParquet::new(Scenario::Int32)
         .await
         .query("SELECT * FROM t where i in (1)")
@@ -416,6 +416,36 @@ async fn prune_int32_eq_in_list() {
     assert_eq!(output.predicate_evaluation_errors(), Some(0));
     assert_eq!(output.row_groups_pruned(), Some(3));
     assert_eq!(output.result_rows, 1, "{}", output.description());
+}
+
+#[tokio::test]
+async fn prune_int32_eq_in_list_2() {
+    // result of sql "SELECT * FROM t where in (1000)", prune all
+    let output = ContextWithParquet::new(Scenario::Int32)
+        .await
+        .query("SELECT * FROM t where i in (1000)")
+        .await;
+
+    println!("{}", output.description());
+    // This should prune out groups without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(4));
+    assert_eq!(output.result_rows, 0, "{}", output.description());
+}
+
+#[tokio::test]
+async fn prune_int32_eq_in_list_negated() {
+    // result of sql "SELECT * FROM t where not in (1)" prune nothing
+    let output = ContextWithParquet::new(Scenario::Int32)
+        .await
+        .query("SELECT * FROM t where i not in (1)")
+        .await;
+
+    println!("{}", output.description());
+    // This should prune out groups without error
+    assert_eq!(output.predicate_evaluation_errors(), Some(0));
+    assert_eq!(output.row_groups_pruned(), Some(0));
+    assert_eq!(output.result_rows, 19, "{}", output.description());
 }
 
 // ----------------------


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2281 .

 # Rationale for this change
Before:
```
explain select count(*) from test where o_orderkey in(2785313, 2, 3);
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                               |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #COUNT(UInt8(1))                                                                                                                                                                                       |
|               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]                                                                                                                                                                |
|               |     Filter: #test.o_orderkey IN ([Int64(2785313), Int64(2), Int64(3)])                                                                                                                                             |
|               |       TableScan: test projection=Some([0]), partial_filters=[#test.o_orderkey IN ([Int64(2785313), Int64(2), Int64(3)])]                                                                                           |
| physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))]                                                                                                                                                        |
|               |   HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))]                                                                                                                                                    |
|               |     CoalescePartitionsExec                                                                                                                                                                                         |
|               |       HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))]                                                                                                                                              |
|               |         CoalesceBatchesExec: target_batch_size=4096                                                                                                                                                                |
|               |           FilterExec: o_orderkey@0 IN ([Literal { value: Int64(2785313) }, Literal { value: Int64(2) }, Literal { value: Int64(3) }])                                                                              |
|               |             RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                                                                                      |
|               |               ParquetExec: limit=None, partitions=[/Users/yangjiang/test-data/tpch-1g-oneFile/orders/part-00000-0e58b960-37a0-44c9-8561-53f0c32cf038-c000.snappy.parquet], predicate=true, projection=[o_orderkey] |
|               |                                                                                                                                                                                                                    |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.007 seconds.
```

Now
```
explain select count(*) from test where o_orderkey in(2785313, 2, 3);
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                                                                                            |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: #COUNT(UInt8(1))                                                                                                                                                                                                                                                                                                                                                    |
|               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]                                                                                                                                                                                                                                                                                                                             |
|               |     Filter: #test.o_orderkey IN ([Int64(2785313), Int64(2), Int64(3)])                                                                                                                                                                                                                                                                                                          |
|               |       TableScan: test projection=Some([0]), partial_filters=[#test.o_orderkey IN ([Int64(2785313), Int64(2), Int64(3)])]                                                                                                                                                                                                                                                        |
| physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))]                                                                                                                                                                                                                                                                                                                     |
|               |   HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))]                                                                                                                                                                                                                                                                                                                 |
|               |     CoalescePartitionsExec                                                                                                                                                                                                                                                                                                                                                      |
|               |       HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))]                                                                                                                                                                                                                                                                                                           |
|               |         CoalesceBatchesExec: target_batch_size=4096                                                                                                                                                                                                                                                                                                                             |
|               |           FilterExec: o_orderkey@0 IN ([Literal { value: Int64(2785313) }, Literal { value: Int64(2) }, Literal { value: Int64(3) }])                                                                                                                                                                                                                                           |
|               |             RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                                                                                                                                                                                                                                                   |
|               |               ParquetExec: limit=None, partitions=[/Users/yangjiang/test-data/tpch-1g-oneFile/orders/part-00000-0e58b960-37a0-44c9-8561-53f0c32cf038-c000.snappy.parquet], predicate=o_orderkey_min@0 <= 2785313 AND 2785313 <= o_orderkey_max@1 OR o_orderkey_min@0 <= 2 AND 2 <= o_orderkey_max@1 OR o_orderkey_min@0 <= 3 AND 3 <= o_orderkey_max@1, projection=[o_orderkey] |
|               |                                                                                                                                                                                                                                                                                                                                                                                 |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.012 seconds.
```
when optimize in `pruning.rs`, try change `in_list` to the combination of `or` for reusing code.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
