### PR TITLE
Add `EXISTS` and `IN` subquery rewriting for correlated filters at filter depth 1

### DIFF
--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -130,7 +130,7 @@ fn issue_filters(
         return push_down(&state, plan);
     }
 
-    let plan = utils::add_filter(plan.clone(), &predicates);
+    let plan = utils::filter_by_all(plan.clone(), &predicates);
 
     state.filters = remove_filters(&state.filters, &predicate_columns);
 
@@ -251,7 +251,7 @@ fn optimize_join(
         Ok(plan)
     } else {
         // wrap the join on the filter whose predicates must be kept
-        let plan = utils::add_filter(plan, &to_keep.0);
+        let plan = utils::filter_by_all(plan, &to_keep.0);
         state.filters = remove_filters(&state.filters, &to_keep.1);
 
         Ok(plan)
@@ -290,7 +290,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             // As those contain only literals, they could be optimized using constant folding
             // and removal of WHERE TRUE / WHERE FALSE
             if !no_col_predicates.is_empty() {
-                Ok(utils::add_filter(
+                Ok(utils::filter_by_all(
                     optimize(input, state)?,
                     &no_col_predicates,
                 ))

--- a/datafusion/core/src/optimizer/subquery_filter_to_join.rs
+++ b/datafusion/core/src/optimizer/subquery_filter_to_join.rs
@@ -54,9 +54,9 @@ impl SubqueryFilterToJoin {
         column_a: &Column,
         column_b: &Column,
     ) -> Option<(Column, Column)> {
-        if column_is_correlated(outer, column_a) {
+        if utils::column_is_correlated(outer, column_a) {
             return Some((column_a.clone(), column_b.clone()));
-        } else if column_is_correlated(outer, column_b) {
+        } else if utils::column_is_correlated(outer, column_b) {
             return Some((column_b.clone(), column_a.clone()));
         }
         None
@@ -376,34 +376,6 @@ fn extract_subquery_filters(expression: &Expr, extracted: &mut Vec<Expr>) -> Res
             }
             _ => extract_subquery_filters(&se, extracted),
         })
-}
-
-fn column_is_correlated(outer: &Arc<DFSchema>, column: &Column) -> bool {
-    for field in outer.fields() {
-        if *column == field.qualified_column() || *column == field.unqualified_column() {
-            return true;
-        }
-    }
-    false
-}
-
-#[allow(unused)]
-fn detect_correlated_columns(outer: &Arc<DFSchema>, expression: &Expr) -> Result<bool> {
-    for se in utils::expr_sub_expressions(expression)?.into_iter() {
-        match se {
-            Expr::Column(c) => {
-                if column_is_correlated(outer, &c) {
-                    return Ok(true);
-                }
-            }
-            _ => {
-                if detect_correlated_columns(outer, &se)? {
-                    return Ok(true);
-                }
-            }
-        }
-    }
-    Ok(false)
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/optimizer/subquery_filter_to_join.rs
+++ b/datafusion/core/src/optimizer/subquery_filter_to_join.rs
@@ -109,10 +109,10 @@ impl SubqueryFilterToJoin {
     fn rewrite_correlated_subquery_as_join(
         &self,
         outer_plan: LogicalPlan,
-        expr: &Expr,
+        subquery_expr: &Expr,
         execution_props: &ExecutionProps,
     ) -> Result<LogicalPlan> {
-        match expr {
+        match subquery_expr {
             Expr::InSubquery {
                 expr,
                 subquery,
@@ -322,10 +322,10 @@ impl OptimizerRule for SubqueryFilterToJoin {
                 // optimized_input value should retain for possible optimization rollback
                 let opt_result = subquery_filters.iter().try_fold(
                     optimized_input.clone(),
-                    |input, &e| {
+                    |outer_plan, &subquery_expr| {
                         self.rewrite_correlated_subquery_as_join(
-                            input,
-                            e,
+                            outer_plan,
+                            &subquery_expr,
                             execution_props,
                         )
                     },

--- a/datafusion/core/src/optimizer/subquery_filter_to_join.rs
+++ b/datafusion/core/src/optimizer/subquery_filter_to_join.rs
@@ -30,12 +30,13 @@ use std::sync::Arc;
 
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::ExecutionProps;
-use crate::logical_plan::plan::{Filter, Join};
+use crate::logical_plan::plan::{Filter, Join, Projection};
 use crate::logical_plan::{
-    build_join_schema, Expr, JoinConstraint, JoinType, LogicalPlan,
+    build_join_schema, Expr, JoinConstraint, JoinType, LogicalPlan, Operator,
 };
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
+use datafusion_common::{Column, DFSchema};
 
 /// Optimizer rule for rewriting subquery filters to joins
 #[derive(Default)]
@@ -46,6 +47,227 @@ impl SubqueryFilterToJoin {
     pub fn new() -> Self {
         Self {}
     }
+
+    fn are_correlated_columns(
+        &self,
+        outer: &Arc<DFSchema>,
+        column_a: &Column,
+        column_b: &Column,
+    ) -> Option<(Column, Column)> {
+        if column_is_correlated(outer, column_a) {
+            return Some((column_a.clone(), column_b.clone()));
+        } else if column_is_correlated(outer, column_b) {
+            return Some((column_b.clone(), column_a.clone()));
+        }
+        None
+    }
+
+    // TODO: do we need to check correlation/dependency only with outer input top-level schema?
+    // NOTE: We only match against an equality filter with an outer column
+    fn extract_correlated_columns(
+        &self,
+        expr: &Expr,
+        outer: &Arc<DFSchema>,
+        correlated_columns: &mut Vec<(Column, Column)>,
+    ) -> Option<Expr> {
+        let mut filters = vec![];
+        // This will also strip aliases
+        utils::split_conjunction(expr, &mut filters);
+
+        let mut non_correlated_predicates = vec![];
+        for filter in filters {
+            match filter {
+                Expr::BinaryExpr { left, op, right } => {
+                    let mut extracted_column = false;
+                    if let (Expr::Column(column_a), Expr::Column(column_b)) =
+                        (left.as_ref(), right.as_ref())
+                    {
+                        if let Some(columns) =
+                            self.are_correlated_columns(outer, &column_a, &column_b)
+                        {
+                            if *op == Operator::Eq {
+                                correlated_columns.push(columns);
+                                extracted_column = true;
+                            }
+                        }
+                    }
+                    if !extracted_column {
+                        non_correlated_predicates.push(filter);
+                    }
+                }
+                _ => non_correlated_predicates.push(filter),
+            }
+        }
+
+        if non_correlated_predicates.is_empty() {
+            None
+        } else {
+            Some(utils::combine_conjunctive(&non_correlated_predicates))
+        }
+    }
+
+    fn rewrite_outer_plan(
+        &self,
+        outer_plan: LogicalPlan,
+        expr: &Expr,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
+        match expr {
+            Expr::InSubquery {
+                expr,
+                subquery,
+                negated,
+            } => {
+                let mut correlated_columns = vec![];
+                let subquery_ref = &*subquery.subquery;
+                let right_decorrelated_plan = match subquery_ref {
+                    // NOTE: We only pattern match against Projection(Filter(..)). We will have another optimization rule
+                    // which tries to pull up all correlated predicates in an InSubquery into a Projection(Filter(..))
+                    // at the root node of the InSubquery's subquery. The Projection at the root must have as its expression
+                    // a single Column.
+                    LogicalPlan::Projection(Projection { input, expr, .. }) => {
+                        if expr.len() != 1 {
+                            return Err(DataFusionError::Plan(
+                                "Only single column allowed in InSubquery".to_string(),
+                            ));
+                        };
+                        if let Expr::Column(right_key) = &expr[0] {
+                            match &**input {
+                                LogicalPlan::Filter(Filter { predicate, input }) => {
+                                    let non_correlated_predicates = self
+                                        .extract_correlated_columns(
+                                            &predicate,
+                                            outer_plan.schema(),
+                                            &mut correlated_columns,
+                                        );
+
+                                    // Strip the projection away and use its input for the semi/anti-join
+                                    // Note that this rule is quite quirky. But a removing a projection below a semi
+                                    // or anti join is inconsequential if it is a Column projection.
+                                    let plan = if let Some(predicate) =
+                                        non_correlated_predicates
+                                    {
+                                        LogicalPlan::Filter(Filter {
+                                            input: input.clone(),
+                                            predicate,
+                                        })
+                                    } else {
+                                        (**input).clone()
+                                    };
+                                    Some((plan, right_key.clone()))
+                                }
+                                _ => None,
+                            }
+                        } else {
+                            // If the projection is not a Column, we don't pattern match
+                            // against correlated predicates
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+
+                let (right_input, right_key) =
+                    if let Some((plan, key)) = right_decorrelated_plan {
+                        let right_input = self.optimize(&plan, execution_props)?;
+                        (right_input, key)
+                    } else {
+                        let right_input = self.optimize(subquery_ref, execution_props)?;
+                        let right_schema = right_input.schema();
+                        if right_schema.fields().len() != 1 {
+                            return Err(DataFusionError::Plan(
+                                "Only single column allowed in InSubquery".to_string(),
+                            ));
+                        }
+                        let right_key = right_schema.field(0).qualified_column();
+
+                        (right_input, right_key)
+                    };
+
+                let left_key = match *expr.clone() {
+                    Expr::Column(col) => col,
+                    _ => {
+                        return Err(DataFusionError::NotImplemented(
+                            "Filtering by expression not implemented for InSubquery"
+                                .to_string(),
+                        ))
+                    }
+                };
+                correlated_columns.push((left_key, right_key));
+
+                let join_type = if *negated {
+                    JoinType::Anti
+                } else {
+                    JoinType::Semi
+                };
+
+                let schema = build_join_schema(
+                    outer_plan.schema(),
+                    right_input.schema(),
+                    &join_type,
+                )?;
+
+                Ok(LogicalPlan::Join(Join {
+                    left: Arc::new(outer_plan),
+                    right: Arc::new(right_input),
+                    on: correlated_columns,
+                    join_type,
+                    join_constraint: JoinConstraint::On,
+                    schema: Arc::new(schema),
+                    null_equals_null: false,
+                }))
+            }
+            Expr::Exists { subquery, negated } => {
+                // NOTE: We only pattern match against Filter(..). We will have another optimization rule
+                // which tries to pull up all correlated predicates in an Exists into a Filter(..)
+                // at the root node of the Exists's subquery
+                let mut correlated_columns = vec![];
+                let right_input = match &*subquery.subquery {
+                    LogicalPlan::Filter(Filter { predicate, input }) => {
+                        let non_correlated_predicates = self.extract_correlated_columns(
+                            &predicate,
+                            outer_plan.schema(),
+                            &mut correlated_columns,
+                        );
+                        if let Some(predicate) = non_correlated_predicates {
+                            Arc::new(LogicalPlan::Filter(Filter {
+                                input: input.clone(),
+                                predicate,
+                            }))
+                        } else {
+                            input.clone()
+                        }
+                    }
+                    _ => subquery.subquery.clone(),
+                };
+
+                let right_input = self.optimize(&right_input, execution_props)?;
+                let right_schema = right_input.schema();
+
+                let join_type = if *negated {
+                    JoinType::Anti
+                } else {
+                    JoinType::Semi
+                };
+
+                let schema =
+                    build_join_schema(outer_plan.schema(), right_schema, &join_type)?;
+
+                Ok(LogicalPlan::Join(Join {
+                    left: Arc::new(outer_plan),
+                    right: Arc::new(right_input),
+                    on: correlated_columns,
+                    join_type,
+                    join_constraint: JoinConstraint::On,
+                    schema: Arc::new(schema),
+                    null_equals_null: false,
+                }))
+            }
+            _ => Err(DataFusionError::Plan(
+                "Unknown expression while rewriting subquery to joins".to_string(),
+            )),
+        }
+    }
 }
 
 impl OptimizerRule for SubqueryFilterToJoin {
@@ -55,6 +277,8 @@ impl OptimizerRule for SubqueryFilterToJoin {
         execution_props: &ExecutionProps,
     ) -> Result<LogicalPlan> {
         match plan {
+            // Pattern match on all plans of the form
+            // Filter: Exists(Filter(..)) AND InSubquery(Filter(..)) AND ...
             LogicalPlan::Filter(Filter { predicate, input }) => {
                 // Apply optimizer rule to current input
                 let optimized_input = self.optimize(input, execution_props)?;
@@ -65,19 +289,24 @@ impl OptimizerRule for SubqueryFilterToJoin {
 
                 // Searching for subquery-based filters
                 let (subquery_filters, regular_filters): (Vec<&Expr>, Vec<&Expr>) =
-                    filters
-                        .into_iter()
-                        .partition(|&e| matches!(e, Expr::InSubquery { .. }));
+                    filters.into_iter().partition(|&e| {
+                        matches!(e, Expr::InSubquery { .. } | Expr::Exists { .. })
+                    });
 
                 // Check all subquery filters could be rewritten
                 //
                 // In case of expressions which could not be rewritten
                 // return original filter with optimized input
+                //
+                // TODO: complex expressions which are disjunctive with our subquery expressions
+                // can be rewritten as unions...
                 let mut subqueries_in_regular = vec![];
                 regular_filters.iter().try_for_each(|&e| {
                     extract_subquery_filters(e, &mut subqueries_in_regular)
                 })?;
 
+                // Since we are unable to simplify the correlated subquery,
+                // we must do a row scan against the outer plan anyway, so we abort
                 if !subqueries_in_regular.is_empty() {
                     return Ok(LogicalPlan::Filter(Filter {
                         predicate: predicate.clone(),
@@ -87,63 +316,11 @@ impl OptimizerRule for SubqueryFilterToJoin {
 
                 // Add subquery joins to new_input
                 // optimized_input value should retain for possible optimization rollback
-                let opt_result = subquery_filters.iter().try_fold(
-                    optimized_input.clone(),
-                    |input, &e| match e {
-                        Expr::InSubquery {
-                            expr,
-                            subquery,
-                            negated,
-                        } => {
-                            let right_input = self.optimize(
-                                &*subquery.subquery,
-                                execution_props
-                            )?;
-                            let right_schema = right_input.schema();
-                            if right_schema.fields().len() != 1 {
-                                return Err(DataFusionError::Plan(
-                                    "Only single column allowed in InSubquery"
-                                        .to_string(),
-                                ));
-                            };
-
-                            let right_key = right_schema.field(0).qualified_column();
-                            let left_key = match *expr.clone() {
-                                Expr::Column(col) => col,
-                                _ => return Err(DataFusionError::NotImplemented(
-                                    "Filtering by expression not implemented for InSubquery"
-                                        .to_string(),
-                                )),
-                            };
-
-                            let join_type = if *negated {
-                                JoinType::Anti
-                            } else {
-                                JoinType::Semi
-                            };
-
-                            let schema = build_join_schema(
-                                optimized_input.schema(),
-                                right_schema,
-                                &join_type,
-                            )?;
-
-                            Ok(LogicalPlan::Join(Join {
-                                left: Arc::new(input),
-                                right: Arc::new(right_input),
-                                on: vec![(left_key, right_key)],
-                                join_type,
-                                join_constraint: JoinConstraint::On,
-                                schema: Arc::new(schema),
-                                null_equals_null: false,
-                            }))
-                        }
-                        _ => Err(DataFusionError::Plan(
-                            "Unknown expression while rewriting subquery to joins"
-                                .to_string(),
-                        )),
-                    }
-                );
+                let opt_result = subquery_filters
+                    .iter()
+                    .try_fold(optimized_input.clone(), |input, &e| {
+                        self.rewrite_outer_plan(input, e, execution_props)
+                    });
 
                 // In case of expressions which could not be rewritten
                 // return original filter with optimized input
@@ -184,16 +361,47 @@ fn extract_subquery_filters(expression: &Expr, extracted: &mut Vec<Expr>) -> Res
                 extracted.push(se);
                 Ok(())
             }
+            Expr::Exists { .. } => {
+                extracted.push(se);
+                Ok(())
+            }
             _ => extract_subquery_filters(&se, extracted),
         })
+}
+
+fn column_is_correlated(outer: &Arc<DFSchema>, column: &Column) -> bool {
+    for field in outer.fields() {
+        if *column == field.qualified_column() || *column == field.unqualified_column() {
+            return true;
+        }
+    }
+    false
+}
+
+fn detect_correlated_columns(outer: &Arc<DFSchema>, expression: &Expr) -> Result<bool> {
+    for se in utils::expr_sub_expressions(expression)?.into_iter() {
+        match se {
+            Expr::Column(c) => {
+                if column_is_correlated(outer, &c) {
+                    return Ok(true);
+                }
+            }
+            _ => {
+                if detect_correlated_columns(outer, &se)? {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::logical_plan::{
-        and, binary_expr, col, in_subquery, lit, not_in_subquery, or, LogicalPlanBuilder,
-        Operator,
+        and, binary_expr, col, exists, in_subquery, lit, not_exists, not_in_subquery, or,
+        LogicalPlanBuilder, Operator,
     };
     use crate::test::*;
 
@@ -348,11 +556,36 @@ mod tests {
         let expected = "Projection: #test.b [b:UInt32]\
         \n  Semi Join: #test.b = #sq.a [a:UInt32, b:UInt32, c:UInt32]\
         \n    TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]\
-        \n    Projection: #sq.a [a:UInt32]\
-        \n      Semi Join: #sq.a = #sq_nested.c [a:UInt32, b:UInt32, c:UInt32]\
-        \n        TableScan: sq projection=None [a:UInt32, b:UInt32, c:UInt32]\
-        \n        Projection: #sq_nested.c [c:UInt32]\
-        \n          TableScan: sq_nested projection=None [a:UInt32, b:UInt32, c:UInt32]";
+        \n    Semi Join: #sq.a = #sq_nested.c [a:UInt32, b:UInt32, c:UInt32]\
+        \n      TableScan: sq projection=None [a:UInt32, b:UInt32, c:UInt32]\
+        \n      Projection: #sq_nested.c [c:UInt32]\
+        \n        TableScan: sq_nested projection=None [a:UInt32, b:UInt32, c:UInt32]";
+
+        assert_optimized_plan_eq(&plan, expected);
+        Ok(())
+    }
+
+    /// Test for IN subquery with additional correlated (dependent) predicate
+    #[test]
+    fn in_subquery_with_correlated_filters() -> Result<()> {
+        let table_a = test_table_scan_with_name("table_a")?;
+        let table_b = test_table_scan_with_name("table_b")?;
+
+        let subquery = LogicalPlanBuilder::from(table_b)
+            .filter(col("table_a.a").eq(col("table_b.a")))?
+            .project(vec![col("c")])?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(table_a)
+            .filter(in_subquery(col("c"), Arc::new(subquery)))?
+            .project(vec![col("table_a.b")])?
+            .build()?;
+
+        let expected = "\
+            Projection: #table_a.b [b:UInt32]\
+            \n  Semi Join: #table_a.a = #table_b.a, #table_a.c = #table_b.c [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_a projection=None [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_b projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -384,6 +617,114 @@ mod tests {
         \n          TableScan: sq_inner projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_exists_simple() -> Result<()> {
+        let table_a = test_table_scan_with_name("table_a")?;
+        let table_b = test_table_scan_with_name("table_b")?;
+        let subquery = LogicalPlanBuilder::from(table_b)
+            .filter(col("table_a.a").eq(col("table_b.a")))?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(table_a)
+            .filter(exists(Arc::new(subquery)))?
+            .project(vec![col("a"), col("b")])?
+            .build()?;
+
+        let expected = "\
+            Projection: #table_a.a, #table_a.b [a:UInt32, b:UInt32]\
+            \n  Semi Join: #table_a.a = #table_b.a [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_a projection=None [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_b projection=None [a:UInt32, b:UInt32, c:UInt32]";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_exists_multiple_correlated_filters() -> Result<()> {
+        let table_a = test_table_scan_with_name("table_a")?;
+        let table_b = test_table_scan_with_name("table_b")?;
+
+        // Test AND and nested filters will be extracted as join columns
+        let subquery = LogicalPlanBuilder::from(table_b)
+            .filter(
+                (col("table_a.c").eq(col("table_b.c"))).and(
+                    (col("table_a.a").eq(col("table_b.a")))
+                        .and(col("table_a.b").eq(col("table_b.b"))),
+                ),
+            )?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(table_a)
+            .filter(exists(Arc::new(subquery)))?
+            .project(vec![col("a"), col("b")])?
+            .build()?;
+
+        let expected = "\
+            Projection: #table_a.a, #table_a.b [a:UInt32, b:UInt32]\
+            \n  Semi Join: #table_a.c = #table_b.c, #table_a.a = #table_b.a, #table_a.b = #table_b.b [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_a projection=None [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_b projection=None [a:UInt32, b:UInt32, c:UInt32]";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_exists_with_non_correlated_filter() -> Result<()> {
+        let table_a = test_table_scan_with_name("table_a")?;
+        let table_b = test_table_scan_with_name("table_b")?;
+        let subquery = LogicalPlanBuilder::from(table_b)
+            .filter(
+                (col("table_a.a").eq(col("table_b.a")))
+                    .and(col("table_b.b").gt(lit("5"))),
+            )?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(table_a)
+            .project(vec![col("a"), col("b")])?
+            .filter(exists(Arc::new(subquery)))?
+            .build()?;
+        let expected = "\
+            Semi Join: #table_a.a = #table_b.a [a:UInt32, b:UInt32]\
+            \n  Projection: #table_a.a, #table_a.b [a:UInt32, b:UInt32]\
+            \n    TableScan: table_a projection=None [a:UInt32, b:UInt32, c:UInt32]\
+            \n  Filter: #table_b.b > Utf8(\"5\") [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_b projection=None [a:UInt32, b:UInt32, c:UInt32]";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    // We only test not exists for the simplest case since all the other code paths
+    // are covered by exists
+    #[test]
+    fn test_not_exists_simple() -> Result<()> {
+        let table_a = test_table_scan_with_name("table_a")?;
+        let table_b = test_table_scan_with_name("table_b")?;
+        let subquery = LogicalPlanBuilder::from(table_b)
+            .filter(col("table_a.a").eq(col("table_b.a")))?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(table_a)
+            .filter(not_exists(Arc::new(subquery)))?
+            .project(vec![col("a"), col("b")])?
+            .build()?;
+
+        let expected = "\
+            Projection: #table_a.a, #table_a.b [a:UInt32, b:UInt32]\
+            \n  Anti Join: #table_a.a = #table_b.a [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_a projection=None [a:UInt32, b:UInt32, c:UInt32]\
+            \n    TableScan: table_b projection=None [a:UInt32, b:UInt32, c:UInt32]";
+
+        assert_optimized_plan_eq(&plan, expected);
+
         Ok(())
     }
 }

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -567,7 +567,6 @@ pub fn split_conjunction<'a>(predicate: &'a Expr, predicates: &mut Vec<&'a Expr>
             split_conjunction(left, predicates);
             split_conjunction(right, predicates);
         }
-        // TODO: are we sure we want to ignore aliases?
         Expr::Alias(expr, _) => {
             split_conjunction(expr, predicates);
         }

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -697,14 +697,11 @@ struct CorrelatedColumnsVisitor<'a> {
 
 impl ExpressionVisitor for CorrelatedColumnsVisitor<'_> {
     fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>> {
-        match expr {
-            Expr::Column(c) => {
-                if column_is_correlated(self.outer_schema, &c) {
-                    *self.contains_correlated_columns = true;
-                    return Ok(Recursion::Stop(self));
-                }
+        if let Expr::Column(c) = expr {
+            if column_is_correlated(self.outer_schema, c) {
+                *self.contains_correlated_columns = true;
+                return Ok(Recursion::Stop(self));
             }
-            _ => {}
         }
         Ok(Recursion::Continue(self))
     }

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -585,8 +585,9 @@ pub fn add_filter(plan: LogicalPlan, predicates: &[&Expr]) -> LogicalPlan {
     })
 }
 
+/// Converts [A, B, C] -> A AND B AND C
 pub fn combine_conjunctive(predicates: &[&Expr]) -> Expr {
-    assert!(predicates.len() > 0);
+    assert!(!predicates.is_empty());
     // reduce filters to a single filter with an AND
     predicates
         .iter()
@@ -596,8 +597,9 @@ pub fn combine_conjunctive(predicates: &[&Expr]) -> Expr {
         })
 }
 
+/// Converts [A, B, C] -> A OR B OR C
 pub fn combine_disjunctive(predicates: &[&Expr]) -> Expr {
-    assert!(predicates.len() > 0);
+    assert!(!predicates.is_empty());
     // reduce filters to a single filter with an AND
     predicates
         .iter()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes: https://github.com/apache/arrow-datafusion/issues/2351
Related: https://github.com/apache/arrow-datafusion/pull/2421

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We perform a simple pattern match in the LogicalPlan optimizer on `InSubquery(Projection(Filter(..)))` and `Exists(Filter(..))`, extracting correlated/dependent columns to be used in the semi/anti join

TODO:
1. Sanity abort if `detect_correlated_columns` in the remainder expression (needs to be correlation free to derive the benefits of semi/antijoin)? Future: rewrite infallibly as SEMIJOIN + UNION ALL.
2. Test no optimization on non-conjunctive clauses containing correlated predicates?
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Future Work

1. Rewrite nested disjunctive expressions in the filter as UNION ALL. 
For instance 
```
SELECT * FROM t 
WHERE 
  EXISTS (..sq1..) OR 
  (a IN (..sq2..) AND a < 100) OR 
  a > 100
``` 
=> 
```
SELECT * FROM t LEFT SEMIJOIN sq1 on ..
UNION ALL
SELECT * FROM t LEFT SEMIJOIN sq2 on a == r.a WHERE a < 100
UNION ALL
SELECT * FROM t WHERE a > 100
```
        