### PR TITLE
Like, NotLike expressions work with literal `NULL`

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1205,29 +1205,29 @@ async fn nested_subquery() -> Result<()> {
 #[tokio::test]
 async fn like_nlike_with_null_lt() {
     let ctx = SessionContext::new();
-    let sql = "SELECT column1 like NULL from (values('a'), ('b'), (NULL)) as t";
+    let sql = "SELECT column1 like NULL as col_null, NULL like column1 as null_col from (values('a'), ('b'), (NULL)) as t";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
-        "+---------------------+",
-        "| t.column1 Like NULL |",
-        "+---------------------+",
-        "|                     |",
-        "|                     |",
-        "|                     |",
-        "+---------------------+",
+        "+----------+----------+",
+        "| col_null | null_col |",
+        "+----------+----------+",
+        "|          |          |",
+        "|          |          |",
+        "|          |          |",
+        "+----------+----------+",
     ];
     assert_batches_eq!(expected, &actual);
 
-    let sql = "SELECT column1 not like NULL from (values('a'), ('b'), (NULL)) as t";
+    let sql = "SELECT column1 not like NULL as col_null, NULL not like column1 as null_col from (values('a'), ('b'), (NULL)) as t";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
-        "+------------------------+",
-        "| t.column1 NotLike NULL |",
-        "+------------------------+",
-        "|                        |",
-        "|                        |",
-        "|                        |",
-        "+------------------------+",
+        "+----------+----------+",
+        "| col_null | null_col |",
+        "+----------+----------+",
+        "|          |          |",
+        "|          |          |",
+        "|          |          |",
+        "+----------+----------+",
     ];
     assert_batches_eq!(expected, &actual);
 }

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1203,6 +1203,36 @@ async fn nested_subquery() -> Result<()> {
 }
 
 #[tokio::test]
+async fn like_nlike_with_null_lt() {
+    let ctx = SessionContext::new();
+    let sql = "SELECT column1 like NULL from (values('a'), ('b'), (NULL)) as t";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+---------------------+",
+        "| t.column1 Like NULL |",
+        "+---------------------+",
+        "|                     |",
+        "|                     |",
+        "|                     |",
+        "+---------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "SELECT column1 not like NULL from (values('a'), ('b'), (NULL)) as t";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+------------------------+",
+        "| t.column1 NotLike NULL |",
+        "+------------------------+",
+        "|                        |",
+        "|                        |",
+        "|                        |",
+        "+------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+}
+
+#[tokio::test]
 async fn comparisons_with_null_lt() {
     let ctx = SessionContext::new();
 

--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -490,6 +490,7 @@ fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
 fn like_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     string_coercion(lhs_type, rhs_type)
         .or_else(|| dictionary_coercion(lhs_type, rhs_type))
+        .or_else(|| null_coercion(lhs_type, rhs_type))
 }
 
 /// Coercion rules for Temporal columns: the type that both lhs and rhs can be


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2626 .

 # Rationale for this change
`like`, `not like` expressions doesn't work well with literal `NULL` in DF.

**To Reproduce**
```
> SELECT column1 like NULL from (values('a'), ('b'), (NULL)) as t
Plan("'Utf8 LIKE Null' can't be evaluated because there isn't a common type to coerce the types to")
```
Postgres works like
```
# SELECT column1 like NULL from (values('a'), ('b'), (NULL)) as t;
 ?column? 
----------
 
 
 
(3 rows)
```

# What changes are included in this PR?
- Introduces `null_coercion` to `like_coercion`
- Enhances `compute_utf8_op_scalar` to produce null array when  scalar value `NULL` inputs.

# Are there any user-facing changes?
No.

# Does this PR break compatibility with Ballista?
No.