### PR TITLE
feat: Support casting to arrays to  primitive type

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2385,8 +2385,8 @@ fn extract_possible_join_keys(
     }
 }
 
-/// Convert SQL data type to relational representation of data type
-pub fn convert_data_type(sql_type: &SQLDataType) -> Result<DataType> {
+/// Convert SQL simple data type to relational representation of data type
+pub fn convert_simple_data_type(sql_type: &SQLDataType) -> Result<DataType> {
     match sql_type {
         SQLDataType::Boolean => Ok(DataType::Boolean),
         SQLDataType::SmallInt(_) => Ok(DataType::Int16),
@@ -2395,7 +2395,10 @@ pub fn convert_data_type(sql_type: &SQLDataType) -> Result<DataType> {
         SQLDataType::Float(_) => Ok(DataType::Float32),
         SQLDataType::Real => Ok(DataType::Float32),
         SQLDataType::Double => Ok(DataType::Float64),
-        SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
+        SQLDataType::Char(_)
+        | SQLDataType::Varchar(_)
+        | SQLDataType::Text
+        | SQLDataType::String => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         SQLDataType::Date => Ok(DataType::Date32),
         SQLDataType::Decimal(precision, scale) => make_decimal_type(*precision, *scale),
@@ -2403,6 +2406,20 @@ pub fn convert_data_type(sql_type: &SQLDataType) -> Result<DataType> {
             "Unsupported SQL type {:?}",
             other
         ))),
+    }
+}
+
+/// Convert SQL data type to relational representation of data type
+pub fn convert_data_type(sql_type: &SQLDataType) -> Result<DataType> {
+    match sql_type {
+        SQLDataType::Array(inner_sql_type) => {
+            let data_type = convert_simple_data_type(inner_sql_type)?;
+
+            Ok(DataType::List(Box::new(Field::new(
+                "field", data_type, true,
+            ))))
+        }
+        other => convert_simple_data_type(other),
     }
 }
 

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -796,6 +796,11 @@ async fn test_regex_expressions() -> Result<()> {
 
 #[tokio::test]
 async fn test_cast_expressions() -> Result<()> {
+    test_expression!("CAST([1,2,3,4] AS INT[])", "[1, 2, 3, 4]");
+    test_expression!(
+        "CAST([1,2,3,4] AS NUMERIC(10,4)[])",
+        "[1.0000, 2.0000, 3.0000, 4.0000]"
+    );
     test_expression!("CAST('0' AS INT)", "0");
     test_expression!("CAST(NULL AS INT)", "NULL");
     test_expression!("TRY_CAST('0' AS INT)", "0");


### PR DESCRIPTION
# Which issue does this PR close?

This PR allows the use of cast with array subtype.

Closes #.

# Are there any user-facing changes?

No

Thanks