### PR TITLE
Allow subqueries without aliases

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -712,12 +712,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 subquery, alias, ..
             } => {
                 let normalized_alias = alias.as_ref().map(|a| normalize_ident(&a.name));
-                // if alias is None, return Err
-                if normalized_alias.is_none() {
-                    return Err(DataFusionError::Plan(
-                        "subquery in FROM must have an alias".to_string(),
-                    ));
-                }
                 let logical_plan = self.query_to_plan_with_alias(
                     *subquery,
                     normalized_alias.clone(),

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -958,6 +958,29 @@ async fn csv_select_nested_without_aliases() -> Result<()> {
 }
 
 #[tokio::test]
+async fn csv_join_unaliased_subqueries() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT o1, o2, c3, p1, p2, p3 FROM \
+        (SELECT c1 AS o1, c2 + 1 AS o2, c3 FROM aggregate_test_100), \
+        (SELECT c1 AS p1, c2 - 1 AS p2, c3 AS p3 FROM aggregate_test_100) LIMIT 5";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+----+----+----+----+----+-----+",
+        "| o1 | o2 | c3 | p1 | p2 | p3  |",
+        "+----+----+----+----+----+-----+",
+        "| c  | 3  | 1  | c  | 1  | 1   |",
+        "| c  | 3  | 1  | d  | 4  | -40 |",
+        "| c  | 3  | 1  | b  | 0  | 29  |",
+        "| c  | 3  | 1  | a  | 0  | -85 |",
+        "| c  | 3  | 1  | b  | 4  | -82 |",
+        "+----+----+----+----+----+-----+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn parallel_query_with_filter() -> Result<()> {
     let tmp_dir = TempDir::new()?;
     let partition_count = 4;

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -926,6 +926,38 @@ async fn csv_select_nested() -> Result<()> {
 }
 
 #[tokio::test]
+async fn csv_select_nested_without_aliases() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT o1, o2, c3
+               FROM (
+                 SELECT c1 AS o1, c2 + 1 AS o2, c3
+                 FROM (
+                   SELECT c1, c2, c3, c4
+                   FROM aggregate_test_100
+                   WHERE c1 = 'a' AND c2 >= 4
+                   ORDER BY c2 ASC, c3 ASC
+                 )
+               )";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+----+----+------+",
+        "| o1 | o2 | c3   |",
+        "+----+----+------+",
+        "| a  | 5  | -101 |",
+        "| a  | 5  | -54  |",
+        "| a  | 5  | -38  |",
+        "| a  | 5  | 65   |",
+        "| a  | 6  | -101 |",
+        "| a  | 6  | -31  |",
+        "| a  | 6  | 36   |",
+        "+----+----+------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn parallel_query_with_filter() -> Result<()> {
     let tmp_dir = TempDir::new()?;
     let partition_count = 4;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2417

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am trying to run some ANSI SQL that works fine in Apache Spark but fails in DataFusion because we currently require subqueries to have aliases.

As described in the [issue](https://github.com/apache/arrow-datafusion/issues/2417) though, Postgres *does* require subqueries to be aliased, so that is probably what determined the current behavior?

Should we make this behavior configurable?

There was a discussion about this in https://github.com/apache/arrow-datafusion/pull/1067 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove the check that caused subqueries without aliases to fail. Note that there were no tests for this functionality.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
