### PR TITLE
Minor: Move test code from `context.rs` into `sql_integration` 

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1603,14 +1603,13 @@ impl FunctionRegistry for TaskContext {
 mod tests {
     use super::*;
     use crate::execution::context::QueryPlanner;
-    use crate::logical_plan::{binary_expr, lit, Operator};
     use crate::physical_plan::functions::make_scalar_function;
     use crate::test;
     use crate::test_util::parquet_test_data;
     use crate::variable::VarType;
     use crate::{
-        assert_batches_eq, assert_batches_sorted_eq,
-        logical_plan::{col, create_udf, sum, Expr},
+        assert_batches_eq,
+        logical_plan::{create_udf, Expr},
     };
     use crate::{logical_plan::create_udaf, physical_plan::expressions::AvgAccumulator};
     use arrow::array::ArrayRef;

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::*;
-use datafusion::scalar::ScalarValue;
+use datafusion::{logical_plan::LogicalPlanBuilder, scalar::ScalarValue};
 
 #[tokio::test]
 async fn csv_query_avg_multi_batch() -> Result<()> {
@@ -1450,8 +1450,7 @@ async fn count_distinct_integers_aggregated_multiple_partitions() -> Result<()> 
 
 #[tokio::test]
 async fn aggregate_with_alias() -> Result<()> {
-    let tmp_dir = TempDir::new()?;
-    let ctx = create_ctx(&tmp_dir, 1).await?;
+    let ctx = SessionContext::new();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -1177,12 +1177,10 @@ async fn boolean_literal() -> Result<()> {
 #[tokio::test]
 async fn unprojected_filter() {
     let ctx = SessionContext::new();
-    let df = ctx
-        .read_table(test::table_with_sequence(1, 3).unwrap())
-        .unwrap();
+    let df = ctx.read_table(table_with_sequence(1, 3).unwrap()).unwrap();
 
     let df = df
-        .select(vec![binary_expr(col("i"), Operator::Plus, col("i"))])
+        .select(vec![col("i") + col("i")])
         .unwrap()
         .filter(col("i").gt(lit(2)))
         .unwrap();

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -79,3 +79,47 @@ async fn union_all_with_aggregate() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
+
+#[tokio::test]
+async fn union_schemas() -> Result<()> {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    let result = ctx
+        .sql("SELECT 1 A UNION ALL SELECT 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    #[rustfmt::skip]
+    let expected = vec![
+        "+---+",
+        "| a |",
+        "+---+",
+        "| 1 |",
+        "| 2 |",
+        "+---+"
+    ];
+    assert_batches_eq!(expected, &result);
+
+    let result = ctx
+        .sql("SELECT 1 UNION SELECT 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let expected = vec![
+        "+----------+",
+        "| Int64(1) |",
+        "+----------+",
+        "| 1        |",
+        "| 2        |",
+        "+----------+",
+    ];
+    assert_batches_eq!(expected, &result);
+    Ok(())
+}


### PR DESCRIPTION
This is just trying to keep the code a little faster to compile and tests more discoverable by moving tests for SQL into the  into `sql_integration`

This PR has no intended changes -- the first commit simply cut/paste's the tests, and then the second and third commit fix the tests to compile in their new home