### PR TITLE
Fix bugs with CTE aliasing and normalize all identifiers in the SQL planner

### DIFF
--- a/datafusion/core/src/catalog/mod.rs
+++ b/datafusion/core/src/catalog/mod.rs
@@ -23,9 +23,6 @@ pub mod catalog;
 pub mod information_schema;
 pub mod schema;
 
-use crate::error::DataFusionError;
-use std::convert::TryFrom;
-
 /// Represents a resolved path to a table of the form "catalog.schema.table"
 #[derive(Clone, Copy)]
 pub struct ResolvedTableReference<'a> {
@@ -129,33 +126,6 @@ impl<'a> From<ResolvedTableReference<'a>> for TableReference<'a> {
             catalog: resolved.catalog,
             schema: resolved.schema,
             table: resolved.table,
-        }
-    }
-}
-
-impl<'a> TryFrom<&'a sqlparser::ast::ObjectName> for TableReference<'a> {
-    type Error = DataFusionError;
-
-    fn try_from(value: &'a sqlparser::ast::ObjectName) -> Result<Self, Self::Error> {
-        let idents = &value.0;
-
-        match idents.len() {
-            1 => Ok(Self::Bare {
-                table: &idents[0].value,
-            }),
-            2 => Ok(Self::Partial {
-                schema: &idents[0].value,
-                table: &idents[1].value,
-            }),
-            3 => Ok(Self::Full {
-                catalog: &idents[0].value,
-                schema: &idents[1].value,
-                table: &idents[2].value,
-            }),
-            _ => Err(DataFusionError::Plan(format!(
-                "invalid table reference: {}",
-                value
-            ))),
         }
     }
 }

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -547,9 +547,9 @@ pub(crate) fn make_decimal_type(
 }
 
 // Normalize an identifer to a lowercase string unless the identifier is quoted.
-pub(crate) fn normalize_ident(id: Ident) -> String {
+pub(crate) fn normalize_ident(id: &Ident) -> String {
     match id.quote_style {
-        Some(_) => id.value,
+        Some(_) => id.value.clone(),
         None => id.value.to_ascii_lowercase(),
     }
 }

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -307,14 +307,8 @@ async fn information_schema_show_columns() {
     let result = plan_and_collect(&ctx, "SHOW columns from t").await.unwrap();
     assert_batches_sorted_eq!(expected, &result);
 
-    // This isn't ideal but it is consistent behavior for `SELECT * from T`
-    let err = plan_and_collect(&ctx, "SHOW columns from T")
-        .await
-        .unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Error during planning: Unknown relation for SHOW COLUMNS: T"
-    );
+    let result = plan_and_collect(&ctx, "SHOW columns from T").await.unwrap();
+    assert_batches_sorted_eq!(expected, &result);
 }
 
 // test errors with WHERE and LIKE

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -307,8 +307,14 @@ async fn information_schema_show_columns() {
     let result = plan_and_collect(&ctx, "SHOW columns from t").await.unwrap();
     assert_batches_sorted_eq!(expected, &result);
 
-    let result = plan_and_collect(&ctx, "SHOW columns from T").await.unwrap();
-    assert_batches_sorted_eq!(expected, &result);
+    // This isn't ideal but it is consistent behavior for `SELECT * from "T"`
+    let err = plan_and_collect(&ctx, "SHOW columns from \"T\"")
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Error during planning: Unknown relation for SHOW COLUMNS: \"T\""
+    );
 }
 
 // test errors with WHERE and LIKE


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2372 and https://github.com/apache/arrow-datafusion/issues/2376

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fixes bugs around CTEs and aliases. These were needed to support running a popular SQL decision support benchmark.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Fix bugs in CTE aliasing
- Normalize all identifiers
- Tests

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
