### PR TITLE
Add SQL query planner support for IN subqueries

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1882,7 +1882,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             SQLExpr::Exists(subquery) => self.parse_exists_subquery(&subquery, false, schema),
 
-            SQLExpr::InSubquery {  expr, subquery, negated } => self.parse_in_subquery(expr, &subquery, negated, schema),
+            SQLExpr::InSubquery {  expr, subquery, negated } => self.parse_in_subquery(&expr, &subquery, negated, schema),
 
             SQLExpr::Subquery(_) => Err(DataFusionError::NotImplemented(
                 "Scalar subqueries are not supported yet".to_owned(),
@@ -1913,13 +1913,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn parse_in_subquery(
         &self,
-        expr: Box<SQLExpr>,
+        expr: &SQLExpr,
         subquery: &Query,
         negated: bool,
         input_schema: &DFSchema,
     ) -> Result<Expr> {
         Ok(Expr::InSubquery {
-            expr: Box::new(self.sql_to_rex(*expr.to_owned(), input_schema)?),
+            expr: Box::new(self.sql_to_rex(expr.clone(), input_schema)?),
             subquery: Subquery {
                 subquery: Arc::new(
                     self.subquery_to_plan(subquery.clone(), input_schema)?,

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1882,9 +1882,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             SQLExpr::Exists(subquery) => self.parse_exists_subquery(&subquery, false, schema),
 
-            SQLExpr::InSubquery { .. } => Err(DataFusionError::NotImplemented(
-                "IN subqueries are not supported yet".to_owned(),
-            )),
+            SQLExpr::InSubquery {  expr, subquery, negated } => self.parse_in_subquery(expr, &subquery, negated, schema),
 
             SQLExpr::Subquery(_) => Err(DataFusionError::NotImplemented(
                 "Scalar subqueries are not supported yet".to_owned(),
@@ -1904,6 +1902,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         input_schema: &DFSchema,
     ) -> Result<Expr> {
         Ok(Expr::Exists {
+            subquery: Subquery {
+                subquery: Arc::new(
+                    self.subquery_to_plan(subquery.clone(), input_schema)?,
+                ),
+            },
+            negated,
+        })
+    }
+
+    fn parse_in_subquery(
+        &self,
+        expr: Box<SQLExpr>,
+        subquery: &Query,
+        negated: bool,
+        input_schema: &DFSchema,
+    ) -> Result<Expr> {
+        Ok(Expr::InSubquery {
+            expr: Box::new(self.sql_to_rex(*expr.to_owned(), input_schema)?),
             subquery: Subquery {
                 subquery: Arc::new(
                     self.subquery_to_plan(subquery.clone(), input_schema)?,
@@ -4305,6 +4321,43 @@ mod tests {
         let expected = format!(
             "Projection: #p.id\
             \n  Filter: EXISTS ({})\
+            \n    SubqueryAlias: p\
+            \n      TableScan: person projection=None",
+            subquery_expected
+        );
+        quick_test(sql, &expected);
+    }
+
+    #[test]
+    fn in_subquery_uncorrelated() {
+        let sql = "SELECT id FROM person p WHERE id IN \
+            (SELECT id FROM person)";
+
+        let subquery_expected = "Subquery: Projection: #person.id\
+        \n  TableScan: person projection=None";
+
+        let expected = format!(
+            "Projection: #p.id\
+            \n  Filter: #p.id IN ({})\
+            \n    SubqueryAlias: p\
+            \n      TableScan: person projection=None",
+            subquery_expected
+        );
+        quick_test(sql, &expected);
+    }
+
+    #[test]
+    fn not_in_subquery_correlated() {
+        let sql = "SELECT id FROM person p WHERE id NOT IN \
+            (SELECT id FROM person WHERE last_name = p.last_name AND state = 'CO')";
+
+        let subquery_expected = "Subquery: Projection: #person.id\
+        \n  Filter: #person.last_name = #p.last_name AND #person.state = Utf8(\"CO\")\
+        \n    TableScan: person projection=None";
+
+        let expected = format!(
+            "Projection: #p.id\
+            \n  Filter: #p.id NOT IN ({})\
             \n    SubqueryAlias: p\
             \n      TableScan: person projection=None",
             subquery_expected


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2237

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add SQL query planner support for IN subqueries

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add SQL query planner support for IN subqueries.

There is a follow-on issue: https://github.com/apache/arrow-datafusion/issues/488

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, SQL query planner now supports for IN subqueries

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
