### PR TITLE
Introduce Expr.variant_name() function

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -294,6 +294,40 @@ impl Expr {
         create_name(self, input_schema)
     }
 
+    /// Return String representation of the variant represented by `self`
+    /// Useful for non-rust based bindings
+    pub fn variant_name(self) -> Result<String> {
+        Ok(String::from(match &self {
+            Expr::AggregateFunction { .. } => "AggregateFunction",
+            Expr::AggregateUDF { .. } => "AggregateUDF",
+            Expr::Alias(..) => "Alias",
+            Expr::Between { .. } => "Between",
+            Expr::BinaryExpr { .. } => "BinaryExpr",
+            Expr::Case { .. } => "Case",
+            Expr::Cast { .. } => "Cast",
+            Expr::Column(..) => "Column",
+            Expr::Exists { .. } => "Exists",
+            Expr::GetIndexedField { .. } => "GetIndexedField",
+            Expr::GroupingSet(..) => "GroupingSet",
+            Expr::InList { .. } => "InList",
+            Expr::InSubquery { .. } => "InSubquery",
+            Expr::IsNotNull(..) => "IsNotNull",
+            Expr::IsNull(..) => "IsNull",
+            Expr::Literal(..) => "Literal",
+            Expr::Negative(..) => "Negative",
+            Expr::Not(..) => "Not",
+            Expr::QualifiedWildcard { .. } => "QualifiedWildcard",
+            Expr::ScalarFunction { .. } => "ScalarFunction",
+            Expr::ScalarSubquery { .. } => "ScalarSubquery",
+            Expr::ScalarUDF { .. } => "ScalarUDF",
+            Expr::ScalarVariable(..) => "ScalarVariable",
+            Expr::Sort { .. } => "Sort",
+            Expr::TryCast { .. } => "TryCast",
+            Expr::WindowFunction { .. } => "WindowFunction",
+            Expr::Wildcard => "Wildcard",
+        }))
+    }
+
     /// Return `self == other`
     pub fn eq(self, other: Expr) -> Expr {
         binary_expr(self, Operator::Eq, other)

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -296,8 +296,8 @@ impl Expr {
 
     /// Return String representation of the variant represented by `self`
     /// Useful for non-rust based bindings
-    pub fn variant_name(self) -> String {
-        String::from(match &self {
+    pub fn variant_name(&self) -> &str {
+        match self {
             Expr::AggregateFunction { .. } => "AggregateFunction",
             Expr::AggregateUDF { .. } => "AggregateUDF",
             Expr::Alias(..) => "Alias",
@@ -325,7 +325,7 @@ impl Expr {
             Expr::TryCast { .. } => "TryCast",
             Expr::WindowFunction { .. } => "WindowFunction",
             Expr::Wildcard => "Wildcard",
-        })
+        }
     }
 
     /// Return `self == other`

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -296,8 +296,8 @@ impl Expr {
 
     /// Return String representation of the variant represented by `self`
     /// Useful for non-rust based bindings
-    pub fn variant_name(self) -> Result<String> {
-        Ok(String::from(match &self {
+    pub fn variant_name(self) -> String {
+        String::from(match &self {
             Expr::AggregateFunction { .. } => "AggregateFunction",
             Expr::AggregateUDF { .. } => "AggregateUDF",
             Expr::Alias(..) => "Alias",
@@ -325,7 +325,7 @@ impl Expr {
             Expr::TryCast { .. } => "TryCast",
             Expr::WindowFunction { .. } => "WindowFunction",
             Expr::Wildcard => "Wildcard",
-        }))
+        })
     }
 
     /// Return `self == other`


### PR DESCRIPTION
# Which issue does this PR close?

Closes: #2563 


 # Rationale for this change
Explain in issue #2563 

# What changes are included in this PR?
Simple function named `variant_name()` added to `Expr`

# Are there any user-facing changes?
Yes, a new function named `Expr::variant_name()` will now be available to end users and present in the documentation.
