### PR TITLE
Update `update_datafusion_versions.py` to include all crates

### DIFF
--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -28,6 +28,17 @@ import argparse
 from pathlib import Path
 import tomlkit
 
+crate_names = [
+    'datafusion',
+    'datafusion-cli',
+    'datafusion-common',
+    'datafusion-data-access',
+    'datafusion-expr',
+    'datafusion-jit',
+    'datafusion-physical-expr',
+    'datafusion-proto',
+    'datafusion-row',
+]
 
 def update_datafusion_version(cargo_toml: str, new_version: str):
     print(f'updating {cargo_toml}')
@@ -47,16 +58,17 @@ def update_downstream_versions(cargo_toml: str, new_version: str):
 
     doc = tomlkit.parse(data)
 
-    df_dep = doc.get('dependencies', {}).get('datafusion')
-    # skip crates that pin datafusion using git hash
-    if df_dep is not None and df_dep.get('version') is not None:
-        print(f'updating datafusion dependency in {cargo_toml}')
-        df_dep['version'] = new_version
+    for crate in crate_names:
+        df_dep = doc.get('dependencies', {}).get(crate)
+        # skip crates that pin datafusion using git hash
+        if df_dep is not None and df_dep.get('version') is not None:
+            print(f'updating {crate} dependency in {cargo_toml}')
+            df_dep['version'] = new_version
 
-    df_dep = doc.get('dev-dependencies', {}).get('datafusion')
-    if df_dep is not None and df_dep.get('version') is not None:
-        print(f'updating datafusion dev-dependency in {cargo_toml}')
-        df_dep['version'] = new_version
+        df_dep = doc.get('dev-dependencies', {}).get(crate)
+        if df_dep is not None and df_dep.get('version') is not None:
+            print(f'updating {crate} dev-dependency in {cargo_toml}')
+            df_dep['version'] = new_version
 
     with open(cargo_toml, 'w') as f:
         f.write(tomlkit.dumps(doc))

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -32,6 +32,7 @@ crates = {
     'datafusion': 'datafusion/core/Cargo.toml',
     'datafusion-cli': 'datafusion-cli/Cargo.toml',
     'datafusion-common': 'datafusion/common/Cargo.toml',
+    'datafusion-data-access': 'data-access/Cargo.toml',
     'datafusion-expr': 'datafusion/expr/Cargo.toml',
     'datafusion-jit': 'datafusion/jit/Cargo.toml',
     'datafusion-physical-expr': 'datafusion/physical-expr/Cargo.toml',

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -85,7 +85,7 @@ def main():
 
     print(f'Updating datafusion versions in {repo_root} to {new_version}')
 
-    update_datafusion_version("datafusion/Cargo.toml", new_version)
+    update_datafusion_version("datafusion/core/Cargo.toml", new_version)
     for cargo_toml in repo_root.rglob('Cargo.toml'):
         update_downstream_versions(cargo_toml, new_version)
 

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -32,7 +32,6 @@ crates = {
     'datafusion': 'datafusion/core/Cargo.toml',
     'datafusion-cli': 'datafusion-cli/Cargo.toml',
     'datafusion-common': 'datafusion/common/Cargo.toml',
-    'datafusion-data-access': 'data-access/Cargo.toml',
     'datafusion-expr': 'datafusion/expr/Cargo.toml',
     'datafusion-jit': 'datafusion/jit/Cargo.toml',
     'datafusion-physical-expr': 'datafusion/physical-expr/Cargo.toml',

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -28,17 +28,17 @@ import argparse
 from pathlib import Path
 import tomlkit
 
-crate_names = [
-    'datafusion',
-    'datafusion-cli',
-    'datafusion-common',
-    'datafusion-data-access',
-    'datafusion-expr',
-    'datafusion-jit',
-    'datafusion-physical-expr',
-    'datafusion-proto',
-    'datafusion-row',
-]
+crates = {
+    'datafusion': 'datafusion/core/Cargo.toml',
+    'datafusion-cli': 'datafusion-cli/Cargo.toml',
+    'datafusion-common': 'datafusion/common/Cargo.toml',
+    'datafusion-data-access': 'data-access/Cargo.toml',
+    'datafusion-expr': 'datafusion/expr/Cargo.toml',
+    'datafusion-jit': 'datafusion/jit/Cargo.toml',
+    'datafusion-physical-expr': 'datafusion/physical-expr/Cargo.toml',
+    'datafusion-proto': 'datafusion/proto/Cargo.toml',
+    'datafusion-row': 'datafusion/row/Cargo.toml'
+}
 
 def update_datafusion_version(cargo_toml: str, new_version: str):
     print(f'updating {cargo_toml}')
@@ -58,7 +58,7 @@ def update_downstream_versions(cargo_toml: str, new_version: str):
 
     doc = tomlkit.parse(data)
 
-    for crate in crate_names:
+    for crate in crates.keys():
         df_dep = doc.get('dependencies', {}).get(crate)
         # skip crates that pin datafusion using git hash
         if df_dep is not None and df_dep.get('version') is not None:
@@ -96,9 +96,8 @@ def main():
     repo_root = Path(__file__).parent.parent.absolute()
 
     print(f'Updating datafusion versions in {repo_root} to {new_version}')
-
-    update_datafusion_version("datafusion/core/Cargo.toml", new_version)
-    for cargo_toml in repo_root.rglob('Cargo.toml'):
+    for cargo_toml in crates.values():
+        update_datafusion_version(cargo_toml, new_version)
         update_downstream_versions(cargo_toml, new_version)
 
     update_docs("README.md", new_version)

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -40,6 +40,13 @@ crates = {
     'datafusion-row': 'datafusion/row/Cargo.toml'
 }
 
+ballista_crates = {
+    'core': 'ballista/rust/core/Cargo.toml',
+    'client': 'ballista/rust/client/Cargo.toml',
+    'executor': 'ballista/rust/executor/Cargo.toml',
+    'scheduler': 'ballista/rust/scheduler/Cargo.toml',
+}
+
 def update_datafusion_version(cargo_toml: str, new_version: str):
     print(f'updating {cargo_toml}')
     with open(cargo_toml) as f:
@@ -95,9 +102,14 @@ def main():
     new_version = args.new_version
     repo_root = Path(__file__).parent.parent.absolute()
 
-    print(f'Updating datafusion versions in {repo_root} to {new_version}')
+    print(f'Updating datafusion crate versions in {repo_root} to {new_version}')
     for cargo_toml in crates.values():
         update_datafusion_version(cargo_toml, new_version)
+
+    print(f'Updating datafusion dependency versions in {repo_root} to {new_version}')
+    for cargo_toml in crates.values():
+        update_downstream_versions(cargo_toml, new_version)
+    for cargo_toml in ballista_crates.values():
         update_downstream_versions(cargo_toml, new_version)
 
     update_docs("README.md", new_version)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2392

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Update the Python script that we use to update crate versions.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Updated `dev/update_datafusion_versions.py` so that it updates the version of all DataFusion crates and updates dependencies in all DataFusion & Ballista crates.

Output from running this script:

```
Updating datafusion crate versions in /home/andy/git/arrow-datafusion to 8.0.0
updating datafusion/core/Cargo.toml
updating datafusion-cli/Cargo.toml
updating datafusion/common/Cargo.toml
updating data-access/Cargo.toml
updating datafusion/expr/Cargo.toml
updating datafusion/jit/Cargo.toml
updating datafusion/physical-expr/Cargo.toml
updating datafusion/proto/Cargo.toml
updating datafusion/row/Cargo.toml
Updating datafusion dependency versions in /home/andy/git/arrow-datafusion to 8.0.0
updating datafusion-common dependency in datafusion/core/Cargo.toml
updating datafusion-data-access dependency in datafusion/core/Cargo.toml
updating datafusion-expr dependency in datafusion/core/Cargo.toml
updating datafusion-jit dependency in datafusion/core/Cargo.toml
updating datafusion-physical-expr dependency in datafusion/core/Cargo.toml
updating datafusion-row dependency in datafusion/core/Cargo.toml
updating datafusion dependency in datafusion-cli/Cargo.toml
updating datafusion-common dependency in datafusion/expr/Cargo.toml
updating datafusion-common dependency in datafusion/jit/Cargo.toml
updating datafusion-expr dependency in datafusion/jit/Cargo.toml
updating datafusion-common dependency in datafusion/physical-expr/Cargo.toml
updating datafusion-expr dependency in datafusion/physical-expr/Cargo.toml
updating datafusion dependency in datafusion/proto/Cargo.toml
updating datafusion-common dependency in datafusion/row/Cargo.toml
updating datafusion-expr dependency in datafusion/row/Cargo.toml
updating datafusion-jit dependency in datafusion/row/Cargo.toml
updating datafusion dependency in ballista/rust/core/Cargo.toml
updating datafusion-proto dependency in ballista/rust/core/Cargo.toml
updating datafusion dependency in ballista/rust/client/Cargo.toml
updating datafusion dependency in ballista/rust/executor/Cargo.toml
updating datafusion dependency in ballista/rust/scheduler/Cargo.toml
updating docs in README.md
```

**NOTE: The `datafusion-data-access` crate is currently at version `1.0.0` and is the only DataFusion crate with a different version number. Running this script will bump it to `8.0.0` in line with all other crates.**

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
