### PR TITLE
Unignore rustdoc code examples in `datafusion-expr` crate

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -50,10 +50,9 @@ pub const UNNAMED_TABLE: &str = "?table?";
 
 /// Builder for logical plans
 ///
-/// ``` ignore
-/// # use datafusion::prelude::*;
-/// # use datafusion::logical_plan::LogicalPlanBuilder;
-/// # use datafusion::error::Result;
+/// ```
+/// # use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+/// # use datafusion_common::Result;
 /// # use arrow::datatypes::{Schema, DataType, Field};
 /// #
 /// # fn main() -> Result<()> {
@@ -72,7 +71,7 @@ pub const UNNAMED_TABLE: &str = "?table?";
 /// // SELECT last_name
 /// // FROM employees
 /// // WHERE salary < 1000
-/// let plan = LogicalPlanBuilder::scan_empty(
+/// let plan = scan_empty(
 ///              Some("employee"),
 ///              &employee_schema(),
 ///              None,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -51,7 +51,7 @@ pub const UNNAMED_TABLE: &str = "?table?";
 /// Builder for logical plans
 ///
 /// ```
-/// # use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+/// # use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::table_scan};
 /// # use datafusion_common::Result;
 /// # use arrow::datatypes::{Schema, DataType, Field};
 /// #
@@ -71,7 +71,7 @@ pub const UNNAMED_TABLE: &str = "?table?";
 /// // SELECT last_name
 /// // FROM employees
 /// // WHERE salary < 1000
-/// let plan = scan_empty(
+/// let plan = table_scan(
 ///              Some("employee"),
 ///              &employee_schema(),
 ///              None,
@@ -934,23 +934,23 @@ pub fn project_with_alias(
     }))
 }
 
-/// Create a LogicalPlanBuilder representing a scan of a table with the provided schema. This
-/// is mostly used for testing and documentation.
-pub fn scan_empty(
+/// Create a LogicalPlanBuilder representing a scan of a table with the provided name and schema.
+/// This is mostly used for testing and documentation.
+pub fn table_scan(
     name: Option<&str>,
     table_schema: &Schema,
     projection: Option<Vec<usize>>,
 ) -> Result<LogicalPlanBuilder> {
     let table_schema = Arc::new(table_schema.clone());
-    let table_source = Arc::new(EmptyTable { table_schema });
+    let table_source = Arc::new(LogicalTableSource { table_schema });
     LogicalPlanBuilder::scan(name.unwrap_or(UNNAMED_TABLE), table_source, projection)
 }
 
-struct EmptyTable {
+struct LogicalTableSource {
     table_schema: SchemaRef,
 }
 
-impl TableSource for EmptyTable {
+impl TableSource for LogicalTableSource {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -974,7 +974,7 @@ mod tests {
     #[test]
     fn plan_builder_simple() -> Result<()> {
         let plan =
-            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))?
+            table_scan(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))?
                 .filter(col("state").eq(lit("CO")))?
                 .project(vec![col("id")])?
                 .build()?;
@@ -991,7 +991,7 @@ mod tests {
     #[test]
     fn plan_builder_schema() {
         let schema = employee_schema();
-        let plan = scan_empty(Some("employee_csv"), &schema, None).unwrap();
+        let plan = table_scan(Some("employee_csv"), &schema, None).unwrap();
 
         let expected =
             DFSchema::try_from_qualified_schema("employee_csv", &schema).unwrap();
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn plan_builder_aggregate() -> Result<()> {
         let plan =
-            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
+            table_scan(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
                 .aggregate(
                     vec![col("state")],
                     vec![sum(col("salary")).alias("total_salary")],
@@ -1026,7 +1026,7 @@ mod tests {
     #[test]
     fn plan_builder_sort() -> Result<()> {
         let plan =
-            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
+            table_scan(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?
                 .sort(vec![
                     Expr::Sort {
                         expr: Box::new(col("state")),
@@ -1051,9 +1051,9 @@ mod tests {
 
     #[test]
     fn plan_using_join_wildcard_projection() -> Result<()> {
-        let t2 = scan_empty(Some("t2"), &employee_schema(), None)?.build()?;
+        let t2 = table_scan(Some("t2"), &employee_schema(), None)?.build()?;
 
-        let plan = scan_empty(Some("t1"), &employee_schema(), None)?
+        let plan = table_scan(Some("t1"), &employee_schema(), None)?
             .join_using(&t2, JoinType::Inner, vec!["id"])?
             .project(vec![Expr::Wildcard])?
             .build()?;
@@ -1072,7 +1072,7 @@ mod tests {
     #[test]
     fn plan_builder_union_combined_single_union() -> Result<()> {
         let plan =
-            scan_empty(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?;
+            table_scan(Some("employee_csv"), &employee_schema(), Some(vec![3, 4]))?;
 
         let plan = plan
             .union(plan.build()?)?
@@ -1169,7 +1169,7 @@ mod tests {
 
     #[test]
     fn projection_non_unique_names() -> Result<()> {
-        let plan = scan_empty(
+        let plan = table_scan(
             Some("employee_csv"),
             &employee_schema(),
             // project id and first_name by column index
@@ -1195,7 +1195,7 @@ mod tests {
 
     #[test]
     fn aggregate_non_unique_names() -> Result<()> {
-        let plan = scan_empty(
+        let plan = table_scan(
             Some("employee_csv"),
             &employee_schema(),
             // project state and salary by column index
@@ -1267,6 +1267,6 @@ mod tests {
             Field::new("b", DataType::UInt32, false),
             Field::new("c", DataType::UInt32, false),
         ]);
-        scan_empty(Some(name), &schema, None)?.build()
+        table_scan(Some(name), &schema, None)?.build()
     }
 }

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -20,7 +20,7 @@ pub mod display;
 mod extension;
 mod plan;
 
-pub use builder::LogicalPlanBuilder;
+pub use builder::{scan_empty, LogicalPlanBuilder};
 pub use plan::{
     Aggregate, Analyze, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
     CreateMemoryTable, CreateView, CrossJoin, DropTable, EmptyRelation, Explain,

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -20,7 +20,7 @@ pub mod display;
 mod extension;
 mod plan;
 
-pub use builder::{scan_empty, LogicalPlanBuilder};
+pub use builder::{table_scan, LogicalPlanBuilder};
 pub use plan::{
     Aggregate, Analyze, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
     CreateMemoryTable, CreateView, CrossJoin, DropTable, EmptyRelation, Explain,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -462,21 +462,20 @@ impl LogicalPlan {
     ///       CsvScan: employee projection=Some([0, 3])
     /// ```
     ///
-    /// ```ignore
+    /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion::logical_plan::{lit, col, LogicalPlanBuilder};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap()
+    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
     /// // Format using display_indent
     /// let display_string = format!("{}", plan.display_indent());
     ///
-    /// assert_eq!("Filter: #foo_csv.id = Int32(5)\
-    ///              \n  TableScan: foo_csv projection=None",
+    /// assert_eq!("Filter: #t1.id = Int32(5)\n  TableScan: t1 projection=None",
     ///             display_string);
     /// ```
     pub fn display_indent(&self) -> impl fmt::Display + '_ {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -464,11 +464,11 @@ impl LogicalPlan {
     ///
     /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::table_scan};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
+    /// let plan = table_scan(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -504,11 +504,11 @@ impl LogicalPlan {
     ///
     /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::table_scan};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
+    /// let plan = table_scan(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -544,11 +544,11 @@ impl LogicalPlan {
     ///
     /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::table_scan};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
+    /// let plan = table_scan(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -603,11 +603,11 @@ impl LogicalPlan {
     /// ```
     /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::table_scan};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
+    /// let plan = table_scan(Some("t1"), &schema, None).unwrap()
     ///     .build().unwrap();
     ///
     /// // Format using display

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -502,21 +502,21 @@ impl LogicalPlan {
     ///      TableScan: employee projection=Some([0, 3]) [id:Int32, state:Utf8]";
     /// ```
     ///
-    /// ```ignore
+    /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion::logical_plan::{lit, col, LogicalPlanBuilder};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo_csv"), &schema, None).unwrap()
+    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
     /// // Format using display_indent_schema
     /// let display_string = format!("{}", plan.display_indent_schema());
     ///
-    /// assert_eq!("Filter: #foo_csv.id = Int32(5) [id:Int32]\
-    ///             \n  TableScan: foo_csv projection=None [id:Int32]",
+    /// assert_eq!("Filter: #t1.id = Int32(5) [id:Int32]\
+    ///             \n  TableScan: t1 projection=None [id:Int32]",
     ///             display_string);
     /// ```
     pub fn display_indent_schema(&self) -> impl fmt::Display + '_ {
@@ -542,13 +542,13 @@ impl LogicalPlan {
     /// This currently produces two graphs -- one with the basic
     /// structure, and one with additional details such as schema.
     ///
-    /// ```ignore
+    /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion::logical_plan::{lit, col, LogicalPlanBuilder};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo.csv"), &schema, None).unwrap()
+    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
     ///     .filter(col("id").eq(lit(5))).unwrap()
     ///     .build().unwrap();
     ///
@@ -601,19 +601,19 @@ impl LogicalPlan {
     /// ```text
     /// Projection: #id
     /// ```
-    /// ```ignore
+    /// ```
     /// use arrow::datatypes::{Field, Schema, DataType};
-    /// use datafusion::logical_plan::{lit, col, LogicalPlanBuilder};
+    /// use datafusion_expr::{lit, col, LogicalPlanBuilder, logical_plan::scan_empty};
     /// let schema = Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false),
     /// ]);
-    /// let plan = LogicalPlanBuilder::scan_empty(Some("foo.csv"), &schema, None).unwrap()
+    /// let plan = scan_empty(Some("t1"), &schema, None).unwrap()
     ///     .build().unwrap();
     ///
     /// // Format using display
     /// let display_string = format!("{}", plan.display());
     ///
-    /// assert_eq!("TableScan: foo.csv projection=None", display_string);
+    /// assert_eq!("TableScan: t1 projection=None", display_string);
     /// ```
     pub fn display(&self) -> impl fmt::Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2308

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Now that `LogicalPlanBuilder` is in `datafusion-expr`, we can re-enable this documentation.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix rustdoc

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Does this PR break compatibility with Ballista?

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->