### PR TITLE
Remove Parquet Empty Projection Workaround

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -322,36 +322,6 @@ impl PartitionColumnProjector {
         }
     }
 
-    // Creates a RecordBatch with values from the partition_values. Used when no non-partition values are read
-    fn project_from_size(
-        &mut self,
-        batch_size: usize,
-        partition_values: &[ScalarValue],
-    ) -> ArrowResult<RecordBatch> {
-        let expected_cols = self.projected_schema.fields().len();
-        if expected_cols != self.projected_partition_indexes.len() {
-            return Err(ArrowError::SchemaError(format!(
-                "Unexepected number of partition values, expected {} but got {}",
-                expected_cols,
-                partition_values.len()
-            )));
-        }
-        //The destination index is not needed. Since there are no non-partition columns it will simply be equivalent to
-        //the index that would be provided by .enumerate()
-        let cols = self
-            .projected_partition_indexes
-            .iter()
-            .map(|(pidx, _)| {
-                create_dict_array(
-                    &mut self.key_buffer_cache,
-                    &partition_values[*pidx],
-                    batch_size,
-                )
-            })
-            .collect();
-        RecordBatch::try_new(Arc::clone(&self.projected_schema), cols)
-    }
-
     // Transform the batch read from the file by inserting the partitioning columns
     // to the right positions as deduced from `projected_schema`
     // - file_batch: batch read from the file, with internal projection applied


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1999 

# Rationale for this change

#2000 added a workaround to special-case empty projections, this has since been fixed upstream with https://github.com/apache/arrow-rs/issues/1537 and so we can remove this code

# What changes are included in this PR?

Removes custom empty projection logic

# Are there any user-facing changes?

No

FYI @pjmore 
