### PR TITLE
[minor]Fix ci clippy for unused import

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -28,11 +28,10 @@ use crate::datasource::TableProvider;
 use crate::logical_plan::window_frames::{WindowFrame, WindowFrameUnits};
 use crate::logical_plan::Expr::Alias;
 use crate::logical_plan::{
-    and, col, lit, normalize_col, normalize_col_with_schemas, provider_as_source,
-    union_with_alias, Column, CreateCatalog, CreateCatalogSchema,
-    CreateExternalTable as PlanCreateExternalTable, CreateMemoryTable, CreateView,
-    DFSchema, DFSchemaRef, DropTable, Expr, FileType, LogicalPlan, LogicalPlanBuilder,
-    Operator, PlanType, ToDFSchema, ToStringifiedPlan,
+    and, col, lit, normalize_col, normalize_col_with_schemas, provider_as_source, Column,
+    CreateCatalog, CreateCatalogSchema, CreateExternalTable as PlanCreateExternalTable,
+    CreateMemoryTable, CreateView, DFSchema, DFSchemaRef, DropTable, Expr, FileType,
+    LogicalPlan, LogicalPlanBuilder, Operator, PlanType, ToDFSchema, ToStringifiedPlan,
 };
 use crate::prelude::JoinType;
 use crate::scalar::ScalarValue;


### PR DESCRIPTION
# Which issue does this PR close?
Block current Pr 
```
 Checking datafusion-common v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/common)
    Checking datafusion-expr v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/expr)
    Checking datafusion-row v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/row)
    Checking datafusion-physical-expr v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/physical-expr)
    Checking datafusion-jit v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/jit)
    Checking datafusion v8.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/core)
error: unused import: `union_with_alias`
  --> datafusion/core/src/sql/planner.rs:32:5
   |
32 |     union_with_alias, Column, CreateCatalog, CreateCatalogSchema,
   |     ^^^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`

error: could not compile `datafusion` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `datafusion` due to previous error
``` 

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
