### PR TITLE
Introduce new `DataFusionError::SchemaError` type

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -681,7 +681,7 @@ mod tests {
         let join = left.join(&right);
         assert!(join.is_err());
         assert_eq!(
-            "Error during planning: Schema contains duplicate \
+            "Schema error: Schema contains duplicate \
         qualified field name \'t1.c0\'",
             &format!("{}", join.err().unwrap())
         );
@@ -695,7 +695,7 @@ mod tests {
         let join = left.join(&right);
         assert!(join.is_err());
         assert_eq!(
-            "Error during planning: Schema contains duplicate \
+            "Schema error: Schema contains duplicate \
         unqualified field name \'c0\'",
             &format!("{}", join.err().unwrap())
         );
@@ -730,7 +730,7 @@ mod tests {
         let join = left.join(&right);
         assert!(join.is_err());
         assert_eq!(
-            "Error during planning: Schema contains qualified \
+            "Schema error: Schema contains qualified \
         field name \'t1.c0\' and unqualified field name \'c0\' which would be ambiguous",
             &format!("{}", join.err().unwrap())
         );

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -22,7 +22,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use crate::error::{DataFusionError, Result};
+use crate::error::{DataFusionError, Result, SchemaError};
 use crate::Column;
 
 use arrow::compute::can_cast_types;
@@ -67,16 +67,19 @@ impl DFSchema {
         for field in &fields {
             if let Some(qualifier) = field.qualifier() {
                 if !qualified_names.insert((qualifier, field.name())) {
-                    return Err(DataFusionError::Plan(format!(
-                        "Schema contains duplicate qualified field name '{}'",
-                        field.qualified_name()
-                    )));
+                    return Err(DataFusionError::SchemaError(
+                        SchemaError::DuplicateQualifiedField {
+                            qualifier: qualifier.to_string(),
+                            name: field.name().to_string(),
+                        },
+                    ));
                 }
             } else if !unqualified_names.insert(field.name()) {
-                return Err(DataFusionError::Plan(format!(
-                    "Schema contains duplicate unqualified field name '{}'",
-                    field.name()
-                )));
+                return Err(DataFusionError::SchemaError(
+                    SchemaError::DuplicateUnqualifiedField {
+                        name: field.name().to_string(),
+                    },
+                ));
             }
         }
 
@@ -94,11 +97,12 @@ impl DFSchema {
         });
         for (qualifier, name) in &qualified_names {
             if unqualified_names.contains(name) {
-                return Err(DataFusionError::Plan(format!(
-                    "Schema contains qualified field name '{}.{}' \
-                    and unqualified field name '{}' which would be ambiguous",
-                    qualifier, name, name
-                )));
+                return Err(DataFusionError::SchemaError(
+                    SchemaError::AmbiguousReference {
+                        qualifier: Some(qualifier.to_string()),
+                        name: name.to_string(),
+                    },
+                ));
             }
         }
         Ok(Self { fields, metadata })
@@ -176,11 +180,11 @@ impl DFSchema {
             }
         }
 
-        Err(DataFusionError::Plan(format!(
-            "No field named '{}'. Valid fields are {}.",
-            name,
-            self.get_field_names()
-        )))
+        Err(DataFusionError::SchemaError(SchemaError::FieldNotExist {
+            qualifier: None,
+            name: name.to_string(),
+            valid_fields: Some(self.get_field_names()),
+        }))
     }
 
     pub fn index_of_column_by_name(
@@ -204,12 +208,11 @@ impl DFSchema {
             })
             .map(|(idx, _)| idx);
         match matches.next() {
-            None => Err(DataFusionError::Plan(format!(
-                "No field named '{}.{}'. Valid fields are {}.",
-                qualifier.unwrap_or("<unqualified>"),
-                name,
-                self.get_field_names()
-            ))),
+            None => Err(DataFusionError::SchemaError(SchemaError::FieldNotExist {
+                qualifier: qualifier.map(|s| s.to_string()),
+                name: name.to_string(),
+                valid_fields: Some(self.get_field_names()),
+            })),
             Some(idx) => match matches.next() {
                 None => Ok(idx),
                 // found more than one matches
@@ -260,16 +263,18 @@ impl DFSchema {
     pub fn field_with_unqualified_name(&self, name: &str) -> Result<&DFField> {
         let matches = self.fields_with_unqualified_name(name);
         match matches.len() {
-            0 => Err(DataFusionError::Plan(format!(
-                "No field with unqualified name '{}'. Valid fields are {}.",
-                name,
-                self.get_field_names()
-            ))),
+            0 => Err(DataFusionError::SchemaError(SchemaError::FieldNotExist {
+                qualifier: None,
+                name: name.to_string(),
+                valid_fields: Some(self.get_field_names()),
+            })),
             1 => Ok(matches[0]),
-            _ => Err(DataFusionError::Plan(format!(
-                "Ambiguous reference to field named '{}'",
-                name
-            ))),
+            _ => Err(DataFusionError::SchemaError(
+                SchemaError::AmbiguousReference {
+                    qualifier: None,
+                    name: name.to_string(),
+                },
+            )),
         }
     }
 
@@ -312,7 +317,7 @@ impl DFSchema {
             .try_for_each(|(l_field, r_field)| {
                 if !can_cast_types(r_field.data_type(), l_field.data_type()) {
                     Err(DataFusionError::Plan(
-                        format!("Column {} (type: {}) is not compatible wiht column {} (type: {})",
+                        format!("Column {} (type: {}) is not compatible with column {} (type: {})",
                             r_field.name(),
                             r_field.data_type(),
                             l_field.name(),
@@ -348,7 +353,7 @@ impl DFSchema {
     }
 
     /// Get comma-separated list of field names for use in error messages
-    fn get_field_names(&self) -> String {
+    fn get_field_names(&self) -> Vec<String> {
         self.fields
             .iter()
             .map(|f| match f.qualifier() {
@@ -356,7 +361,6 @@ impl DFSchema {
                 None => format!("'{}'", f.name()),
             })
             .collect::<Vec<_>>()
-            .join(", ")
     }
 
     /// Get metadata of this schema

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -62,8 +62,11 @@ pub enum DataFusionError {
     // This error is raised when one of those invariants is not verified during execution.
     Internal(String),
     /// This error happens whenever a plan is not valid. Examples include
-    /// impossible casts, schema inference not possible and non-unique column names.
+    /// impossible casts.
     Plan(String),
+    /// This error happens with schema-related errors, such as schema inference not possible
+    /// and non-unique column names.
+    SchemaError(SchemaError),
     /// Error returned during execution of the query.
     /// Examples include files not found, errors in parsing certain types.
     Execution(String),
@@ -76,6 +79,70 @@ pub enum DataFusionError {
     #[cfg(feature = "jit")]
     /// Error occurs during code generation
     JITError(ModuleError),
+}
+
+#[derive(Debug)]
+pub enum SchemaError {
+    /// Schema contains qualified and unqualified field with same unqualified name
+    AmbiguousReference {
+        qualifier: Option<String>,
+        name: String,
+    },
+    /// Schema contains duplicate qualified field name
+    DuplicateQualifiedField { qualifier: String, name: String },
+    /// Schema contains duplicate unqualified field name
+    DuplicateUnqualifiedField { name: String },
+    /// No field with this name
+    FieldNotExist {
+        qualifier: Option<String>,
+        name: String,
+        valid_fields: Option<Vec<String>>,
+    },
+}
+
+impl Display for SchemaError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FieldNotExist {
+                qualifier,
+                name,
+                valid_fields,
+            } => {
+                write!(f, "No field named ")?;
+                if let Some(q) = qualifier {
+                    write!(f, "'{}.{}'", q, name)?;
+                } else {
+                    write!(f, "'{}'", name)?;
+                }
+                if let Some(field_names) = valid_fields {
+                    write!(f, ". Valid fields are {}", field_names.join(", "))
+                } else {
+                    write!(f, "")
+                }
+            }
+            Self::DuplicateQualifiedField { qualifier, name } => {
+                write!(
+                    f,
+                    "Schema contains duplicate qualified field name '{}.{}'",
+                    qualifier, name
+                )
+            }
+            Self::DuplicateUnqualifiedField { name } => {
+                write!(
+                    f,
+                    "Schema contains duplicate unqualified field name '{}'",
+                    name
+                )
+            }
+            Self::AmbiguousReference { qualifier, name } => {
+                if let Some(q) = qualifier {
+                    write!(f, "Ambiguous reference to qualified field '{}.{}'", q, name)
+                } else {
+                    write!(f, "Ambiguous reference to unqualified field '{}'", name)
+                }
+            }
+        }
+    }
 }
 
 impl From<io::Error> for DataFusionError {
@@ -158,6 +225,9 @@ impl Display for DataFusionError {
             }
             DataFusionError::Plan(ref desc) => {
                 write!(f, "Error during planning: {}", desc)
+            }
+            DataFusionError::SchemaError(ref desc) => {
+                write!(f, "Schema error: {}", desc)
             }
             DataFusionError::Execution(ref desc) => {
                 write!(f, "Execution error: {}", desc)

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -81,6 +81,7 @@ pub enum DataFusionError {
     JITError(ModuleError),
 }
 
+/// Schema-related errors
 #[derive(Debug)]
 pub enum SchemaError {
     /// Schema contains qualified and unqualified field with same unqualified name
@@ -115,10 +116,9 @@ impl Display for SchemaError {
                     write!(f, "'{}'", name)?;
                 }
                 if let Some(field_names) = valid_fields {
-                    write!(f, ". Valid fields are {}", field_names.join(", "))
-                } else {
-                    write!(f, "")
+                    write!(f, ". Valid fields are {}", field_names.join(", "))?;
                 }
+                write!(f, ".")
             }
             Self::DuplicateQualifiedField { qualifier, name } => {
                 write!(
@@ -136,7 +136,7 @@ impl Display for SchemaError {
             }
             Self::AmbiguousReference { qualifier, name } => {
                 if let Some(q) = qualifier {
-                    write!(f, "Ambiguous reference to qualified field '{}.{}'", q, name)
+                    write!(f, "Schema contains qualified field name '{}.{}' and unqualified field name '{}' which would be ambiguous", q, name, name)
                 } else {
                     write!(f, "Ambiguous reference to unqualified field '{}'", name)
                 }

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -84,7 +84,7 @@ pub enum DataFusionError {
 /// Schema-related errors
 #[derive(Debug)]
 pub enum SchemaError {
-    /// Schema contains qualified and unqualified field with same unqualified name
+    /// Schema contains a (possibly) qualified and unqualified field with same unqualified name
     AmbiguousReference {
         qualifier: Option<String>,
         name: String,

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -24,5 +24,5 @@ mod scalar;
 
 pub use column::Column;
 pub use dfschema::{DFField, DFSchema, DFSchemaRef, ExprSchema, ToDFSchema};
-pub use error::{DataFusionError, Result};
+pub use error::{DataFusionError, Result, SchemaError};
 pub use scalar::{ScalarType, ScalarValue};

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -1429,7 +1429,10 @@ mod tests {
         .project(vec![col("id"), col("first_name").alias("id")]);
 
         match plan {
-            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference { qualifier, name })) => {
+            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference {
+                qualifier,
+                name,
+            })) => {
                 assert_eq!("employee_csv", qualifier.unwrap().as_str());
                 assert_eq!("id", &name);
                 Ok(())
@@ -1452,7 +1455,10 @@ mod tests {
         .aggregate(vec![col("state")], vec![sum(col("salary")).alias("state")]);
 
         match plan {
-            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference { qualifier, name })) => {
+            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference {
+                qualifier,
+                name,
+            })) => {
                 assert_eq!("employee_csv", qualifier.unwrap().as_str());
                 assert_eq!("state", &name);
                 Ok(())

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -1202,6 +1202,7 @@ pub(crate) fn expand_qualified_wildcard(
 #[cfg(test)]
 mod tests {
     use arrow::datatypes::{DataType, Field};
+    use datafusion_common::SchemaError;
     use datafusion_expr::expr_fn::exists;
 
     use crate::logical_plan::StringifiedPlan;
@@ -1428,16 +1429,13 @@ mod tests {
         .project(vec![col("id"), col("first_name").alias("id")]);
 
         match plan {
-            Err(DataFusionError::Plan(e)) => {
-                assert_eq!(
-                    e,
-                    "Schema contains qualified field name 'employee_csv.id' \
-                    and unqualified field name 'id' which would be ambiguous"
-                );
+            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference { qualifier, name })) => {
+                assert_eq!("employee_csv", qualifier.unwrap().as_str());
+                assert_eq!("id", &name);
                 Ok(())
             }
             _ => Err(DataFusionError::Plan(
-                "Plan should have returned an DataFusionError::Plan".to_string(),
+                "Plan should have returned an DataFusionError::SchemaError".to_string(),
             )),
         }
     }
@@ -1454,16 +1452,13 @@ mod tests {
         .aggregate(vec![col("state")], vec![sum(col("salary")).alias("state")]);
 
         match plan {
-            Err(DataFusionError::Plan(e)) => {
-                assert_eq!(
-                    e,
-                    "Schema contains qualified field name 'employee_csv.state' and \
-                    unqualified field name 'state' which would be ambiguous"
-                );
+            Err(DataFusionError::SchemaError(SchemaError::AmbiguousReference { qualifier, name })) => {
+                assert_eq!("employee_csv", qualifier.unwrap().as_str());
+                assert_eq!("state", &name);
                 Ok(())
             }
             _ => Err(DataFusionError::Plan(
-                "Plan should have returned an DataFusionError::Plan".to_string(),
+                "Plan should have returned an DataFusionError::SchemaError".to_string(),
             )),
         }
     }

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -3740,7 +3740,7 @@ mod tests {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!(
             "Plan(\"Column Int64(1) (type: Int64) is \
-            not compatible wiht column IntervalMonthDayNano\
+            not compatible with column IntervalMonthDayNano\
             (\\\"950737950189618795196236955648\\\") \
             (type: Interval(MonthDayNano))\")",
             format!("{:?}", err)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2370

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am in the process of fixing what I view as tech debt in some of our code for looking up fields and expressions in schemas and as a first step I would like better error information.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Introduce new `DataFusionError::SchemaError` with an enum of possible errors instead of strings. This allows the caller to handle the various errors differently.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, error type is updated.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
