### PR TITLE
Do not allow HAVING clause in non-aggregate queries

### DIFF
--- a/datafusion/core/tests/sql/group_by.rs
+++ b/datafusion/core/tests/sql/group_by.rs
@@ -195,19 +195,13 @@ async fn csv_query_having_without_group_by() -> Result<()> {
     let ctx = SessionContext::new();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 HAVING c2 >= 4 AND c3 > 90";
-    let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec![
-        "+----+----+-----+",
-        "| c1 | c2 | c3  |",
-        "+----+----+-----+",
-        "| c  | 4  | 123 |",
-        "| c  | 5  | 118 |",
-        "| d  | 4  | 102 |",
-        "| e  | 4  | 96  |",
-        "| e  | 4  | 97  |",
-        "+----+----+-----+",
-    ];
-    assert_batches_sorted_eq!(expected, &actual);
+    let err = ctx
+        .create_logical_plan(sql)
+        .expect_err("query should have failed");
+    assert_eq!(
+        "Plan(\"HAVING clause can only be used with aggregate queries\")",
+        format!("{:?}", err)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2460

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Neither Postgres nor Spark supports the use of the `HAVING` clause in non-aggregate queries.

I am also motivated to reduce complexity in the aggregate code while we fix some issues there.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Stop allowing the use of `HAVING` in non-aggregate queries.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, users will need to use `WHERE` instead of `HAVING` for non-aggregate queries.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
