### PR TITLE
[Experimental] Add SQL planner support for EXISTS subquery expression

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -166,7 +166,7 @@ impl DFSchema {
         )))
     }
 
-    fn index_of_column_by_name(
+    pub fn index_of_column_by_name(
         &self,
         qualifier: Option<&str>,
         name: &str,

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -80,6 +80,10 @@ impl ExpressionVisitor for ApplicabilityVisitor<'_> {
                 *self.is_applicable &= self.col_names.contains(name);
                 Recursion::Stop(self) // leaf node anyway
             }
+            Expr::UnresolvedColumn(name) => {
+                *self.is_applicable &= self.col_names.contains(name);
+                Recursion::Stop(self) // leaf node anyway
+            }
             Expr::Literal(_)
             | Expr::Alias(_, _)
             | Expr::ScalarVariable(_, _)

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -80,7 +80,7 @@ impl ExpressionVisitor for ApplicabilityVisitor<'_> {
                 *self.is_applicable &= self.col_names.contains(name);
                 Recursion::Stop(self) // leaf node anyway
             }
-            Expr::UnresolvedColumn(name) => {
+            Expr::UnresolvedColumn(logical_plan::Column { ref name, .. }) => {
                 *self.is_applicable &= self.col_names.contains(name);
                 Recursion::Stop(self) // leaf node anyway
             }

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -96,6 +96,7 @@ impl ExpressionVisitor for ApplicabilityVisitor<'_> {
             | Expr::BinaryExpr { .. }
             | Expr::Between { .. }
             | Expr::InList { .. }
+            | Expr::Exists { .. }
             | Expr::GetIndexedField { .. }
             | Expr::Case { .. } => Recursion::Continue(self),
 

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -80,6 +80,8 @@ use crate::physical_optimizer::repartition::Repartition;
 
 use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use crate::logical_plan::plan::Explain;
+use crate::optimizer::check_analysis::CheckAnalysis;
+use crate::optimizer::resolve_columns::ResolveColumns;
 use crate::physical_plan::file_format::{plan_to_csv, plan_to_json, plan_to_parquet};
 use crate::physical_plan::planner::DefaultPhysicalPlanner;
 use crate::physical_plan::udaf::AggregateUDF;
@@ -1200,7 +1202,10 @@ impl SessionState {
         SessionState {
             session_id,
             optimizers: vec![
-                // Simplify expressions first to maximize the chance
+                // resolve unresolved columns first
+                Arc::new(ResolveColumns::new()),
+                Arc::new(CheckAnalysis::new()),
+                // Simplify expressions early to maximize the chance
                 // of applying other optimizations
                 Arc::new(SimplifyExpressions::new()),
                 Arc::new(EliminateFilter::new()),

--- a/datafusion/core/src/logical_plan/expr_rewriter.rs
+++ b/datafusion/core/src/logical_plan/expr_rewriter.rs
@@ -111,6 +111,7 @@ impl ExprRewritable for Expr {
         let expr = match self {
             Expr::Alias(expr, name) => Expr::Alias(rewrite_boxed(expr, rewriter)?, name),
             Expr::Column(_) => self.clone(),
+            Expr::UnresolvedColumn(_) => self.clone(),
             Expr::ScalarVariable(ty, names) => Expr::ScalarVariable(ty, names),
             Expr::Literal(value) => Expr::Literal(value),
             Expr::BinaryExpr { left, op, right } => Expr::BinaryExpr {

--- a/datafusion/core/src/logical_plan/expr_rewriter.rs
+++ b/datafusion/core/src/logical_plan/expr_rewriter.rs
@@ -218,6 +218,10 @@ impl ExprRewritable for Expr {
                 list: rewrite_vec(list, rewriter)?,
                 negated,
             },
+            Expr::Exists(exists) => {
+                // TODO rewrite subquery here?
+                Expr::Exists(exists.clone())
+            }
             Expr::Wildcard => Expr::Wildcard,
             Expr::QualifiedWildcard { qualifier } => {
                 Expr::QualifiedWildcard { qualifier }

--- a/datafusion/core/src/logical_plan/expr_visitor.rs
+++ b/datafusion/core/src/logical_plan/expr_visitor.rs
@@ -171,6 +171,10 @@ impl ExprVisitable for Expr {
                 list.iter()
                     .try_fold(visitor, |visitor, arg| arg.accept(visitor))
             }
+            Expr::Exists(_) => {
+                //TODO do we need to recurse into the subquery here?
+                Ok(visitor)
+            }
         }?;
 
         visitor.post_visit(self)

--- a/datafusion/core/src/logical_plan/expr_visitor.rs
+++ b/datafusion/core/src/logical_plan/expr_visitor.rs
@@ -104,6 +104,7 @@ impl ExprVisitable for Expr {
             | Expr::Sort { expr, .. }
             | Expr::GetIndexedField { expr, .. } => expr.accept(visitor),
             Expr::Column(_)
+            | Expr::UnresolvedColumn(_)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_)
             | Expr::Wildcard

--- a/datafusion/core/src/optimizer/check_analysis.rs
+++ b/datafusion/core/src/optimizer/check_analysis.rs
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::execution::context::ExecutionProps;
+use crate::optimizer::optimizer::OptimizerRule;
+use datafusion_common::DataFusionError;
+use datafusion_expr::{Expr, LogicalPlan};
+
+pub struct CheckAnalysis {}
+
+impl CheckAnalysis {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for CheckAnalysis {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> datafusion_common::Result<LogicalPlan> {
+        for expr in &plan.expressions() {
+            match expr {
+                Expr::UnresolvedColumn(col) => {
+                    let schemas = plan.all_schemas();
+                    if schemas.is_empty() {
+                        // TODO is this reachable?
+                        return Err(DataFusionError::Plan(format!(
+                            "Invalid identifier '{}'",
+                            col
+                        )))
+
+                    } else {
+                        // TODO show all schemas / merge schemas?
+                        return Err(DataFusionError::Plan(format!(
+                            "Invalid identifier '{}' for schema {}",
+                            col, schemas[0]
+                        )))
+                    }
+                }
+                _ => {}
+            }
+        }
+        for input in &plan.inputs() {
+            self.optimize(input, execution_props)?;
+        }
+        Ok(plan.clone())
+    }
+
+    fn name(&self) -> &str {
+        "CheckAnalysis"
+    }
+}

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -463,6 +463,7 @@ impl ExprIdentifierVisitor<'_> {
                 desc.push_str("InList-");
                 desc.push_str(&negated.to_string());
             }
+            Expr::Exists(_) => todo!(),
             Expr::Wildcard => {
                 desc.push_str("Wildcard-");
             }

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -382,6 +382,10 @@ impl ExprIdentifierVisitor<'_> {
                 desc.push_str("Column-");
                 desc.push_str(&column.flat_name());
             }
+            Expr::UnresolvedColumn(name) => {
+                desc.push_str("UnresolvedColumn-");
+                desc.push_str(&name);
+            }
             Expr::ScalarVariable(_, var_names) => {
                 desc.push_str("ScalarVariable-");
                 desc.push_str(&var_names.join("."));

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -382,9 +382,9 @@ impl ExprIdentifierVisitor<'_> {
                 desc.push_str("Column-");
                 desc.push_str(&column.flat_name());
             }
-            Expr::UnresolvedColumn(name) => {
+            Expr::UnresolvedColumn(column) => {
                 desc.push_str("UnresolvedColumn-");
-                desc.push_str(&name);
+                desc.push_str(&column.flat_name());
             }
             Expr::ScalarVariable(_, var_names) => {
                 desc.push_str("ScalarVariable-");

--- a/datafusion/core/src/optimizer/mod.rs
+++ b/datafusion/core/src/optimizer/mod.rs
@@ -19,6 +19,7 @@
 //! some simple rules to a logical plan, such as "Projection Push Down" and "Type Coercion".
 
 #![allow(clippy::module_inception)]
+pub mod check_analysis;
 pub mod common_subexpr_eliminate;
 pub mod eliminate_filter;
 pub mod eliminate_limit;
@@ -26,6 +27,7 @@ pub mod filter_push_down;
 pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod resolve_columns;
 pub mod simplify_expressions;
 pub mod single_distinct_to_groupby;
 pub mod to_approx_perc;

--- a/datafusion/core/src/optimizer/resolve_columns.rs
+++ b/datafusion/core/src/optimizer/resolve_columns.rs
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+///! Optimizer rule for resolving columns
+use crate::execution::context::ExecutionProps;
+use crate::optimizer::optimizer::OptimizerRule;
+use datafusion_common::{DFSchemaRef, Result};
+use datafusion_expr::expr::Subquery;
+use datafusion_expr::logical_plan::{Filter, Projection};
+use datafusion_expr::{Expr, LogicalPlan};
+use std::sync::Arc;
+
+/// Optimizer rule for resolving columns
+pub struct ResolveColumns {}
+
+impl ResolveColumns {
+    /// Create new instance of the ResolveColumns optimizer rule
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn resolve_expr_in_plan(
+        &self,
+        plan: &LogicalPlan,
+        outer_schema: Option<Vec<DFSchemaRef>>,
+    ) -> datafusion_common::Result<LogicalPlan> {
+        /*
+        Projection: *
+          Filter: Exists(SELECT id FROM bar WHERE id = foo.id)
+            SubqueryAlias: foo
+              Join
+                TableScan
+                TableScan
+         */
+        let plan_rewrite = match plan {
+            LogicalPlan::Projection(projection) => {
+                // TODO skip all of this if there are no Exists expressions
+                let mut expr_rewrite = vec![];
+                for e in &projection.expr {
+                    let expr_new = match e {
+                        Expr::Exists(subquery) => {
+                            let outer_schema: Vec<DFSchemaRef> =
+                                plan.all_schemas().iter().map(|s| (*s).clone()).collect();
+                            let subquery_plan_rewrite = self.resolve_expr_in_plan(
+                                &subquery.plan,
+                                Some(outer_schema),
+                            )?;
+                            Expr::Exists(Subquery {
+                                plan: Arc::new(subquery_plan_rewrite),
+                            })
+                        }
+                        _ => e.clone(),
+                    };
+                    expr_rewrite.push(expr_new);
+                }
+                LogicalPlan::Projection(Projection {
+                    expr: expr_rewrite,
+                    input: projection.input.clone(),
+                    schema: projection.schema.clone(),
+                    alias: projection.alias.clone(),
+                })
+            }
+            LogicalPlan::Filter(filter) => {
+                let predicate_rewrite = match &filter.predicate {
+                    Expr::UnresolvedColumn(col) => {
+                        let mut resolved_column: Option<Expr> = None;
+                        if let Some(x) = outer_schema {
+                            for s in &x {
+                                if s.index_of_column(col).is_ok() {
+                                    // TODO do we need Expr::OuterColumn ?
+                                    resolved_column = Some(Expr::Column(col.clone()));
+                                    break;
+                                }
+                            }
+                        }
+                        resolved_column.unwrap_or(filter.predicate.clone())
+                    }
+                    _ => filter.predicate.clone(),
+                };
+                LogicalPlan::Filter(Filter {
+                    predicate: predicate_rewrite,
+                    input: filter.input.clone(),
+                })
+            }
+            _ => plan.clone(),
+        };
+
+        Ok(plan_rewrite)
+    }
+}
+
+impl OptimizerRule for ResolveColumns {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        _execution_props: &ExecutionProps,
+    ) -> datafusion_common::Result<LogicalPlan> {
+        self.resolve_expr_in_plan(plan, None)
+    }
+
+    fn name(&self) -> &str {
+        "ResolveColumns"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical_plan::{col, LogicalPlanBuilder};
+    use crate::test::*;
+    use datafusion_expr::expr::exists;
+
+    #[test]
+    fn correlated_exists_subquery() -> Result<()> {
+        let foo = test_table_scan_with_name("foo")?;
+        let bar = test_table_scan_with_name("bar")?;
+
+        // SELECT a FROM bar WHERE a = foo.a
+        let subquery = LogicalPlanBuilder::from(bar)
+            .project(vec![col("a")])?
+            .filter(col("a").eq(col("foo.a")))?
+            .build()?;
+
+        // SELECT * FROM foo WHERE EXISTS(SELECT a FROM bar WHERE a = foo.a)
+        let plan = LogicalPlanBuilder::from(foo)
+            .filter(exists(subquery))?
+            .build()?;
+
+        let expected = "Filter: EXISTS (Subquery { plan: Filter: #bar.a = #foo.a\
+        \n  Projection: #bar.a\
+        \n    TableScan: bar projection=None })\
+        \n  TableScan: foo projection=None";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let optimized_plan = optimize(plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+        let rule = ResolveColumns::new();
+        rule.optimize(plan, &ExecutionProps::new())
+    }
+}

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -394,6 +394,7 @@ impl<'a> ConstEvaluator<'a> {
             | Expr::TryCast { .. }
             | Expr::InList { .. }
             | Expr::GetIndexedField { .. } => true,
+            Expr::Exists(_) => todo!(),
         }
     }
 

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -375,6 +375,7 @@ impl<'a> ConstEvaluator<'a> {
             | Expr::AggregateUDF { .. }
             | Expr::ScalarVariable(_, _)
             | Expr::Column(_)
+            | Expr::UnresolvedColumn(_)
             | Expr::WindowFunction { .. }
             | Expr::Sort { .. }
             | Expr::Wildcard

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -63,7 +63,12 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
             Expr::Column(qc) => {
                 self.accum.insert(qc.clone());
             }
-            Expr::UnresolvedColumn(_) => todo!(),
+            Expr::UnresolvedColumn(col) => {
+                return Err(DataFusionError::Plan(format!(
+                    "Plan contains unresolved column '{}'",
+                    col
+                )))
+            }
             Expr::ScalarVariable(_, var_names) => {
                 self.accum.insert(Column::from_name(var_names.join(".")));
             }

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -85,6 +85,7 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
             | Expr::AggregateFunction { .. }
             | Expr::AggregateUDF { .. }
             | Expr::InList { .. }
+            | Expr::Exists(_)
             | Expr::Wildcard
             | Expr::QualifiedWildcard { .. }
             | Expr::GetIndexedField { .. } => {}
@@ -367,6 +368,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
             }
             Ok(expr_list)
         }
+        Expr::Exists(_) => todo!(),
         Expr::Wildcard { .. } => Err(DataFusionError::Internal(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
@@ -503,6 +505,7 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
         | Expr::Literal(_)
         | Expr::InList { .. }
         | Expr::ScalarVariable(_, _) => Ok(expr.clone()),
+        Expr::Exists(_) => todo!(),
         Expr::Sort {
             asc, nulls_first, ..
         } => Ok(Expr::Sort {

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -63,6 +63,7 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
             Expr::Column(qc) => {
                 self.accum.insert(qc.clone());
             }
+            Expr::UnresolvedColumn(_) => todo!(),
             Expr::ScalarVariable(_, var_names) => {
                 self.accum.insert(Column::from_name(var_names.join(".")));
             }
@@ -348,7 +349,10 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
             }
             Ok(expr_list)
         }
-        Expr::Column(_) | Expr::Literal(_) | Expr::ScalarVariable(_, _) => Ok(vec![]),
+        Expr::Column(_)
+        | Expr::UnresolvedColumn(_)
+        | Expr::Literal(_)
+        | Expr::ScalarVariable(_, _) => Ok(vec![]),
         Expr::Between {
             expr, low, high, ..
         } => Ok(vec![
@@ -495,6 +499,7 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
         Expr::Not(_) => Ok(Expr::Not(Box::new(expressions[0].clone()))),
         Expr::Negative(_) => Ok(Expr::Negative(Box::new(expressions[0].clone()))),
         Expr::Column(_)
+        | Expr::UnresolvedColumn(_)
         | Expr::Literal(_)
         | Expr::InList { .. }
         | Expr::ScalarVariable(_, _) => Ok(expr.clone()),

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -190,6 +190,7 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
                 Ok(format!("{} IN ({:?})", expr, list))
             }
         }
+        Expr::Exists(_) => todo!(),
         Expr::Between {
             expr,
             negated,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -90,6 +90,10 @@ fn physical_name(e: &Expr) -> Result<String> {
 
 fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
     match e {
+        Expr::UnresolvedColumn(name) => Err(DataFusionError::Plan(format!(
+            "Cannot get physical expression name for unresolved column '{}'",
+            name
+        ))),
         Expr::Column(c) => {
             if is_first_expr {
                 Ok(c.name.clone())
@@ -917,6 +921,10 @@ pub fn create_physical_expr(
             let idx = input_dfschema.index_of_column(c)?;
             Ok(Arc::new(Column::new(&c.name, idx)))
         }
+        Expr::UnresolvedColumn(name) => Err(DataFusionError::Plan(format!(
+            "Cannot create physical expression for unresolved column '{}'",
+            name
+        ))),
         Expr::Literal(value) => Ok(Arc::new(Literal::new(value.clone()))),
         Expr::ScalarVariable(_, variable_names) => {
             if &variable_names[0][0..2] == "@@" {

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1460,11 +1460,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // interpret names with '.' as if they were
                     // compound indenfiers, but this is not a compound
                     // identifier. (e.g. it is "foo.bar" not foo.bar)
-                    Ok(Expr::UnresolvedColumn(normalize_ident(id)))
-                    // Ok(Expr::Column(Column {
-                    //     relation: None,
-                    //     name: normalize_ident(id),
-                    // }))
+                    Ok(Expr::UnresolvedColumn(Column {
+                        relation: None,
+                        name: normalize_ident(id),
+                    }))
                 }
             }
 
@@ -1498,11 +1497,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     match (var_names.pop(), var_names.pop()) {
                         (Some(name), Some(relation)) if var_names.is_empty() => {
                             // table.column identifier
-                            Ok(Expr::UnresolvedColumn(format!("{}.{}", relation, name)))
-                            // Ok(Expr::Column(Column {
-                            //     relation: Some(relation),
-                            //     name,
-                            // }))
+                            Ok(Expr::UnresolvedColumn(Column {
+                                relation: Some(relation),
+                                name,
+                            }))
                         }
                         _ => Err(DataFusionError::NotImplemented(format!(
                             "Unsupported compound identifier '{:?}'",

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -284,6 +284,7 @@ where
                     .collect::<Result<Vec<Expr>>>()?,
                 negated: *negated,
             }),
+            Expr::Exists(_) => todo!(),
             Expr::BinaryExpr { left, right, op } => Ok(Expr::BinaryExpr {
                 left: Box::new(clone_with_replacement(&**left, replacement_fn)?),
                 op: *op,

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -368,9 +368,10 @@ where
                 asc: *asc,
                 nulls_first: *nulls_first,
             }),
-            Expr::Column { .. } | Expr::Literal(_) | Expr::ScalarVariable(_, _) => {
-                Ok(expr.clone())
-            }
+            Expr::Column { .. }
+            | Expr::UnresolvedColumn(_)
+            | Expr::Literal(_)
+            | Expr::ScalarVariable(_, _) => Ok(expr.clone()),
             Expr::Wildcard => Ok(Expr::Wildcard),
             Expr::QualifiedWildcard { .. } => Ok(expr.clone()),
             Expr::GetIndexedField { expr, key } => Ok(Expr::GetIndexedField {

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -85,6 +85,8 @@ pub enum Expr {
     Alias(Box<Expr>, String),
     /// A named reference to a qualified filed in a schema.
     Column(Column),
+    /// A column that has not been resolved yet
+    UnresolvedColumn(String),
     /// A named reference to a variable in a registry.
     ScalarVariable(DataType, Vec<String>),
     /// A constant value.
@@ -401,6 +403,7 @@ impl fmt::Debug for Expr {
         match self {
             Expr::Alias(expr, alias) => write!(f, "{:?} AS {}", expr, alias),
             Expr::Column(c) => write!(f, "{}", c),
+            Expr::UnresolvedColumn(c) => write!(f, "{}?", c),
             Expr::ScalarVariable(_, var_names) => write!(f, "{}", var_names.join(".")),
             Expr::Literal(v) => write!(f, "{:?}", v),
             Expr::Case {
@@ -565,6 +568,7 @@ fn create_name(e: &Expr, input_schema: &DFSchema) -> Result<String> {
     match e {
         Expr::Alias(_, name) => Ok(name.clone()),
         Expr::Column(c) => Ok(c.flat_name()),
+        Expr::UnresolvedColumn(name) => Ok(name.clone()),
         Expr::ScalarVariable(_, variable_names) => Ok(variable_names.join(".")),
         Expr::Literal(value) => Ok(format!("{:?}", value)),
         Expr::BinaryExpr { left, op, right } => {

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -57,10 +57,12 @@ impl ExprSchemable for Expr {
                 expr.get_type(schema)
             }
             Expr::Column(c) => Ok(schema.data_type(c)?.clone()),
-            Expr::UnresolvedColumn(c) => Err(DataFusionError::Plan(format!(
-                "Cannot determine type for unresolved column '{}'",
-                c
-            ))),
+            Expr::UnresolvedColumn(c) => {
+                Err(DataFusionError::Plan(format!(
+                    "Cannot determine type for unresolved column '{}'",
+                    c
+                )))
+            },
             Expr::ScalarVariable(ty, _) => Ok(ty.clone()),
             Expr::Literal(l) => Ok(l.get_datatype()),
             Expr::Case { when_then_expr, .. } => when_then_expr[0].1.get_type(schema),

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -106,6 +106,7 @@ impl ExprSchemable for Expr {
             | Expr::IsNull(_)
             | Expr::Between { .. }
             | Expr::InList { .. }
+            | Expr::Exists(_)
             | Expr::IsNotNull(_) => Ok(DataType::Boolean),
             Expr::BinaryExpr {
                 ref left,
@@ -152,6 +153,7 @@ impl ExprSchemable for Expr {
             | Expr::Sort { expr, .. }
             | Expr::Between { expr, .. }
             | Expr::InList { expr, .. } => expr.nullable(input_schema),
+            Expr::Exists(_) => Ok(false),
             Expr::Column(c) => input_schema.nullable(c),
             Expr::Literal(value) => Ok(value.is_null()),
             Expr::Case {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Prototype for issue https://github.com/apache/arrow-datafusion/issues/2219.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We want to support SQL subqueries.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] SQL planner creates `Expr::UnresolvedColumn` when building `LogicalPlan`
- [x] SQL planner supports `EXISTS` SQL AST node
- [ ] New optimizer rule (not implemented yet) will then do the column resolution and replace `Expr::UnresolvedColumn` with `Expr::Column`

Note that the goal of PR is just implementing SQL planner -> Logical Plan and does not attempt to rewrite the plan as a join or to implement physical execution. Those will be handled in separate PRs.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, there is a new `Expr` variant so this is an API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
