### PR TITLE
chore(doc) remove ballista from datafusion-cli readme

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "datafusion-row",
+ "datafusion-sql",
  "futures",
  "hashbrown 0.12.1",
  "lazy_static",
@@ -451,6 +452,19 @@ dependencies = [
  "datafusion-common",
  "paste",
  "rand",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "8.0.0"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "hashbrown 0.12.1",
+ "sqlparser",
+ "tokio",
 ]
 
 [[package]]

--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -75,19 +75,4 @@ cd arrow-datafusion/datafusion-cli
 cargo build
 ```
 
-## Ballista
-
-If you want to execute the SQL in ballista by `datafusion-cli`, you must build/compile the `datafusion-cli` with features of "ballista" first.
-
-```bash
-cd arrow-datafusion/datafusion-cli
-cargo build --features ballista
-```
-
-The DataFusion CLI can connect to a Ballista scheduler for query execution.
-
-```bash
-datafusion-cli --host localhost --port 50050
-```
-
 [df]: https://crates.io/crates/datafusion

--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -25,20 +25,18 @@ The DataFusion CLI allows SQL queries to be executed by an in-process DataFusion
 
 ```ignore
 USAGE:
-    datafusion-cli [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Reduce printing other than the results and work quietly
-    -V, --version    Prints version information
+    datafusion-cli [OPTIONS]
 
 OPTIONS:
-    -c, --batch-size <batch-size>    The batch size of each query, or use DataFusion default
-    -p, --data-path <data-path>      Path to your data, default to current directory
-    -f, --file <file>...             Execute commands from file(s), then exit
-        --format <format>            Output format [default: table]  [possible values: csv, tsv, table, json, ndjson]
-        --host <host>                Ballista scheduler host
-        --port <port>                Ballista scheduler port
+    -c, --batch-size <BATCH_SIZE>    The batch size of each query, or use DataFusion default
+    -f, --file <FILE>...             Execute commands from file(s), then exit
+        --format <FORMAT>            [default: table] [possible values: csv, tsv, table, json,
+                                     nd-json]
+    -h, --help                       Print help information
+    -p, --data-path <DATA_PATH>      Path to your data, default to current directory
+    -q, --quiet                      Reduce printing other than the results and work quietly
+    -r, --rc <RC>...                 Run the provided files on startup instead of ~/.datafusionrc
+    -V, --version                    Print version information
 ```
 
 ## Example

--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -21,8 +21,7 @@
 
 [DataFusion](df) is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-The DataFusion CLI allows SQL queries to be executed by an in-process DataFusion context, or by a distributed
-Ballista context.
+The DataFusion CLI allows SQL queries to be executed by an in-process DataFusion context.
 
 ```ignore
 USAGE:


### PR DESCRIPTION
# Which issue does this PR close?
NONE

 # Rationale for this change
improve documentation

# What changes are included in this PR?
- remove ballista from datafusion-cli readme
- build datafusion-cli and update Cargo.lock

# Are there any user-facing changes?
no
# Does this PR break compatibility with Ballista?
NA