### PR TITLE
Add SQL query planner support for Scalar Subqueries

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1886,9 +1886,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 "IN subqueries are not supported yet".to_owned(),
             )),
 
-            SQLExpr::Subquery(_) => Err(DataFusionError::NotImplemented(
-                "Scalar subqueries are not supported yet".to_owned(),
-            )),
+            SQLExpr::Subquery(subquery) => self.parse_scalar_subquery(&subquery, schema),
 
             _ => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported ast node {:?} in sqltorel",
@@ -1911,6 +1909,16 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             },
             negated,
         })
+    }
+
+    fn parse_scalar_subquery(
+        &self,
+        subquery: &Query,
+        input_schema: &DFSchema,
+    ) -> Result<Expr> {
+        Ok(Expr::ScalarSubquery(Subquery {
+            subquery: Arc::new(self.subquery_to_plan(subquery.clone(), input_schema)?),
+        }))
     }
 
     fn function_args_to_expr(
@@ -4307,6 +4315,24 @@ mod tests {
             \n  Filter: EXISTS ({})\
             \n    SubqueryAlias: p\
             \n      TableScan: person projection=None",
+            subquery_expected
+        );
+        quick_test(sql, &expected);
+    }
+
+    #[test]
+    fn scalar_subquery() {
+        let sql = "SELECT p.id, (SELECT MAX(id) FROM person WHERE last_name = p.last_name) FROM person p";
+
+        let subquery_expected = "Subquery: Projection: #MAX(person.id)\
+        \n  Aggregate: groupBy=[[]], aggr=[[MAX(#person.id)]]\
+        \n    Filter: #person.last_name = #p.last_name\
+        \n      TableScan: person projection=None";
+
+        let expected = format!(
+            "Projection: #p.id, ({})\
+            \n  SubqueryAlias: p\
+            \n    TableScan: person projection=None",
             subquery_expected
         );
         quick_test(sql, &expected);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2353

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add SQL query planner support for Scalar Subqueries

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add SQL query planner support for Scalar Subqueries

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Add SQL query planner support for Scalar Subqueries

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
