### PR TITLE
Implement physical planner support for DATE +/- INTERVAL

### DIFF
--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -294,7 +294,7 @@ impl<'a> ExprRewriter for ConstEvaluator<'a> {
 
         // if this expr is not ok to evaluate, mark entire parent
         // stack as not ok (as all parents have at least one child or
-        // descendant that is non evaluateable
+        // descendant that can not be evaluated
 
         if !Self::can_evaluate(expr) {
             // walk back up stack, marking first parent that is not mutable
@@ -317,10 +317,8 @@ impl<'a> ExprRewriter for ConstEvaluator<'a> {
 
     fn mutate(&mut self, expr: Expr) -> Result<Expr> {
         if self.can_evaluate.pop().unwrap() {
-            match self.evaluate_to_scalar(&expr) {
-                Ok(scalar) => Ok(Expr::Literal(scalar)),
-                Err(_) => Ok(expr),
-            }
+            let scalar = self.evaluate_to_scalar(expr)?;
+            Ok(Expr::Literal(scalar))
         } else {
             Ok(expr)
         }
@@ -402,9 +400,9 @@ impl<'a> ConstEvaluator<'a> {
     }
 
     /// Internal helper to evaluates an Expr
-    pub(crate) fn evaluate_to_scalar(&self, expr: &Expr) -> Result<ScalarValue> {
+    pub(crate) fn evaluate_to_scalar(&self, expr: Expr) -> Result<ScalarValue> {
         if let Expr::Literal(s) = expr {
-            return Ok(s.clone());
+            return Ok(s);
         }
 
         let phys_expr = create_physical_expr(

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -38,7 +38,7 @@ use crate::physical_plan::cross_join::CrossJoinExec;
 use crate::physical_plan::explain::ExplainExec;
 use crate::physical_plan::expressions;
 use crate::physical_plan::expressions::{
-    BinaryExpr, CaseExpr, Column, GetIndexedFieldExpr, Literal, PhysicalSortExpr,
+    CaseExpr, Column, GetIndexedFieldExpr, Literal, PhysicalSortExpr,
 };
 use crate::physical_plan::filter::FilterExec;
 use crate::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
@@ -59,7 +59,7 @@ use crate::{
     physical_plan::displayable,
 };
 use arrow::compute::SortOptions;
-use arrow::datatypes::{IntervalUnit, Schema, SchemaRef};
+use arrow::datatypes::{Schema, SchemaRef};
 use arrow::{compute::can_cast_types, datatypes::DataType};
 use async_trait::async_trait;
 use datafusion_physical_expr::expressions::DateIntervalExpr;
@@ -966,12 +966,12 @@ pub fn create_physical_expr(
                 execution_props,
             )?;
             match (lhs.data_type(input_schema)?, rhs.data_type(input_schema)?) {
-                (DataType::Date32, DataType::Interval(_)) => {
-                    Ok(Arc::new(DateIntervalExpr::new()))
-                }
-                (DataType::Date64, DataType::Interval(_)) => {
-                    Ok(Arc::new(DateIntervalExpr::new()))
-                }
+                (DataType::Date32, DataType::Interval(_)) => Ok(Arc::new(
+                    DateIntervalExpr::try_new(lhs, *op, rhs, input_schema)?,
+                )),
+                (DataType::Date64, DataType::Interval(_)) => Ok(Arc::new(
+                    DateIntervalExpr::try_new(lhs, *op, rhs, input_schema)?,
+                )),
                 _ => {
                     // assume that we can coerce both sides into a common type
                     // and then perform a binary operation

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -965,13 +965,21 @@ pub fn create_physical_expr(
                 input_schema,
                 execution_props,
             )?;
-            match (lhs.data_type(input_schema)?, rhs.data_type(input_schema)?) {
-                (DataType::Date32, DataType::Interval(_)) => Ok(Arc::new(
-                    DateIntervalExpr::try_new(lhs, *op, rhs, input_schema)?,
-                )),
-                (DataType::Date64, DataType::Interval(_)) => Ok(Arc::new(
-                    DateIntervalExpr::try_new(lhs, *op, rhs, input_schema)?,
-                )),
+            match (
+                lhs.data_type(input_schema)?,
+                op,
+                rhs.data_type(input_schema)?,
+            ) {
+                (
+                    DataType::Date32 | DataType::Date64,
+                    Operator::Plus | Operator::Minus,
+                    DataType::Interval(_),
+                ) => Ok(Arc::new(DateIntervalExpr::try_new(
+                    lhs,
+                    *op,
+                    rhs,
+                    input_schema,
+                )?)),
                 _ => {
                     // assume that we can coerce both sides into a common type
                     // and then perform a binary operation

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -438,28 +438,6 @@ async fn timestamp_minmax() -> Result<()> {
 }
 
 #[tokio::test]
-async fn timestamp_date_literal_plus_interval() -> Result<()> {
-    let ctx = SessionContext::new();
-    let table_a = make_timestamp_tz_table::<TimestampMillisecondType>(None)?;
-    ctx.register_table("table_a", table_a)?;
-
-    let sql = "SELECT * FROM table_a WHERE CAST(ts AS DATE) \
-        BETWEEN CAST('2022-02-22' AS DATE) \
-            AND CAST('2022-02-22' AS DATE) + INTERVAL '30 DAYS'";
-    let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec![
-        "+-------------------------+----------------------------+",
-        "| MIN(table_a.ts)         | MAX(table_b.ts)            |",
-        "+-------------------------+----------------------------+",
-        "| 2020-09-08 11:42:29.190 | 2020-09-08 13:42:29.190855 |",
-        "+-------------------------+----------------------------+",
-    ];
-    assert_batches_eq!(expected, &actual);
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn timestamp_coercion() -> Result<()> {
     {
         let ctx = SessionContext::new();

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::PhysicalExpr;
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion_expr::ColumnarValue;
+use std::any::Any;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub struct DateIntervalExpr {}
+
+impl DateIntervalExpr {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Display for DateIntervalExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TBD")
+    }
+}
+
+impl PhysicalExpr for DateIntervalExpr {
+    fn as_any(&self) -> &dyn Any {
+        todo!()
+    }
+
+    fn data_type(&self, input_schema: &Schema) -> datafusion_common::Result<DataType> {
+        todo!()
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> datafusion_common::Result<bool> {
+        todo!()
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> datafusion_common::Result<ColumnarValue> {
+        todo!()
+    }
+}

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -22,6 +22,7 @@ mod binary;
 mod case;
 mod cast;
 mod column;
+mod datetime;
 mod get_indexed_field;
 mod in_list;
 mod is_not_null;
@@ -67,6 +68,7 @@ pub use cast::{
     cast, cast_column, cast_with_options, CastExpr, DEFAULT_DATAFUSION_CAST_OPTIONS,
 };
 pub use column::{col, Column};
+pub use datetime::DateIntervalExpr;
 pub use get_indexed_field::GetIndexedFieldExpr;
 pub use in_list::{in_list, InListExpr};
 pub use is_not_null::{is_not_null, IsNotNullExpr};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2236

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Increasing our SQL support.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Implement `DateIntervalExpr` physical expression. Note that for now it only supports scalar inputs. This is enough to support SQL expressions such as `cast('1999-4-01' as date) + INTERVAL '60 DAYS'` which get simplified during optimization and replaced with a scalar value.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
