### PR TITLE
Remove `scan_csv` methods from `LogicalPlanBuilder`

### DIFF
--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -1019,11 +1019,8 @@ mod roundtrip_tests {
     use crate::serde::{AsLogicalPlan, BallistaCodec};
     use async_trait::async_trait;
     use core::panic;
-    use datafusion::arrow::datatypes::SchemaRef;
-    use datafusion::common::{DFField, DFSchema, DFSchemaRef};
-    use datafusion::datasource::MemTable;
-    use datafusion::logical_plan::plan::DefaultTableSource;
-    use datafusion::logical_plan::{source_as_provider, TableScan};
+    use datafusion::common::DFSchemaRef;
+    use datafusion::logical_plan::source_as_provider;
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
         datafusion_data_access::{
@@ -1038,7 +1035,6 @@ mod roundtrip_tests {
         },
         prelude::*,
     };
-    use std::collections::HashMap;
     use std::io;
     use std::sync::Arc;
 
@@ -1371,7 +1367,7 @@ mod roundtrip_tests {
         let schema = test_schema();
         let ctx = SessionContext::new();
         let options = CsvReadOptions::new().schema(&schema);
-        let df = ctx.read_csv("employee.csv", options).await?;
+        let df = ctx.read_csv(table_name, options).await?;
         let plan = match df.to_logical_plan()? {
             LogicalPlan::TableScan(ref scan) => {
                 let mut scan = scan.clone();

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -1016,19 +1016,19 @@ macro_rules! into_logical_plan {
 mod roundtrip_tests {
 
     use super::super::{super::error::Result, protobuf};
-    use crate::error::BallistaError;
     use crate::serde::{AsLogicalPlan, BallistaCodec};
     use async_trait::async_trait;
     use core::panic;
-    use datafusion::logical_plan::source_as_provider;
+    use datafusion::arrow::datatypes::SchemaRef;
+    use datafusion::common::{DFField, DFSchema, DFSchemaRef};
+    use datafusion::datasource::MemTable;
+    use datafusion::logical_plan::plan::DefaultTableSource;
+    use datafusion::logical_plan::{source_as_provider, TableScan};
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
         datafusion_data_access::{
             self,
-            object_store::{
-                local::LocalFileSystem, FileMetaStream, ListEntryStream, ObjectReader,
-                ObjectStore,
-            },
+            object_store::{FileMetaStream, ListEntryStream, ObjectReader, ObjectStore},
             SizedFile,
         },
         datasource::listing::ListingTable,
@@ -1038,6 +1038,7 @@ mod roundtrip_tests {
         },
         prelude::*,
     };
+    use std::collections::HashMap;
     use std::io;
     use std::sync::Arc;
 
@@ -1142,26 +1143,11 @@ mod roundtrip_tests {
         let test_expr: Vec<Expr> =
             vec![col("c1") + col("c2"), Expr::Literal((4.0).into())];
 
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
-
         let plan = std::sync::Arc::new(
-            LogicalPlanBuilder::scan_csv(
-                Arc::new(LocalFileSystem {}),
-                "employee.csv",
-                CsvReadOptions::new().schema(&schema).has_header(true),
-                Some(vec![3, 4]),
-                4,
-            )
-            .await
-            .and_then(|plan| plan.sort(vec![col("salary")]))
-            .and_then(|plan| plan.build())
-            .map_err(BallistaError::DataFusionError)?,
+            test_scan_csv("employee.csv", Some(vec![3, 4]))
+                .await?
+                .sort(vec![col("salary")])?
+                .build()?,
         );
 
         for partition_count in test_partition_counts.iter() {
@@ -1198,13 +1184,7 @@ mod roundtrip_tests {
 
     #[test]
     fn roundtrip_create_external_table() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
+        let schema = test_schema();
 
         let df_schema_ref = schema.to_dfschema_ref()?;
 
@@ -1236,39 +1216,17 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_analyze() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
+        let verbose_plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .sort(vec![col("salary")])?
+            .explain(true, true)?
+            .build()?;
 
-        let verbose_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
-        .and_then(|plan| plan.explain(true, true))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
-        .and_then(|plan| plan.explain(false, true))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .sort(vec![col("salary")])?
+            .explain(false, true)?
+            .build()?;
 
         roundtrip_test!(plan);
 
@@ -1279,39 +1237,17 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_explain() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
+        let verbose_plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .sort(vec![col("salary")])?
+            .explain(true, false)?
+            .build()?;
 
-        let verbose_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
-        .and_then(|plan| plan.explain(true, false))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
-        .and_then(|plan| plan.explain(false, false))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .sort(vec![col("salary")])?
+            .explain(false, false)?
+            .build()?;
 
         roundtrip_test!(plan);
 
@@ -1322,36 +1258,14 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_join() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
+        let scan_plan = test_scan_csv("employee1", Some(vec![0, 3, 4]))
+            .await?
+            .build()?;
 
-        let scan_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee1",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![0, 3, 4]),
-            4,
-        )
-        .await?
-        .build()
-        .map_err(BallistaError::DataFusionError)?;
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee2",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![0, 3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.join(&scan_plan, JoinType::Inner, (vec!["id"], vec!["id"])))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee2", Some(vec![0, 3, 4]))
+            .await?
+            .join(&scan_plan, JoinType::Inner, (vec!["id"], vec!["id"]))?
+            .build()?;
 
         roundtrip_test!(plan);
         Ok(())
@@ -1359,25 +1273,10 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_sort() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.sort(vec![col("salary")]))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .sort(vec![col("salary")])?
+            .build()?;
         roundtrip_test!(plan);
 
         Ok(())
@@ -1385,15 +1284,11 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_empty_relation() -> Result<()> {
-        let plan_false = LogicalPlanBuilder::empty(false)
-            .build()
-            .map_err(BallistaError::DataFusionError)?;
+        let plan_false = LogicalPlanBuilder::empty(false).build()?;
 
         roundtrip_test!(plan_false);
 
-        let plan_true = LogicalPlanBuilder::empty(true)
-            .build()
-            .map_err(BallistaError::DataFusionError)?;
+        let plan_true = LogicalPlanBuilder::empty(true).build()?;
 
         roundtrip_test!(plan_true);
 
@@ -1402,25 +1297,10 @@ mod roundtrip_tests {
 
     #[tokio::test]
     async fn roundtrip_logical_plan() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            "employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.aggregate(vec![col("state")], vec![max(col("salary"))]))
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .aggregate(vec![col("state")], vec![max(col("salary"))])?
+            .build()?;
 
         roundtrip_test!(plan);
 
@@ -1440,24 +1320,9 @@ mod roundtrip_tests {
 
         println!("Object Store {:?}", os);
 
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
-            Field::new("state", DataType::Utf8, false),
-            Field::new("salary", DataType::Int32, false),
-        ]);
-
-        let plan = LogicalPlanBuilder::scan_csv(
-            custom_object_store.clone(),
-            "test://employee.csv",
-            CsvReadOptions::new().schema(&schema).has_header(true),
-            Some(vec![3, 4]),
-            4,
-        )
-        .await
-        .and_then(|plan| plan.build())
-        .map_err(BallistaError::DataFusionError)?;
+        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+            .await?
+            .build()?;
 
         let proto: protobuf::LogicalPlanNode =
             protobuf::LogicalPlanNode::try_from_logical_plan(
@@ -1487,5 +1352,37 @@ mod roundtrip_tests {
         assert_eq!(round_trip_store, format!("{:?}", custom_object_store));
 
         Ok(())
+    }
+
+    fn test_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ])
+    }
+
+    async fn test_scan_csv(
+        table_name: &str,
+        projection: Option<Vec<usize>>,
+    ) -> Result<LogicalPlanBuilder> {
+        let schema = test_schema();
+        let ctx = SessionContext::new();
+        let options = CsvReadOptions::new().schema(&schema);
+        let df = ctx.read_csv("employee.csv", options).await?;
+        let plan = match df.to_logical_plan()? {
+            LogicalPlan::TableScan(ref scan) => {
+                let mut scan = scan.clone();
+                scan.projection = projection;
+                let mut projected_schema = scan.projected_schema.as_ref().clone();
+                projected_schema = projected_schema.replace_qualifier(table_name);
+                scan.projected_schema = DFSchemaRef::new(projected_schema);
+                LogicalPlan::TableScan(scan)
+            }
+            _ => unimplemented!(),
+        };
+        Ok(LogicalPlanBuilder::from(plan))
     }
 }

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -1303,6 +1303,7 @@ mod roundtrip_tests {
         Ok(())
     }
 
+    #[ignore] // see https://github.com/apache/arrow-datafusion/issues/2546
     #[tokio::test]
     async fn roundtrip_logical_plan_custom_ctx() -> Result<()> {
         let ctx = SessionContext::new();
@@ -1312,11 +1313,13 @@ mod roundtrip_tests {
         ctx.runtime_env()
             .register_object_store("test", custom_object_store.clone());
 
-        let (_, uri) = ctx.runtime_env().object_store("test://foo.csv")?;
+        let (os, uri) = ctx.runtime_env().object_store("test://foo.csv")?;
+        assert_eq!("TestObjectStore", &format!("{:?}", os));
+        assert_eq!("foo.csv", uri);
 
         let schema = test_schema();
         let plan = ctx
-            .read_csv(uri, CsvReadOptions::new().schema(&schema).has_header(true))
+            .read_csv("test://employee.csv", CsvReadOptions::new().schema(&schema).has_header(true))
             .await?
             .to_logical_plan()?;
 

--- a/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -1312,13 +1312,13 @@ mod roundtrip_tests {
         ctx.runtime_env()
             .register_object_store("test", custom_object_store.clone());
 
-        let (os, _) = ctx.runtime_env().object_store("test://foo.csv")?;
+        let (_, uri) = ctx.runtime_env().object_store("test://foo.csv")?;
 
-        println!("Object Store {:?}", os);
-
-        let plan = test_scan_csv("employee.csv", Some(vec![3, 4]))
+        let schema = test_schema();
+        let plan = ctx
+            .read_csv(uri, CsvReadOptions::new().schema(&schema).has_header(true))
             .await?
-            .build()?;
+            .to_logical_plan()?;
 
         let proto: protobuf::LogicalPlanNode =
             protobuf::LogicalPlanNode::try_from_logical_plan(

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -558,18 +558,23 @@ impl SessionContext {
         let uri: String = uri.into();
         let (object_store, path) = self.runtime_env().object_store(&uri)?;
         let target_partitions = self.copied_config().target_partitions;
-        Ok(Arc::new(DataFrame::new(
-            self.state.clone(),
-            &LogicalPlanBuilder::scan_csv(
-                object_store,
-                path,
-                options,
-                None,
-                target_partitions,
-            )
-            .await?
-            .build()?,
-        )))
+        let path = path.to_string();
+        let listing_options = options.to_listing_options(target_partitions);
+        let resolved_schema = match options.schema {
+            Some(s) => Arc::new(s.to_owned()),
+            None => {
+                listing_options
+                    .infer_schema(Arc::clone(&object_store), &path)
+                    .await?
+            }
+        };
+        let config = ListingTableConfig::new(object_store, path.clone())
+            .with_listing_options(listing_options)
+            .with_schema(resolved_schema);
+        let provider = ListingTable::try_new(config)?;
+
+        let plan = LogicalPlanBuilder::scan(path, Arc::new(provider), None)?.build()?;
+        Ok(Arc::new(DataFrame::new(self.state.clone(), &plan)))
     }
 
     /// Creates a DataFrame for reading a Parquet data source.

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -20,7 +20,7 @@
 use crate::datasource::{
     empty::EmptyTable,
     listing::{ListingTable, ListingTableConfig},
-    MemTable, TableProvider,
+    TableProvider,
 };
 use crate::error::{DataFusionError, Result};
 use crate::logical_expr::ExprSchemable;
@@ -31,10 +31,7 @@ use crate::logical_plan::plan::{
 use crate::optimizer::utils;
 use crate::prelude::*;
 use crate::scalar::ScalarValue;
-use arrow::{
-    datatypes::{DataType, Schema, SchemaRef},
-    record_batch::RecordBatch,
-};
+use arrow::datatypes::{DataType, Schema};
 use datafusion_data_access::object_store::ObjectStore;
 use std::convert::TryFrom;
 use std::iter;
@@ -192,65 +189,6 @@ impl LogicalPlanBuilder {
         let schema =
             DFSchemaRef::new(DFSchema::new_with_metadata(fields, HashMap::new())?);
         Ok(Self::from(LogicalPlan::Values(Values { schema, values })))
-    }
-
-    /// Scan a memory data source
-    pub fn scan_memory(
-        partitions: Vec<Vec<RecordBatch>>,
-        schema: SchemaRef,
-        projection: Option<Vec<usize>>,
-    ) -> Result<Self> {
-        let provider = Arc::new(MemTable::try_new(schema, partitions)?);
-        Self::scan(UNNAMED_TABLE, provider, projection)
-    }
-
-    /// Scan a CSV data source
-    pub async fn scan_csv(
-        object_store: Arc<dyn ObjectStore>,
-        path: impl Into<String>,
-        options: CsvReadOptions<'_>,
-        projection: Option<Vec<usize>>,
-        target_partitions: usize,
-    ) -> Result<Self> {
-        let path = path.into();
-        Self::scan_csv_with_name(
-            object_store,
-            path.clone(),
-            options,
-            projection,
-            path,
-            target_partitions,
-        )
-        .await
-    }
-
-    /// Scan a CSV data source and register it with a given table name
-    pub async fn scan_csv_with_name(
-        object_store: Arc<dyn ObjectStore>,
-        path: impl Into<String>,
-        options: CsvReadOptions<'_>,
-        projection: Option<Vec<usize>>,
-        table_name: impl Into<String>,
-        target_partitions: usize,
-    ) -> Result<Self> {
-        let listing_options = options.to_listing_options(target_partitions);
-
-        let path: String = path.into();
-
-        let resolved_schema = match options.schema {
-            Some(s) => Arc::new(s.to_owned()),
-            None => {
-                listing_options
-                    .infer_schema(Arc::clone(&object_store), &path)
-                    .await?
-            }
-        };
-        let config = ListingTableConfig::new(object_store, path)
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-        let provider = ListingTable::try_new(config)?;
-
-        Self::scan(table_name, Arc::new(provider), projection)
     }
 
     /// Scan a Parquet data source

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -17,10 +17,7 @@
 
 //! This module provides a builder for creating LogicalPlans
 
-use crate::datasource::{
-    empty::EmptyTable,
-    TableProvider,
-};
+use crate::datasource::{empty::EmptyTable, TableProvider};
 use crate::error::{DataFusionError, Result};
 use crate::logical_expr::ExprSchemable;
 use crate::logical_plan::plan::{
@@ -943,8 +940,8 @@ mod tests {
     use datafusion_common::SchemaError;
     use datafusion_expr::expr_fn::exists;
 
-    use crate::prelude::*;
     use crate::logical_plan::StringifiedPlan;
+    use crate::prelude::*;
     use crate::test::test_table_scan_with_name;
 
     use super::super::{col, lit, sum};

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1528,7 +1528,6 @@ fn tuple_err<T, R>(value: (Result<T>, Result<R>)) -> Result<(T, R)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datafusion_data_access::object_store::local::LocalFileSystem;
     use crate::execution::context::TaskContext;
     use crate::execution::options::CsvReadOptions;
     use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
@@ -1536,7 +1535,7 @@ mod tests {
     use crate::physical_plan::{
         expressions, DisplayFormatType, Partitioning, Statistics,
     };
-    use crate::prelude::SessionConfig;
+    use crate::prelude::{SessionConfig, SessionContext};
     use crate::scalar::ScalarValue;
     use crate::{
         logical_plan::LogicalPlanBuilder, physical_plan::SendableRecordBatchStream,
@@ -1566,25 +1565,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_all_operators() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            path,
-            options,
-            None,
-            1,
-        )
-        .await?
-        // filter clause needs the type coercion rule applied
-        .filter(col("c7").lt(lit(5_u8)))?
-        .project(vec![col("c1"), col("c2")])?
-        .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
-        .sort(vec![col("c1").sort(true, true)])?
-        .limit(10)?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            // filter clause needs the type coercion rule applied
+            .filter(col("c7").lt(lit(5_u8)))?
+            .project(vec![col("c1"), col("c2")])?
+            .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
+            .sort(vec![col("c1").sort(true, true)])?
+            .limit(10)?
+            .build()?;
 
         let plan = plan(&logical_plan).await?;
 
@@ -1618,20 +1607,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_csv_plan() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            path,
-            options,
-            None,
-            1,
-        )
-        .await?
-        .filter(col("c7").lt(col("c12")))?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            .filter(col("c7").lt(col("c12")))?
+            .build()?;
 
         let plan = plan(&logical_plan).await?;
 
@@ -1644,10 +1623,6 @@ mod tests {
 
     #[tokio::test]
     async fn errors() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-
         let bool_expr = col("c1").eq(col("c1"));
         let cases = vec![
             // utf8 < u32
@@ -1666,15 +1641,7 @@ mod tests {
             col("c1").like(col("c2")),
         ];
         for case in cases {
-            let logical_plan = LogicalPlanBuilder::scan_csv(
-                Arc::new(LocalFileSystem {}),
-                &path,
-                options.clone(),
-                None,
-                1,
-            )
-            .await?
-            .project(vec![case.clone()]);
+            let logical_plan = test_csv_scan().await?.project(vec![case.clone()]);
             let message = format!(
                 "Expression {:?} expected to error due to impossible coercion",
                 case
@@ -1757,27 +1724,17 @@ mod tests {
 
     #[tokio::test]
     async fn in_list_types() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-
         // expression: "a in ('a', 1)"
         let list = vec![
             Expr::Literal(ScalarValue::Utf8(Some("a".to_string()))),
             Expr::Literal(ScalarValue::Int64(Some(1))),
         ];
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options.clone(),
-            None,
-            1,
-        )
-        .await?
-        // filter clause needs the type coercion rule applied
-        .filter(col("c12").lt(lit(0.05)))?
-        .project(vec![col("c1").in_list(list, false)])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            // filter clause needs the type coercion rule applied
+            .filter(col("c12").lt(lit(0.05)))?
+            .project(vec![col("c1").in_list(list, false)])?
+            .build()?;
         let execution_plan = plan(&logical_plan).await?;
         // verify that the plan correctly adds cast from Int64(1) to Utf8
         let expected = "InListExpr { expr: Column { name: \"c1\", index: 0 }, list: [Literal { value: Utf8(\"a\") }, CastExpr { expr: Literal { value: Int64(1) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }], negated: false, set: None }";
@@ -1788,18 +1745,12 @@ mod tests {
             Expr::Literal(ScalarValue::Boolean(Some(true))),
             Expr::Literal(ScalarValue::Utf8(Some("a".to_string()))),
         ];
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options.clone(),
-            None,
-            1,
-        )
-        .await?
-        // filter clause needs the type coercion rule applied
-        .filter(col("c12").lt(lit(0.05)))?
-        .project(vec![col("c12").lt_eq(lit(0.025)).in_list(list, false)])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            // filter clause needs the type coercion rule applied
+            .filter(col("c12").lt(lit(0.05)))?
+            .project(vec![col("c12").lt_eq(lit(0.025)).in_list(list, false)])?
+            .build()?;
         let execution_plan = plan(&logical_plan).await;
 
         let expected_error = "Unsupported CAST from Utf8 to Boolean";
@@ -1818,10 +1769,6 @@ mod tests {
 
     #[tokio::test]
     async fn in_set_test() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-
         // OPTIMIZER_INSET_THRESHOLD = 10
         // expression: "a in ('a', 1, 2, ..30)"
         let mut list = vec![Expr::Literal(ScalarValue::Utf8(Some("a".to_string())))];
@@ -1829,17 +1776,11 @@ mod tests {
             list.push(Expr::Literal(ScalarValue::Int64(Some(i))));
         }
 
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options,
-            None,
-            1,
-        )
-        .await?
-        .filter(col("c12").lt(lit(0.05)))?
-        .project(vec![col("c1").in_list(list, false)])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            .filter(col("c12").lt(lit(0.05)))?
+            .project(vec![col("c1").in_list(list, false)])?
+            .build()?;
         let execution_plan = plan(&logical_plan).await?;
         let expected = "expr: [(InListExpr { expr: Column { name: \"c1\", index: 0 }, list: [Literal { value: Utf8(\"a\") }, CastExpr { expr: Literal { value: Int64(1) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(2) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(3) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(4) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(5) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(6) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(7) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(8) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(9) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(10) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(11) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(12) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(13) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(14) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(15) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(16) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(17) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(18) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(19) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(20) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(21) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(22) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(23) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(24) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(25) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(26) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(27) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(28) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(29) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(30) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }], negated: false, set: Some(InSet { set:";
         assert!(format!("{:?}", execution_plan).contains(expected));
@@ -1848,26 +1789,17 @@ mod tests {
 
     #[tokio::test]
     async fn in_set_null_test() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
         // test NULL
         let mut list = vec![Expr::Literal(ScalarValue::Int64(None))];
         for i in 1..31 {
             list.push(Expr::Literal(ScalarValue::Int64(Some(i))));
         }
 
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options,
-            None,
-            1,
-        )
-        .await?
-        .filter(col("c12").lt(lit(0.05)))?
-        .project(vec![col("c1").in_list(list, false)])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            .filter(col("c12").lt(lit(0.05)))?
+            .project(vec![col("c1").in_list(list, false)])?
+            .build()?;
         let execution_plan = plan(&logical_plan).await?;
         let expected = "expr: [(InListExpr { expr: Column { name: \"c1\", index: 0 }, list: [CastExpr { expr: Literal { value: Int64(NULL) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(1) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(2) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(3) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(4) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(5) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(6) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(7) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(8) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(9) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(10) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(11) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(12) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(13) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(14) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(15) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(16) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(17) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(18) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(19) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(20) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(21) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(22) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(23) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(24) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(25) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(26) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(27) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(28) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(29) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }, CastExpr { expr: Literal { value: Int64(30) }, cast_type: Utf8, cast_options: CastOptions { safe: false } }], negated: false, set: Some(InSet { set: ";
         assert!(format!("{:?}", execution_plan).contains(expected));
@@ -1876,21 +1808,10 @@ mod tests {
 
     #[tokio::test]
     async fn hash_agg_input_schema() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-        let logical_plan = LogicalPlanBuilder::scan_csv_with_name(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options,
-            None,
-            "aggregate_test_100",
-            1,
-        )
-        .await?
-        .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
+            .build()?;
 
         let execution_plan = plan(&logical_plan).await?;
         let final_hash_agg = execution_plan
@@ -1910,20 +1831,10 @@ mod tests {
 
     #[tokio::test]
     async fn hash_agg_group_by_partitioned() -> Result<()> {
-        let testdata = crate::test_util::arrow_test_data();
-        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
-
-        let options = CsvReadOptions::new().schema_infer_max_records(100);
-        let logical_plan = LogicalPlanBuilder::scan_csv(
-            Arc::new(LocalFileSystem {}),
-            &path,
-            options,
-            None,
-            1,
-        )
-        .await?
-        .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
-        .build()?;
+        let logical_plan = test_csv_scan()
+            .await?
+            .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
+            .build()?;
 
         let execution_plan = plan(&logical_plan).await?;
         let formatted = format!("{:?}", execution_plan);
@@ -2111,5 +2022,15 @@ mod tests {
                 )])),
             })))
         }
+    }
+
+    async fn test_csv_scan() -> Result<LogicalPlanBuilder> {
+        let ctx = SessionContext::new();
+        let testdata = crate::test_util::arrow_test_data();
+        let path = format!("{}/csv/aggregate_test_100.csv", testdata);
+        let options = CsvReadOptions::new().schema_infer_max_records(100);
+        Ok(LogicalPlanBuilder::from(
+            ctx.read_csv(path, options).await?.to_logical_plan()?,
+        ))
     }
 }

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -237,7 +237,8 @@ async fn projection_on_memory_scan() -> Result<()> {
         ],
     )?]];
 
-    let plan = LogicalPlanBuilder::scan_memory(partitions, schema, None)?
+    let provider = Arc::new(MemTable::try_new(schema, partitions)?);
+    let plan = LogicalPlanBuilder::scan(UNNAMED_TABLE, provider, None)?
         .project(vec![col("b")])?
         .build()?;
     assert_fields_eq(&plan, vec!["b"]);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2536

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- `LogicalPlanBuilder` should be in same crate as `LogicalPlan`
- `LogicalPlanBuilder` should not need to know about data sources & object store but just `TableSource`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Move some logic from `LogicalPlanBuilder` to `SessionContext`
- Reduce duplication in the test code
- Ignored one problematic test and filed https://github.com/apache/arrow-datafusion/issues/2546 to fix

There will be separate PRs to remove the other scan methods (parquet, json, avro).

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this changes the `LogicalPlanBuilder` API

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
