### PR TITLE
Support scalar values for func Array

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -1391,6 +1391,29 @@ impl ScalarValue {
                 }
                 Self::Struct(Some(Box::new(field_values)), Box::new(fields.clone()))
             }
+            DataType::FixedSizeList(nested_type, _len) => {
+                let list_array = array
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast FixedSizeListArray".to_string(),
+                        )
+                    })?;
+                let value = match list_array.is_null(index) {
+                    true => None,
+                    false => {
+                        let nested_array = list_array.value(index);
+                        let scalar_vec = (0..nested_array.len())
+                            .map(|i| ScalarValue::try_from_array(&nested_array, i))
+                            .collect::<Result<Vec<_>>>()?;
+                        Some(scalar_vec)
+                    }
+                };
+                let value = value.map(Box::new);
+                let data_type = Box::new(nested_type.data_type().clone());
+                ScalarValue::List(value, data_type)
+            }
             other => {
                 return Err(DataFusionError::NotImplemented(format!(
                     "Can't create a scalar from array of type \"{:?}\"",

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -1392,14 +1392,8 @@ impl ScalarValue {
                 Self::Struct(Some(Box::new(field_values)), Box::new(fields.clone()))
             }
             DataType::FixedSizeList(nested_type, _len) => {
-                let list_array = array
-                    .as_any()
-                    .downcast_ref::<FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(
-                            "Failed to downcast FixedSizeListArray".to_string(),
-                        )
-                    })?;
+                let list_array =
+                    array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
                 let value = match list_array.is_null(index) {
                     true => None,
                     false => {

--- a/datafusion/core/tests/sql/functions.rs
+++ b/datafusion/core/tests/sql/functions.rs
@@ -144,6 +144,17 @@ async fn query_array() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_array_scalar() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "SELECT array(1, 2, 3);";
+    let actual = execute(&ctx, sql).await;
+    let expected = vec![vec!["[1, 2, 3]"]];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_count_distinct() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Int32, true)]));
 

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -59,7 +59,7 @@ macro_rules! array {
     }};
 }
 
-fn array_array(args: &[&dyn Array]) -> Result<ArrayRef> {
+fn array_array(args: &[ArrayRef]) -> Result<ArrayRef> {
     // do not accept 0 arguments.
     if args.is_empty() {
         return Err(DataFusionError::Internal(
@@ -90,18 +90,12 @@ fn array_array(args: &[&dyn Array]) -> Result<ArrayRef> {
 
 /// put values in an array.
 pub fn array(values: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let arrays: Vec<&dyn Array> = values
-        .iter()
-        .map(|value| {
-            if let ColumnarValue::Array(value) = value {
-                Ok(value.as_ref())
-            } else {
-                Err(DataFusionError::NotImplemented(
-                    "Array is not implemented for scalar values.".to_string(),
-                ))
-            }
-        })
-        .collect::<Result<_>>()?;
-
-    Ok(ColumnarValue::Array(array_array(&arrays)?))
+    let mut arrays: Vec<ArrayRef> = vec![];
+    for x in values {
+        match x {
+            ColumnarValue::Array(array) => arrays.push(array.clone()),
+            ColumnarValue::Scalar(scalar) => arrays.push(scalar.to_array().clone()),
+        }
+    }
+    Ok(ColumnarValue::Array(array_array(arrays.as_slice())?))
 }

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -90,12 +90,12 @@ fn array_array(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// put values in an array.
 pub fn array(values: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let mut arrays: Vec<ArrayRef> = vec![];
-    for x in values {
-        match x {
-            ColumnarValue::Array(array) => arrays.push(array.clone()),
-            ColumnarValue::Scalar(scalar) => arrays.push(scalar.to_array().clone()),
-        }
-    }
+    let arrays: Vec<ArrayRef> = values
+        .iter()
+        .map(|x| match x {
+            ColumnarValue::Array(array) => array.clone(),
+            ColumnarValue::Scalar(scalar) => scalar.to_array().clone(),
+        })
+        .collect();
     Ok(ColumnarValue::Array(array_array(arrays.as_slice())?))
 }


### PR DESCRIPTION
# Which issue does this PR close?
 
Closes #2331.

Now 
```
DataFusion CLI v7.0.0
❯
SELECT array(1, 2, 3);
+-----------------------------------+
| array(Int64(1),Int64(2),Int64(3)) |
+-----------------------------------+
| [1, 2, 3]                         |
+-----------------------------------+
1 row in set. Query took 0.005 seconds.
❯
```

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
