### PR TITLE
Fix size_of_scalar test

### DIFF
--- a/datafusion/core/src/scalar.rs
+++ b/datafusion/core/src/scalar.rs
@@ -377,7 +377,7 @@ mod tests {
         #[cfg(target_arch = "aarch64")]
         assert_eq!(std::mem::size_of::<ScalarValue>(), 64);
 
-        #[cfg(target_arch = "amd64")]
+        #[cfg(not(target_arch = "aarch64"))]
         assert_eq!(std::mem::size_of::<ScalarValue>(), 48);
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A
 # Rationale for this change

This test is important. It verifies that the memory use of code like GroupByHash is not changed. Quoting:

```
        // Since ScalarValues are used in a non trivial number of places,
        // making it larger means significant more memory consumption
        // per distinct value.
```

It turns out that the way the `cfgs` were setup the test never was invoked.

The change seems to have come in via #1455 from @maxburke 

I found this while reviewing https://github.com/apache/arrow-datafusion/pull/2523

# What changes are included in this PR?
Fix test so it is always invoked

# Are there any user-facing changes?
no