### PR TITLE
WIP: Remove `Union::alias`

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -208,7 +208,8 @@ impl DataFrame {
         Ok(Arc::new(DataFrame::new(self.session_state.clone(), &plan)))
     }
 
-    /// Calculate the union two [`DataFrame`]s.  The two [`DataFrame`]s must have exactly the same schema
+    /// Calculate the union of two [`DataFrame`]s, preserving duplicate rows.The
+    /// two [`DataFrame`]s must have exactly the same schema
     ///
     /// ```
     /// # use datafusion::prelude::*;
@@ -228,7 +229,8 @@ impl DataFrame {
         Ok(Arc::new(DataFrame::new(self.session_state.clone(), &plan)))
     }
 
-    /// Calculate the union distinct two [`DataFrame`]s.  The two [`DataFrame`]s must have exactly the same schema
+    /// Calculate the distinct union of two [`DataFrame`]s.  The
+    /// two [`DataFrame`]s must have exactly the same schema
     ///
     /// ```
     /// # use datafusion::prelude::*;
@@ -237,7 +239,29 @@ impl DataFrame {
     /// # async fn main() -> Result<()> {
     /// let ctx = SessionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
-    /// let df = df.union(df.clone())?;
+    /// let df = df.union_distinct(df.clone())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn union_distinct(&self, dataframe: Arc<DataFrame>) -> Result<Arc<DataFrame>> {
+        Ok(Arc::new(DataFrame::new(
+            self.session_state.clone(),
+            &LogicalPlanBuilder::from(self.plan.clone())
+                .union(dataframe.plan.clone())?
+                .distinct()?
+                .build()?,
+        )))
+    }
+
+    /// Filter out duplicate rows
+    ///
+    /// ```
+    /// # use datafusion::prelude::*;
+    /// # use datafusion::error::Result;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// let ctx = SessionContext::new();
+    /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
     /// let df = df.distinct()?;
     /// # Ok(())
     /// # }

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -247,8 +247,7 @@ impl DataFrame {
         Ok(Arc::new(DataFrame::new(
             self.session_state.clone(),
             &LogicalPlanBuilder::from(self.plan.clone())
-                .union(dataframe.plan.clone())?
-                .distinct()?
+                .union_distinct(dataframe.plan.clone())?
                 .build()?,
         )))
     }

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -855,10 +855,10 @@ pub fn project_with_column_index_alias(
 }
 
 /// Union two logical plans with an optional alias.
-pub fn union_with_alias(
+fn union_with_alias(
     left_plan: LogicalPlan,
     right_plan: LogicalPlan,
-    alias: Option<String>,
+    _alias: Option<String>,
 ) -> Result<LogicalPlan> {
     let union_schema = left_plan.schema().clone();
     let inputs_iter = vec![left_plan, right_plan]
@@ -893,15 +893,12 @@ pub fn union_with_alias(
     }
 
     let union_schema = (**inputs[0].schema()).clone();
-    let union_schema = Arc::new(match alias {
-        Some(ref alias) => union_schema.replace_qualifier(alias.as_str()),
-        None => union_schema.strip_qualifiers(),
-    });
+    let union_schema = Arc::new(union_schema.strip_qualifiers());
 
     Ok(LogicalPlan::Union(Union {
         inputs,
         schema: union_schema,
-        alias,
+        alias: None,
     }))
 }
 

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -442,9 +442,14 @@ impl LogicalPlanBuilder {
         })))
     }
 
-    /// Apply a union
+    /// Apply a union, preserving duplicate rows
     pub fn union(&self, plan: LogicalPlan) -> Result<Self> {
         Ok(Self::from(union_with_alias(self.plan.clone(), plan, None)?))
+    }
+
+    /// Apply a union, removing duplicate rows
+    pub fn union_distinct(&self, plan: LogicalPlan) -> Result<Self> {
+        self.union(plan)?.distinct()
     }
 
     /// Apply deduplication: Only distinct (different) values are returned)

--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -898,7 +898,6 @@ fn union_with_alias(
     Ok(LogicalPlan::Union(Union {
         inputs,
         schema: union_schema,
-        alias: None,
     }))
 }
 

--- a/datafusion/core/src/logical_plan/mod.rs
+++ b/datafusion/core/src/logical_plan/mod.rs
@@ -27,9 +27,7 @@ mod expr_simplier;
 pub mod plan;
 mod registry;
 pub mod window_frames;
-pub use builder::{
-    build_join_schema, union_with_alias, LogicalPlanBuilder, UNNAMED_TABLE,
-};
+pub use builder::{build_join_schema, LogicalPlanBuilder, UNNAMED_TABLE};
 pub use datafusion_common::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use datafusion_expr::{
     expr_fn::binary_expr,

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -359,11 +359,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             // sort is filter-commutable
             push_down(&state, plan)
         }
-        LogicalPlan::Union(Union {
-            inputs: _,
-            schema,
-            alias: _,
-        }) => {
+        LogicalPlan::Union(Union { schema, .. }) => {
             // union changing all qualifiers while building logical plan so we need
             // to rewrite filters to push unqualified columns to inputs
             let projection = schema

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -564,8 +564,7 @@ mod tests {
     use crate::datasource::{TableProvider, TableType};
     use crate::logical_plan::plan::provider_as_source;
     use crate::logical_plan::{
-        and, col, lit, sum, union_with_alias, DFSchema, Expr, LogicalPlanBuilder,
-        Operator,
+        and, col, lit, sum, DFSchema, Expr, LogicalPlanBuilder, Operator,
     };
     use crate::physical_plan::ExecutionPlan;
     use crate::prelude::JoinType;
@@ -894,26 +893,23 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn union_all_with_alias() -> Result<()> {
-        let table_scan = test_table_scan()?;
-        let union =
-            union_with_alias(table_scan.clone(), table_scan, Some("t".to_string()))?;
-
-        let plan = LogicalPlanBuilder::from(union)
-            .filter(col("t.a").eq(lit(1i64)))?
-            .build()?;
-
-        // filter appears below Union without relation qualifier
-        let expected = "\
-            Union\
-            \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None\
-            \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None";
-        assert_optimized_plan_eq(&plan, expected);
-        Ok(())
-    }
+    // #[test]
+    // fn union_all_with_alias() -> Result<()> {
+    //     let table_scan = test_table_scan()?;
+    //     let plan = LogicalPlanBuilder::from(table_scan.clone()).union(table_scan)?
+    //         .filter(col("t.a").eq(lit(1i64)))?
+    //         .build()?;
+    //
+    //     // filter appears below Union without relation qualifier
+    //     let expected = "\
+    //         Union\
+    //         \n  Filter: #a = Int64(1)\
+    //         \n    TableScan: test projection=None\
+    //         \n  Filter: #a = Int64(1)\
+    //         \n    TableScan: test projection=None";
+    //     assert_optimized_plan_eq(&plan, expected);
+    //     Ok(())
+    // }
 
     /// verifies that filters with the same columns are correctly placed
     #[test]

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -100,14 +100,7 @@ fn limit_push_down(
                 alias: alias.clone(),
             }))
         }
-        (
-            LogicalPlan::Union(Union {
-                inputs,
-                alias,
-                schema,
-            }),
-            Some(upper_limit),
-        ) => {
+        (LogicalPlan::Union(Union { inputs, schema }), Some(upper_limit)) => {
             // Push down limit through UNION
             let new_inputs = inputs
                 .iter()
@@ -125,7 +118,6 @@ fn limit_push_down(
                 .collect::<Result<_>>()?;
             Ok(LogicalPlan::Union(Union {
                 inputs: new_inputs,
-                alias: alias.clone(),
                 schema: schema.clone(),
             }))
         }

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -388,11 +388,7 @@ fn optimize_plan(
                 schema: a.schema.clone(),
             }))
         }
-        LogicalPlan::Union(Union {
-            inputs,
-            schema,
-            alias,
-        }) => {
+        LogicalPlan::Union(Union { inputs, schema }) => {
             // UNION inputs will reference the same column with different identifiers, so we need
             // to populate new_required_columns by unqualified column name based on required fields
             // from the resulting UNION output
@@ -434,7 +430,6 @@ fn optimize_plan(
             Ok(LogicalPlan::Union(Union {
                 inputs: new_inputs,
                 schema: Arc::new(new_schema),
-                alias: alias.clone(),
             }))
         }
         LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -208,13 +208,10 @@ pub fn from_plan(
         LogicalPlan::Extension(e) => Ok(LogicalPlan::Extension(Extension {
             node: e.node.from_template(expr, inputs),
         })),
-        LogicalPlan::Union(Union { schema, alias, .. }) => {
-            Ok(LogicalPlan::Union(Union {
-                inputs: inputs.to_vec(),
-                schema: schema.clone(),
-                alias: alias.clone(),
-            }))
-        }
+        LogicalPlan::Union(Union { schema, .. }) => Ok(LogicalPlan::Union(Union {
+            inputs: inputs.to_vec(),
+            schema: schema.clone(),
+        })),
         LogicalPlan::Analyze(a) => {
             assert!(expr.is_empty());
             assert_eq!(inputs.len(), 1);

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1039,8 +1039,6 @@ pub struct Union {
     pub inputs: Vec<LogicalPlan>,
     /// Union schema. Should be the same for all inputs.
     pub schema: DFSchemaRef,
-    /// Union output relation alias
-    pub alias: Option<String>,
 }
 
 /// Creates an in memory table.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Builds on https://github.com/apache/arrow-datafusion/pull/2574 so we need to merge that first

Closes https://github.com/apache/arrow-datafusion/issues/2213

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The `alias` attribute in `Union` was actually only used from a single test so wasn't really needed.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Remove `Union.alias` and the one test that used it

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

API change

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
