### PR TITLE
Fix Ballista executing during plan

### DIFF
--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -23,6 +23,7 @@
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 
 use std::any::Any;
+use std::future::Future;
 use std::iter::Iterator;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -49,10 +50,12 @@ use datafusion::physical_plan::metrics::{
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
-use futures::StreamExt;
+use futures::{StreamExt, TryFutureExt, TryStreamExt};
 
+use datafusion::arrow::error::ArrowError;
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::repartition::BatchPartitioner;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use log::{debug, info};
 
 /// ShuffleWriterExec represents a section of a query plan that has consistent partitioning and
@@ -137,149 +140,155 @@ impl ShuffleWriterExec {
         self.shuffle_output_partitioning.as_ref()
     }
 
-    pub async fn execute_shuffle_write(
+    pub fn execute_shuffle_write(
         &self,
         input_partition: usize,
         context: Arc<TaskContext>,
-    ) -> Result<Vec<ShuffleWritePartition>> {
-        let now = Instant::now();
-
-        let mut stream = self.plan.execute(input_partition, context).await?;
-
+    ) -> impl Future<Output = Result<Vec<ShuffleWritePartition>>> {
         let mut path = PathBuf::from(&self.work_dir);
         path.push(&self.job_id);
         path.push(&format!("{}", self.stage_id));
 
         let write_metrics = ShuffleWriteMetrics::new(input_partition, &self.metrics);
+        let output_partitioning = self.shuffle_output_partitioning.clone();
+        let plan = self.plan.clone();
 
-        match &self.shuffle_output_partitioning {
-            None => {
-                let timer = write_metrics.write_time.timer();
-                path.push(&format!("{}", input_partition));
-                std::fs::create_dir_all(&path)?;
-                path.push("data.arrow");
-                let path = path.to_str().unwrap();
-                info!("Writing results to {}", path);
+        async move {
+            let now = Instant::now();
+            let mut stream = plan.execute(input_partition, context).await?;
 
-                // stream results to disk
-                let stats = utils::write_stream_to_disk(
-                    &mut stream,
-                    path,
-                    &write_metrics.write_time,
-                )
-                .await
-                .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
+            match output_partitioning {
+                None => {
+                    let timer = write_metrics.write_time.timer();
+                    path.push(&format!("{}", input_partition));
+                    std::fs::create_dir_all(&path)?;
+                    path.push("data.arrow");
+                    let path = path.to_str().unwrap();
+                    info!("Writing results to {}", path);
 
-                write_metrics
-                    .input_rows
-                    .add(stats.num_rows.unwrap_or(0) as usize);
-                write_metrics
-                    .output_rows
-                    .add(stats.num_rows.unwrap_or(0) as usize);
-                timer.done();
+                    // stream results to disk
+                    let stats = utils::write_stream_to_disk(
+                        &mut stream,
+                        path,
+                        &write_metrics.write_time,
+                    )
+                    .await
+                    .map_err(|e| DataFusionError::Execution(format!("{:?}", e)))?;
 
-                info!(
-                    "Executed partition {} in {} seconds. Statistics: {}",
-                    input_partition,
-                    now.elapsed().as_secs(),
-                    stats
-                );
+                    write_metrics
+                        .input_rows
+                        .add(stats.num_rows.unwrap_or(0) as usize);
+                    write_metrics
+                        .output_rows
+                        .add(stats.num_rows.unwrap_or(0) as usize);
+                    timer.done();
 
-                Ok(vec![ShuffleWritePartition {
-                    partition_id: input_partition as u64,
-                    path: path.to_owned(),
-                    num_batches: stats.num_batches.unwrap_or(0),
-                    num_rows: stats.num_rows.unwrap_or(0),
-                    num_bytes: stats.num_bytes.unwrap_or(0),
-                }])
-            }
+                    info!(
+                        "Executed partition {} in {} seconds. Statistics: {}",
+                        input_partition,
+                        now.elapsed().as_secs(),
+                        stats
+                    );
 
-            Some(Partitioning::Hash(exprs, n)) => {
-                let num_output_partitions = *n;
-
-                // we won't necessary produce output for every possible partition, so we
-                // create writers on demand
-                let mut writers: Vec<Option<IPCWriter>> = vec![];
-                for _ in 0..num_output_partitions {
-                    writers.push(None);
+                    Ok(vec![ShuffleWritePartition {
+                        partition_id: input_partition as u64,
+                        path: path.to_owned(),
+                        num_batches: stats.num_batches.unwrap_or(0),
+                        num_rows: stats.num_rows.unwrap_or(0),
+                        num_bytes: stats.num_bytes.unwrap_or(0),
+                    }])
                 }
 
-                let mut partitioner = BatchPartitioner::try_new(
-                    Partitioning::Hash(exprs.clone(), *n),
-                    write_metrics.repart_time.clone(),
-                )?;
-
-                while let Some(result) = stream.next().await {
-                    let input_batch = result?;
-
-                    write_metrics.input_rows.add(input_batch.num_rows());
-
-                    partitioner.partition(
-                        input_batch,
-                        |output_partition, output_batch| {
-                            // write non-empty batch out
-
-                            // TODO optimize so we don't write or fetch empty partitions
-                            // if output_batch.num_rows() > 0 {
-                            let timer = write_metrics.write_time.timer();
-                            match &mut writers[output_partition] {
-                                Some(w) => {
-                                    w.write(&output_batch)?;
-                                }
-                                None => {
-                                    let mut path = path.clone();
-                                    path.push(&format!("{}", output_partition));
-                                    std::fs::create_dir_all(&path)?;
-
-                                    path.push(format!("data-{}.arrow", input_partition));
-                                    info!("Writing results to {:?}", path);
-
-                                    let mut writer =
-                                        IPCWriter::new(&path, stream.schema().as_ref())?;
-
-                                    writer.write(&output_batch)?;
-                                    writers[output_partition] = Some(writer);
-                                }
-                            }
-                            write_metrics.output_rows.add(output_batch.num_rows());
-                            timer.done();
-                            Ok(())
-                        },
-                    )?;
-                }
-
-                let mut part_locs = vec![];
-
-                for (i, w) in writers.iter_mut().enumerate() {
-                    match w {
-                        Some(w) => {
-                            w.finish()?;
-                            info!(
-                                "Finished writing shuffle partition {} at {:?}. Batches: {}. Rows: {}. Bytes: {}.",
-                                i,
-                                w.path(),
-                                w.num_batches,
-                                w.num_rows,
-                                w.num_bytes
-                            );
-
-                            part_locs.push(ShuffleWritePartition {
-                                partition_id: i as u64,
-                                path: w.path().to_string_lossy().to_string(),
-                                num_batches: w.num_batches,
-                                num_rows: w.num_rows,
-                                num_bytes: w.num_bytes,
-                            });
-                        }
-                        None => {}
+                Some(Partitioning::Hash(exprs, num_output_partitions)) => {
+                    // we won't necessary produce output for every possible partition, so we
+                    // create writers on demand
+                    let mut writers: Vec<Option<IPCWriter>> = vec![];
+                    for _ in 0..num_output_partitions {
+                        writers.push(None);
                     }
-                }
-                Ok(part_locs)
-            }
 
-            _ => Err(DataFusionError::Execution(
-                "Invalid shuffle partitioning scheme".to_owned(),
-            )),
+                    let mut partitioner = BatchPartitioner::try_new(
+                        Partitioning::Hash(exprs, num_output_partitions),
+                        write_metrics.repart_time.clone(),
+                    )?;
+
+                    while let Some(result) = stream.next().await {
+                        let input_batch = result?;
+
+                        write_metrics.input_rows.add(input_batch.num_rows());
+
+                        partitioner.partition(
+                            input_batch,
+                            |output_partition, output_batch| {
+                                // write non-empty batch out
+
+                                // TODO optimize so we don't write or fetch empty partitions
+                                // if output_batch.num_rows() > 0 {
+                                let timer = write_metrics.write_time.timer();
+                                match &mut writers[output_partition] {
+                                    Some(w) => {
+                                        w.write(&output_batch)?;
+                                    }
+                                    None => {
+                                        let mut path = path.clone();
+                                        path.push(&format!("{}", output_partition));
+                                        std::fs::create_dir_all(&path)?;
+
+                                        path.push(format!(
+                                            "data-{}.arrow",
+                                            input_partition
+                                        ));
+                                        info!("Writing results to {:?}", path);
+
+                                        let mut writer = IPCWriter::new(
+                                            &path,
+                                            stream.schema().as_ref(),
+                                        )?;
+
+                                        writer.write(&output_batch)?;
+                                        writers[output_partition] = Some(writer);
+                                    }
+                                }
+                                write_metrics.output_rows.add(output_batch.num_rows());
+                                timer.done();
+                                Ok(())
+                            },
+                        )?;
+                    }
+
+                    let mut part_locs = vec![];
+
+                    for (i, w) in writers.iter_mut().enumerate() {
+                        match w {
+                            Some(w) => {
+                                w.finish()?;
+                                info!(
+                                    "Finished writing shuffle partition {} at {:?}. Batches: {}. Rows: {}. Bytes: {}.",
+                                    i,
+                                    w.path(),
+                                    w.num_batches,
+                                    w.num_rows,
+                                    w.num_bytes
+                                );
+
+                                part_locs.push(ShuffleWritePartition {
+                                    partition_id: i as u64,
+                                    path: w.path().to_string_lossy().to_string(),
+                                    num_batches: w.num_batches,
+                                    num_rows: w.num_rows,
+                                    num_bytes: w.num_bytes,
+                                });
+                            }
+                            None => {}
+                        }
+                    }
+                    Ok(part_locs)
+                }
+
+                _ => Err(DataFusionError::Execution(
+                    "Invalid shuffle partitioning scheme".to_owned(),
+                )),
+            }
         }
     }
 }
@@ -291,7 +300,7 @@ impl ExecutionPlan for ShuffleWriterExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.plan.schema()
+        result_schema()
     }
 
     fn output_partitioning(&self) -> Partitioning {
@@ -332,50 +341,61 @@ impl ExecutionPlan for ShuffleWriterExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let part_loc = self.execute_shuffle_write(partition, context).await?;
-
-        // build metadata result batch
-        let num_writers = part_loc.len();
-        let mut partition_builder = UInt32Builder::new(num_writers);
-        let mut path_builder = StringBuilder::new(num_writers);
-        let mut num_rows_builder = UInt64Builder::new(num_writers);
-        let mut num_batches_builder = UInt64Builder::new(num_writers);
-        let mut num_bytes_builder = UInt64Builder::new(num_writers);
-
-        for loc in &part_loc {
-            path_builder.append_value(loc.path.clone())?;
-            partition_builder.append_value(loc.partition_id as u32)?;
-            num_rows_builder.append_value(loc.num_rows)?;
-            num_batches_builder.append_value(loc.num_batches)?;
-            num_bytes_builder.append_value(loc.num_bytes)?;
-        }
-
-        // build arrays
-        let partition_num: ArrayRef = Arc::new(partition_builder.finish());
-        let path: ArrayRef = Arc::new(path_builder.finish());
-        let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
-            Box::new(num_rows_builder),
-            Box::new(num_batches_builder),
-            Box::new(num_bytes_builder),
-        ];
-        let mut stats_builder = StructBuilder::new(
-            PartitionStats::default().arrow_struct_fields(),
-            field_builders,
-        );
-        for _ in 0..num_writers {
-            stats_builder.append(true)?;
-        }
-        let stats = Arc::new(stats_builder.finish());
-
-        // build result batch containing metadata
         let schema = result_schema();
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![partition_num, path, stats])
-                .map_err(DataFusionError::ArrowError)?;
 
-        debug!("RESULTS METADATA:\n{:?}", batch);
+        let schema_captured = schema.clone();
+        let fut_stream = self
+            .execute_shuffle_write(partition, context)
+            .and_then(|part_loc| async move {
+                // build metadata result batch
+                let num_writers = part_loc.len();
+                let mut partition_builder = UInt32Builder::new(num_writers);
+                let mut path_builder = StringBuilder::new(num_writers);
+                let mut num_rows_builder = UInt64Builder::new(num_writers);
+                let mut num_batches_builder = UInt64Builder::new(num_writers);
+                let mut num_bytes_builder = UInt64Builder::new(num_writers);
 
-        Ok(Box::pin(MemoryStream::try_new(vec![batch], schema, None)?))
+                for loc in &part_loc {
+                    path_builder.append_value(loc.path.clone())?;
+                    partition_builder.append_value(loc.partition_id as u32)?;
+                    num_rows_builder.append_value(loc.num_rows)?;
+                    num_batches_builder.append_value(loc.num_batches)?;
+                    num_bytes_builder.append_value(loc.num_bytes)?;
+                }
+
+                // build arrays
+                let partition_num: ArrayRef = Arc::new(partition_builder.finish());
+                let path: ArrayRef = Arc::new(path_builder.finish());
+                let field_builders: Vec<Box<dyn ArrayBuilder>> = vec![
+                    Box::new(num_rows_builder),
+                    Box::new(num_batches_builder),
+                    Box::new(num_bytes_builder),
+                ];
+                let mut stats_builder = StructBuilder::new(
+                    PartitionStats::default().arrow_struct_fields(),
+                    field_builders,
+                );
+                for _ in 0..num_writers {
+                    stats_builder.append(true)?;
+                }
+                let stats = Arc::new(stats_builder.finish());
+
+                // build result batch containing metadata
+                let batch = RecordBatch::try_new(
+                    schema_captured.clone(),
+                    vec![partition_num, path, stats],
+                )?;
+
+                debug!("RESULTS METADATA:\n{:?}", batch);
+
+                MemoryStream::try_new(vec![batch], schema_captured, None)
+            })
+            .map_err(|e| ArrowError::ExternalError(Box::new(e)));
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::once(fut_stream).try_flatten(),
+        )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/datafusion/core/src/physical_plan/stream.rs
+++ b/datafusion/core/src/physical_plan/stream.rs
@@ -78,7 +78,7 @@ impl RecordBatchStream for RecordBatchReceiverStream {
 pin_project! {
     /// Combines a [`Stream`] with a [`SchemaRef`] implementing
     /// [`RecordBatchStream`] for the combination
-    pub(crate) struct RecordBatchStreamAdapter<S> {
+    pub struct RecordBatchStreamAdapter<S> {
         schema: SchemaRef,
 
         #[pin]
@@ -88,7 +88,7 @@ pin_project! {
 
 impl<S> RecordBatchStreamAdapter<S> {
     /// Creates a new [`RecordBatchStreamAdapter`] from the provided schema and stream
-    pub(crate) fn new(schema: SchemaRef, stream: S) -> Self {
+    pub fn new(schema: SchemaRef, stream: S) -> Self {
         Self { schema, stream }
     }
 }
@@ -112,6 +112,10 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         self.project().stream.poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2307 

Closes #2426 

 # Rationale for this change

`ExecutionPlan::execute` is expected to defer computation to the returned `SendableRecordBatchStream`, this is necessary for result streaming to work correctly. Currently the Ballista ExecutionPlan instead evaluate in `ExecutionPlan::execute`, which is not correct.

# What changes are included in this PR?

Defers plan evaluation to the `SendableRecordBatchStream` 

# Are there any user-facing changes?

Yes, I replaced `ballista::core::WrappedStream` with the `RecordBatchStreamAdapter` from DataFusion
