### PR TITLE
remove duplicated `fn aggregate()` in aggregate expression tests

### DIFF
--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -171,6 +171,7 @@ impl Accumulator for AvgAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
@@ -309,20 +310,5 @@ mod tests {
             ScalarValue::from(3_f64),
             DataType::Float64
         )
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 }

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -192,6 +192,7 @@ impl Accumulator for CorrelationAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op2;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
@@ -443,21 +444,6 @@ mod tests {
         assert!(actual == ScalarValue::from(1_f64));
 
         Ok(())
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 
     fn merge(

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -353,6 +353,7 @@ impl Accumulator for CovarianceAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op2;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
@@ -618,21 +619,6 @@ mod tests {
         assert!(actual == ScalarValue::from(0.6666666666666666));
 
         Ok(())
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 
     fn merge(

--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -217,6 +217,7 @@ impl Accumulator for StddevAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
@@ -415,21 +416,6 @@ mod tests {
         assert!(actual == ScalarValue::from(std::f64::consts::SQRT_2));
 
         Ok(())
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 
     fn merge(

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -333,6 +333,7 @@ impl Accumulator for SumAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
@@ -530,20 +531,5 @@ mod tests {
             ScalarValue::from(15_f64),
             DataType::Float64
         )
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 }

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -297,6 +297,7 @@ impl Accumulator for VarianceAccumulator {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
     use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
@@ -496,21 +497,6 @@ mod tests {
         assert!(actual == ScalarValue::from(2_f64));
 
         Ok(())
-    }
-
-    fn aggregate(
-        batch: &RecordBatch,
-        agg: Arc<dyn AggregateExpr>,
-    ) -> Result<ScalarValue> {
-        let mut accum = agg.create_accumulator()?;
-        let expr = agg.expressions();
-        let values = expr
-            .iter()
-            .map(|e| e.evaluate(batch))
-            .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-            .collect::<Result<Vec<_>>>()?;
-        accum.update_batch(&values)?;
-        accum.evaluate()
     }
 
     fn merge(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2399 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Here are duplicated `fn aggregate() ` implementations in multiple aggregate expressions including `sum.rs`, `average.rs,` `correlation.rs`, etc.
We can remove them and `use crate::expressions::tests::aggregate` instead.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- removes duplicated `fn aggregate() ` implementations
- adds code `use crate::expressions::tests::aggregate` instead.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
