### PR TITLE
Normalize subquery aliases

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -716,7 +716,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             .fields()
                             .iter()
                             .map(|field| col(field.name())),
-                        alias.as_ref().map(|a| a.name.value.to_string()),
+                        alias.as_ref().map(|a| normalize_ident(a.name.clone())),
                     )?,
                     alias,
                 )

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -135,6 +135,24 @@ async fn parallel_projection() -> Result<()> {
 }
 
 #[tokio::test]
+async fn subquery_alias_case_insensitive() -> Result<()> {
+    let partition_count = 1;
+    let results =
+        partitioned_csv::execute("SELECT V1.c1, v1.C2 FROM (SELECT test.C1, TEST.c2 FROM test) V1 ORDER BY v1.c1, V1.C2 LIMIT 1", partition_count).await?;
+
+    let expected = vec![
+        "+----+----+",
+        "| c1 | c2 |",
+        "+----+----+",
+        "| 0  | 1  |",
+        "+----+----+",
+    ];
+    assert_batches_sorted_eq!(expected, &results);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn projection_on_table_scan() -> Result<()> {
     let tmp_dir = TempDir::new()?;
     let partition_count = 4;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2358

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Subquery aliases should follow the same case-sensitivity rules as all other SQL identifiers

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Subquery alias identifiers are now normalized

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
