### PR TITLE
Persist session configs in scheduler

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -763,6 +763,11 @@ message TaskDefinition {
   repeated KeyValuePair props = 5;
 }
 
+message JobSessionConfig {
+  string session_id = 1;
+  repeated KeyValuePair configs = 2;
+}
+
 message PollWorkResult {
   TaskDefinition task = 1;
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2498 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently the Ballista scheduler will go into a crash loop after restart. See issue for details. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Save the session configurations into the scheduler's persistent state so we can recreate `SessionContext` after restart. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
