### PR TITLE
MINOR: Refactor `datafusion-proto` dependencies and imports

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -20,7 +20,7 @@ mod dfschema;
 mod error;
 #[cfg(feature = "pyarrow")]
 mod pyarrow;
-mod scalar;
+pub mod scalar;
 
 pub use column::Column;
 pub use dfschema::{DFField, DFSchema, DFSchemaRef, ExprSchema, ToDFSchema};

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -36,9 +36,9 @@ path = "src/lib.rs"
 
 [dependencies]
 arrow = { version = "14.0.0" }
+datafusion = { path = "../core", version = "8.0.0" }
 datafusion-common = { path = "../common", version = "8.0.0" }
 datafusion-expr = { path = "../expr", version = "8.0.0" }
-datafusion = { path = "../core", version = "8.0.0" }
 prost = "0.10"
 
 [build-dependencies]

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -35,6 +35,9 @@ path = "src/lib.rs"
 [features]
 
 [dependencies]
+arrow = { version = "14.0.0" }
+datafusion-common = { path = "../common", version = "8.0.0" }
+datafusion-expr = { path = "../expr", version = "8.0.0" }
 datafusion = { path = "../core", version = "8.0.0" }
 prost = "0.10"
 

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -17,13 +17,12 @@
 
 //! Serialization / Deserialization to Bytes
 use crate::{from_proto::parse_expr, protobuf};
-use datafusion::{
-    common::{DataFusionError, Result},
-    logical_plan::{Expr, FunctionRegistry},
-};
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::Expr;
 use prost::{bytes::BytesMut, Message};
 
 // Reexport Bytes which appears in the API
+use datafusion::logical_plan::FunctionRegistry;
 pub use prost::bytes::Bytes;
 
 mod registry;

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -31,8 +31,7 @@ mod registry;
 /// bytes.
 ///
 /// ```
-/// use datafusion::prelude::*;
-/// use datafusion::logical_plan::Expr;
+/// use datafusion_expr::{col, lit, Expr};
 /// use datafusion_proto::bytes::Serializeable;
 ///
 /// // Create a new `Expr` a < 32
@@ -97,13 +96,13 @@ impl Serializeable for Expr {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::Arc;
-
+    use arrow::{array::ArrayRef, datatypes::DataType};
+    use datafusion::prelude::SessionContext;
     use datafusion::{
-        arrow::array::ArrayRef, arrow::datatypes::DataType, logical_expr::Volatility,
         logical_plan::create_udf, physical_plan::functions::make_scalar_function,
-        prelude::*,
     };
+    use datafusion_expr::{lit, Volatility};
+    use std::sync::Arc;
 
     #[test]
     #[should_panic(

--- a/datafusion/proto/src/bytes/registry.rs
+++ b/datafusion/proto/src/bytes/registry.rs
@@ -17,11 +17,9 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use datafusion::{
-    common::{DataFusionError, Result},
-    logical_expr::{AggregateUDF, ScalarUDF},
-    logical_plan::FunctionRegistry,
-};
+use datafusion::logical_plan::FunctionRegistry;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::{AggregateUDF, ScalarUDF};
 
 /// A default [`FunctionRegistry`] registry that does not resolve any
 /// user defined functions

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -26,17 +26,17 @@ use datafusion::logical_plan::FunctionRegistry;
 use datafusion_common::{
     Column, DFField, DFSchema, DFSchemaRef, DataFusionError, ScalarValue,
 };
-use datafusion_expr::logical_plan::{PlanType, StringifiedPlan};
 use datafusion_expr::{
     abs, acos, array, ascii, asin, atan, bit_length, btrim, ceil, character_length, chr,
     coalesce, concat_expr, concat_ws_expr, cos, date_part, date_trunc, digest, exp,
-    floor, left, ln, log10, log2, lower, lpad, ltrim, md5, now_expr, nullif,
-    octet_length, power, random, regexp_match, regexp_replace, repeat, replace, reverse,
-    right, round, rpad, rtrim, sha224, sha256, sha384, sha512, signum, sin, split_part,
-    sqrt, starts_with, strpos, substr, tan, to_hex, to_timestamp_micros,
-    to_timestamp_millis, to_timestamp_seconds, translate, trim, trunc, upper,
-    AggregateFunction, BuiltInWindowFunction, BuiltinScalarFunction, Expr, Operator,
-    WindowFrame, WindowFrameBound, WindowFrameUnits,
+    floor, left, ln, log10, log2,
+    logical_plan::{PlanType, StringifiedPlan},
+    lower, lpad, ltrim, md5, now_expr, nullif, octet_length, power, random, regexp_match,
+    regexp_replace, repeat, replace, reverse, right, round, rpad, rtrim, sha224, sha256,
+    sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, tan,
+    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, translate,
+    trim, trunc, upper, AggregateFunction, BuiltInWindowFunction, BuiltinScalarFunction,
+    Expr, Operator, WindowFrame, WindowFrameBound, WindowFrameUnits,
 };
 use std::sync::Arc;
 
@@ -908,7 +908,6 @@ pub fn parse_expr(
     proto: &protobuf::LogicalExprNode,
     registry: &dyn FunctionRegistry,
 ) -> Result<Expr, Error> {
-    use datafusion::logical_expr::window_function;
     use protobuf::{logical_expr_node::ExprType, window_expr_node, ScalarFunction};
 
     let expr_type = proto
@@ -964,7 +963,7 @@ pub fn parse_expr(
                     let aggr_function = protobuf::AggregateFunction::try_from(i)?.into();
 
                     Ok(Expr::WindowFunction {
-                        fun: window_function::WindowFunction::AggregateFunction(
+                        fun: datafusion_expr::window_function::WindowFunction::AggregateFunction(
                             aggr_function,
                         ),
                         args: vec![parse_required_expr(&expr.expr, registry, "expr")?],
@@ -979,7 +978,7 @@ pub fn parse_expr(
                         .into();
 
                     Ok(Expr::WindowFunction {
-                        fun: window_function::WindowFunction::BuiltInWindowFunction(
+                        fun: datafusion_expr::window_function::WindowFunction::BuiltInWindowFunction(
                             built_in_function,
                         ),
                         args: vec![parse_required_expr(&expr.expr, registry, "expr")?],

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -21,29 +21,22 @@ use crate::protobuf::plan_type::PlanTypeEnum::{
     OptimizedLogicalPlan, OptimizedPhysicalPlan,
 };
 use crate::protobuf::{OptimizedLogicalPlanType, OptimizedPhysicalPlanType};
-use datafusion::logical_plan::plan::StringifiedPlan;
-use datafusion::logical_plan::{FunctionRegistry, PlanType};
-use datafusion::prelude::bit_length;
-use datafusion::{
-    arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit, UnionMode},
-    error::DataFusionError,
-    logical_expr::{BuiltInWindowFunction, BuiltinScalarFunction},
-    logical_plan::{
-        abs, acos, ascii, asin, atan, ceil, character_length, chr, concat_expr,
-        concat_ws_expr, cos, digest, exp, floor, left, ln, log10, log2, now_expr, nullif,
-        power, random, regexp_replace, repeat, replace, reverse, right, round, signum,
-        sin, split_part, sqrt, starts_with, strpos, substr, tan, to_hex,
-        to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, translate, trunc,
-        window_frames::{WindowFrame, WindowFrameBound, WindowFrameUnits},
-        Column, DFField, DFSchema, DFSchemaRef, Expr, Operator,
-    },
-    physical_plan::aggregates::AggregateFunction,
-    prelude::{
-        array, btrim, coalesce, date_part, date_trunc, lower, lpad, ltrim, md5,
-        octet_length, regexp_match, rpad, rtrim, sha224, sha256, sha384, sha512, trim,
-        upper,
-    },
-    scalar::ScalarValue,
+use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit, UnionMode};
+use datafusion::logical_plan::FunctionRegistry;
+use datafusion_common::{
+    Column, DFField, DFSchema, DFSchemaRef, DataFusionError, ScalarValue,
+};
+use datafusion_expr::logical_plan::{PlanType, StringifiedPlan};
+use datafusion_expr::{
+    abs, acos, array, ascii, asin, atan, bit_length, btrim, ceil, character_length, chr,
+    coalesce, concat_expr, concat_ws_expr, cos, date_part, date_trunc, digest, exp,
+    floor, left, ln, log10, log2, lower, lpad, ltrim, md5, now_expr, nullif,
+    octet_length, power, random, regexp_match, regexp_replace, repeat, replace, reverse,
+    right, round, rpad, rtrim, sha224, sha256, sha384, sha512, signum, sin, split_part,
+    sqrt, starts_with, strpos, substr, tan, to_hex, to_timestamp_micros,
+    to_timestamp_millis, to_timestamp_seconds, translate, trim, trunc, upper,
+    AggregateFunction, BuiltInWindowFunction, BuiltinScalarFunction, Expr, Operator,
+    WindowFrame, WindowFrameBound, WindowFrameUnits,
 };
 use std::sync::Arc;
 

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -29,17 +29,17 @@ pub mod to_proto;
 mod roundtrip_tests {
     use super::from_proto::parse_expr;
     use super::protobuf;
-    use datafusion::arrow::array::ArrayRef;
+    use arrow::{
+        array::ArrayRef,
+        datatypes::{DataType, Field, IntervalUnit, TimeUnit, UnionMode},
+    };
     use datafusion::logical_plan::create_udaf;
     use datafusion::physical_plan::functions::make_scalar_function;
-    use datafusion::physical_plan::Accumulator;
-    use datafusion::{
-        arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit, UnionMode},
-        logical_expr::{BuiltinScalarFunction::Sqrt, Volatility},
-        logical_plan::{col, Expr},
-        physical_plan::aggregates,
-        prelude::*,
-        scalar::ScalarValue,
+    use datafusion::prelude::{create_udf, SessionContext};
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{
+        col, lit, Accumulator, AggregateFunction, BuiltinScalarFunction::Sqrt, Expr,
+        Volatility,
     };
     use std::sync::Arc;
 
@@ -704,7 +704,7 @@ mod roundtrip_tests {
     #[test]
     fn roundtrip_approx_percentile_cont() {
         let test_expr = Expr::AggregateFunction {
-            fun: aggregates::AggregateFunction::ApproxPercentileCont,
+            fun: AggregateFunction::ApproxPercentileCont,
             args: vec![col("bananas"), lit(0.42_f32)],
             distinct: false,
         };

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -726,7 +726,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
     type Error = Error;
 
     fn try_from(val: &ScalarValue) -> Result<Self, Self::Error> {
-        use datafusion::scalar;
+        use datafusion_common::scalar;
         use protobuf::{scalar_value::Value, PrimitiveScalarType};
 
         let scalar_val = match val {

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -19,28 +19,22 @@
 //! DataFusion logical plans to be serialized and transmitted between
 //! processes.
 
-use crate::protobuf;
-use crate::protobuf::plan_type::PlanTypeEnum::{
-    FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan,
-    OptimizedLogicalPlan, OptimizedPhysicalPlan,
-};
 use crate::protobuf::{
+    self,
+    plan_type::PlanTypeEnum::{
+        FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan,
+        OptimizedLogicalPlan, OptimizedPhysicalPlan,
+    },
     EmptyMessage, OptimizedLogicalPlanType, OptimizedPhysicalPlanType,
 };
-
-use datafusion::logical_plan::plan::StringifiedPlan;
-use datafusion::logical_plan::PlanType;
-use datafusion::{
-    arrow::datatypes::{
-        DataType, Field, IntervalUnit, Schema, SchemaRef, TimeUnit, UnionMode,
-    },
-    logical_expr::{BuiltInWindowFunction, BuiltinScalarFunction, WindowFunction},
-    logical_plan::{
-        window_frames::{WindowFrame, WindowFrameBound, WindowFrameUnits},
-        Column, DFField, DFSchemaRef, Expr,
-    },
-    physical_plan::aggregates::AggregateFunction,
-    scalar::ScalarValue,
+use arrow::datatypes::{
+    DataType, Field, IntervalUnit, Schema, SchemaRef, TimeUnit, UnionMode,
+};
+use datafusion_common::{Column, DFField, DFSchemaRef, ScalarValue};
+use datafusion_expr::{
+    logical_plan::PlanType, logical_plan::StringifiedPlan, AggregateFunction,
+    BuiltInWindowFunction, BuiltinScalarFunction, Expr, WindowFrame, WindowFrameBound,
+    WindowFrameUnits, WindowFunction,
 };
 
 #[derive(Debug)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR adds specific dependencies on `datafusion-common` and `datafusion-expr` and updates the imports to reference those crates directly rather than use the re-exports from the core `datafusion` crate.

The implementation of `datafusion-proto` now only depends on a single item from the core crate and that is `FunctionRegistry`. We could potentially move this out in the future so that other projects can use `datafusion-proto` without depending on the core crate.

The tests still depend heavily on the core crate.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add new dependencies in Cargo.toml and refactor the imports

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Does this PR break compatibility with Ballista?

No

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->