### PR TITLE
Support struct_expr generate struct in sql

### DIFF
--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -50,6 +50,7 @@ use datafusion_physical_expr::conditional_expressions;
 use datafusion_physical_expr::datetime_expressions;
 use datafusion_physical_expr::math_expressions;
 use datafusion_physical_expr::string_expressions;
+use datafusion_physical_expr::struct_expressions;
 use std::sync::Arc;
 
 /// Create a physical (function) expression.
@@ -299,6 +300,7 @@ pub fn create_physical_fun(
 
         // string functions
         BuiltinScalarFunction::Array => Arc::new(array_expressions::array),
+        BuiltinScalarFunction::Struct => Arc::new(struct_expressions::struct_expr),
         BuiltinScalarFunction::Ascii => Arc::new(|args| match args[0].data_type() {
             DataType::Utf8 => {
                 make_scalar_function(string_expressions::ascii::<i32>)(args)

--- a/datafusion/core/src/prelude.rs
+++ b/datafusion/core/src/prelude.rs
@@ -37,5 +37,5 @@ pub use crate::logical_plan::{
     md5, min, not_exists, not_in_subquery, now, octet_length, random, regexp_match,
     regexp_replace, repeat, replace, reverse, right, rpad, rtrim, scalar_subquery,
     sha224, sha256, sha384, sha512, split_part, starts_with, strpos, substr, sum, to_hex,
-    translate, trim, upper, Column, JoinType, Partitioning,
+    translate, trim, upper, Column, Expr, JoinType, Partitioning,
 };

--- a/datafusion/core/tests/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe_functions.rs
@@ -28,7 +28,6 @@ use datafusion::datasource::MemTable;
 
 use datafusion::error::Result;
 
-// use datafusion::logical_plan::Expr;
 use datafusion::prelude::*;
 
 use datafusion::execution::context::SessionContext;

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -514,14 +514,14 @@ async fn test_array_literals() -> Result<()> {
 async fn test_struct_literals() -> Result<()> {
     test_expression!(
         "STRUCT(1,2,3,4,5)",
-        "{\"f_0\": 1, \"f_1\": 2, \"f_2\": 3, \"f_3\": 4, \"f_4\": 5}"
+        "{\"c_0\": 1, \"c_1\": 2, \"c_2\": 3, \"c_3\": 4, \"c_4\": 5}"
     );
-    test_expression!("STRUCT(Null)", "{\"f_0\": null}");
-    test_expression!("STRUCT(1,Null)", "{\"f_0\": \"1\", \"f_1\": null}");
-    test_expression!("STRUCT(true, false)", "{\"f_0\": true, \"f_1\": false}");
+    test_expression!("STRUCT(Null)", "{\"c_0\": null}");
+    test_expression!("STRUCT(1,Null)", "{\"c_0\": \"1\", \"c_1\": null}");
+    test_expression!("STRUCT(true, false)", "{\"c_0\": true, \"c_1\": false}");
     test_expression!(
         "STRUCT('str1', 'str2')",
-        "{\"f_0\": \"str1\", \"f_1\": \"str2\"}"
+        "{\"c_0\": \"str1\", \"c_1\": \"str2\"}"
     );
 
     Ok(())

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -517,7 +517,8 @@ async fn test_struct_literals() -> Result<()> {
         "{\"c0\": 1, \"c1\": 2, \"c2\": 3, \"c3\": 4, \"c4\": 5}"
     );
     test_expression!("STRUCT(Null)", "{\"c0\": null}");
-    test_expression!("STRUCT(1,Null)", "{\"c0\": \"1\", \"c1\": null}");
+    test_expression!("STRUCT(2)", "{\"c0\": 2}");
+    test_expression!("STRUCT('1',Null)", "{\"c0\": \"1\", \"c1\": null}");
     test_expression!("STRUCT(true, false)", "{\"c0\": true, \"c1\": false}");
     test_expression!(
         "STRUCT('str1', 'str2')",

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -514,14 +514,14 @@ async fn test_array_literals() -> Result<()> {
 async fn test_struct_literals() -> Result<()> {
     test_expression!(
         "STRUCT(1,2,3,4,5)",
-        "{\"c_0\": 1, \"c_1\": 2, \"c_2\": 3, \"c_3\": 4, \"c_4\": 5}"
+        "{\"c0\": 1, \"c1\": 2, \"c2\": 3, \"c3\": 4, \"c4\": 5}"
     );
-    test_expression!("STRUCT(Null)", "{\"c_0\": null}");
-    test_expression!("STRUCT(1,Null)", "{\"c_0\": \"1\", \"c_1\": null}");
-    test_expression!("STRUCT(true, false)", "{\"c_0\": true, \"c_1\": false}");
+    test_expression!("STRUCT(Null)", "{\"c0\": null}");
+    test_expression!("STRUCT(1,Null)", "{\"c0\": \"1\", \"c1\": null}");
+    test_expression!("STRUCT(true, false)", "{\"c0\": true, \"c1\": false}");
     test_expression!(
         "STRUCT('str1', 'str2')",
-        "{\"c_0\": \"str1\", \"c_1\": \"str2\"}"
+        "{\"c0\": \"str1\", \"c1\": \"str2\"}"
     );
 
     Ok(())

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -511,6 +511,23 @@ async fn test_array_literals() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_struct_literals() -> Result<()> {
+    test_expression!(
+        "STRUCT(1,2,3,4,5)",
+        "{\"f_0\": 1, \"f_1\": 2, \"f_2\": 3, \"f_3\": 4, \"f_4\": 5}"
+    );
+    test_expression!("STRUCT(Null)", "{\"f_0\": null}");
+    test_expression!("STRUCT(1,Null)", "{\"f_0\": \"1\", \"f_1\": null}");
+    test_expression!("STRUCT(true, false)", "{\"f_0\": true, \"f_1\": false}");
+    test_expression!(
+        "STRUCT('str1', 'str2')",
+        "{\"f_0\": \"str1\", \"f_1\": \"str2\"}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_interval_expressions() -> Result<()> {
     // day nano intervals
     test_expression!(

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -158,6 +158,8 @@ pub enum BuiltinScalarFunction {
     Upper,
     /// regexp_match
     RegexpMatch,
+    ///struct
+    Struct,
 }
 
 impl BuiltinScalarFunction {
@@ -236,6 +238,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Trim => Volatility::Immutable,
             BuiltinScalarFunction::Upper => Volatility::Immutable,
             BuiltinScalarFunction::RegexpMatch => Volatility::Immutable,
+            BuiltinScalarFunction::Struct => Volatility::Immutable,
 
             // Stable builtin functions
             BuiltinScalarFunction::Now => Volatility::Stable,
@@ -329,6 +332,7 @@ impl FromStr for BuiltinScalarFunction {
             "trim" => BuiltinScalarFunction::Trim,
             "upper" => BuiltinScalarFunction::Upper,
             "regexp_match" => BuiltinScalarFunction::RegexpMatch,
+            "struct" => BuiltinScalarFunction::Struct,
             _ => {
                 return Err(DataFusionError::Plan(format!(
                     "There is no built-in function named {}",

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -222,13 +222,7 @@ pub fn return_type(
             _ => Ok(DataType::Float64),
         },
 
-        BuiltinScalarFunction::Struct => {
-            // let fields = input_expr_types
-            //     .iter()
-            //     .map(|x| Field::new("item", x.clone(), true))
-            //     .collect();
-            Ok(DataType::Struct(vec![]))
-        }
+        BuiltinScalarFunction::Struct => Ok(DataType::Struct(vec![])),
 
         BuiltinScalarFunction::Abs
         | BuiltinScalarFunction::Acos

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -223,11 +223,11 @@ pub fn return_type(
         },
 
         BuiltinScalarFunction::Struct => {
-            let fields = input_expr_types
-                .iter()
-                .map(|x| Field::new("item", x.clone(), true))
-                .collect();
-            Ok(DataType::Struct(fields))
+            // let fields = input_expr_types
+            //     .iter()
+            //     .map(|x| Field::new("item", x.clone(), true))
+            //     .collect();
+            Ok(DataType::Struct(vec![]))
         }
 
         BuiltinScalarFunction::Abs

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -21,8 +21,8 @@ use crate::nullif::SUPPORTED_NULLIF_TYPES;
 use crate::type_coercion::data_types;
 use crate::ColumnarValue;
 use crate::{
-    array_expressions, conditional_expressions, Accumulator, BuiltinScalarFunction,
-    Signature, TypeSignature,
+    array_expressions, conditional_expressions, struct_expressions, Accumulator,
+    BuiltinScalarFunction, Signature, TypeSignature,
 };
 use arrow::datatypes::{DataType, Field, TimeUnit};
 use datafusion_common::{DataFusionError, Result};
@@ -222,6 +222,14 @@ pub fn return_type(
             _ => Ok(DataType::Float64),
         },
 
+        BuiltinScalarFunction::Struct => {
+            let fields = input_expr_types
+                .iter()
+                .map(|x| Field::new("item", x.clone(), true))
+                .collect();
+            Ok(DataType::Struct(fields))
+        }
+
         BuiltinScalarFunction::Abs
         | BuiltinScalarFunction::Acos
         | BuiltinScalarFunction::Asin
@@ -254,6 +262,10 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
     match fun {
         BuiltinScalarFunction::Array => Signature::variadic(
             array_expressions::SUPPORTED_ARRAY_TYPES.to_vec(),
+            fun.volatility(),
+        ),
+        BuiltinScalarFunction::Struct => Signature::variadic(
+            struct_expressions::SUPPORTED_STRUCT_TYPES.to_vec(),
             fun.volatility(),
         ),
         BuiltinScalarFunction::Concat | BuiltinScalarFunction::ConcatWithSeparator => {

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -32,6 +32,7 @@ pub mod logical_plan;
 mod nullif;
 mod operator;
 mod signature;
+pub mod struct_expressions;
 mod table_source;
 pub mod type_coercion;
 mod udaf;

--- a/datafusion/expr/src/struct_expressions.rs
+++ b/datafusion/expr/src/struct_expressions.rs
@@ -15,26 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod aggregate;
-pub mod array_expressions;
-pub mod conditional_expressions;
-#[cfg(feature = "crypto_expressions")]
-pub mod crypto_expressions;
-pub mod datetime_expressions;
-pub mod expressions;
-mod functions;
-pub mod math_expressions;
-mod physical_expr;
-#[cfg(feature = "regex_expressions")]
-pub mod regex_expressions;
-mod sort_expr;
-pub mod string_expressions;
-pub mod struct_expressions;
-#[cfg(feature = "unicode_expressions")]
-pub mod unicode_expressions;
-pub mod window;
+use arrow::datatypes::DataType;
 
-pub use aggregate::AggregateExpr;
-pub use functions::ScalarFunctionExpr;
-pub use physical_expr::PhysicalExpr;
-pub use sort_expr::PhysicalSortExpr;
+/// Currently supported types by the struct function.
+pub static SUPPORTED_STRUCT_TYPES: &[DataType] = &[
+    DataType::Boolean,
+    DataType::UInt8,
+    DataType::UInt16,
+    DataType::UInt32,
+    DataType::UInt64,
+    DataType::Int8,
+    DataType::Int16,
+    DataType::Int32,
+    DataType::Int64,
+    DataType::Float32,
+    DataType::Float64,
+    DataType::Utf8,
+    DataType::LargeUtf8,
+];

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -35,7 +35,7 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .enumerate()
         .map(|(i, arg)| -> (Field, ArrayRef) {
-            let field_name = format!("c_{}", i).clone();
+            let field_name = format!("c_{}", i);
             match arg.data_type() {
                 DataType::Utf8 => (
                     Field::new(field_name.as_str(), DataType::Utf8, true),

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -35,58 +35,22 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .enumerate()
         .map(|(i, arg)| -> (Field, ArrayRef) {
-            let field_name = format!("c_{}", i);
+            let field_name = format!("c{}", i);
             match arg.data_type() {
-                DataType::Utf8 => (
-                    Field::new(field_name.as_str(), DataType::Utf8, true),
-                    arg.clone(),
-                ),
-                DataType::LargeUtf8 => (
-                    Field::new(field_name.as_str(), DataType::LargeUtf8, true),
-                    arg.clone(),
-                ),
-                DataType::Boolean => (
-                    Field::new(field_name.as_str(), DataType::Boolean, true),
-                    arg.clone(),
-                ),
-                DataType::Float32 => (
-                    Field::new(field_name.as_str(), DataType::Float64, true),
-                    arg.clone(),
-                ),
-                DataType::Float64 => (
-                    Field::new(field_name.as_str(), DataType::Float64, true),
-                    arg.clone(),
-                ),
-                DataType::Int8 => (
-                    Field::new(field_name.as_str(), DataType::Int8, true),
-                    arg.clone(),
-                ),
-                DataType::Int16 => (
-                    Field::new(field_name.as_str(), DataType::Int16, true),
-                    arg.clone(),
-                ),
-                DataType::Int32 => (
-                    Field::new(field_name.as_str(), DataType::Int32, true),
-                    arg.clone(),
-                ),
-                DataType::Int64 => (
-                    Field::new(field_name.as_str(), DataType::Int64, true),
-                    arg.clone(),
-                ),
-                DataType::UInt8 => (
-                    Field::new(field_name.as_str(), DataType::UInt8, true),
-                    arg.clone(),
-                ),
-                DataType::UInt16 => (
-                    Field::new(field_name.as_str(), DataType::UInt16, true),
-                    arg.clone(),
-                ),
-                DataType::UInt32 => (
-                    Field::new(field_name.as_str(), DataType::UInt32, true),
-                    arg.clone(),
-                ),
-                DataType::UInt64 => (
-                    Field::new(field_name.as_str(), DataType::UInt64, true),
+                DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Boolean
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64 => (
+                    Field::new(field_name.as_str(), arg.data_type().clone(), true),
                     arg.clone(),
                 ),
                 data_type => unimplemented!("struct not support {} type", data_type),

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -59,8 +59,7 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
                 ))),
             }
         })
-        .map(|x| x.unwrap())
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(Arc::new(StructArray::from(vec)))
 }

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -34,7 +34,7 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
     let vec: Vec<_> = args
         .iter()
         .enumerate()
-        .map(|(i, arg)| -> (Field, ArrayRef) {
+        .map(|(i, arg)| -> Result<(Field, ArrayRef)> {
             let field_name = format!("c{}", i);
             match arg.data_type() {
                 DataType::Utf8
@@ -49,13 +49,17 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
                 | DataType::UInt8
                 | DataType::UInt16
                 | DataType::UInt32
-                | DataType::UInt64 => (
+                | DataType::UInt64 => Ok((
                     Field::new(field_name.as_str(), arg.data_type().clone(), true),
                     arg.clone(),
-                ),
-                data_type => unimplemented!("struct not support {} type", data_type),
+                )),
+                data_type => Err(DataFusionError::NotImplemented(format!(
+                    "Struct is not implemented for type '{:?}'.",
+                    data_type
+                ))),
             }
         })
+        .map(|x| x.unwrap())
         .collect();
 
     Ok(Arc::new(StructArray::from(vec)))

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Struct expressions
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field};
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::ColumnarValue;
+use std::sync::Arc;
+
+fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
+    // do not accept 0 arguments.
+    if args.is_empty() {
+        return Err(DataFusionError::Internal(
+            "struct requires at least one argument".to_string(),
+        ));
+    }
+
+    let vec: Vec<_> = args
+        .iter()
+        .enumerate()
+        .map(|(i, arg)| -> (Field, ArrayRef) {
+            match arg.data_type() {
+                DataType::Utf8 => (
+                    Field::new(&*format!("f_{}", i), DataType::Utf8, true),
+                    arg.clone(),
+                ),
+                DataType::LargeUtf8 => (
+                    Field::new(&*format!("f_{}", i), DataType::LargeUtf8, true),
+                    arg.clone(),
+                ),
+                DataType::Boolean => (
+                    Field::new(&*format!("f_{}", i), DataType::Boolean, true),
+                    arg.clone(),
+                ),
+                DataType::Float32 => (
+                    Field::new(&*format!("f_{}", i), DataType::Float64, true),
+                    arg.clone(),
+                ),
+                DataType::Float64 => (
+                    Field::new(&*format!("f_{}", i), DataType::Float64, true),
+                    arg.clone(),
+                ),
+                DataType::Int8 => (
+                    Field::new(&*format!("f_{}", i), DataType::Int8, true),
+                    arg.clone(),
+                ),
+                DataType::Int16 => (
+                    Field::new(&*format!("f_{}", i), DataType::Int16, true),
+                    arg.clone(),
+                ),
+                DataType::Int32 => (
+                    Field::new(&*format!("f_{}", i), DataType::Int32, true),
+                    arg.clone(),
+                ),
+                DataType::Int64 => (
+                    Field::new(&*format!("f_{}", i), DataType::Int64, true),
+                    arg.clone(),
+                ),
+                DataType::UInt8 => (
+                    Field::new(&*format!("f_{}", i), DataType::UInt8, true),
+                    arg.clone(),
+                ),
+                DataType::UInt16 => (
+                    Field::new(&*format!("f_{}", i), DataType::UInt16, true),
+                    arg.clone(),
+                ),
+                DataType::UInt32 => (
+                    Field::new(&*format!("f_{}", i), DataType::UInt32, true),
+                    arg.clone(),
+                ),
+                DataType::UInt64 => (
+                    Field::new(&*format!("f_{}", i), DataType::UInt64, true),
+                    arg.clone(),
+                ),
+                data_type => unimplemented!("struct not support {} type", data_type),
+            }
+        })
+        .collect();
+
+    Ok(Arc::new(StructArray::from(vec)))
+}
+
+/// put values in an array.
+pub fn struct_expr(values: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let arrays: Vec<ArrayRef> = values
+        .iter()
+        .map(|x| match x {
+            ColumnarValue::Array(array) => array.clone(),
+            ColumnarValue::Scalar(scalar) => scalar.to_array().clone(),
+        })
+        .collect();
+    Ok(ColumnarValue::Array(array_struct(arrays.as_slice())?))
+}

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -35,57 +35,58 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .enumerate()
         .map(|(i, arg)| -> (Field, ArrayRef) {
+            let field_name = format!("c_{}", i).clone();
             match arg.data_type() {
                 DataType::Utf8 => (
-                    Field::new(&*format!("f_{}", i), DataType::Utf8, true),
+                    Field::new(field_name.as_str(), DataType::Utf8, true),
                     arg.clone(),
                 ),
                 DataType::LargeUtf8 => (
-                    Field::new(&*format!("f_{}", i), DataType::LargeUtf8, true),
+                    Field::new(field_name.as_str(), DataType::LargeUtf8, true),
                     arg.clone(),
                 ),
                 DataType::Boolean => (
-                    Field::new(&*format!("f_{}", i), DataType::Boolean, true),
+                    Field::new(field_name.as_str(), DataType::Boolean, true),
                     arg.clone(),
                 ),
                 DataType::Float32 => (
-                    Field::new(&*format!("f_{}", i), DataType::Float64, true),
+                    Field::new(field_name.as_str(), DataType::Float64, true),
                     arg.clone(),
                 ),
                 DataType::Float64 => (
-                    Field::new(&*format!("f_{}", i), DataType::Float64, true),
+                    Field::new(field_name.as_str(), DataType::Float64, true),
                     arg.clone(),
                 ),
                 DataType::Int8 => (
-                    Field::new(&*format!("f_{}", i), DataType::Int8, true),
+                    Field::new(field_name.as_str(), DataType::Int8, true),
                     arg.clone(),
                 ),
                 DataType::Int16 => (
-                    Field::new(&*format!("f_{}", i), DataType::Int16, true),
+                    Field::new(field_name.as_str(), DataType::Int16, true),
                     arg.clone(),
                 ),
                 DataType::Int32 => (
-                    Field::new(&*format!("f_{}", i), DataType::Int32, true),
+                    Field::new(field_name.as_str(), DataType::Int32, true),
                     arg.clone(),
                 ),
                 DataType::Int64 => (
-                    Field::new(&*format!("f_{}", i), DataType::Int64, true),
+                    Field::new(field_name.as_str(), DataType::Int64, true),
                     arg.clone(),
                 ),
                 DataType::UInt8 => (
-                    Field::new(&*format!("f_{}", i), DataType::UInt8, true),
+                    Field::new(field_name.as_str(), DataType::UInt8, true),
                     arg.clone(),
                 ),
                 DataType::UInt16 => (
-                    Field::new(&*format!("f_{}", i), DataType::UInt16, true),
+                    Field::new(field_name.as_str(), DataType::UInt16, true),
                     arg.clone(),
                 ),
                 DataType::UInt32 => (
-                    Field::new(&*format!("f_{}", i), DataType::UInt32, true),
+                    Field::new(field_name.as_str(), DataType::UInt32, true),
                     arg.clone(),
                 ),
                 DataType::UInt64 => (
-                    Field::new(&*format!("f_{}", i), DataType::UInt64, true),
+                    Field::new(field_name.as_str(), DataType::UInt64, true),
                     arg.clone(),
                 ),
                 data_type => unimplemented!("struct not support {} type", data_type),
@@ -96,7 +97,7 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
     Ok(Arc::new(StructArray::from(vec)))
 }
 
-/// put values in an array.
+/// put values in a struct array.
 pub fn struct_expr(values: &[ColumnarValue]) -> Result<ColumnarValue> {
     let arrays: Vec<ArrayRef> = values
         .iter()

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -185,6 +185,7 @@ enum ScalarFunction {
   Upper=62;
   Coalesce=63;
   Power=64;
+  StructFun=65;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -467,6 +467,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
             ScalarFunction::Coalesce => Self::Coalesce,
             ScalarFunction::Power => Self::Power,
+            ScalarFunction::StructFun => Self::Struct,
         }
     }
 }

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1070,6 +1070,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,
             BuiltinScalarFunction::Coalesce => Self::Coalesce,
             BuiltinScalarFunction::Power => Self::Power,
+            BuiltinScalarFunction::Struct => Self::StructFun,
         };
 
         Ok(scalar_function)


### PR DESCRIPTION
# Which issue does this PR close?

Related #2043.

 # Rationale for this change
Support construct a struct in SQL.
```
select STRUCT(1,2,3);
+------------------------------------+
| struct(Int64(1),Int64(2),Int64(3)) |
+------------------------------------+
| {"f_0": 1, "f_1": 2, "f_2": 3}     |
+------------------------------------+
1 row in set. Query took 0.003 seconds.
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Now the struct Field only support default name like `f_n`
I want to use `select struct(1 as a)' as field name, but got error in parsing
```
 select STRUCT(1 as a);  🤔 Invalid statement: sql parser error: Expected ), found: as
``` 
I think it should fix in sql-parse, if wrong plz correct me.
I will create follow up ticket for this, if this PR is fine.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
