### PR TITLE
Support limit push down for offset_plan

### DIFF
--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -24,6 +24,7 @@ use crate::logical_plan::plan::Projection;
 use crate::logical_plan::{Limit, TableScan};
 use crate::logical_plan::{LogicalPlan, Union};
 use crate::optimizer::optimizer::OptimizerRule;
+use datafusion_expr::logical_plan::Offset;
 use std::sync::Arc;
 
 /// Optimization rule that tries pushes down LIMIT n
@@ -43,18 +44,24 @@ fn limit_push_down(
     upper_limit: Option<usize>,
     plan: &LogicalPlan,
     _execution_props: &ExecutionProps,
+    is_offset: bool,
 ) -> Result<LogicalPlan> {
     match (plan, upper_limit) {
         (LogicalPlan::Limit(Limit { n, input }), upper_limit) => {
-            let smallest = upper_limit.map(|x| std::cmp::min(x, *n)).unwrap_or(*n);
+            let new_limit: usize = if is_offset {
+                *n
+            } else {
+                upper_limit.map(|x| std::cmp::min(x, *n)).unwrap_or(*n)
+            };
             Ok(LogicalPlan::Limit(Limit {
-                n: smallest,
+                n: new_limit,
                 // push down limit to plan (minimum of upper limit and current limit)
                 input: Arc::new(limit_push_down(
                     _optimizer,
-                    Some(smallest),
+                    Some(new_limit),
                     input.as_ref(),
                     _execution_props,
+                    false,
                 )?),
             }))
         }
@@ -95,6 +102,7 @@ fn limit_push_down(
                     upper_limit,
                     input.as_ref(),
                     _execution_props,
+                    false,
                 )?),
                 schema: schema.clone(),
                 alias: alias.clone(),
@@ -119,6 +127,7 @@ fn limit_push_down(
                             Some(upper_limit),
                             x,
                             _execution_props,
+                            false,
                         )?),
                     }))
                 })
@@ -127,6 +136,21 @@ fn limit_push_down(
                 inputs: new_inputs,
                 alias: alias.clone(),
                 schema: schema.clone(),
+            }))
+        }
+        // offset 5 limit 10 then push limit 15 (5 + 10)
+        // Limit should always be Offset's input
+        (LogicalPlan::Offset(Offset { offset, input }), Some(upper_limit)) => {
+            let new_limit = offset + upper_limit;
+            Ok(LogicalPlan::Offset(Offset {
+                offset: *offset,
+                input: Arc::new(limit_push_down(
+                    _optimizer,
+                    Some(new_limit),
+                    input.as_ref(),
+                    _execution_props,
+                    true,
+                )?),
             }))
         }
         // For other nodes we can't push down the limit
@@ -138,7 +162,9 @@ fn limit_push_down(
             let inputs = plan.inputs();
             let new_inputs = inputs
                 .iter()
-                .map(|plan| limit_push_down(_optimizer, None, plan, _execution_props))
+                .map(|plan| {
+                    limit_push_down(_optimizer, None, plan, _execution_props, false)
+                })
                 .collect::<Result<Vec<_>>>()?;
 
             utils::from_plan(plan, &expr, &new_inputs)
@@ -152,7 +178,7 @@ impl OptimizerRule for LimitPushDown {
         plan: &LogicalPlan,
         execution_props: &ExecutionProps,
     ) -> Result<LogicalPlan> {
-        limit_push_down(self, None, plan, execution_props)
+        limit_push_down(self, None, plan, execution_props, false)
     }
 
     fn name(&self) -> &str {
@@ -273,6 +299,118 @@ mod test {
         \n  Aggregate: groupBy=[[#test.a]], aggr=[[MAX(#test.b)]]\
         \n    Limit: 1000\
         \n      TableScan: test projection=None, limit=1000";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn limit_pushdown_with_offset_projection_table_provider() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .project(vec![col("a")])?
+            .offset(10)?
+            .limit(1000)?
+            .build()?;
+
+        // Should push the limit down to table provider
+        // When it has a select
+        let expected = "Limit: 1000\
+        \n  Offset: 10\
+        \n    Projection: #test.a\
+        \n      TableScan: test projection=None, limit=1010";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn limit_pushdown_with_offset_after_limit() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .project(vec![col("a")])?
+            .limit(1000)?
+            .offset(10)?
+            .build()?;
+
+        // Not push the limit down to table provider
+        // When offset after limit
+        let expected = "Offset: 10\
+        \n  Limit: 1000\
+        \n    Projection: #test.a\
+        \n      TableScan: test projection=None, limit=1000";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn limit_push_down_with_offset_take_smaller_limit() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .offset(10)?
+            .limit(1000)?
+            .limit(10)?
+            .build()?;
+
+        // Should push down the smallest limit
+        // Towards table scan
+        // This rule doesn't replace multiple limits
+        let expected = "Limit: 10\
+        \n  Limit: 10\
+        \n    Offset: 10\
+        \n      TableScan: test projection=None, limit=20";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn limit_doesnt_push_down_with_offset_aggregation() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("a")], vec![max(col("b"))])?
+            .offset(10)?
+            .limit(1000)?
+            .build()?;
+
+        // Limit should *not* push down aggregate node
+        let expected = "Limit: 1000\
+        \n  Offset: 10\
+        \n    Aggregate: groupBy=[[#test.a]], aggr=[[MAX(#test.b)]]\
+        \n      TableScan: test projection=None";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn limit_should_push_down_with_offset_union() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan.clone())
+            .union(LogicalPlanBuilder::from(table_scan).build()?)?
+            .offset(10)?
+            .limit(1000)?
+            .build()?;
+
+        // Limit should push down through union
+        let expected = "Limit: 1000\
+        \n  Offset: 10\
+        \n    Union\
+        \n      Limit: 1010\
+        \n        TableScan: test projection=None, limit=1010\
+        \n      Limit: 1010\
+        \n        TableScan: test projection=None, limit=1010";
 
         assert_optimized_plan_eq(&plan, expected);
 

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -188,13 +188,13 @@ impl OptimizerRule for LimitPushDown {
 
 #[cfg(test)]
 mod test {
-    use datafusion_expr::exists;
-    use datafusion_expr::logical_plan::JoinType;
     use super::*;
     use crate::{
         logical_plan::{col, max, LogicalPlan, LogicalPlanBuilder},
         test::*,
     };
+    use datafusion_expr::exists;
+    use datafusion_expr::logical_plan::JoinType;
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = LimitPushDown::new();
@@ -425,7 +425,11 @@ mod test {
         let table_scan_2 = test_table_scan_with_name("test2")?;
 
         let plan = LogicalPlanBuilder::from(table_scan_1)
-            .join(&LogicalPlanBuilder::from(table_scan_2).build()?, JoinType::Left, (vec!["a"], vec!["a"]))?
+            .join(
+                &LogicalPlanBuilder::from(table_scan_2).build()?,
+                JoinType::Left,
+                (vec!["a"], vec!["a"]),
+            )?
             .limit(1000)?
             .offset(10)?
             .build()?;
@@ -444,7 +448,6 @@ mod test {
 
     #[test]
     fn limit_should_push_down_with_offset_sub_query() -> Result<()> {
-
         let table_scan_1 = test_table_scan_with_name("test1")?;
         let table_scan_2 = test_table_scan_with_name("test2")?;
 

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -141,8 +141,8 @@ fn limit_push_down(
         // offset 5 limit 10 then push limit 15 (5 + 10)
         // Limit should always be Offset's input
         (LogicalPlan::Offset(Offset { offset, input }), upper_limit) => {
-            let new_limit: usize = if upper_limit.is_some() {
-                upper_limit.unwrap() + *offset
+            let new_limit = if let Some(ul) = upper_limit {
+                ul + *offset
             } else {
                 *offset
             };

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -296,9 +296,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         let plan = self.order_by(plan, query.order_by)?;
 
-        let plan: LogicalPlan = self.offset(plan, query.offset)?;
+        let plan: LogicalPlan = self.limit(plan, query.limit)?;
 
-        self.limit(plan, query.limit)
+        //make limit as offset's input will enable limit push down simply
+        self.offset(plan, query.offset)
     }
 
     fn set_expr_to_plan(
@@ -4825,8 +4826,8 @@ mod tests {
     #[test]
     fn test_offset_with_limit() {
         let sql = "select id from person where person.id > 100 LIMIT 5 OFFSET 0;";
-        let expected = "Limit: 5\
-                                    \n  Offset: 0\
+        let expected = "Offset: 0\
+                                    \n  Limit: 5\
                                     \n    Projection: #person.id\
                                     \n      Filter: #person.id > Int64(100)\
                                     \n        TableScan: person projection=None";

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -4381,7 +4381,6 @@ mod tests {
 
     fn quick_test_with_limit_pushdown(sql: &str, expected: &str) {
         let plan = logical_plan(sql).unwrap();
-        assert_eq!(format!("{:?}", plan), expected);
         let rule = LimitPushDown::new();
         let optimized_plan = rule
             .optimize(&plan, &ExecutionProps::new())
@@ -4866,7 +4865,7 @@ mod tests {
     fn test_offset_after_limit_with_limit_push() {
         let sql = "select id from person where person.id > 100 LIMIT 5 OFFSET 3;";
         let expected = "Offset: 3\
-                                    \n  Limit: 5\
+                                    \n  Limit: 8\
                                     \n    Projection: #person.id\
                                     \n      Filter: #person.id > Int64(100)\
                                     \n        TableScan: person projection=None";
@@ -4878,7 +4877,7 @@ mod tests {
     fn test_offset_before_limit_with_limit_push() {
         let sql = "select id from person where person.id > 100 OFFSET 3 LIMIT 5;";
         let expected = "Offset: 3\
-                                    \n  Limit: 5\
+                                    \n  Limit: 8\
                                     \n    Projection: #person.id\
                                     \n      Filter: #person.id > Int64(100)\
                                     \n        TableScan: person projection=None";


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2550.

like in pg
```
postgres=# explain analyze  select * from users limit 5 offset 2;
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.05..0.17 rows=5 width=80) (actual time=0.059..0.167 rows=5 loops=1)
   ->  Seq Scan on users  (cost=0.00..239.02 rows=10002 width=80) (actual time=0.007..0.050 rows=7 loops=1)
 Planning Time: 0.050 ms
 Execution Time: 0.231 ms
(4 rows)

postgres=# explain analyze  select * from users limit 5 offset 7;
                                                 QUERY PLAN
-------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.17..0.29 rows=5 width=80) (actual time=0.117..0.226 rows=5 loops=1)
   ->  Seq Scan on users  (cost=0.00..239.02 rows=10002 width=80) (actual time=0.013..0.082 rows=12 loops=1)
 Planning Time: 0.060 ms
 Execution Time: 0.350 ms
(4 rows)
```
if we have `limit a + offset b` will push limit `a+b` to tableScan

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
