### PR TITLE
Limit cpu cores used when generating changelog

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -127,6 +127,10 @@ CHANGELOG_GITHUB_TOKEN=<TOKEN> ./dev/release/update_change_log-all.sh master 8.0
 git commit -a -m 'Create changelog for release'
 ```
 
+_If you see the error `"You have exceeded a secondary rate limit"` when running this script, try reducing the CPU 
+allocation to slow the process down and throttle the number of GitHub requests made per minute, by modifying the 
+value of the `--cpus` argument._
+
 You can add `invalid` or `development-process` label to exclude items from
 release notes. Add `datafusion`, `ballista` and `python` labels to group items
 into each sub-project's change log.

--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -55,6 +55,7 @@ git checkout "${SINCE_TAG}" "${OUTPUT_PATH}"
 sed -i.bak '1,18d' "${OUTPUT_PATH}"
 
 docker run -it --rm \
+    --cpus "0.1" \
     -e CHANGELOG_GITHUB_TOKEN=$CHANGELOG_GITHUB_TOKEN \
     -v "$(pwd)":/usr/local/src/your-app \
     githubchangeloggenerator/github-changelog-generator \


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2487

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Could not generate change logs without this change

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Limit CPU cores used by docker to slow the process down. Also added docs.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
