### PR TITLE
Remove `scan_parquet` methods from `LogicalPlanBuilder`

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -595,9 +595,7 @@ impl SessionContext {
             .with_schema(resolved_schema);
 
         let provider = ListingTable::try_new(config)?;
-        let logical_plan =
-            LogicalPlanBuilder::scan(&uri, Arc::new(provider), None)?.build()?;
-        Ok(Arc::new(DataFrame::new(self.state.clone(), &logical_plan)))
+        self.read_table(Arc::new(provider))
     }
 
     /// Creates a DataFrame for reading a custom TableProvider.

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -581,15 +581,22 @@ impl SessionContext {
         let uri: String = uri.into();
         let (object_store, path) = self.runtime_env().object_store(&uri)?;
         let target_partitions = self.copied_config().target_partitions;
-        let logical_plan = LogicalPlanBuilder::scan_parquet(
-            object_store,
-            path,
-            options,
-            None,
-            target_partitions,
-        )
-        .await?
-        .build()?;
+
+        let listing_options = options.to_listing_options(target_partitions);
+        let path: String = path.into();
+
+        // with parquet we resolve the schema in all cases
+        let resolved_schema = listing_options
+            .infer_schema(Arc::clone(&object_store), &path)
+            .await?;
+
+        let config = ListingTableConfig::new(object_store, path)
+            .with_listing_options(listing_options)
+            .with_schema(resolved_schema);
+
+        let provider = ListingTable::try_new(config)?;
+        let logical_plan =
+            LogicalPlanBuilder::scan(&uri, Arc::new(provider), None)?.build()?;
         Ok(Arc::new(DataFrame::new(self.state.clone(), &logical_plan)))
     }
 

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -253,51 +253,6 @@ impl LogicalPlanBuilder {
         Self::scan(table_name, Arc::new(provider), projection)
     }
 
-    /// Scan a Parquet data source
-    pub async fn scan_parquet(
-        object_store: Arc<dyn ObjectStore>,
-        path: impl Into<String>,
-        options: ParquetReadOptions<'_>,
-        projection: Option<Vec<usize>>,
-        target_partitions: usize,
-    ) -> Result<Self> {
-        let path = path.into();
-        Self::scan_parquet_with_name(
-            object_store,
-            path.clone(),
-            options,
-            projection,
-            target_partitions,
-            path,
-        )
-        .await
-    }
-
-    /// Scan a Parquet data source and register it with a given table name
-    pub async fn scan_parquet_with_name(
-        object_store: Arc<dyn ObjectStore>,
-        path: impl Into<String>,
-        options: ParquetReadOptions<'_>,
-        projection: Option<Vec<usize>>,
-        target_partitions: usize,
-        table_name: impl Into<String>,
-    ) -> Result<Self> {
-        let listing_options = options.to_listing_options(target_partitions);
-        let path: String = path.into();
-
-        // with parquet we resolve the schema in all cases
-        let resolved_schema = listing_options
-            .infer_schema(Arc::clone(&object_store), &path)
-            .await?;
-
-        let config = ListingTableConfig::new(object_store, path)
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-
-        let provider = ListingTable::try_new(config)?;
-        Self::scan(table_name, Arc::new(provider), projection)
-    }
-
     /// Scan an Avro data source
     pub async fn scan_avro(
         object_store: Arc<dyn ObjectStore>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2536

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- `LogicalPlanBuilder` should be in the same crate as `LogicalPlan`
- `LogicalPlanBuilder` should not need to know about data sources & object stores but just `TableSource`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Move some logic from `LogicalPlanBuilder` to `SessionContext`

There will be separate PRs to remove the other scan methods (parquet, json, avro).

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this changes the `LogicalPlanBuilder` API

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
