### PR TITLE
Minor: remove code that is now in arrow

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -61,14 +61,6 @@ use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::binary_rule::binary_operator_data_type;
 use datafusion_expr::{binary_rule::coerce_types, ColumnarValue, Operator};
 
-// TODO move to arrow_rs
-// https://github.com/apache/arrow-rs/issues/1312
-fn as_decimal_array(arr: &dyn Array) -> &DecimalArray {
-    arr.as_any()
-        .downcast_ref::<DecimalArray>()
-        .expect("Unable to downcast to typed array to DecimalArray")
-}
-
 /// create a `dyn_op` wrapper function for the specified operation
 /// that call the underlying dyn_op arrow kernel if the type is
 /// supported, and translates ArrowError to DataFusionError


### PR DESCRIPTION
This code https://github.com/apache/arrow-rs/issues/1312 was moved to arrow, so use the copy there


 # Rationale for this change
Less code == better

# What changes are included in this PR?
delete copy of code from datafusion

# Are there any user-facing changes?
No, this is entirely internal