### PR TITLE
Remove `scan_empty` method from `LogicalPlanBuilder`

### DIFF
--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -297,6 +297,7 @@ mod test {
     use datafusion::execution::context::default_session_builder;
     use datafusion::logical_plan::{col, sum, LogicalPlan, LogicalPlanBuilder};
     use datafusion::prelude::{SessionConfig, SessionContext};
+    use datafusion::test_util::scan_empty;
 
     use crate::scheduler_server::event::QueryStageSchedulerEvent;
     use crate::scheduler_server::SchedulerServer;
@@ -606,7 +607,7 @@ mod test {
             Field::new("gmv", DataType::UInt64, false),
         ]);
 
-        LogicalPlanBuilder::scan_empty(None, &schema, Some(vec![0, 1]))
+        scan_empty(None, &schema, Some(vec![0, 1]))
             .unwrap()
             .aggregate(vec![col("id")], vec![sum(col("gmv"))])
             .unwrap()

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -951,20 +951,18 @@ mod tests {
     use crate::logical_plan::StringifiedPlan;
     use crate::prelude::*;
     use crate::test::test_table_scan_with_name;
+    use crate::test_util::scan_empty;
 
     use super::super::{col, lit, sum};
     use super::*;
 
     #[test]
     fn plan_builder_simple() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
-            Some("employee_csv"),
-            &employee_schema(),
-            Some(vec![0, 3]),
-        )?
-        .filter(col("state").eq(lit("CO")))?
-        .project(vec![col("id")])?
-        .build()?;
+        let plan =
+            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))?
+                .filter(col("state").eq(lit("CO")))?
+                .project(vec![col("id")])?
+                .build()?;
 
         let expected = "Projection: #employee_csv.id\
         \n  Filter: #employee_csv.state = Utf8(\"CO\")\
@@ -978,8 +976,7 @@ mod tests {
     #[test]
     fn plan_builder_schema() {
         let schema = employee_schema();
-        let plan =
-            LogicalPlanBuilder::scan_empty(Some("employee_csv"), &schema, None).unwrap();
+        let plan = scan_empty(Some("employee_csv"), &schema, None).unwrap();
 
         let expected =
             DFSchema::try_from_qualified_schema("employee_csv", &schema).unwrap();
@@ -989,19 +986,16 @@ mod tests {
 
     #[test]
     fn plan_builder_aggregate() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
-            Some("employee_csv"),
-            &employee_schema(),
-            Some(vec![3, 4]),
-        )?
-        .aggregate(
-            vec![col("state")],
-            vec![sum(col("salary")).alias("total_salary")],
-        )?
-        .project(vec![col("state"), col("total_salary")])?
-        .limit(10)?
-        .offset(2)?
-        .build()?;
+        let plan =
+            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
+                .aggregate(
+                    vec![col("state")],
+                    vec![sum(col("salary")).alias("total_salary")],
+                )?
+                .project(vec![col("state"), col("total_salary")])?
+                .limit(10)?
+                .offset(2)?
+                .build()?;
 
         let expected = "Offset: 2\
         \n  Limit: 10\
@@ -1016,24 +1010,21 @@ mod tests {
 
     #[test]
     fn plan_builder_sort() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
-            Some("employee_csv"),
-            &employee_schema(),
-            Some(vec![3, 4]),
-        )?
-        .sort(vec![
-            Expr::Sort {
-                expr: Box::new(col("state")),
-                asc: true,
-                nulls_first: true,
-            },
-            Expr::Sort {
-                expr: Box::new(col("salary")),
-                asc: false,
-                nulls_first: false,
-            },
-        ])?
-        .build()?;
+        let plan =
+            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
+                .sort(vec![
+                    Expr::Sort {
+                        expr: Box::new(col("state")),
+                        asc: true,
+                        nulls_first: true,
+                    },
+                    Expr::Sort {
+                        expr: Box::new(col("salary")),
+                        asc: false,
+                        nulls_first: false,
+                    },
+                ])?
+                .build()?;
 
         let expected = "Sort: #employee_csv.state ASC NULLS FIRST, #employee_csv.salary DESC NULLS LAST\
         \n  TableScan: employee_csv projection=Some([3, 4])";
@@ -1045,10 +1036,9 @@ mod tests {
 
     #[test]
     fn plan_using_join_wildcard_projection() -> Result<()> {
-        let t2 = LogicalPlanBuilder::scan_empty(Some("t2"), &employee_schema(), None)?
-            .build()?;
+        let t2 = scan_empty(Some("t2"), &employee_schema(), None)?.build()?;
 
-        let plan = LogicalPlanBuilder::scan_empty(Some("t1"), &employee_schema(), None)?
+        let plan = scan_empty(Some("t1"), &employee_schema(), None)?
             .join_using(&t2, JoinType::Inner, vec!["id"])?
             .project(vec![Expr::Wildcard])?
             .build()?;
@@ -1066,11 +1056,8 @@ mod tests {
 
     #[test]
     fn plan_builder_union_combined_single_union() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
-            Some("employee_csv"),
-            &employee_schema(),
-            Some(vec![3, 4]),
-        )?;
+        let plan =
+            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?;
 
         let plan = plan
             .union(plan.build()?)?
@@ -1167,7 +1154,7 @@ mod tests {
 
     #[test]
     fn projection_non_unique_names() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
+        let plan = scan_empty(
             Some("employee_csv"),
             &employee_schema(),
             // project id and first_name by column index
@@ -1193,7 +1180,7 @@ mod tests {
 
     #[test]
     fn aggregate_non_unique_names() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan_empty(
+        let plan = scan_empty(
             Some("employee_csv"),
             &employee_schema(),
             // project state and salary by column index

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -17,7 +17,7 @@
 
 //! This module provides a builder for creating LogicalPlans
 
-use crate::datasource::{empty::EmptyTable, TableProvider};
+use crate::datasource::TableProvider;
 use crate::error::{DataFusionError, Result};
 use crate::logical_expr::ExprSchemable;
 use crate::logical_plan::plan::{
@@ -52,7 +52,7 @@ pub const UNNAMED_TABLE: &str = "?table?";
 
 /// Builder for logical plans
 ///
-/// ```
+/// ``` ignore
 /// # use datafusion::prelude::*;
 /// # use datafusion::logical_plan::LogicalPlanBuilder;
 /// # use datafusion::error::Result;
@@ -186,17 +186,6 @@ impl LogicalPlanBuilder {
         let schema =
             DFSchemaRef::new(DFSchema::new_with_metadata(fields, HashMap::new())?);
         Ok(Self::from(LogicalPlan::Values(Values { schema, values })))
-    }
-
-    /// Scan an empty data source, mainly used in tests
-    pub fn scan_empty(
-        name: Option<&str>,
-        table_schema: &Schema,
-        projection: Option<Vec<usize>>,
-    ) -> Result<Self> {
-        let table_schema = Arc::new(table_schema.clone());
-        let provider = Arc::new(EmptyTable::new(table_schema));
-        Self::scan(name.unwrap_or(UNNAMED_TABLE), provider, projection)
     }
 
     /// Convert a table provider into a builder with a TableScan

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -100,8 +100,9 @@ pub fn source_as_provider(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{col, lit, LogicalPlanBuilder};
+    use super::super::{col, lit};
     use super::*;
+    use crate::test_util::scan_empty;
     use arrow::datatypes::{DataType, Field, Schema};
 
     fn employee_schema() -> Schema {
@@ -115,18 +116,14 @@ mod tests {
     }
 
     fn display_plan() -> LogicalPlan {
-        LogicalPlanBuilder::scan_empty(
-            Some("employee_csv"),
-            &employee_schema(),
-            Some(vec![0, 3]),
-        )
-        .unwrap()
-        .filter(col("state").eq(lit("CO")))
-        .unwrap()
-        .project(vec![col("id")])
-        .unwrap()
-        .build()
-        .unwrap()
+        scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))
+            .unwrap()
+            .filter(col("state").eq(lit("CO")))
+            .unwrap()
+            .project(vec![col("id")])
+            .unwrap()
+            .build()
+            .unwrap()
     }
 
     #[test]
@@ -424,7 +421,7 @@ mod tests {
             Field::new("state", DataType::Utf8, false),
         ]);
 
-        LogicalPlanBuilder::scan_empty(None, &schema, Some(vec![0, 1]))
+        scan_empty(None, &schema, Some(vec![0, 1]))
             .unwrap()
             .filter(col("state").eq(lit("CO")))
             .unwrap()

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -517,6 +517,7 @@ mod tests {
         col, exprlist_to_fields, lit, max, min, Expr, JoinType, LogicalPlanBuilder,
     };
     use crate::test::*;
+    use crate::test_util::scan_empty;
     use arrow::datatypes::DataType;
 
     #[test]
@@ -646,8 +647,7 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan =
-            LogicalPlanBuilder::scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(&table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]))?
@@ -688,8 +688,7 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan =
-            LogicalPlanBuilder::scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(&table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]))?
@@ -732,8 +731,7 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("a", DataType::UInt32, false)]);
-        let table2_scan =
-            LogicalPlanBuilder::scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join_using(&table2_scan, JoinType::Left, vec!["a"])?

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -749,6 +749,7 @@ mod tests {
     };
     use crate::physical_plan::functions::make_scalar_function;
     use crate::physical_plan::udf::ScalarUDF;
+    use crate::test_util::scan_empty;
 
     #[test]
     fn test_simplify_or_true() {
@@ -1508,7 +1509,7 @@ mod tests {
             Field::new("c", DataType::Boolean, false),
             Field::new("d", DataType::UInt32, false),
         ]);
-        LogicalPlanBuilder::scan_empty(Some("test"), &schema, None)
+        scan_empty(Some("test"), &schema, None)
             .expect("creating scan")
             .build()
             .expect("building plan")

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1543,6 +1543,7 @@ mod tests {
     };
     use crate::prelude::{SessionConfig, SessionContext};
     use crate::scalar::ScalarValue;
+    use crate::test_util::scan_empty;
     use crate::{
         logical_plan::LogicalPlanBuilder, physical_plan::SendableRecordBatchStream,
     };
@@ -1856,13 +1857,12 @@ mod tests {
     async fn test_explain() {
         let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
 
-        let logical_plan =
-            LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
-                .unwrap()
-                .explain(true, false)
-                .unwrap()
-                .build()
-                .unwrap();
+        let logical_plan = scan_empty(Some("employee"), &schema, None)
+            .unwrap()
+            .explain(true, false)
+            .unwrap()
+            .build()
+            .unwrap();
 
         let plan = plan(&logical_plan).await.unwrap();
         if let Some(plan) = plan.as_any().downcast_ref::<ExplainExec>() {

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -21,9 +21,9 @@ use crate::arrow::array::UInt32Array;
 use crate::datasource::{listing::local_unpartitioned_file, MemTable, TableProvider};
 use crate::error::Result;
 use crate::from_slice::FromSlice;
-use crate::logical_plan::{LogicalPlan, LogicalPlanBuilder};
+use crate::logical_plan::LogicalPlan;
 use crate::physical_plan::file_format::{CsvExec, FileScanConfig};
-use crate::test_util::aggr_test_schema;
+use crate::test_util::{aggr_test_schema, scan_empty};
 use array::{Array, ArrayRef};
 use arrow::array::{self, DecimalBuilder, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -132,7 +132,7 @@ pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
         Field::new("b", DataType::UInt32, false),
         Field::new("c", DataType::UInt32, false),
     ]);
-    LogicalPlanBuilder::scan_empty(Some(name), &schema, None)?.build()
+    scan_empty(Some(name), &schema, None)?.build()
 }
 
 /// some tests share a common table

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -20,7 +20,10 @@
 use std::collections::BTreeMap;
 use std::{env, error::Error, path::PathBuf, sync::Arc};
 
+use crate::datasource::empty::EmptyTable;
+use crate::logical_plan::{LogicalPlanBuilder, UNNAMED_TABLE};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion_common::DataFusionError;
 
 /// Compares formatted output of a record batch with an expected
 /// vector of strings, with the result of pretty formatting record
@@ -230,6 +233,17 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
             pb.display(),
         ).into())
     }
+}
+
+/// Scan an empty data source, mainly used in tests
+pub fn scan_empty(
+    name: Option<&str>,
+    table_schema: &Schema,
+    projection: Option<Vec<usize>>,
+) -> Result<LogicalPlanBuilder, DataFusionError> {
+    let table_schema = Arc::new(table_schema.clone());
+    let provider = Arc::new(EmptyTable::new(table_schema));
+    LogicalPlanBuilder::scan(name.unwrap_or(UNNAMED_TABLE), provider, projection)
 }
 
 /// Get the schema for the aggregate_test_* csv files

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -16,7 +16,8 @@
 // under the License.
 
 use super::*;
-use datafusion::{logical_plan::LogicalPlanBuilder, scalar::ScalarValue};
+use datafusion::scalar::ScalarValue;
+use datafusion::test_util::scan_empty;
 
 #[tokio::test]
 async fn csv_query_avg_multi_batch() -> Result<()> {
@@ -1479,7 +1480,7 @@ async fn aggregate_with_alias() -> Result<()> {
         Field::new("c2", DataType::UInt32, false),
     ]));
 
-    let plan = LogicalPlanBuilder::scan_empty(None, schema.as_ref(), None)?
+    let plan = scan_empty(None, schema.as_ref(), None)?
         .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
         .project(vec![col("c1"), sum(col("c2")).alias("total_salary")])?
         .build()?;

--- a/datafusion/core/tests/sql/explain.rs
+++ b/datafusion/core/tests/sql/explain.rs
@@ -16,8 +16,9 @@
 // under the License.
 
 use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::test_util::scan_empty;
 use datafusion::{
-    logical_plan::{LogicalPlan, LogicalPlanBuilder, PlanType},
+    logical_plan::{LogicalPlan, PlanType},
     prelude::SessionContext,
 };
 
@@ -25,7 +26,7 @@ use datafusion::{
 fn optimize_explain() {
     let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
 
-    let plan = LogicalPlanBuilder::scan_empty(Some("employee"), &schema, None)
+    let plan = scan_empty(Some("employee"), &schema, None)
         .unwrap()
         .explain(true, false)
         .unwrap()

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use datafusion::logical_plan::{LogicalPlanBuilder, UNNAMED_TABLE};
+use datafusion::test_util::scan_empty;
 use tempfile::TempDir;
 
 use super::*;
@@ -209,7 +210,7 @@ async fn preserve_nullability_on_projection() -> Result<()> {
     let schema: Schema = ctx.table("test").unwrap().schema().clone().into();
     assert!(!schema.field_with_name("c1")?.is_nullable());
 
-    let plan = LogicalPlanBuilder::scan_empty(None, &schema, None)?
+    let plan = scan_empty(None, &schema, None)?
         .project(vec![col("c1")])?
         .build()?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2536

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- `LogicalPlanBuilder` should be in the same crate as `LogicalPlan`
- `LogicalPlanBuilder` should not need to know about data sources & object stores but just `TableSource`
- `scan_empty` is only used from tests

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Move `scan_empty` from `LogicalPlanBuilder` to tests

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, this changes the `LogicalPlanBuilder` API

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
