### PR TITLE
chore(dep): bump cranelift to 0.84.0

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-keywords = [ "arrow", "query", "sql" ]
+keywords = ["arrow", "query", "sql"]
 edition = "2021"
 rust-version = "1.59"
 
@@ -40,7 +40,7 @@ pyarrow = ["pyo3"]
 [dependencies]
 arrow = { version = "14.0.0", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
-cranelift-module = { version = "0.83.0", optional = true }
+cranelift-module = { version = "0.84.0", optional = true }
 ordered-float = "3.0"
 parquet = { version = "14.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -37,10 +37,10 @@ jit = []
 
 [dependencies]
 arrow = { version = "14.0.0" }
-cranelift = "0.83.0"
-cranelift-jit = "0.83.0"
-cranelift-module = "0.83.0"
-cranelift-native = "0.83.0"
+cranelift = "0.84.0"
+cranelift-jit = "0.84.0"
+cranelift-module = "0.84.0"
+cranelift-native = "0.84.0"
 datafusion-common = { path = "../common", version = "8.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "8.0.0" }
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2592 
Closes #2593
Closes #2594
Closes #2595

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Cannot find a formal release note. Got [this](https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md#0370) from wasmtime 0.37 version's release:

>Updated Cranelift to use regalloc2, a new register allocator. This should result in ~20% faster compile times, and for programs that suffered from register-allocation pressure before, up to ~20% faster generated code.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Does this PR break compatibility with Ballista?

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->