### PR TITLE
Export minimum C API and examples for C, Ruby and Python

### DIFF
--- a/datafusion/c/Cargo.toml
+++ b/datafusion/c/Cargo.toml
@@ -15,24 +15,32 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[workspace]
-members = [
-    "datafusion/c",
-    "datafusion/common",
-    "datafusion/core",
-    "datafusion/data-access",
-    "datafusion/expr",
-    "datafusion/jit",
-    "datafusion/physical-expr",
-    "datafusion/proto",
-    "datafusion/row",
-    "datafusion/sql",
-    "datafusion-examples",
-    "benchmarks",
+[package]
+name = "datafusion_c"
+description = "DataFusion C API"
+version = "8.0.0"
+homepage = "https://github.com/apache/arrow-datafusion"
+repository = "https://github.com/apache/arrow-datafusion"
+readme = "../../README.md"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+license = "Apache-2.0"
+keywords = ["arrow", "c"]
+include = [
+    "src/**/*.rs",
+    "Cargo.toml",
 ]
-exclude = ["datafusion-cli"]
+edition = "2021"
+rust-version = "1.59"
 
-[profile.release]
-codegen-units = 1
-lto = true
+[lib]
+name = "datafusion_c"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
 
+[features]
+default = []
+
+[dependencies]
+datafusion = { path = "../core", version = "8.0.0" }
+libc = "0.2"
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/c/Cargo.toml
+++ b/datafusion/c/Cargo.toml
@@ -33,9 +33,9 @@ edition = "2021"
 rust-version = "1.59"
 
 [lib]
+crate-type = ["cdylib"]
 name = "datafusion_c"
 path = "src/lib.rs"
-crate-type = ["cdylib"]
 
 [features]
 default = []

--- a/datafusion/c/examples/README.md
+++ b/datafusion/c/examples/README.md
@@ -1,0 +1,83 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# DataFusion C API examples
+
+## How to run
+
+Build `libdatafusion_c.so`:
+
+```bash
+cargo build
+```
+
+C example:
+
+```
+cc \
+  -o target/debug/sql \
+  -I datafusion/c/include \
+  datafusion/c/examples/sql.c \
+  -L target/debug \
+  -Wl,--rpath=target/debug \
+  -ldatafusion_c
+target/debug/sql
+```
+
+Output:
+
+```text
++----------+
+| Int64(1) |
++----------+
+| 1        |
++----------+
+```
+
+Python example:
+
+```bash
+LD_LIBRARY_PATH=$PWD/target/debug datafusion/c/examples/sql.py
+```
+
+Output:
+
+```text
++----------+
+| Int64(1) |
++----------+
+| 1        |
++----------+
+```
+
+Ruby example:
+
+```bash
+LD_LIBRARY_PATH=$PWD/target/debug datafusion/c/examples/sql.rb
+```
+
+Output:
+
+```text
++----------+
+| Int64(1) |
++----------+
+| 1        |
++----------+
+```

--- a/datafusion/c/examples/sql.c
+++ b/datafusion/c/examples/sql.c
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <datafusion.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main(void)
+{
+  DFSessionContext *context = df_session_context_new();
+  DFError *error = NULL;
+  DFDataFrame *data_frame = df_session_context_sql(context, "SELECT 1;", &error);
+  if (error) {
+    printf("failed to run SQL: %s\n", df_error_get_message(error));
+    df_error_free(error);
+    df_session_context_free(context);
+    return EXIT_FAILURE;
+  }
+  df_data_frame_show(data_frame, &error);
+  if (error) {
+    printf("failed to show data frame: %s\n", df_error_get_message(error));
+    df_error_free(error);
+  }
+  df_data_frame_unref(data_frame);
+  df_session_context_free(context);
+  return EXIT_SUCCESS;
+}

--- a/datafusion/c/examples/sql.c
+++ b/datafusion/c/examples/sql.c
@@ -39,7 +39,7 @@ main(void)
     printf("failed to show data frame: %s\n", df_error_get_message(error));
     df_error_free(error);
   }
-  df_data_frame_unref(data_frame);
+  df_data_frame_free(data_frame);
   df_session_context_free(context);
   return EXIT_SUCCESS;
 }

--- a/datafusion/c/examples/sql.py
+++ b/datafusion/c/examples/sql.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from cffi import FFI
+
+ffi = FFI()
+ffi.cdef("""
+typedef struct DFError_ DFError;
+extern void df_error_free(DFError *error);
+extern const char *df_error_get_message(DFError *error);
+
+
+typedef struct DFDataFrame_ DFDataFrame;
+extern void df_data_frame_free(DFDataFrame *data_frame);
+extern void df_data_frame_show(DFDataFrame *data_frame, DFError **error);
+
+
+typedef struct DFSessionContext_ DFSessionContext;
+extern DFSessionContext *df_session_context_new(void);
+extern void df_session_context_free(DFSessionContext *ctx);
+extern DFDataFrame *df_session_context_sql(DFSessionContext *ctx,
+                                           const char *sql,
+                                           DFError **error);
+""")
+datafusion = ffi.dlopen('libdatafusion_c.so')
+try:
+    context = datafusion.df_session_context_new()
+    try:
+        error = ffi.new('DFError **')
+        try:
+            data_frame = datafusion.df_session_context_sql(
+                context, b'SELECT 1;', error)
+            if error[0] != ffi.NULL:
+                message = datafusion.df_error_get_message(error[0])
+                print(f'failed to run SQL: {ffi.string(message).decode()}')
+                exit(1)
+            try:
+                datafusion.df_data_frame_show(data_frame, error);
+                if error[0] != ffi.NULL:
+                    message = datafusion.df_error_get_message(error[0])
+                    print('failed to show data frame: ' +
+                          f'{ffi.string(message).decode()}')
+                    exit(1)
+            finally:
+                datafusion.df_data_frame_free(data_frame)
+        finally:
+            if error[0] != ffi.NULL:
+                datafusion.df_error_free(error[0])
+    finally:
+        datafusion.df_session_context_free(context)
+finally:
+    ffi.dlclose(datafusion)

--- a/datafusion/c/examples/sql.rb
+++ b/datafusion/c/examples/sql.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "fiddle/import"
+
+module DataFusion
+  extend Fiddle::Importer
+
+  dlload "libdatafusion_c.so"
+
+  typealias "DFError *", "void *"
+  extern "void df_error_free(DFError *error)"
+  extern "const char *df_error_get_message(DFError *error)"
+
+  typealias "DFDataFrame *", "void *"
+  extern "void df_data_frame_free(DFDataFrame *data_frame)"
+  extern "void df_data_frame_show(DFDataFrame *data_frame, DFError **error)"
+
+  typealias "DFSessionContext *", "void *"
+  extern "DFSessionContext *df_session_context_new(void)"
+  extern "void df_session_context_free(DFSessionContext *ctx)"
+  extern "DFDataFrame *df_session_context_sql(DFSessionContext *ctx, const char *sql, DFError **error)"
+end
+
+begin
+  context = DataFusion.df_session_context_new
+  Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP, Fiddle::RUBY_FREE) do |error|
+    begin
+      data_frame = DataFusion.df_session_context_sql(context, "SELECT 1;", error)
+      unless error.ptr.null?
+        message = DataFusion.df_error_get_message(error.ptr)
+        puts("failed to run SQL: #{message}")
+        exit(false)
+      end
+      begin
+        DataFusion.df_data_frame_show(data_frame, error)
+        unless error.ptr.null?
+          message = DataFusion.df_error_get_message(error.ptr)
+          puts("failed to show data frame: #{message}")
+          exit(false)
+        end
+      ensure
+        DataFusion.df_data_frame_free(data_frame)
+      end
+    ensure
+      DataFusion.df_error_free(error.ptr) unless error.ptr.null?
+    end
+  end
+ensure
+  DataFusion.df_session_context_free(context)
+end

--- a/datafusion/c/include/datafusion.h
+++ b/datafusion/c/include/datafusion.h
@@ -30,7 +30,7 @@ extern const char *df_error_get_message(DFError *error);
 
 
 typedef struct DFDataFrame_ DFDataFrame;
-extern void df_data_frame_unref(DFDataFrame *data_frame);
+extern void df_data_frame_free(DFDataFrame *data_frame);
 extern void df_data_frame_show(DFDataFrame *data_frame, DFError **error);
 
 

--- a/datafusion/c/include/datafusion.h
+++ b/datafusion/c/include/datafusion.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct DFError_ DFError;
+extern void df_error_free(DFError *error);
+extern const char *df_error_get_message(DFError *error);
+
+
+typedef struct DFDataFrame_ DFDataFrame;
+extern void df_data_frame_unref(DFDataFrame *data_frame);
+extern void df_data_frame_show(DFDataFrame *data_frame, DFError **error);
+
+
+typedef struct DFSessionContext_ DFSessionContext;
+extern DFSessionContext *df_session_context_new(void);
+extern void df_session_context_free(DFSessionContext *ctx);
+extern DFDataFrame *df_session_context_sql(DFSessionContext *ctx,
+                                           const char *sql,
+                                           DFError **error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/datafusion/c/src/lib.rs
+++ b/datafusion/c/src/lib.rs
@@ -32,10 +32,7 @@ pub struct DFError {
 
 impl DFError {
     pub fn new(code: u32, message: *mut libc::c_char) -> Self {
-        Self {
-            code,
-            message,
-        }
+        Self { code, message }
     }
 }
 
@@ -67,7 +64,9 @@ pub unsafe extern "C" fn df_error_free(error: *mut DFError) {
 /// This function should not be called with `error` that is freed by
 /// `df_error_free()`.
 #[no_mangle]
-pub unsafe extern "C" fn df_error_get_message(error: *mut DFError) -> *const libc::c_char {
+pub unsafe extern "C" fn df_error_get_message(
+    error: *mut DFError,
+) -> *const libc::c_char {
     (*error).message
 }
 
@@ -116,9 +115,7 @@ pub struct DFDataFrame {
 
 impl DFDataFrame {
     pub fn new(data_frame: Arc<DataFrame>) -> Self {
-        Self {
-            data_frame,
-        }
+        Self { data_frame }
     }
 }
 

--- a/datafusion/c/src/lib.rs
+++ b/datafusion/c/src/lib.rs
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::boxed::Box;
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::future::Future;
+use std::sync::Arc;
+
+use datafusion::dataframe::DataFrame;
+use datafusion::execution::context::SessionContext;
+
+#[repr(C)]
+pub struct DFError {
+    code: u32,
+    message: *mut libc::c_char,
+}
+
+impl DFError {
+    pub fn new(code: u32, message: *mut libc::c_char) -> Self {
+        Self {
+            code: code,
+            message: message,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn df_error_new(code: u32, message: *const libc::c_char) -> *mut DFError {
+    let error = DFError::new(code, unsafe { libc::strdup(message) });
+    return Box::into_raw(Box::new(error));
+}
+
+#[no_mangle]
+pub extern "C" fn df_error_free(error: *mut DFError) {
+    unsafe {
+        libc::free((*error).message as *mut libc::c_void);
+        Box::from_raw(error)
+    };
+}
+
+#[no_mangle]
+pub extern "C" fn df_error_get_message(error: *mut DFError) -> *const libc::c_char {
+    unsafe { (*error).message }
+}
+
+trait IntoDFError {
+    type Value;
+    fn into_df_error(
+        self,
+        error: *mut *mut DFError,
+        error_value: Option<Self::Value>,
+    ) -> Option<Self::Value>;
+}
+
+impl<V, E: std::fmt::Display> IntoDFError for Result<V, E> {
+    type Value = V;
+    fn into_df_error(
+        self,
+        error: *mut *mut DFError,
+        error_value: Option<Self::Value>,
+    ) -> Option<Self::Value> {
+        match self {
+            Ok(value) => Some(value),
+            Err(e) => {
+                if !error.is_null() {
+                    let c_string_message = match CString::new(format!("{}", e)) {
+                        Ok(c_string_message) => c_string_message,
+                        Err(_) => return error_value,
+                    };
+                    unsafe {
+                        *error = df_error_new(1, c_string_message.as_ptr());
+                    };
+                }
+                error_value
+            }
+        }
+    }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+#[repr(C)]
+pub struct DFDataFrame {
+    data_frame: Arc<DataFrame>,
+}
+
+impl DFDataFrame {
+    pub fn new(data_frame: Arc<DataFrame>) -> Self {
+        Self {
+            data_frame: data_frame,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn df_data_frame_unref(data_frame: *mut DFDataFrame) {
+    unsafe { Box::from_raw(data_frame) };
+}
+
+#[no_mangle]
+pub extern "C" fn df_data_frame_show(
+    data_frame: *mut DFDataFrame,
+    error: *mut *mut DFError,
+) {
+    let future = unsafe { (*data_frame).data_frame.show() };
+    block_on(future).into_df_error(error, None);
+}
+
+#[no_mangle]
+pub extern "C" fn df_session_context_new() -> *mut SessionContext {
+    let ctx = SessionContext::new();
+    return Box::into_raw(Box::new(ctx));
+}
+
+#[no_mangle]
+pub extern "C" fn df_session_context_free(ctx: *mut SessionContext) {
+    unsafe { Box::from_raw(ctx) };
+}
+
+#[no_mangle]
+pub extern "C" fn df_session_context_sql(
+    ctx: *mut SessionContext,
+    sql: *const libc::c_char,
+    error: *mut *mut DFError,
+) -> *mut DFDataFrame {
+    let cstr_sql = unsafe { CStr::from_ptr(sql) };
+    let maybe_rs_sql = cstr_sql.to_str().into_df_error(error, None);
+    let rs_sql = match maybe_rs_sql {
+        Some(rs_sql) => rs_sql,
+        None => return std::ptr::null_mut(),
+    };
+    let result = block_on(unsafe { (*ctx).sql(rs_sql) });
+    let maybe_data_frame = result.into_df_error(error, None);
+    match maybe_data_frame {
+        Some(data_frame) => Box::into_raw(Box::new(DFDataFrame::new(data_frame))),
+        None => std::ptr::null_mut(),
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1113.

# Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #1113.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This exports minimum C API to write the following Rust code in C:

    use datafusion::prelude::*;

    #[tokio::main]
    async fn main() -> datafusion::error::Result<()> {
      // register the table
      let mut ctx = ExecutionContext::new();

      // create a plan to run a SQL query
      let df = ctx.sql("SELECT 1").await?;

      // execute and print results
      df.show().await?;
      Ok(())
    }

See datafusion/c/examples/sql.c for C version. You can build and run
datafusion/c/examples/sql.c by the following command lines:

    $ cargo build
    $ cc -o target/debug/sql datafusion/c/examples/sql.c -Idatafusion/c/include -Ltarget/debug -Wl,--rpath=target/debug -ldatafusion_c
    $ target/debug/sql
    +----------+
    | Int64(1) |
    +----------+
    | 1        |
    +----------+

This implementation doesn't export Future like
datafusion-python. Async functions are block_on()-ed in exported
API. But I think that we can export Future in follow-up tasks.

Follow-up tasks:

  * Add support for testing by "cargo test"
  * Add support for building and running examples by "cargo ..."
  * Add support for installing datafusion.h
  * Add documentation

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Users can use DataFusion from C and/or FFI.

# Does this PR break compatibility with Ballista?

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->

No.
