### PR TITLE
Add metrics for ParquetExec

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -49,6 +49,7 @@ use datafusion_common::Column;
 use datafusion_data_access::object_store::ObjectStore;
 use datafusion_expr::Expr;
 
+use crate::physical_plan::metrics::BaselineMetrics;
 use crate::physical_plan::stream::RecordBatchReceiverStream;
 use crate::{
     datasource::{file_format::parquet::ChunkObjectReader, listing::PartitionedFile},
@@ -227,6 +228,7 @@ impl ExecutionPlan for ParquetExec {
             files: self.base_config.file_groups[partition_index].clone().into(),
             projector: partition_col_proj,
             adapter: SchemaAdapter::new(self.base_config.file_schema.clone()),
+            baseline_metrics: BaselineMetrics::new(&self.metrics, partition_index),
         };
 
         // Use spawn_blocking only if running from a tokio context (#2201)
@@ -308,6 +310,7 @@ struct ParquetExecStream {
     files: VecDeque<PartitionedFile>,
     projector: PartitionColumnProjector,
     adapter: SchemaAdapter,
+    baseline_metrics: BaselineMetrics,
 }
 
 impl ParquetExecStream {
@@ -366,6 +369,10 @@ impl Iterator for ParquetExecStream {
     type Item = ArrowResult<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let cloned_time = self.baseline_metrics.elapsed_compute().clone();
+        // records time on drop
+        let _timer = cloned_time.timer();
+
         if self.error || matches!(self.remaining_rows, Some(0)) {
             return None;
         }
@@ -425,7 +432,8 @@ impl Stream for ParquetExecStream {
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        Poll::Ready(Iterator::next(&mut *self))
+        let poll = Poll::Ready(Iterator::next(&mut *self));
+        self.baseline_metrics.record_poll(poll)
     }
 }
 

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -420,6 +420,11 @@ impl Iterator for ParquetExecStream {
                 _ => self.error = result.is_err(),
             }
 
+            //record output rows in parquetExec
+            if let Ok(batch) = &result {
+                self.baseline_metrics.record_output(batch.num_rows());
+            }
+
             return Some(result);
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?
add metrics=`[output_rows, elapsed_compute]` in ParquetExec

Got this in this pr
```
ParquetExec: 
limit=None, 
partitions=[/Users/yangjiang/test-data/tchp-1g/orders/part-00001-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet, /Users/yangjiang/test-data/tchp-1g/orders/part-00000-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet, /Users/yangjiang/test-data/tchp-1g/orders/part-00002-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet, /Users/yangjiang/test-data/tchp-1g/orders/part-00004-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet, /Users/yangjiang/test-data/tchp-1g/orders/part-00003-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet], 
projection=[o_totalprice, o_orderdate, o_orderpriority],
metrics=[output_rows=0, elapsed_compute=924.453343ms, spill_count=0, spilled_bytes=0, mem_used=0, bytes_scanned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00000-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=2411369, predicate_evaluation_errors{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00001-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0, row_groups_pruned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00001-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0, bytes_scanned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00002-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=2411574, num_predicate_creation_errors=0, predicate_evaluation_errors{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00002-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0, bytes_scanned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00001-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=2411368, predicate_evaluation_errors{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00000-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0, row_groups_pruned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00002-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0, row_groups_pruned{filename=/Users/yangjiang/test-data/tchp-1g/orders/part-00000-e87df013-b3f8-493f-93c2-3da94f34e357-c000.snappy.parquet}=0]
```

Closes #2497.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
