### PR TITLE
MINOR: Partial fix for SQL aggregate queries with aliases

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1135,7 +1135,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// The return value is a triplet of the following items:
     ///
     /// * `plan`                   - A [LogicalPlan::Aggregate] plan for the newly created aggregate.
-    /// * `select_exprs_post_aggr` - The projection expressions rewritten to refernce columns from
+    /// * `select_exprs_post_aggr` - The projection expressions rewritten to reference columns from
     ///                              the aggregate
     /// * `having_expr_post_aggr`  - The "having" expression rewritten to reference a column from
     ///                              the aggregate

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1150,8 +1150,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .iter()
             .chain(aggr_exprs.iter())
             .cloned()
-            .map(|expr| expr_as_column_expr(&expr, &input)) //TODO did this matter
-            .collect::<Result<Vec<Expr>>>()?;
+            .collect::<Vec<Expr>>();
 
         let plan = LogicalPlanBuilder::from(input.clone())
             .aggregate(group_by_exprs, aggr_exprs)?

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1028,7 +1028,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .collect::<Result<Vec<Expr>>>()?;
 
         // process group by, aggregation or having
-        let (plan, select_exprs_post_aggr, having_expr_post_aggr_opt) =
+        let (plan, select_exprs_post_aggr, having_expr_post_aggr) =
             if !group_by_exprs.is_empty() || !aggr_exprs.is_empty() {
                 self.aggregate(
                     plan,
@@ -1056,7 +1056,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 (plan, select_exprs, having_expr_opt)
             };
 
-        let plan = if let Some(having_expr_post_aggr) = having_expr_post_aggr_opt {
+        let plan = if let Some(having_expr_post_aggr) = having_expr_post_aggr {
             LogicalPlanBuilder::from(plan)
                 .filter(having_expr_post_aggr)?
                 .build()?
@@ -1124,20 +1124,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ///
     /// * `input`           - The input plan that will be aggregated. The grouping, aggregate, and
     ///                       "having" expressions must all be resolvable from this plan.
-    /// * `select_exprs`    - TBD
-    /// * `having_expr_opt` - Optional HAVING clause
+    /// * `select_exprs`    - The projection expressions from the SELECT clause.
+    /// * `having_expr_opt` - Optional HAVING clause.
     /// * `group_by_exprs`  - Grouping expressions from the GROUP BY clause. These can be column
-    ///                       references or more complex expressions
+    ///                       references or more complex expressions.
     /// * `aggr_exprs`      - Aggregate expressions, such as `SUM(a)` or `COUNT(1)`.
     ///
     /// # Return
     ///
-    /// The return value is a triplet of (plan, select_exprs_post_aggr, having_expr_post_aggr_opt)
-    /// where:
+    /// The return value is a triplet of the following items:
     ///
-    /// * `plan` - A [LogicalPlan::Aggregate] plan
-    /// * `select_exprs_post_aggr` - ???
-    /// * `having_expr_post_aggr_opt` - ???
+    /// * `plan`                   - A [LogicalPlan::Aggregate] plan for the newly created aggregate.
+    /// * `select_exprs_post_aggr` - The projection expressions rewritten to refernce columns from
+    ///                              the aggregate
+    /// * `having_expr_post_aggr`  - The "having" expression rewritten to reference a column from
+    ///                              the aggregate
     fn aggregate(
         &self,
         input: LogicalPlan,
@@ -1178,7 +1179,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         // Rewrite the HAVING expression to use the columns produced by the
         // aggregation.
-        let having_expr_post_aggr_opt = if let Some(having_expr) = having_expr_opt {
+        let having_expr_post_aggr = if let Some(having_expr) = having_expr_opt {
             let having_expr_post_aggr =
                 rebase_expr(having_expr, &aggr_projection_exprs, &input)?;
 
@@ -1193,7 +1194,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             None
         };
 
-        Ok((plan, select_exprs_post_aggr, having_expr_post_aggr_opt))
+        Ok((plan, select_exprs_post_aggr, having_expr_post_aggr))
     }
 
     /// Wrap a plan in a limit

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -59,12 +59,12 @@ pub(crate) fn find_window_exprs(exprs: &[Expr]) -> Vec<Expr> {
 }
 
 /// Collect all deeply nested `Expr::Column`'s. They are returned in order of
-/// appearance (depth first), with duplicates omitted.
+/// appearance (depth first), and may contain duplicates.
 pub(crate) fn find_column_exprs(exprs: &[Expr]) -> Vec<Expr> {
     exprs
         .iter()
-        .flat_map(|e| find_columns_referenced_by_expr(e))
-        .map(|col| Expr::Column(col))
+        .flat_map(find_columns_referenced_by_expr)
+        .map(Expr::Column)
         .collect()
 }
 

--- a/datafusion/core/src/sql/utils.rs
+++ b/datafusion/core/src/sql/utils.rs
@@ -142,7 +142,10 @@ where
 /// Convert any `Expr` to an `Expr::Column`.
 pub(crate) fn expr_as_column_expr(expr: &Expr, plan: &LogicalPlan) -> Result<Expr> {
     match expr {
-        Expr::Column(_) => Ok(expr.clone()),
+        Expr::Column(col) => match plan.schema().field_from_column(col) {
+            Ok(field) => Ok(Expr::Column(field.qualified_column())),
+            _ => Ok(expr.clone()),
+        },
         _ => Ok(Expr::Column(Column::from_name(expr.name(plan.schema())?))),
     }
 }

--- a/datafusion/core/tests/sql/group_by.rs
+++ b/datafusion/core/tests/sql/group_by.rs
@@ -233,6 +233,27 @@ async fn csv_query_group_by_avg() -> Result<()> {
 }
 
 #[tokio::test]
+async fn csv_query_group_by_with_aliases() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT c1 AS c12, avg(c12) AS c1 FROM aggregate_test_100 GROUP BY c1";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-----+---------------------+",
+        "| c12 | c1                  |",
+        "+-----+---------------------+",
+        "| a   | 0.48754517466109415 |",
+        "| b   | 0.41040709263815384 |",
+        "| c   | 0.6600456536439784  |",
+        "| d   | 0.48855379387549824 |",
+        "| e   | 0.48600669271341534 |",
+        "+-----+---------------------+",
+    ];
+    assert_batches_sorted_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn csv_query_group_by_int_count() -> Result<()> {
     let ctx = SessionContext::new();
     register_aggregate_csv(&ctx).await?;

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -251,6 +251,77 @@ pub enum Expr {
     QualifiedWildcard { qualifier: String },
 }
 
+/// Recursively find all columns referenced by an expression
+pub fn find_columns_referenced_by_expr(e: &Expr) -> Vec<Column> {
+    match e {
+        Expr::Alias(expr, _)
+        | Expr::Negative(expr)
+        | Expr::Cast { expr, .. }
+        | Expr::TryCast { expr, .. }
+        | Expr::Sort { expr, .. }
+        | Expr::InList { expr, .. }
+        | Expr::InSubquery { expr, .. }
+        | Expr::GetIndexedField { expr, .. }
+        | Expr::Not(expr)
+        | Expr::IsNotNull(expr)
+        | Expr::IsNull(expr) => find_columns_referenced_by_expr(expr),
+        Expr::Column(c) => vec![c.clone()],
+        Expr::BinaryExpr { left, right, .. } => {
+            let mut cols = vec![];
+            cols.extend(find_columns_referenced_by_expr(left.as_ref()));
+            cols.extend(find_columns_referenced_by_expr(right.as_ref()));
+            cols
+        }
+        Expr::Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        } => {
+            let mut cols = vec![];
+            if let Some(expr) = expr {
+                cols.extend(find_columns_referenced_by_expr(expr.as_ref()));
+            }
+            for (w, t) in when_then_expr {
+                cols.extend(find_columns_referenced_by_expr(w.as_ref()));
+                cols.extend(find_columns_referenced_by_expr(t.as_ref()));
+            }
+            if let Some(else_expr) = else_expr {
+                cols.extend(find_columns_referenced_by_expr(else_expr.as_ref()));
+            }
+            cols
+        }
+        Expr::ScalarFunction { args, .. } => args
+            .iter()
+            .flat_map(|e| find_columns_referenced_by_expr(e))
+            .collect(),
+        Expr::AggregateFunction { args, .. } => args
+            .iter()
+            .flat_map(|e| find_columns_referenced_by_expr(e))
+            .collect(),
+        Expr::ScalarVariable(_, _)
+        | Expr::Exists { .. }
+        | Expr::Wildcard
+        | Expr::QualifiedWildcard { .. }
+        | Expr::ScalarSubquery(_)
+        | Expr::Literal(_) => vec![],
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            let mut cols = vec![];
+            cols.extend(find_columns_referenced_by_expr(expr.as_ref()));
+            cols.extend(find_columns_referenced_by_expr(low.as_ref()));
+            cols.extend(find_columns_referenced_by_expr(high.as_ref()));
+            cols
+        }
+        Expr::ScalarUDF { args, .. }
+        | Expr::WindowFunction { args, .. }
+        | Expr::AggregateUDF { args, .. } => args
+            .iter()
+            .flat_map(find_columns_referenced_by_expr)
+            .collect(),
+    }
+}
+
 /// Fixed seed for the hashing so that Ords are consistent across runs
 const SEED: ahash::RandomState = ahash::RandomState::with_seeds(0, 0, 0, 0);
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -292,11 +292,11 @@ pub fn find_columns_referenced_by_expr(e: &Expr) -> Vec<Column> {
         }
         Expr::ScalarFunction { args, .. } => args
             .iter()
-            .flat_map(|e| find_columns_referenced_by_expr(e))
+            .flat_map(find_columns_referenced_by_expr)
             .collect(),
         Expr::AggregateFunction { args, .. } => args
             .iter()
-            .flat_map(|e| find_columns_referenced_by_expr(e))
+            .flat_map(find_columns_referenced_by_expr)
             .collect(),
         Expr::ScalarVariable(_, _)
         | Expr::Exists { .. }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This is working towards a fix for https://github.com/apache/arrow-datafusion/issues/2430

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See the added unit test for an example of a query that previously failed.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Fixes code for finding columns referenced from expressions so that it now fully recurses through the expression tree
- Removes aliases from the alias_map before parsing the grouping expressions so that the grouping expressions don't try and use aliased expressions from the projection
- Added documentation for the planner aggregate method

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
