### PR TITLE
Add support for list_dir() on local fs

### DIFF
--- a/data-access/Cargo.toml
+++ b/data-access/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.41"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures = "0.3"
 glob = "0.3.0"
 parking_lot = "0.12"

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -85,9 +85,7 @@ impl ObjectStore for LocalFileSystem {
             Ok(Box::pin(list_entries))
         } else {
             Ok(Box::pin(
-                self.list_file(prefix)
-                    .await?
-                    .map_ok(ListEntry::FileMeta),
+                self.list_file(prefix).await?.map_ok(ListEntry::FileMeta),
             ))
         }
     }

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -57,7 +57,7 @@ impl ObjectStore for LocalFileSystem {
             if d != "/" && d != "\\" {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "delimiter not supported on local filesystem",
+                    format!("delimiter not supported on local filesystem: {}", d),
                 ));
             }
             let mut entry_stream = tokio::fs::read_dir(prefix).await?;
@@ -97,12 +97,12 @@ impl ObjectStore for LocalFileSystem {
 
 /// Try to convert a PathBuf reference into a &str
 pub fn path_as_str(path: &std::path::Path) -> Result<&str> {
-    if let Some(child_path) = path.to_str() {
-        Ok(child_path)
+    if let Some(path) = path.to_str() {
+        Ok(path)
     } else {
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "Invalid path".to_string(),
+            format!("Invalid path: {}", path.display()),
         ))
     }
 }

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -23,9 +23,9 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::{stream, AsyncRead, StreamExt};
+use futures::{stream, AsyncRead, StreamExt, TryStreamExt};
 
-use crate::{FileMeta, Result, SizedFile};
+use crate::{FileMeta, ListEntry, Result, SizedFile};
 
 use super::{
     FileMetaStream, ListEntryStream, ObjectReader, ObjectReaderStream, ObjectStore,
@@ -50,14 +50,62 @@ impl ObjectStore for LocalFileSystem {
 
     async fn list_dir(
         &self,
-        _prefix: &str,
-        _delimiter: Option<String>,
+        prefix: &str,
+        delimiter: Option<String>,
     ) -> Result<ListEntryStream> {
-        todo!()
+        if let Some(d) = delimiter {
+            if d != "/" && d != "\\" {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "delimiter not supported on local filesystem",
+                ));
+            }
+            let mut entry_stream = tokio::fs::read_dir(prefix).await?;
+
+            let list_entries = stream::poll_fn(move |cx| {
+                entry_stream.poll_next_entry(cx).map(|res| match res {
+                    Ok(Some(x)) => Some(Ok(x)),
+                    Ok(None) => None,
+                    Err(err) => Some(Err(err)),
+                })
+            })
+            .then(|entry| async {
+                let entry = entry?;
+                let entry = if entry.file_type().await?.is_dir() {
+                    ListEntry::Prefix(path_as_str(&entry.path())?.to_string())
+                } else {
+                    ListEntry::FileMeta(get_meta(
+                        path_as_str(&entry.path())?.to_string(),
+                        entry.metadata().await?,
+                    ))
+                };
+                Ok(entry)
+            });
+
+            Ok(Box::pin(list_entries))
+        } else {
+            Ok(Box::pin(
+                self.list_file(prefix)
+                    .await?
+                    .map_ok(ListEntry::FileMeta),
+            ))
+        }
     }
 
     fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>> {
         Ok(Arc::new(LocalFileReader::new(file)?))
+    }
+}
+
+/// Try to convert a PathBuf reference into a &str
+pub fn path_as_str(path: &std::path::Path) -> Result<&str> {
+    if let Some(child_path) = path.to_str() {
+        Ok(child_path)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Invalid path".to_string(),
+        ))
     }
 }
 
@@ -103,17 +151,17 @@ impl ObjectReader for LocalFileReader {
     }
 }
 
-async fn list_all(prefix: String) -> Result<FileMetaStream> {
-    fn get_meta(path: String, metadata: Metadata) -> FileMeta {
-        FileMeta {
-            sized_file: SizedFile {
-                path,
-                size: metadata.len(),
-            },
-            last_modified: metadata.modified().map(chrono::DateTime::from).ok(),
-        }
+fn get_meta(path: String, metadata: Metadata) -> FileMeta {
+    FileMeta {
+        sized_file: SizedFile {
+            path,
+            size: metadata.len(),
+        },
+        last_modified: metadata.modified().map(chrono::DateTime::from).ok(),
     }
+}
 
+async fn list_all(prefix: String) -> Result<FileMetaStream> {
     async fn find_files_in_dir(
         path: String,
         to_visit: &mut Vec<String>,
@@ -122,18 +170,12 @@ async fn list_all(prefix: String) -> Result<FileMetaStream> {
         let mut files = Vec::new();
 
         while let Some(child) = dir.next_entry().await? {
-            if let Some(child_path) = child.path().to_str() {
-                let metadata = child.metadata().await?;
-                if metadata.is_dir() {
-                    to_visit.push(child_path.to_string());
-                } else {
-                    files.push(get_meta(child_path.to_owned(), metadata))
-                }
+            let child_path = path_as_str(&child.path())?.to_string();
+            let metadata = child.metadata().await?;
+            if metadata.is_dir() {
+                to_visit.push(child_path.to_string());
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Invalid path".to_string(),
-                ));
+                files.push(get_meta(child_path.to_owned(), metadata))
             }
         }
         Ok(files)
@@ -191,6 +233,8 @@ pub fn local_unpartitioned_file(file: String) -> FileMeta {
 
 #[cfg(test)]
 mod tests {
+    use crate::ListEntry;
+
     use super::*;
     use futures::StreamExt;
     use std::collections::HashSet;
@@ -227,6 +271,53 @@ mod tests {
         assert!(all_files.contains(a_path.to_str().unwrap()));
         assert!(all_files.contains(b_path.to_str().unwrap()));
         assert!(all_files.contains(c_path.to_str().unwrap()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_dir() -> Result<()> {
+        // tmp/a.txt
+        // tmp/x/b.txt
+        let tmp = tempdir()?;
+        let x_path = tmp.path().join("x");
+        let a_path = tmp.path().join("a.txt");
+        let b_path = x_path.join("b.txt");
+        create_dir(&x_path)?;
+        File::create(&a_path)?;
+        File::create(&b_path)?;
+
+        fn get_path(entry: ListEntry) -> String {
+            match entry {
+                ListEntry::FileMeta(f) => f.sized_file.path,
+                ListEntry::Prefix(path) => path,
+            }
+        }
+
+        async fn assert_equal_paths(
+            expected: Vec<&std::path::PathBuf>,
+            actual: ListEntryStream,
+        ) -> Result<()> {
+            let expected: HashSet<String> = expected
+                .iter()
+                .map(|x| x.to_str().unwrap().to_string())
+                .collect();
+            let actual: HashSet<String> = actual.map_ok(get_path).try_collect().await?;
+            assert_eq!(expected, actual);
+            Ok(())
+        }
+
+        // Providing no delimiter means recursive file listing
+        let files = LocalFileSystem
+            .list_dir(tmp.path().to_str().unwrap(), None)
+            .await?;
+        assert_equal_paths(vec![&a_path, &b_path], files).await?;
+
+        // Providing slash as delimiter means list immediate files and directories
+        let files = LocalFileSystem
+            .list_dir(tmp.path().to_str().unwrap(), Some("/".to_string()))
+            .await?;
+        assert_equal_paths(vec![&a_path, &x_path], files).await?;
 
         Ok(())
     }

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -97,10 +97,12 @@ impl ObjectStore for LocalFileSystem {
 
 /// Try to convert a PathBuf reference into a &str
 pub fn path_as_str(path: &std::path::Path) -> Result<&str> {
-    path.to_str().ok_or_else(|| io::Error::new(
-        io::ErrorKind::InvalidInput,
-        format!("Invalid path '{}'", path.display()),
-    ))
+    path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid path '{}'", path.display()),
+        )
+    })
 }
 
 struct LocalFileReader {

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -97,11 +97,10 @@ impl ObjectStore for LocalFileSystem {
 
 /// Try to convert a PathBuf reference into a &str
 pub fn path_as_str(path: &std::path::Path) -> Result<&str> {
-    path.to_str()
-      .map_err(|e| io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Invalid path '{}': {}", path.display(), e),
-        )))
+    path.to_str().ok_or_else(|| io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("Invalid path '{}'", path.display()),
+    ))
 }
 
 struct LocalFileReader {

--- a/data-access/src/object_store/local.rs
+++ b/data-access/src/object_store/local.rs
@@ -97,14 +97,11 @@ impl ObjectStore for LocalFileSystem {
 
 /// Try to convert a PathBuf reference into a &str
 pub fn path_as_str(path: &std::path::Path) -> Result<&str> {
-    if let Some(path) = path.to_str() {
-        Ok(path)
-    } else {
-        Err(io::Error::new(
+    path.to_str()
+      .map_err(|e| io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Invalid path: {}", path.display()),
-        ))
-    }
+            format!("Invalid path '{}': {}", path.display(), e),
+        )))
 }
 
 struct LocalFileReader {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2466.

 # Rationale for this change

Simply implementing this for localfs. I don't know of any other ObjectStore that does implement this yet (it's also left as TODO for S3 and HDFS), but it seems like it will be useful.

# What changes are included in this PR?

* Adds implementation of `list_dir()` for `LocalFileSystem`, with associated tests.
* Adds a convenience function `path_to_str()` which was helpful internally, but I also added to public API since it's likely helpful for users as well.

# Are there any user-facing changes?

All user-facing changes are new functionality; nothing breaks existing functionality.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
