### PR TITLE
fix `NULL <op> column` evaluation, tests for same

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot",
- "sqlparser 0.16.0",
+ "sqlparser",
  "tempfile",
  "tokio",
 ]
@@ -232,7 +232,7 @@ dependencies = [
  "prost-types",
  "rustc_version",
  "serde",
- "sqlparser 0.16.0",
+ "sqlparser",
  "tokio",
  "tonic",
  "tonic-build",
@@ -507,7 +507,7 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "smallvec",
- "sqlparser 0.17.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -536,12 +536,12 @@ dependencies = [
  "arrow",
  "ordered-float 3.0.0",
  "parquet",
- "sqlparser 0.17.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-data-access"
-version = "1.0.0"
+version = "7.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -559,7 +559,7 @@ dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
- "sqlparser 0.17.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -1934,15 +1934,6 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9a527b68048eb95495a1508f6c8395c8defcff5ecdbe8ad4106d08a2ef2a3c"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1452,9 +1452,10 @@ mod tests {
             .enumerate()
             .map(|(i, g)| row_group_predicate(g, i))
             .collect::<Vec<_>>();
-        // no row group is filtered out because the predicate expression can't be evaluated
-        // when a null array is generated for a statistics column,
-        assert_eq!(row_group_filter, vec![true, true]);
+
+        // bool = NULL always evaluates to NULL (and thus will not
+        // pass predicates. Ideally these should both be false
+        assert_eq!(row_group_filter, vec![false, true]);
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -26,10 +26,6 @@ use arrow::compute::kernels::arithmetic::{
 };
 use arrow::compute::kernels::boolean::{and_kleene, not, or_kleene};
 use arrow::compute::kernels::comparison::{
-    eq_bool_scalar, gt_bool_scalar, gt_eq_bool_scalar, lt_bool_scalar, lt_eq_bool_scalar,
-    neq_bool_scalar,
-};
-use arrow::compute::kernels::comparison::{
     eq_dyn_bool_scalar, gt_dyn_bool_scalar, gt_eq_dyn_bool_scalar, lt_dyn_bool_scalar,
     lt_eq_dyn_bool_scalar, neq_dyn_bool_scalar,
 };
@@ -44,12 +40,10 @@ use arrow::compute::kernels::comparison::{
 use arrow::compute::kernels::comparison::{
     eq_scalar, gt_eq_scalar, gt_scalar, lt_eq_scalar, lt_scalar, neq_scalar,
 };
-use arrow::compute::kernels::comparison::{
-    eq_utf8_scalar, gt_eq_utf8_scalar, gt_utf8_scalar, like_utf8_scalar,
-    lt_eq_utf8_scalar, lt_utf8_scalar, neq_utf8_scalar, nlike_utf8_scalar,
-    regexp_is_match_utf8_scalar,
-};
 use arrow::compute::kernels::comparison::{like_utf8, nlike_utf8, regexp_is_match_utf8};
+use arrow::compute::kernels::comparison::{
+    like_utf8_scalar, nlike_utf8_scalar, regexp_is_match_utf8_scalar,
+};
 use arrow::datatypes::{ArrowNumericType, DataType, Schema, TimeUnit};
 use arrow::error::ArrowError::DivideByZero;
 use arrow::record_batch::RecordBatch;
@@ -746,7 +740,7 @@ macro_rules! compute_op_scalar {
 }
 
 /// Invoke a dyn compute kernel on a data array and a scalar value
-/// LEFT is Primitive or Dictionart array of numeric values, RIGHT is scalar value
+/// LEFT is Primitive or Dictionary array of numeric values, RIGHT is scalar value
 /// OP_TYPE is the return type of scalar function
 macro_rules! compute_op_dyn_scalar {
     ($LEFT:expr, $RIGHT:expr, $OP:ident, $OP_TYPE:expr) => {{
@@ -1156,39 +1150,25 @@ impl BinaryExpr {
         array: &dyn Array,
         scalar: &ScalarValue,
     ) -> Result<Option<Result<ArrayRef>>> {
+        let bool_type = &DataType::Boolean;
         let scalar_result = match &self.op {
             Operator::Lt => {
-                binary_array_op_dyn_scalar!(array, scalar.clone(), lt, &DataType::Boolean)
+                binary_array_op_dyn_scalar!(array, scalar.clone(), lt, bool_type)
             }
             Operator::LtEq => {
-                binary_array_op_dyn_scalar!(
-                    array,
-                    scalar.clone(),
-                    lt_eq,
-                    &DataType::Boolean
-                )
+                binary_array_op_dyn_scalar!(array, scalar.clone(), lt_eq, bool_type)
             }
             Operator::Gt => {
-                binary_array_op_dyn_scalar!(array, scalar.clone(), gt, &DataType::Boolean)
+                binary_array_op_dyn_scalar!(array, scalar.clone(), gt, bool_type)
             }
             Operator::GtEq => {
-                binary_array_op_dyn_scalar!(
-                    array,
-                    scalar.clone(),
-                    gt_eq,
-                    &DataType::Boolean
-                )
+                binary_array_op_dyn_scalar!(array, scalar.clone(), gt_eq, bool_type)
             }
             Operator::Eq => {
-                binary_array_op_dyn_scalar!(array, scalar.clone(), eq, &DataType::Boolean)
+                binary_array_op_dyn_scalar!(array, scalar.clone(), eq, bool_type)
             }
             Operator::NotEq => {
-                binary_array_op_dyn_scalar!(
-                    array,
-                    scalar.clone(),
-                    neq,
-                    &DataType::Boolean
-                )
+                binary_array_op_dyn_scalar!(array, scalar.clone(), neq, bool_type)
             }
             Operator::Like => {
                 binary_string_array_op_scalar!(array, scalar.clone(), like)
@@ -1255,14 +1235,25 @@ impl BinaryExpr {
         scalar: &ScalarValue,
         array: &ArrayRef,
     ) -> Result<Option<Result<ArrayRef>>> {
+        let bool_type = &DataType::Boolean;
         let scalar_result = match &self.op {
-            Operator::Lt => binary_array_op_scalar!(array, scalar.clone(), gt),
-            Operator::LtEq => binary_array_op_scalar!(array, scalar.clone(), gt_eq),
-            Operator::Gt => binary_array_op_scalar!(array, scalar.clone(), lt),
-            Operator::GtEq => binary_array_op_scalar!(array, scalar.clone(), lt_eq),
-            Operator::Eq => binary_array_op_scalar!(array, scalar.clone(), eq),
+            Operator::Lt => {
+                binary_array_op_dyn_scalar!(array, scalar.clone(), gt, bool_type)
+            }
+            Operator::LtEq => {
+                binary_array_op_dyn_scalar!(array, scalar.clone(), gt_eq, bool_type)
+            }
+            Operator::Gt => {
+                binary_array_op_dyn_scalar!(array, scalar.clone(), lt, bool_type)
+            }
+            Operator::GtEq => {
+                binary_array_op_dyn_scalar!(array, scalar.clone(), lt_eq, bool_type)
+            }
+            Operator::Eq => {
+                binary_array_op_dyn_scalar!(array, scalar.clone(), eq, bool_type)
+            }
             Operator::NotEq => {
-                binary_array_op_scalar!(array, scalar.clone(), neq)
+                binary_array_op_dyn_scalar!(array, scalar.clone(), neq, bool_type)
             }
             // if scalar operation is not supported - fallback to array implementation
             _ => None,


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/1179 and https://github.com/apache/arrow-datafusion/issues/2482 .

 # Rationale for this change

While adding tests suggested in https://github.com/apache/arrow-datafusion/pull/2481 for reversed arguments, it uncovered a bug if the argument order was different.

Previously we tested `column1 < NULL` but not `NULL < column1`. When I did so I got 

```
---- sql::expr::comparisons_with_null_neq_reverse stdout ----
thread 'sql::expr::comparisons_with_null_neq_reverse' panicked at 'called `Result::unwrap()` on an `Err` value: "ArrowError(ExternalError(Internal(\"Cannot convert Int64(NULL) to i64\"))) at Executing physical plan for 'select NULL != column1 from (VALUES (1, 'foo' ,2.3), (2, 'bar', 5.4)) as t': ProjectionExec { expr: [(BinaryExpr { left: TryCastExpr { expr: Literal { value: NULL }, cast_type: Int64 }, op: NotEq, right: Column { name: \"column1\", index: 0 } }, \"NULL NotEq t.column1\")], schema: Schema { fields: [Field { name: \"NULL NotEq t.column1\", data_type: Boolean, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, input: ProjectionExec { expr: [(Column { name: \"column1\", index: 0 }, \"column1\")], schema: Schema { fields: [Field { name: \"column1\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, input: ValuesExec { schema: Schema { fields: [Field { name: \"column1\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: \"column2\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: \"column3\", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, data: [RecordBatch { schema: Schema { fields: [Field { name: \"column1\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: \"column2\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, Field { name: \"column3\", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }], metadata: {} }, columns: [PrimitiveArray<Int64>\n[\n  1,\n  2,\n], StringArray\n[\n  \"foo\",\n  \"bar\",\n], PrimitiveArray<Float64>\n[\n  2.3,\n  5.4,\n]], row_count: 2 }] }, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [] } } } }, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [] } } } }"', datafusion/core/tests/sql/mod.rs:563:10
```

# What changes are included in this PR?

This PR adds a test exercising the order of expressions with null constants, and fixes evaluation of same 

# Are there any user-facing changes?

Fewer internal errors 

cc @WinkerDu  and @yjshen 