### PR TITLE
feat: Support CompoundIdentifier as GetIndexedField access

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1608,11 +1608,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 } else {
                     match (var_names.pop(), var_names.pop()) {
                         (Some(name), Some(relation)) if var_names.is_empty() => {
-                            // table.column identifier
-                            Ok(Expr::Column(Column {
-                                relation: Some(relation),
-                                name,
-                            }))
+                            if let Some(field) = schema.fields().iter().find(|f| f.name().eq(&relation)) {
+                                // Access to a field of a column which is a structure, example: SELECT my_struct.key
+                                Ok(Expr::GetIndexedField {
+                                    expr: Box::new(Expr::Column(field.qualified_column())),
+                                    key: ScalarValue::Utf8(Some(name)),
+                                })
+                            } else {
+                                // table.column identifier
+                                Ok(Expr::Column(Column {
+                                    relation: Some(relation),
+                                    name,
+                                }))
+                            }
                         }
                         _ => Err(DataFusionError::NotImplemented(format!(
                             "Unsupported compound identifier '{:?}'",

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -629,6 +629,21 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
         "+----------------+",
     ];
     assert_batches_eq!(expected, &actual);
+
+    // Access to field of struct by CompoundIdentifier
+    let sql = "SELECT some_struct.bar as l0 FROM structs LIMIT 3";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+----------------+",
+        "| l0             |",
+        "+----------------+",
+        "| [0, 1, 2, 3]   |",
+        "| [4, 5, 6, 7]   |",
+        "| [8, 9, 10, 11] |",
+        "+----------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
     let sql = "SELECT some_struct[\"bar\"][0] as i0 FROM structs LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]


### PR DESCRIPTION
# Which issue does this PR close?

I didn't create a new issue for it.

 # Rationale for this change

Right now, DF supports `GetIndexed` access on top of `MapAccessExpr`, which is not correct for PostgreSQL dialect.

For example:

```sql
/// DF supports it, but It doesn't work with PostgreSQL
SELECT (information_schema._pg_expandarray(ARRAY [1,2,3,4]))["x"];

/// This PR introduce the correct style of accessing a field of structure, Works with PostgreSQL
SELECT (information_schema._pg_expandarray(ARRAY [1,2,3,4])).x;
```

# What changes are included in this PR?

From subject.
