### PR TITLE
Reduce duplication in file scan tests

### DIFF
--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -242,61 +242,22 @@ fn stats_union(mut left: Statistics, right: Statistics) -> Statistics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datafusion_data_access::object_store::{
-        local::LocalFileSystem, ObjectStore,
-    };
-    use crate::{test, test_util};
+    use crate::test;
 
     use crate::prelude::SessionContext;
-    use crate::{
-        physical_plan::{
-            collect,
-            file_format::{CsvExec, FileScanConfig},
-        },
-        scalar::ScalarValue,
-    };
+    use crate::{physical_plan::collect, scalar::ScalarValue};
     use arrow::record_batch::RecordBatch;
 
     #[tokio::test]
     async fn test_union_partitions() -> Result<()> {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
-        let schema = test_util::aggr_test_schema();
-        let fs: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem {});
 
         // Create csv's with different partitioning
-        let (_, files) = test::create_partitioned_csv("aggregate_test_100.csv", 4)?;
-        let (_, files2) = test::create_partitioned_csv("aggregate_test_100.csv", 5)?;
+        let csv = test::scan_partitioned_csv(4)?;
+        let csv2 = test::scan_partitioned_csv(5)?;
 
-        let csv = CsvExec::new(
-            FileScanConfig {
-                object_store: Arc::clone(&fs),
-                file_schema: Arc::clone(&schema),
-                file_groups: files,
-                statistics: Statistics::default(),
-                projection: None,
-                limit: None,
-                table_partition_cols: vec![],
-            },
-            true,
-            b',',
-        );
-
-        let csv2 = CsvExec::new(
-            FileScanConfig {
-                object_store: Arc::clone(&fs),
-                file_schema: Arc::clone(&schema),
-                file_groups: files2,
-                statistics: Statistics::default(),
-                projection: None,
-                limit: None,
-                table_partition_cols: vec![],
-            },
-            true,
-            b',',
-        );
-
-        let union_exec = Arc::new(UnionExec::new(vec![Arc::new(csv), Arc::new(csv2)]));
+        let union_exec = Arc::new(UnionExec::new(vec![csv, csv2]));
 
         // Should have 9 partitions and 9 output batches
         assert_eq!(union_exec.output_partitioning().partition_count(), 9);


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2504 
Part of #2489 
Part of #2293

 # Rationale for this change

#2504 #2489 #2293 will all require making changes to the interface of the physical operators, in order to reduce the churn, this PR first eliminates some duplication from the tests

# What changes are included in this PR?

Extracts common test logic into functions

# Are there any user-facing changes?

No, the only changes are to tests
