### PR TITLE
MINOR: Move `ExprVisitable` and `exprlist_to_columns` to datafusion-expr crate

### DIFF
--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -36,6 +36,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion_data_access::object_store::ObjectStore;
+use datafusion_expr::utils::expr_to_columns;
 use std::convert::TryFrom;
 use std::iter;
 use std::{
@@ -600,7 +601,7 @@ impl LogicalPlanBuilder {
             .into_iter()
             .try_for_each::<_, Result<()>>(|expr| {
                 let mut columns: HashSet<Column> = HashSet::new();
-                utils::expr_to_columns(&expr, &mut columns)?;
+                expr_to_columns(&expr, &mut columns)?;
 
                 columns.into_iter().for_each(|c| {
                     if schema.field_from_column(&c).is_err() {

--- a/datafusion/core/src/logical_plan/mod.rs
+++ b/datafusion/core/src/logical_plan/mod.rs
@@ -25,7 +25,6 @@ pub(crate) mod builder;
 mod expr;
 mod expr_rewriter;
 mod expr_simplier;
-mod expr_visitor;
 pub mod plan;
 mod registry;
 pub mod window_frames;
@@ -33,9 +32,11 @@ pub use builder::{
     build_join_schema, union_with_alias, LogicalPlanBuilder, UNNAMED_TABLE,
 };
 pub use datafusion_common::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
-pub use datafusion_expr::{expr_fn::binary_expr, Operator};
-
-pub use crate::logical_expr::ExprSchemable;
+pub use datafusion_expr::{
+    expr_fn::binary_expr,
+    expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion},
+    ExprSchemable, Operator,
+};
 pub use expr::{
     abs, acos, and, approx_distinct, approx_percentile_cont, array, ascii, asin, atan,
     avg, bit_length, btrim, call_fn, case, ceil, character_length, chr, coalesce, col,
@@ -56,7 +57,6 @@ pub use expr_rewriter::{
     ExprRewriter, RewriteRecursion,
 };
 pub use expr_simplier::{ExprSimplifiable, SimplifyInfo};
-pub use expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion};
 pub use plan::{provider_as_source, source_as_provider};
 pub use plan::{
     CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateMemoryTable,

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -36,6 +36,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::RecordBatch,
 };
+use datafusion_expr::utils::expr_to_columns;
 
 use crate::execution::context::ExecutionProps;
 use crate::physical_plan::planner::create_physical_expr;
@@ -412,9 +413,9 @@ impl<'a> PruningExpressionBuilder<'a> {
     ) -> Result<Self> {
         // find column name; input could be a more complicated expression
         let mut left_columns = HashSet::<Column>::new();
-        utils::expr_to_columns(left, &mut left_columns)?;
+        expr_to_columns(left, &mut left_columns)?;
         let mut right_columns = HashSet::<Column>::new();
-        utils::expr_to_columns(right, &mut right_columns)?;
+        expr_to_columns(right, &mut right_columns)?;
         let (column_expr, scalar_expr, columns, correct_operator) =
             match (left_columns.len(), right_columns.len()) {
                 (1, 0) => (left, right, left_columns, op),

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -28,9 +28,8 @@ use crate::datasource::TableProvider;
 use crate::logical_plan::window_frames::{WindowFrame, WindowFrameUnits};
 use crate::logical_plan::Expr::Alias;
 use crate::logical_plan::{
-    and, builder::expand_qualified_wildcard, builder::expand_wildcard, col, lit,
-    normalize_col, normalize_col_with_schemas, union_with_alias, Column, CreateCatalog,
-    CreateCatalogSchema, CreateExternalTable as PlanCreateExternalTable,
+    and, col, lit, normalize_col, normalize_col_with_schemas, union_with_alias, Column,
+    CreateCatalog, CreateCatalogSchema, CreateExternalTable as PlanCreateExternalTable,
     CreateMemoryTable, CreateView, DFSchema, DFSchemaRef, DropTable, Expr, FileType,
     LogicalPlan, LogicalPlanBuilder, Operator, PlanType, ToDFSchema, ToStringifiedPlan,
 };
@@ -39,6 +38,7 @@ use crate::scalar::ScalarValue;
 use crate::sql::utils::{make_decimal_type, normalize_ident, resolve_columns};
 use crate::{
     error::{DataFusionError, Result},
+    logical_expr::utils::{expand_qualified_wildcard, expand_wildcard},
     physical_plan::aggregates,
     physical_plan::udaf::AggregateUDF,
     physical_plan::udf::ScalarUDF,

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -34,7 +34,6 @@ use crate::logical_plan::{
     CreateMemoryTable, CreateView, DFSchema, DFSchemaRef, DropTable, Expr, FileType,
     LogicalPlan, LogicalPlanBuilder, Operator, PlanType, ToDFSchema, ToStringifiedPlan,
 };
-use crate::optimizer::utils::exprlist_to_columns;
 use crate::prelude::JoinType;
 use crate::scalar::ScalarValue;
 use crate::sql::utils::{make_decimal_type, normalize_ident, resolve_columns};
@@ -46,6 +45,7 @@ use crate::{
     sql::parser::{CreateExternalTable, Statement as DFStatement},
 };
 use arrow::datatypes::*;
+use datafusion_expr::utils::exprlist_to_columns;
 use datafusion_expr::{window_function::WindowFunction, BuiltinScalarFunction};
 use hashbrown::HashMap;
 

--- a/datafusion/expr/src/expr_visitor.rs
+++ b/datafusion/expr/src/expr_visitor.rs
@@ -17,9 +17,8 @@
 
 //! Expression visitor
 
-use super::Expr;
+use crate::{expr::GroupingSet, Expr};
 use datafusion_common::Result;
-use datafusion_expr::expr::GroupingSet;
 
 /// Controls how the visitor recursion should proceed.
 pub enum Recursion<V: ExpressionVisitor> {

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -35,6 +35,7 @@ pub mod conditional_expressions;
 pub mod expr;
 pub mod expr_fn;
 pub mod expr_schema;
+pub mod expr_visitor;
 pub mod field_util;
 pub mod function;
 mod literal;
@@ -47,6 +48,7 @@ mod table_source;
 pub mod type_coercion;
 mod udaf;
 mod udf;
+pub mod utils;
 pub mod window_frame;
 pub mod window_function;
 

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -18,8 +18,8 @@
 //! Expression utilities
 
 use crate::expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion};
-use crate::Expr;
-use datafusion_common::{Column, Result};
+use crate::{Expr, LogicalPlan};
+use datafusion_common::{Column, DFField, DFSchema, DataFusionError, Result};
 use std::collections::HashSet;
 
 /// Recursively walk a list of expression trees, collecting the unique set of columns
@@ -81,4 +81,63 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
 pub fn expr_to_columns(expr: &Expr, accum: &mut HashSet<Column>) -> Result<()> {
     expr.accept(ColumnNameVisitor { accum })?;
     Ok(())
+}
+
+/// Resolves an `Expr::Wildcard` to a collection of `Expr::Column`'s.
+pub fn expand_wildcard(schema: &DFSchema, plan: &LogicalPlan) -> Result<Vec<Expr>> {
+    let using_columns = plan.using_columns()?;
+    let columns_to_skip = using_columns
+        .into_iter()
+        // For each USING JOIN condition, only expand to one column in projection
+        .flat_map(|cols| {
+            let mut cols = cols.into_iter().collect::<Vec<_>>();
+            // sort join columns to make sure we consistently keep the same
+            // qualified column
+            cols.sort();
+            cols.into_iter().skip(1)
+        })
+        .collect::<HashSet<_>>();
+
+    if columns_to_skip.is_empty() {
+        Ok(schema
+            .fields()
+            .iter()
+            .map(|f| Expr::Column(f.qualified_column()))
+            .collect::<Vec<Expr>>())
+    } else {
+        Ok(schema
+            .fields()
+            .iter()
+            .filter_map(|f| {
+                let col = f.qualified_column();
+                if !columns_to_skip.contains(&col) {
+                    Some(Expr::Column(col))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<Expr>>())
+    }
+}
+
+/// Resolves an `Expr::Wildcard` to a collection of qualified `Expr::Column`'s.
+pub fn expand_qualified_wildcard(
+    qualifier: &str,
+    schema: &DFSchema,
+    plan: &LogicalPlan,
+) -> Result<Vec<Expr>> {
+    let qualified_fields: Vec<DFField> = schema
+        .fields_with_qualified(qualifier)
+        .into_iter()
+        .cloned()
+        .collect();
+    if qualified_fields.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "Invalid qualifier {}",
+            qualifier
+        )));
+    }
+    let qualifier_schema =
+        DFSchema::new_with_metadata(qualified_fields, schema.metadata().clone())?;
+    expand_wildcard(&qualifier_schema, plan)
 }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Expression utilities
+
+use crate::expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion};
+use crate::Expr;
+use datafusion_common::{Column, Result};
+use std::collections::HashSet;
+
+/// Recursively walk a list of expression trees, collecting the unique set of columns
+/// referenced in the expression
+pub fn exprlist_to_columns(expr: &[Expr], accum: &mut HashSet<Column>) -> Result<()> {
+    for e in expr {
+        expr_to_columns(e, accum)?;
+    }
+    Ok(())
+}
+
+/// Recursively walk an expression tree, collecting the unique set of column names
+/// referenced in the expression
+struct ColumnNameVisitor<'a> {
+    accum: &'a mut HashSet<Column>,
+}
+
+impl ExpressionVisitor for ColumnNameVisitor<'_> {
+    fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>> {
+        match expr {
+            Expr::Column(qc) => {
+                self.accum.insert(qc.clone());
+            }
+            Expr::ScalarVariable(_, var_names) => {
+                self.accum.insert(Column::from_name(var_names.join(".")));
+            }
+            Expr::Alias(_, _)
+            | Expr::Literal(_)
+            | Expr::BinaryExpr { .. }
+            | Expr::Not(_)
+            | Expr::IsNotNull(_)
+            | Expr::IsNull(_)
+            | Expr::Negative(_)
+            | Expr::Between { .. }
+            | Expr::Case { .. }
+            | Expr::Cast { .. }
+            | Expr::TryCast { .. }
+            | Expr::Sort { .. }
+            | Expr::ScalarFunction { .. }
+            | Expr::ScalarUDF { .. }
+            | Expr::WindowFunction { .. }
+            | Expr::AggregateFunction { .. }
+            | Expr::GroupingSet(_)
+            | Expr::AggregateUDF { .. }
+            | Expr::InList { .. }
+            | Expr::Exists { .. }
+            | Expr::InSubquery { .. }
+            | Expr::ScalarSubquery(_)
+            | Expr::Wildcard
+            | Expr::QualifiedWildcard { .. }
+            | Expr::GetIndexedField { .. } => {}
+        }
+        Ok(Recursion::Continue(self))
+    }
+}
+
+/// Recursively walk an expression tree, collecting the unique set of columns
+/// referenced in the expression
+pub fn expr_to_columns(expr: &Expr, accum: &mut HashSet<Column>) -> Result<()> {
+    expr.accept(ColumnNameVisitor { accum })?;
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2345

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- `ExprVisitable` and `exprlist_to_columns` are used by the SQL planner and also by the optimizer. They were in the core crate but can be moved to the `datafusion-expr` crate.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Move some code around. No functional changes.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this is an API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
