### PR TITLE
Support binary mathematical operators work with `NULL` literals

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1254,3 +1254,51 @@ async fn comparisons_with_null_lt() {
         assert!(batch.columns()[0].is_null(1));
     }
 }
+
+#[tokio::test]
+async fn binary_mathematical_operator_with_null_lt() {
+    let ctx = SessionContext::new();
+
+    let cases = vec![
+        // 1. Integer and NULL
+        "select column1 + NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column1 - NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column1 * NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column1 / NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column1 % NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        // 2. Float and NULL
+        "select column2 + NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column2 - NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column2 * NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column2 / NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select column2 % NULL from (VALUES (1, 2.3), (2, 5.4)) as t",
+        // ----
+        // ---- same queries, reversed argument order
+        // ----
+        // 3. NULL and Integer
+        "select NULL + column1 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL - column1 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL * column1 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL / column1 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL % column1 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        // 4. NULL and Float
+        "select NULL + column2 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL - column2 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL * column2 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL / column2 from (VALUES (1, 2.3), (2, 5.4)) as t",
+        "select NULL % column2 from (VALUES (1, 2.3), (2, 5.4)) as t",
+    ];
+
+    for sql in cases {
+        println!("Computing: {}", sql);
+
+        let mut actual = execute_to_batches(&ctx, sql).await;
+        assert_eq!(actual.len(), 1);
+
+        let batch = actual.pop().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 1);
+        assert!(batch.columns()[0].is_null(0));
+        assert!(batch.columns()[0].is_null(1));
+    }
+}

--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -282,7 +282,7 @@ fn mathematics_numerical_coercion(
     use arrow::datatypes::DataType::*;
 
     // error on any non-numeric type
-    if !is_numeric(lhs_type) || !is_numeric(rhs_type) {
+    if !both_numeric_or_null_and_numeric(lhs_type, rhs_type) {
         return None;
     };
 
@@ -410,6 +410,15 @@ pub fn is_numeric(dt: &DataType) -> bool {
             }
             _ => false,
         }
+}
+
+/// Determine if at least of one of lhs and rhs is numeric, and the other must be NULL or numeric
+fn both_numeric_or_null_and_numeric(lhs_type: &DataType, rhs_type: &DataType) -> bool {
+    match (lhs_type, rhs_type) {
+        (_, DataType::Null) => is_numeric(lhs_type),
+        (DataType::Null, _) => is_numeric(rhs_type),
+        _ => is_numeric(lhs_type) && is_numeric(rhs_type),
+    }
 }
 
 /// Coercion rules for dictionary values (aka the type of the  dictionary itself)

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -701,57 +701,17 @@ macro_rules! compute_bool_op {
 /// LEFT is array, RIGHT is scalar value
 macro_rules! compute_op_scalar {
     ($LEFT:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
-        match $RIGHT {
-            ScalarValue::Int8(v) => compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT),
-            ScalarValue::Int16(v) => compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT),
-            ScalarValue::Int32(v) => compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT),
-            ScalarValue::Int64(v) => compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT),
-            ScalarValue::UInt8(v) => compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT),
-            ScalarValue::UInt16(v) => {
-                compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT)
-            }
-            ScalarValue::UInt32(v) => {
-                compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT)
-            }
-            ScalarValue::UInt64(v) => {
-                compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT)
-            }
-            ScalarValue::Float32(v) => {
-                compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT)
-            }
-            ScalarValue::Float64(v) => {
-                compute_array_op_scalar!($LEFT, $RIGHT, v, $OP, $DT)
-            }
-            _ => {
-                let ll = $LEFT
-                    .as_any()
-                    .downcast_ref::<$DT>()
-                    .expect("compute_op failed to downcast array");
-                Ok(Arc::new(paste::expr! {[<$OP _scalar>]}(
-                    &ll,
-                    $RIGHT.try_into()?,
-                )?))
-            }
-        }
-    }};
-}
-
-/// Invoke a compute kernel on a data array and a scalar value
-/// return NULL array of LEFT's data type if RIGHT is NULL
-macro_rules! compute_array_op_scalar {
-    ($LEFT:expr, $RIGHT_SCALAR:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
-        if let Some(_) = $RIGHT {
+        if $RIGHT.is_null() {
+            Ok(Arc::new(new_null_array($LEFT.data_type(), $LEFT.len())))
+        } else {
             let ll = $LEFT
                 .as_any()
                 .downcast_ref::<$DT>()
                 .expect("compute_op failed to downcast array");
             Ok(Arc::new(paste::expr! {[<$OP _scalar>]}(
                 &ll,
-                $RIGHT_SCALAR.try_into()?,
+                $RIGHT.try_into()?,
             )?))
-        } else {
-            // when the $RIGHT is a NULL, generate a NULL array of $LEFT's data type
-            Ok(Arc::new(new_null_array($LEFT.data_type(), $LEFT.len())))
         }
     }};
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2609 .

 # Rationale for this change
There is bug when binary mathematical operators `+`, `-`, `*`, `/`, `%` work with literal `NULL`

**To reproduce**
```
> select column1 + NULL from (VALUES (1, 2.3), (2, 5.4)) as t
Plan("'Int64 + Null' can't be evaluated because there isn't a common type to coerce the types to")
```
Postgres works like
```
# select column1 + NULL from (VALUES (1, 2.3), (2, 5.4)) as t;
 ?column? 
----------
         
         
(2 rows)
```


# What changes are included in this PR?
- Adjusts `mathematics_numerical_coercion` in `binary_rule.rs`, make it work well on condition that at most one side of lhs or rhs is `NULL`
- Enhances `compute_op_scalar` macro in `binary.rs` to produce `NULL` array when scalar value is `NULL`

# Are there any user-facing changes?
No.