### PR TITLE
Make datafusion-proto match exhaustive

### DIFF
--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -713,7 +713,15 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
             Expr::Wildcard => Self {
                 expr_type: Some(ExprType::Wildcard(true)),
             },
-            _ => unimplemented!(),
+            Expr::ScalarSubquery(_) | Expr::InSubquery { .. } | Expr::Exists { .. } => {
+                // we would need to add logical plan operators to datafusion.proto to support this
+                // see discussion in https://github.com/apache/arrow-datafusion/issues/2565
+                unimplemented!("subquery expressions are not supported yet")
+            }
+            Expr::QualifiedWildcard { .. }
+            | Expr::GetIndexedField { .. }
+            | Expr::TryCast { .. }
+            | Expr::GroupingSet(_) => unimplemented!(),
         };
 
         Ok(expr_node)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2565

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When adding new Expr variants, we should also be adding code to datafusion_proto to handle them but we are not forced into doing this today because the match statement handles the _ case with an error.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make match exhaustive.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
