### PR TITLE
Make expected result string in unit tests more readable

### DIFF
--- a/datafusion/core/tests/dataframe.rs
+++ b/datafusion/core/tests/dataframe.rs
@@ -113,8 +113,15 @@ async fn sort_on_unprojected_columns() -> Result<()> {
         .unwrap();
     let results = df.collect().await.unwrap();
 
+    #[rustfmt::skip]
     let expected = vec![
-        "+-----+", "| a   |", "+-----+", "| 100 |", "| 10  |", "| 10  |", "| 1   |",
+        "+-----+",
+        "| a   |",
+        "+-----+",
+        "| 100 |",
+        "| 10  |",
+        "| 10  |",
+        "| 1   |",
         "+-----+",
     ];
     assert_batches_eq!(expected, &results);
@@ -145,8 +152,14 @@ async fn filter_with_alias_overwrite() -> Result<()> {
         .unwrap();
     let results = df.collect().await.unwrap();
 
+    #[rustfmt::skip]
     let expected = vec![
-        "+------+", "| a    |", "+------+", "| true |", "| true |", "+------+",
+        "+------+",
+        "| a    |",
+        "+------+",
+        "| true |",
+        "| true |",
+        "+------+",
     ];
     assert_batches_eq!(expected, &results);
 

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -421,14 +421,13 @@ async fn csv_query_approx_percentile_cont() -> Result<()> {
         ($ctx:ident, column=$column:literal, percentile=$percentile:literal, actual=$actual:literal) => {
             let sql = format!("SELECT (ABS(1 - CAST(approx_percentile_cont({}, {}) AS DOUBLE) / {}) < 0.05) AS q FROM aggregate_test_100", $column, $percentile, $actual);
             let actual = execute_to_batches(&ctx, &sql).await;
-            //
-            //   "+------+",
-            //   "| q    |",
-            //   "+------+",
-            //   "| true |",
-            //   "+------+",
-            //
-            let want = ["+------+", "| q    |", "+------+", "| true |", "+------+"];
+            let want = [
+                "+------+",
+                "| q    |",
+                "+------+",
+                "| true |",
+                "+------+"
+            ];
             assert_batches_eq!(want, &actual);
         };
     }

--- a/datafusion/core/tests/sql/limit.rs
+++ b/datafusion/core/tests/sql/limit.rs
@@ -23,7 +23,15 @@ async fn csv_query_limit() -> Result<()> {
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 2";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+----+", "| c1 |", "+----+", "| c  |", "| d  |", "+----+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| c  |",
+        "| d  |",
+        "+----+"
+    ];
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
@@ -101,8 +109,14 @@ async fn limit() -> Result<()> {
         .await
         .unwrap();
 
+    #[rustfmt::skip]
     let expected = vec![
-        "+------+", "| i    |", "+------+", "| 1000 |", "| 999  |", "| 998  |",
+        "+------+",
+        "| i    |",
+        "+------+",
+        "| 1000 |",
+        "| 999  |",
+        "| 998  |",
         "+------+",
     ];
 
@@ -112,8 +126,15 @@ async fn limit() -> Result<()> {
         .await
         .unwrap();
 
+    #[rustfmt::skip]
     let expected = vec![
-        "+---+", "| i |", "+---+", "| 1 |", "| 2 |", "| 3 |", "+---+",
+        "+---+",
+        "| i |",
+        "+---+",
+        "| 1 |",
+        "| 2 |",
+        "| 3 |",
+        "+---+",
     ];
 
     assert_batches_eq!(expected, &results);

--- a/datafusion/core/tests/sql/order.rs
+++ b/datafusion/core/tests/sql/order.rs
@@ -25,9 +25,20 @@ async fn test_sort_unprojected_col() -> Result<()> {
     // execute the query
     let sql = "SELECT id FROM alltypes_plain ORDER BY int_col, double_col";
     let actual = execute_to_batches(&ctx, sql).await;
+    #[rustfmt::skip]
     let expected = vec![
-        "+----+", "| id |", "+----+", "| 4  |", "| 6  |", "| 2  |", "| 0  |", "| 5  |",
-        "| 7  |", "| 3  |", "| 1  |", "+----+",
+        "+----+",
+        "| id |",
+        "+----+",
+        "| 4  |",
+        "| 6  |",
+        "| 2  |",
+        "| 0  |",
+        "| 5  |",
+        "| 7  |",
+        "| 3  |",
+        "| 1  |",
+        "+----+",
     ];
     assert_batches_eq!(expected, &actual);
     Ok(())

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -27,7 +27,14 @@ async fn projection_same_fields() -> Result<()> {
     let sql = "select (1+1) as a from (select 1 as a) as b;";
     let actual = execute_to_batches(&ctx, sql).await;
 
-    let expected = vec!["+---+", "| a |", "+---+", "| 2 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| a |",
+        "+---+",
+        "| 2 |",
+        "+---+"
+    ];
     assert_batches_eq!(expected, &actual);
 
     Ok(())

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -509,8 +509,15 @@ async fn query_get_indexed_field() -> Result<()> {
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT some_list[0] as i0 FROM ints LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
+    #[rustfmt::skip]
     let expected = vec![
-        "+----+", "| i0 |", "+----+", "| 0  |", "| 4  |", "| 7  |", "+----+",
+        "+----+",
+        "| i0 |",
+        "+----+",
+        "| 0  |",
+        "| 4  |",
+        "| 7  |",
+        "+----+",
     ];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -567,8 +574,15 @@ async fn query_nested_get_indexed_field() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     let sql = "SELECT some_list[0][0] as i0 FROM ints LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
+    #[rustfmt::skip]
     let expected = vec![
-        "+----+", "| i0 |", "+----+", "| 0  |", "| 5  |", "| 11 |", "+----+",
+        "+----+",
+        "| i0 |",
+        "+----+",
+        "| 0  |",
+        "| 5  |",
+        "| 11 |",
+        "+----+",
     ];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -617,8 +631,15 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     let sql = "SELECT some_struct[\"bar\"][0] as i0 FROM structs LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
+    #[rustfmt::skip]
     let expected = vec![
-        "+----+", "| i0 |", "+----+", "| 0  |", "| 4  |", "| 8  |", "+----+",
+        "+----+",
+        "| i0 |",
+        "+----+",
+        "| 0  |",
+        "| 4  |",
+        "| 8  |",
+        "+----+",
     ];
     assert_batches_eq!(expected, &actual);
     Ok(())
@@ -875,19 +896,41 @@ async fn query_cte() -> Result<()> {
     let sql =
         "WITH t AS (SELECT 1 AS a), u AS (SELECT 2 AS a) SELECT * FROM t UNION ALL SELECT * FROM u";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+---+", "| a |", "+---+", "| 1 |", "| 2 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| a |",
+        "+---+",
+        "| 1 |",
+        "| 2 |",
+        "+---+"
+    ];
     assert_batches_eq!(expected, &actual);
 
     // with + join
     let sql = "WITH t AS (SELECT 1 AS id1), u AS (SELECT 1 AS id2, 5 as x) SELECT x FROM t JOIN u ON (id1 = id2)";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+---+", "| x |", "+---+", "| 5 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| x |",
+        "+---+",
+        "| 5 |",
+        "+---+"
+    ];
     assert_batches_eq!(expected, &actual);
 
     // backward reference
     let sql = "WITH t AS (SELECT 1 AS id1), u AS (SELECT * FROM t) SELECT * from u";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+-----+", "| id1 |", "+-----+", "| 1   |", "+-----+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+-----+",
+        "| id1 |",
+        "+-----+",
+        "| 1   |",
+        "+-----+"
+    ];
     assert_batches_eq!(expected, &actual);
 
     Ok(())

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -22,7 +22,15 @@ async fn union_all() -> Result<()> {
     let ctx = SessionContext::new();
     let sql = "SELECT 1 as x UNION ALL SELECT 2 as x";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+---+", "| x |", "+---+", "| 1 |", "| 2 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| x |",
+        "+---+",
+        "| 1 |",
+        "| 2 |",
+        "+---+"
+    ];
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
@@ -43,7 +51,14 @@ async fn union_distinct() -> Result<()> {
     let ctx = SessionContext::new();
     let sql = "SELECT 1 as x UNION SELECT 1 as x";
     let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec!["+---+", "| x |", "+---+", "| 1 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| x |",
+        "+---+",
+        "| 1 |",
+        "+---+"
+    ];
     assert_batches_eq!(expected, &actual);
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2412 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Some unit tests in DataFusion organize expected result string vector in one line, like `sql::union::union_distinct` do
```
#[tokio::test]
async fn union_distinct() -> Result<()> {
    let ctx = SessionContext::new();
    let sql = "SELECT 1 as x UNION SELECT 1 as x";
    let actual = execute_to_batches(&ctx, sql).await;
    let expected = vec!["+---+", "| x |", "+---+", "| 1 |", "+---+"];
    assert_batches_eq!(expected, &actual);
    Ok(())
}
```
We can separate the expected result string vector into multiple line to make it more readable and easier to follow, by adding a `#[rustfmt::skip]` tag to skip fmt check as following code
```
#[tokio::test]
async fn union_distinct() -> Result<()> {
    let ctx = SessionContext::new();
    let sql = "SELECT 1 as x UNION SELECT 1 as x";
    let actual = execute_to_batches(&ctx, sql).await;
    #[rustfmt::skip]
    let expected = vec![
        "+---+",
        "| x |",
        "+---+",
        "| 1 |",
        "+---+"
    ];
    assert_batches_eq!(expected, &actual);
    Ok(())
}
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Separates the expected result string vector into multiple line
- adds a `#[rustfmt::skip]` tag to skip fmt check 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
