### PR TITLE
Remove unused  `binary_array_op_scalar!` in binary.rs

### DIFF
--- a/datafusion/physical-expr/src/expressions/nullif.rs
+++ b/datafusion/physical-expr/src/expressions/nullif.rs
@@ -17,17 +17,15 @@
 
 use std::sync::Arc;
 
-use crate::expressions::binary::{eq_decimal, eq_decimal_scalar, eq_null};
 use arrow::array::Array;
 use arrow::array::*;
+use arrow::compute::eq_dyn;
 use arrow::compute::kernels::boolean::nullif;
-use arrow::compute::kernels::comparison::{
-    eq, eq_bool, eq_bool_scalar, eq_scalar, eq_utf8, eq_utf8_scalar,
-};
-use arrow::datatypes::{DataType, TimeUnit};
-use datafusion_common::ScalarValue;
+use arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
+
+use super::binary::array_eq_scalar;
 
 /// Invoke a compute kernel on a primitive array and a Boolean Array
 macro_rules! compute_bool_array_op {
@@ -82,7 +80,7 @@ pub fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 
     match (lhs, rhs) {
         (ColumnarValue::Array(lhs), ColumnarValue::Scalar(rhs)) => {
-            let cond_array = binary_array_op_scalar!(lhs, rhs.clone(), eq).unwrap()?;
+            let cond_array = array_eq_scalar(lhs, rhs)?;
 
             let array = primitive_bool_array_op!(lhs, *cond_array, nullif)?;
 
@@ -90,10 +88,10 @@ pub fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         }
         (ColumnarValue::Array(lhs), ColumnarValue::Array(rhs)) => {
             // Get args0 == args1 evaluated and produce a boolean array
-            let cond_array = binary_array_op!(lhs, rhs, eq)?;
+            let cond_array = eq_dyn(lhs, rhs)?;
 
             // Now, invoke nullif on the result
-            let array = primitive_bool_array_op!(lhs, *cond_array, nullif)?;
+            let array = primitive_bool_array_op!(lhs, cond_array, nullif)?;
             Ok(ColumnarValue::Array(array))
         }
         _ => Err(DataFusionError::NotImplemented(
@@ -105,7 +103,7 @@ pub fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_common::Result;
+    use datafusion_common::{Result, ScalarValue};
 
     #[test]
     fn nullif_int32() -> Result<()> {


### PR DESCRIPTION
~Draft until https://github.com/apache/arrow-datafusion/pull/2510 is merged~

# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/1179 and https://github.com/apache/arrow-datafusion/issues/2482 .


 # Rationale for this change
(the real reason for this is that I got nerd-sniped trying to clean up expression evaluation )
1. The `binary_array_op_scalar!` doesn't handle null constants (see https://github.com/apache/arrow-datafusion/pull/2510)
2. It is duplicative of `binary_array_op_dyn_scalar!`


# What changes are included in this PR?
1. Remove `binary_array_op_dyn_scalar!`
2. Remove code that then becomes unused without that macro 🎉 

# Are there any user-facing changes?
No, all internal changes 
