### PR TITLE
ArrayIndex support with expression as key

### DIFF
--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -36,7 +36,7 @@ datafusion = { path = "../../../datafusion/core", version = "7.0.0" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
-sqlparser = "0.16"
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "f4f346865d446342ba2a39681496d8e72886416a" }
 tempfile = "3"
 tokio = "1.0"
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -53,7 +53,7 @@ parse_arg = "0.1.3"
 prost = "0.10"
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-sqlparser = "0.16"
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "f4f346865d446342ba2a39681496d8e72886416a" }
 tokio = "1.0"
 tonic = "0.7"
 uuid = { version = "1.0", features = ["v4"] }

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -44,4 +44,4 @@ cranelift-module = { version = "0.83.0", optional = true }
 ordered-float = "3.0"
 parquet = { version = "13", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
-sqlparser = "0.16"
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "f4f346865d446342ba2a39681496d8e72886416a" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -79,7 +79,7 @@ pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }
 rand = "0.8"
 smallvec = { version = "1.6", features = ["union"] }
-sqlparser = "0.16"
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "f4f346865d446342ba2a39681496d8e72886416a" }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -95,7 +95,8 @@ impl ExpressionVisitor for ApplicabilityVisitor<'_> {
             | Expr::Exists { .. }
             | Expr::InSubquery { .. }
             | Expr::ScalarSubquery(_)
-            | Expr::GetIndexedField { .. }
+            | Expr::MapAccess { .. }
+            | Expr::ArrayIndex { .. }
             | Expr::Case { .. } => Recursion::Continue(self),
 
             Expr::ScalarFunction { fun, .. } => self.visit_volatility(fun.volatility()),

--- a/datafusion/core/src/logical_plan/expr_rewriter.rs
+++ b/datafusion/core/src/logical_plan/expr_rewriter.rs
@@ -232,9 +232,13 @@ impl ExprRewritable for Expr {
             Expr::QualifiedWildcard { qualifier } => {
                 Expr::QualifiedWildcard { qualifier }
             }
-            Expr::GetIndexedField { expr, key } => Expr::GetIndexedField {
+            Expr::MapAccess { expr, key } => Expr::MapAccess {
                 expr: rewrite_boxed(expr, rewriter)?,
                 key,
+            },
+            Expr::ArrayIndex { expr, key } => Expr::ArrayIndex {
+                expr: rewrite_boxed(expr, rewriter)?,
+                key: rewrite_boxed(key, rewriter)?,
             },
         };
 

--- a/datafusion/core/src/logical_plan/expr_visitor.rs
+++ b/datafusion/core/src/logical_plan/expr_visitor.rs
@@ -102,7 +102,8 @@ impl ExprVisitable for Expr {
             | Expr::Cast { expr, .. }
             | Expr::TryCast { expr, .. }
             | Expr::Sort { expr, .. }
-            | Expr::GetIndexedField { expr, .. } => expr.accept(visitor),
+            | Expr::MapAccess { expr, .. }
+            | Expr::ArrayIndex { expr, .. } => expr.accept(visitor),
             Expr::Column(_)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_)

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -478,8 +478,12 @@ impl ExprIdentifierVisitor<'_> {
                 desc.push_str("QualifiedWildcard-");
                 desc.push_str(qualifier);
             }
-            Expr::GetIndexedField { key, .. } => {
-                desc.push_str("GetIndexedField-");
+            Expr::MapAccess { key, .. } => {
+                desc.push_str("MapAccess-");
+                desc.push_str(&key.to_string());
+            }
+            Expr::ArrayIndex { key, .. } => {
+                desc.push_str("ArrayIndex-");
                 desc.push_str(&key.to_string());
             }
         }

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -395,7 +395,8 @@ impl<'a> ConstEvaluator<'a> {
             | Expr::Cast { .. }
             | Expr::TryCast { .. }
             | Expr::InList { .. }
-            | Expr::GetIndexedField { .. } => true,
+            | Expr::MapAccess { .. }
+            | Expr::ArrayIndex { .. } => true,
         }
     }
 

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -400,9 +400,13 @@ where
             }),
             Expr::Wildcard => Ok(Expr::Wildcard),
             Expr::QualifiedWildcard { .. } => Ok(expr.clone()),
-            Expr::GetIndexedField { expr, key } => Ok(Expr::GetIndexedField {
+            Expr::MapAccess { expr, key } => Ok(Expr::MapAccess {
                 expr: Box::new(clone_with_replacement(expr.as_ref(), replacement_fn)?),
                 key: key.clone(),
+            }),
+            Expr::ArrayIndex { expr, key } => Ok(Expr::ArrayIndex {
+                expr: Box::new(clone_with_replacement(expr.as_ref(), replacement_fn)?),
+                key: Box::new(clone_with_replacement(key.as_ref(), replacement_fn)?),
             }),
         },
     }

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -38,4 +38,4 @@ path = "src/lib.rs"
 ahash = { version = "0.7", default-features = false }
 arrow = { version = "13", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
-sqlparser = "0.16"
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "f4f346865d446342ba2a39681496d8e72886416a" }

--- a/datafusion/expr/src/columnar_value.rs
+++ b/datafusion/expr/src/columnar_value.rs
@@ -25,7 +25,7 @@ use datafusion_common::ScalarValue;
 use std::sync::Arc;
 
 /// Represents the result from an expression
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ColumnarValue {
     /// Array of values
     Array(ArrayRef),

--- a/datafusion/physical-expr/src/expressions/array_index.rs
+++ b/datafusion/physical-expr/src/expressions/array_index.rs
@@ -1,0 +1,407 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! get field of a `ListArray`
+
+use crate::PhysicalExpr;
+use arrow::array::{
+    Array, Int32Array, Int64Array, UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::array::{ListArray, StructArray};
+use arrow::compute::concat;
+use arrow::{
+    datatypes::{DataType, Schema},
+    record_batch::RecordBatch,
+};
+use datafusion_common::DataFusionError;
+use datafusion_common::Result;
+use datafusion_common::ScalarValue;
+use datafusion_expr::field_util::get_array_index_field;
+use datafusion_expr::{field_util::get_map_access_field, ColumnarValue};
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::{any::Any, sync::Arc};
+
+/// expression to get a field of an array.
+#[derive(Debug)]
+pub struct ArrayIndexExpr {
+    arg: Arc<dyn PhysicalExpr>,
+    key: Arc<dyn PhysicalExpr>,
+}
+
+impl ArrayIndexExpr {
+    /// Create new get field expression
+    pub fn new(arg: Arc<dyn PhysicalExpr>, key: Arc<dyn PhysicalExpr>) -> Self {
+        Self { arg, key }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
+    }
+}
+
+impl std::fmt::Display for ArrayIndexExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "({}).[{}]", self.arg, self.key)
+    }
+}
+
+impl PhysicalExpr for ArrayIndexExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
+        let data_type = self.arg.data_type(input_schema)?;
+        get_array_index_field(&data_type).map(|f| f.data_type().clone())
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        let data_type = self.arg.data_type(input_schema)?;
+        get_array_index_field(&data_type).map(|f| f.is_nullable())
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let arg = self.arg.evaluate(batch)?;
+        let key = self.key.evaluate(batch)?;
+        match (arg, key) {
+            (ColumnarValue::Array(array), ColumnarValue::Array(wrapper)) => match (array.data_type(), wrapper.data_type()) {
+                (DataType::List(_), _) if wrapper.is_null(0) => {
+                    let scalar_null: ScalarValue = array.data_type().try_into()?;
+                    Ok(ColumnarValue::Scalar(scalar_null))
+                },
+                (DataType::List(_), DataType::Int64) => {
+                    let as_list_array =
+                        array.as_any().downcast_ref::<ListArray>().unwrap();
+
+                    if as_list_array.is_empty() {
+                        let scalar_null: ScalarValue = array.data_type().try_into()?;
+                        return Ok(ColumnarValue::Scalar(scalar_null))
+                    }
+
+                    let key = match wrapper.data_type() {
+                        DataType::Int16 => wrapper.as_any().downcast_ref::<Int64Array>().unwrap().value(0) as usize,
+                        DataType::Int32 => wrapper.as_any().downcast_ref::<Int64Array>().unwrap().value(0) as usize,
+                        DataType::Int64 => wrapper.as_any().downcast_ref::<Int64Array>().unwrap().value(0) as usize,
+                        DataType::UInt16 => wrapper.as_any().downcast_ref::<UInt16Array>().unwrap().value(0) as usize,
+                        DataType::UInt32 => wrapper.as_any().downcast_ref::<UInt32Array>().unwrap().value(0) as usize,
+                        DataType::UInt64 => wrapper.as_any().downcast_ref::<UInt64Array>().unwrap().value(0) as usize,
+                        _ => unreachable!(),
+                    };
+
+                    let sliced_array: Vec<Arc<dyn Array>> = as_list_array
+                        .iter()
+                        .filter_map(|o| o.map(|list| list.slice(key, 1)))
+                        .collect();
+                    let vec = sliced_array.iter().map(|a| a.as_ref()).collect::<Vec<&dyn Array>>();
+                    let iter = concat(vec.as_slice()).unwrap();
+                    Ok(ColumnarValue::Array(iter))
+                },
+                (dt, key) => Err(DataFusionError::NotImplemented(format!("array index field is only possible on lists with integers indexes. Tried {} with {} index", dt, key))),
+            },
+            (ColumnarValue::Array(array), ColumnarValue::Scalar(key)) => match (array.data_type(), key.get_datatype()) {
+                (DataType::List(_), _) if key.is_null() => {
+                    let scalar_null: ScalarValue = array.data_type().try_into()?;
+                    Ok(ColumnarValue::Scalar(scalar_null))
+                }
+                (DataType::List(_), DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64) => {
+                    let as_list_array =
+                        array.as_any().downcast_ref::<ListArray>().unwrap();
+                    if as_list_array.is_empty() {
+                        let scalar_null: ScalarValue = array.data_type().try_into()?;
+                        return Ok(ColumnarValue::Scalar(scalar_null))
+                    }
+
+                    let key = match key {
+                        ScalarValue::Int16(v) => v.unwrap() as usize,
+                        ScalarValue::Int32(v) => v.unwrap() as usize,
+                        ScalarValue::Int64(v) => v.unwrap() as usize,
+                        ScalarValue::UInt16(v) => v.unwrap() as usize,
+                        ScalarValue::UInt32(v) => v.unwrap() as usize,
+                        ScalarValue::UInt64(v) => v.unwrap() as usize,
+                        _ => unreachable!(),
+                    };
+
+                    let sliced_array: Vec<Arc<dyn Array>> = as_list_array
+                        .iter()
+                        .filter_map(|o| o.map(|list| list.slice(key, 1)))
+                        .collect();
+                    let vec = sliced_array.iter().map(|a| a.as_ref()).collect::<Vec<&dyn Array>>();
+                    let iter = concat(vec.as_slice()).unwrap();
+                    Ok(ColumnarValue::Array(iter))
+                }
+                (dt, key) => Err(DataFusionError::NotImplemented(format!("array index field is only possible on lists with integers indexes. Tried {} with {} index", dt, key))),
+            },
+            (_, key) => Err(DataFusionError::NotImplemented(format!(
+                "array index access is not yet implemented for value: {:?}",
+                key
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expressions::{col, lit};
+    use arrow::array::GenericListArray;
+    use arrow::array::{
+        Int64Array, Int64Builder, ListBuilder, StringBuilder, StructArray, StructBuilder,
+    };
+    use arrow::{array::StringArray, datatypes::Field};
+    use datafusion_common::Result;
+    //
+    // fn build_utf8_lists(list_of_lists: Vec<Vec<Option<&str>>>) -> GenericListArray<i32> {
+    //     let builder = StringBuilder::new(list_of_lists.len());
+    //     let mut lb = ListBuilder::new(builder);
+    //     for values in list_of_lists {
+    //         let builder = lb.values();
+    //         for value in values {
+    //             match value {
+    //                 None => builder.append_null(),
+    //                 Some(v) => builder.append_value(v),
+    //             }
+    //             .unwrap()
+    //         }
+    //         lb.append(true).unwrap();
+    //     }
+    //
+    //     lb.finish()
+    // }
+    //
+    // fn get_indexed_field_test(
+    //     list_of_lists: Vec<Vec<Option<&str>>>,
+    //     index: i64,
+    //     expected: Vec<Option<&str>>,
+    // ) -> Result<()> {
+    //     let schema = list_schema("l");
+    //     let list_col = build_utf8_lists(list_of_lists);
+    //     let expr = col("l", &schema).unwrap();
+    //     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_col)])?;
+    //     let key = ScalarValue::Int64(Some(index));
+    //     let expr = Arc::new(ArrayIndexExpr::new(expr, key));
+    //     let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
+    //     let result = result
+    //         .as_any()
+    //         .downcast_ref::<StringArray>()
+    //         .expect("failed to downcast to StringArray");
+    //     let expected = &StringArray::from(expected);
+    //     assert_eq!(expected, result);
+    //     Ok(())
+    // }
+    //
+    // fn list_schema(col: &str) -> Schema {
+    //     Schema::new(vec![Field::new(
+    //         col,
+    //         DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+    //         true,
+    //     )])
+    // }
+    //
+    // #[test]
+    // fn get_indexed_field_list() -> Result<()> {
+    //     let list_of_lists = vec![
+    //         vec![Some("a"), Some("b"), None],
+    //         vec![None, Some("c"), Some("d")],
+    //         vec![Some("e"), None, Some("f")],
+    //     ];
+    //     let expected_list = vec![
+    //         vec![Some("a"), None, Some("e")],
+    //         vec![Some("b"), Some("c"), None],
+    //         vec![None, Some("d"), Some("f")],
+    //     ];
+    //
+    //     for (i, expected) in expected_list.into_iter().enumerate() {
+    //         get_indexed_field_test(list_of_lists.clone(), i as i64, expected)?;
+    //     }
+    //     Ok(())
+    // }
+    //
+    // #[test]
+    // fn get_indexed_field_empty_list() -> Result<()> {
+    //     let schema = list_schema("l");
+    //     let builder = StringBuilder::new(0);
+    //     let mut lb = ListBuilder::new(builder);
+    //     let expr = col("l", &schema).unwrap();
+    //     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lb.finish())])?;
+    //     let key = ScalarValue::Int64(Some(0));
+    //     let expr = Arc::new(ArrayIndexExpr::new(expr, key));
+    //     let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
+    //     assert!(result.is_empty());
+    //     Ok(())
+    // }
+    //
+    // fn get_indexed_field_test_failure(
+    //     schema: Schema,
+    //     expr: Arc<dyn PhysicalExpr>,
+    //     key: ScalarValue,
+    //     expected: &str,
+    // ) -> Result<()> {
+    //     let builder = StringBuilder::new(3);
+    //     let mut lb = ListBuilder::new(builder);
+    //     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lb.finish())])?;
+    //     let expr = Arc::new(ArrayIndexExpr::new(expr, key));
+    //     let r = expr.evaluate(&batch).map(|_| ());
+    //     assert!(r.is_err());
+    //     assert_eq!(format!("{}", r.unwrap_err()), expected);
+    //     Ok(())
+    // }
+    //
+    // #[test]
+    // fn get_indexed_field_invalid_scalar() -> Result<()> {
+    //     let schema = list_schema("l");
+    //     let expr = lit(ScalarValue::Utf8(Some("a".to_string())));
+    //     get_indexed_field_test_failure(schema, expr,  ScalarValue::Int64(Some(0)), "This feature is not implemented: field access is not yet implemented for scalar values")
+    // }
+    //
+    // #[test]
+    // fn get_indexed_field_invalid_list_index() -> Result<()> {
+    //     let schema = list_schema("l");
+    //     let expr = col("l", &schema).unwrap();
+    //     get_indexed_field_test_failure(schema, expr,  ScalarValue::Int8(Some(0)), "This feature is not implemented: get indexed field is only possible on lists with int64 indexes. Tried List(Field { name: \"item\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }) with 0 index")
+    // }
+    //
+    // fn build_struct(
+    //     fields: Vec<Field>,
+    //     list_of_tuples: Vec<(Option<i64>, Vec<Option<&str>>)>,
+    // ) -> StructArray {
+    //     let foo_builder = Int64Array::builder(list_of_tuples.len());
+    //     let str_builder = StringBuilder::new(list_of_tuples.len());
+    //     let bar_builder = ListBuilder::new(str_builder);
+    //     let mut builder = StructBuilder::new(
+    //         fields,
+    //         vec![Box::new(foo_builder), Box::new(bar_builder)],
+    //     );
+    //     for (int_value, list_value) in list_of_tuples {
+    //         let fb = builder.field_builder::<Int64Builder>(0).unwrap();
+    //         match int_value {
+    //             None => fb.append_null(),
+    //             Some(v) => fb.append_value(v),
+    //         }
+    //         .unwrap();
+    //         builder.append(true).unwrap();
+    //         let lb = builder
+    //             .field_builder::<ListBuilder<StringBuilder>>(1)
+    //             .unwrap();
+    //         for str_value in list_value {
+    //             match str_value {
+    //                 None => lb.values().append_null(),
+    //                 Some(v) => lb.values().append_value(v),
+    //             }
+    //             .unwrap();
+    //         }
+    //         lb.append(true).unwrap();
+    //     }
+    //     builder.finish()
+    // }
+    //
+    // fn get_indexed_field_mixed_test(
+    //     list_of_tuples: Vec<(Option<i64>, Vec<Option<&str>>)>,
+    //     expected_strings: Vec<Vec<Option<&str>>>,
+    //     expected_ints: Vec<Option<i64>>,
+    // ) -> Result<()> {
+    //     let struct_col = "s";
+    //     let fields = vec![
+    //         Field::new("foo", DataType::Int64, true),
+    //         Field::new(
+    //             "bar",
+    //             DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+    //             true,
+    //         ),
+    //     ];
+    //     let schema = Schema::new(vec![Field::new(
+    //         struct_col,
+    //         DataType::Struct(fields.clone()),
+    //         true,
+    //     )]);
+    //     let struct_col = build_struct(fields, list_of_tuples.clone());
+    //
+    //     let struct_col_expr = col("s", &schema).unwrap();
+    //     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_col)])?;
+    //
+    //     let int_field_key = ScalarValue::Utf8(Some("foo".to_string()));
+    //     let get_field_expr = Arc::new(ArrayIndexExpr::new(
+    //         struct_col_expr.clone(),
+    //         int_field_key,
+    //     ));
+    //     let result = get_field_expr
+    //         .evaluate(&batch)?
+    //         .into_array(batch.num_rows());
+    //     let result = result
+    //         .as_any()
+    //         .downcast_ref::<Int64Array>()
+    //         .expect("failed to downcast to Int64Array");
+    //     let expected = &Int64Array::from(expected_ints);
+    //     assert_eq!(expected, result);
+    //
+    //     let list_field_key = ScalarValue::Utf8(Some("bar".to_string()));
+    //     let get_list_expr =
+    //         Arc::new(ArrayIndexExpr::new(struct_col_expr, list_field_key));
+    //     let result = get_list_expr.evaluate(&batch)?.into_array(batch.num_rows());
+    //     let result = result
+    //         .as_any()
+    //         .downcast_ref::<ListArray>()
+    //         .unwrap_or_else(|| panic!("failed to downcast to ListArray : {:?}", result));
+    //     let expected =
+    //         &build_utf8_lists(list_of_tuples.into_iter().map(|t| t.1).collect());
+    //     assert_eq!(expected, result);
+    //
+    //     for (i, expected) in expected_strings.into_iter().enumerate() {
+    //         let get_nested_str_expr = Arc::new(ArrayIndexExpr::new(
+    //             get_list_expr.clone(),
+    //             ScalarValue::Int64(Some(i as i64)),
+    //         ));
+    //         let result = get_nested_str_expr
+    //             .evaluate(&batch)?
+    //             .into_array(batch.num_rows());
+    //         let result = result
+    //             .as_any()
+    //             .downcast_ref::<StringArray>()
+    //             .unwrap_or_else(|| {
+    //                 panic!("failed to downcast to StringArray : {:?}", result)
+    //             });
+    //         let expected = &StringArray::from(expected);
+    //         assert_eq!(expected, result);
+    //     }
+    //     Ok(())
+    // }
+    //
+    // #[test]
+    // fn get_indexed_field_struct() -> Result<()> {
+    //     let list_of_structs = vec![
+    //         (Some(10), vec![Some("a"), Some("b"), None]),
+    //         (Some(15), vec![None, Some("c"), Some("d")]),
+    //         (None, vec![Some("e"), None, Some("f")]),
+    //     ];
+    //
+    //     let expected_list = vec![
+    //         vec![Some("a"), None, Some("e")],
+    //         vec![Some("b"), Some("c"), None],
+    //         vec![None, Some("d"), Some("f")],
+    //     ];
+    //
+    //     let expected_ints = vec![Some(10), Some(15), None];
+    //
+    //     get_indexed_field_mixed_test(
+    //         list_of_structs.clone(),
+    //         expected_list,
+    //         expected_ints,
+    //     )?;
+    //     Ok(())
+    // }
+}

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -19,15 +19,16 @@
 
 #[macro_use]
 mod binary;
+mod array_index;
 mod case;
 mod cast;
 mod column;
 mod datetime;
-mod get_indexed_field;
 mod in_list;
 mod is_not_null;
 mod is_null;
 mod literal;
+mod map_access;
 mod negative;
 mod not;
 mod nullif;
@@ -64,6 +65,7 @@ pub use crate::window::nth_value::NthValue;
 pub use crate::window::rank::{dense_rank, percent_rank, rank};
 pub use crate::window::row_number::RowNumber;
 
+pub use array_index::ArrayIndexExpr;
 pub use binary::{binary, BinaryExpr};
 pub use case::{case, CaseExpr};
 pub use cast::{
@@ -71,11 +73,11 @@ pub use cast::{
 };
 pub use column::{col, Column};
 pub use datetime::DateIntervalExpr;
-pub use get_indexed_field::GetIndexedFieldExpr;
 pub use in_list::{in_list, InListExpr};
 pub use is_not_null::{is_not_null, IsNotNullExpr};
 pub use is_null::{is_null, IsNullExpr};
 pub use literal::{lit, Literal};
+pub use map_access::MapAccessExpr;
 pub use negative::{negative, NegativeExpr};
 pub use not::{not, NotExpr};
 pub use nullif::nullif_func;


### PR DESCRIPTION
# Which issue does this PR close?

https://github.com/apache/arrow-datafusion/issues/2442

Closes #2442.

# What changes are included in this PR?

In the Planner: Support of ArrayIndex
In the Logical/PhysicalPlan: Split of GetIndexedField into ArrayIndexExpr & MapAccessExpr
