### PR TITLE
Adds unit test cases of mathematical expressions working with `null` literal

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -418,6 +418,31 @@ async fn test_boolean_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_mathematical_expressions_with_null() -> Result<()> {
+    test_expression!("sqrt(NULL)", "NULL");
+    test_expression!("sin(NULL)", "NULL");
+    test_expression!("cos(NULL)", "NULL");
+    test_expression!("tan(NULL)", "NULL");
+    test_expression!("asin(NULL)", "NULL");
+    test_expression!("acos(NULL)", "NULL");
+    test_expression!("atan(NULL)", "NULL");
+    test_expression!("floor(NULL)", "NULL");
+    test_expression!("ceil(NULL)", "NULL");
+    test_expression!("round(NULL)", "NULL");
+    test_expression!("trunc(NULL)", "NULL");
+    test_expression!("abs(NULL)", "NULL");
+    test_expression!("signum(NULL)", "NULL");
+    test_expression!("exp(NULL)", "NULL");
+    test_expression!("ln(NULL)", "NULL");
+    test_expression!("log2(NULL)", "NULL");
+    test_expression!("log10(NULL)", "NULL");
+    test_expression!("power(NULL, 2)", "NULL");
+    test_expression!("power(NULL, NULL)", "NULL");
+    test_expression!("power(2, NULL)", "NULL");
+    Ok(())
+}
+
+#[tokio::test]
 #[cfg_attr(not(feature = "crypto_expressions"), ignore)]
 async fn test_crypto_expressions() -> Result<()> {
     test_expression!("md5('tom')", "34b7da764b21d298ef307d04d8152dc5");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1188 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Since #2364 is merged, mathematical function calls with `null` literal work well. This pr is just adding unit test cases of mathematical expressions working with `null` literal.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Adds unit test cases of mathematical expressions working with null
- All mathematical expressions is listed in `math_expressions.rs`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
