### PR TITLE
Don't sort batches during plan

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -32,7 +32,7 @@ use crate::physical_plan::metrics::{
 };
 use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeStream;
 use crate::physical_plan::sorts::SortedStream;
-use crate::physical_plan::stream::{RecordBatchBoxStream, RecordBatchReceiverStream};
+use crate::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
 use crate::physical_plan::{
     DisplayFormatType, Distribution, EmptyRecordBatchStream, ExecutionPlan, Partitioning,
     RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -779,7 +779,7 @@ impl ExecutionPlan for SortExec {
 
         debug!("End SortExec's input.execute for partition: {}", partition);
 
-        Ok(Box::pin(RecordBatchBoxStream::new(
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
             futures::stream::once(
                 do_sort(
@@ -791,8 +791,7 @@ impl ExecutionPlan for SortExec {
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
             )
-            .try_flatten()
-            .boxed(),
+            .try_flatten(),
         )))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1939.

 # Rationale for this change

Currently SortExec performs the sort during the query plan

# What changes are included in this PR?

This makes the SortExec lazy

# Are there any user-facing changes?

SortExec no longer computes values during query planning
