### PR TITLE
[Doc]add doc for enable SIMD need `cargo nightly`

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -47,7 +47,7 @@ The benchmark can then be run (assuming the data created from `dbgen` is in `./d
 cargo run --release --bin tpch -- benchmark datafusion --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
 ```
 
-You can enable the features `simd` (to use SIMD instructions) and/or `mimalloc` or `snmalloc` (to use either the mimalloc or snmalloc allocator) as features by passing them in as `--features`:
+You can enable the features `simd` (to use SIMD instructions, `cargo nightly` is required.) and/or `mimalloc` or `snmalloc` (to use either the mimalloc or snmalloc allocator) as features by passing them in as `--features`:
 
 ```
 cargo run --release --features "simd mimalloc" --bin tpch -- benchmark datafusion --iterations 3 --path ./data --format tbl --query 1 --batch-size 4096
@@ -113,7 +113,7 @@ RUST_LOG=info cargo run --release
 
 By default the executor will bind to `0.0.0.0` and listen on port 50051.
 
-You can add SIMD/snmalloc/LTO flags to improve speed (with longer build times):
+You can add SIMD(`cargo nightly` is required)/snmalloc/LTO flags to improve speed (with longer build times):
 
 ```
 RUST_LOG=info RUSTFLAGS='-C target-cpu=native -C lto -C codegen-units=1 -C embed-bitcode' cargo run --release --bin executor --features "simd snmalloc" --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
# Which issue does this PR close?
I have tested the `simd` flag in my local. But the doc does not say using nightly. got
```
error[E0554]: `#![feature]` may not be used on the stable release channel
   --> /Users/yangjiang/.cargo/registry/src/github.com-1ecc6299db9ec823/packed_simd_2-0.3.7/src/lib.rs:214:1
    |
214 | / #![feature(
215 | |     adt_const_params,
216 | |     repr_simd,
217 | |     rustc_attrs,
...   |
226 | |     custom_inner_attributes,
227 | | )]
    | |__^
```

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
