### PR TITLE
Physical Plan for OFFSET

### DIFF
--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -387,6 +387,19 @@ mod test {
     }
 
     #[test]
+    fn limit_pushdown_should_not_pushdown_limit_with_offset_only() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(table_scan).offset(10)?.build()?;
+
+        // Should not push any limit down to table provider
+        // When it has a select
+        let expected = "Offset: 10\
+    \n  TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+        Ok(())
+    }
+
+    #[test]
     fn limit_pushdown_with_offset_projection_table_provider() -> Result<()> {
         let table_scan = test_table_scan()?;
 

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -559,6 +559,7 @@ pub mod join_utils;
 pub mod limit;
 pub mod memory;
 pub mod metrics;
+pub mod offset;
 pub mod planner;
 pub mod projection;
 pub mod repartition;

--- a/datafusion/core/src/physical_plan/offset.rs
+++ b/datafusion/core/src/physical_plan/offset.rs
@@ -303,6 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn not_enough_to_skip() -> Result<()> {
+        // there are total of 100 rows, we skipped 101 rows (offset = 3)
         let row_count = offset_with_value(101).await?;
         assert_eq!(row_count, 0);
         Ok(())

--- a/datafusion/core/src/physical_plan/offset.rs
+++ b/datafusion/core/src/physical_plan/offset.rs
@@ -1,0 +1,310 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the OFFSET plan
+
+use crate::execution::context::TaskContext;
+use arrow::array::ArrayRef;
+use arrow::array::UInt64Array;
+use arrow::compute::take;
+use arrow::datatypes::SchemaRef;
+use arrow::error::Result as ArrowResult;
+use arrow::record_batch::RecordBatch;
+
+use datafusion_physical_expr::PhysicalSortExpr;
+use std::any::Any;
+use std::fmt::Formatter;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::stream::{Stream, StreamExt};
+use log::debug;
+
+use super::metrics::ExecutionPlanMetricsSet;
+use crate::error::{DataFusionError, Result};
+use crate::physical_plan::metrics::{BaselineMetrics, MetricsSet};
+use crate::physical_plan::{
+    DisplayFormatType, Distribution, ExecutionPlan, Partitioning, RecordBatchStream,
+    SendableRecordBatchStream, Statistics,
+};
+
+/// Offset execution plan
+#[derive(Debug)]
+pub struct OffsetExec {
+    /// Input execution plan
+    input: Arc<dyn ExecutionPlan>,
+    /// Number of rows to skip
+    offset: usize,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl OffsetExec {
+    /// Create a new OffsetExec
+    pub fn new(input: Arc<dyn ExecutionPlan>, offset: usize) -> Self {
+        OffsetExec {
+            input,
+            offset,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Number of rows to ignore
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+impl ExecutionPlan for OffsetExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::SinglePartition
+    }
+
+    /// Get the output partitioning of this plan
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn relies_on_input_order(&self) -> bool {
+        self.input.output_ordering().is_some()
+    }
+
+    fn maintains_input_order(&self) -> bool {
+        true
+    }
+
+    fn benefits_from_input_partitioning(&self) -> bool {
+        false
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.input.output_ordering()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(OffsetExec::new(children[0].clone(), self.offset)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        debug!("Start OffsetExec::execute for partition: {}", partition);
+
+        if 0 != partition {
+            return Err(DataFusionError::Internal(format!(
+                "OffsetExec invalid partition {}",
+                partition
+            )));
+        }
+
+        if 1 != self.input.output_partitioning().partition_count() {
+            return Err(DataFusionError::Internal(
+                "OffsetExec requires a single input partition".to_owned(),
+            ));
+        }
+
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        let stream = self.input.execute(0, context)?;
+        Ok(Box::pin(OffsetStream::new(
+            stream,
+            self.offset,
+            baseline_metrics,
+        )))
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(f, "OffsetExec: offset={}", self.offset)
+            }
+        }
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Statistics {
+        let input_stats = self.input.statistics();
+        match input_stats {
+            Statistics {
+                num_rows: Some(nr), ..
+            } => Statistics {
+                num_rows: Some(nr - self.offset),
+                is_exact: input_stats.is_exact,
+                ..Default::default()
+            },
+            _ => Statistics::default(),
+        }
+    }
+}
+
+pub struct OffsetStream {
+    /// Number of rows to skip, starts with 1.
+    offset: usize,
+    input: SendableRecordBatchStream,
+    schema: SchemaRef,
+    // The next row offset to skip,
+    // the first poll_next increases it to 1;
+    // valid range is [0, self.offset + 1]
+    skipped: usize,
+
+    /// Execution time metrics
+    baseline_metrics: BaselineMetrics,
+}
+
+impl OffsetStream {
+    fn new(
+        input: SendableRecordBatchStream,
+        offset: usize,
+        baseline_metrics: BaselineMetrics,
+    ) -> Self {
+        let schema = input.schema();
+        Self {
+            offset,
+            input,
+            schema,
+            skipped: 0,
+            baseline_metrics,
+        }
+    }
+}
+
+/// Remove a RecordBatch's first n rows
+pub fn cut_batch(batch: &RecordBatch, n: usize) -> RecordBatch {
+    // todo
+    // cast
+    // unwrap
+    let indices = UInt64Array::from_iter_values(n as u64..batch.num_rows() as u64);
+    let columns: Vec<ArrayRef> = (0..batch.num_columns())
+        .map(|i| take(batch.column(i), &indices, None).unwrap())
+        .collect();
+    RecordBatch::try_new(batch.schema(), columns).unwrap()
+}
+
+impl Stream for OffsetStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.skipped == self.offset {
+            let poll = self.input.poll_next_unpin(cx);
+            return self.baseline_metrics.record_poll(poll);
+        }
+
+        let loop_pool = loop {
+            let poll = self.input.poll_next_unpin(cx);
+            let poll = poll.map_ok(|batch| {
+                if batch.num_rows() + self.skipped <= self.offset {
+                    self.skipped += batch.num_rows();
+                    RecordBatch::new_empty(self.input.schema())
+                } else {
+                    let new_batch = cut_batch(&batch, self.offset - self.skipped);
+                    self.skipped = self.offset;
+                    new_batch
+                }
+            });
+
+            match &poll {
+                Poll::Ready(Some(Ok(batch)))
+                    if batch.num_rows() > 0 && self.skipped == self.offset =>
+                {
+                    break poll
+                }
+                Poll::Ready(Some(Err(_e))) => break poll,
+                Poll::Ready(None) => break poll,
+                Poll::Pending => break poll,
+                _ => {
+                    // continue to poll input stream
+                }
+            }
+        };
+        self.baseline_metrics.record_poll(loop_pool)
+    }
+}
+
+impl RecordBatchStream for OffsetStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+    use crate::physical_plan::common;
+    use crate::prelude::SessionContext;
+    use crate::test;
+
+    async fn offset_with_value(offset: usize) -> Result<usize> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let num_partitions = 4;
+        let csv = test::scan_partitioned_csv(num_partitions)?;
+
+        assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
+
+        let offset = OffsetExec::new(Arc::new(CoalescePartitionsExec::new(csv)), offset);
+
+        // the result should contain 4 batches (one per input partition)
+        let iter = offset.execute(0, task_ctx)?;
+        let batches = common::collect(iter).await?;
+        Ok(batches.iter().map(|batch| batch.num_rows()).sum())
+    }
+
+    #[tokio::test]
+    async fn enough_to_skip() -> Result<()> {
+        // there are total of 100 rows, we skipped 3 rows (offset = 3)
+        let row_count = offset_with_value(3).await?;
+        assert_eq!(row_count, 97);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn not_enough_to_skip() -> Result<()> {
+        let row_count = offset_with_value(101).await?;
+        assert_eq!(row_count, 0);
+        Ok(())
+    }
+}

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -89,6 +89,7 @@ pub mod intersection;
 pub mod joins;
 pub mod json;
 pub mod limit;
+pub mod offset;
 pub mod order;
 pub mod parquet;
 pub mod predicates;
@@ -541,6 +542,8 @@ async fn execute_to_batches(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch>
         .unwrap();
     let logical_schema = plan.schema();
 
+    println!("plan-1: {:?}", plan);
+
     let msg = format!("Optimizing logical plan for '{}': {:?}", sql, plan);
     let plan = ctx
         .optimize(&plan)
@@ -548,6 +551,7 @@ async fn execute_to_batches(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch>
         .unwrap();
     let optimized_logical_schema = plan.schema();
 
+    println!("plan-2: {:?}", plan);
     let msg = format!("Creating physical plan for '{}': {:?}", sql, plan);
     let plan = ctx
         .create_physical_plan(&plan)

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -542,8 +542,6 @@ async fn execute_to_batches(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch>
         .unwrap();
     let logical_schema = plan.schema();
 
-    println!("plan-1: {:?}", plan);
-
     let msg = format!("Optimizing logical plan for '{}': {:?}", sql, plan);
     let plan = ctx
         .optimize(&plan)
@@ -551,7 +549,6 @@ async fn execute_to_batches(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch>
         .unwrap();
     let optimized_logical_schema = plan.schema();
 
-    println!("plan-2: {:?}", plan);
     let msg = format!("Creating physical plan for '{}': {:?}", sql, plan);
     let plan = ctx
         .create_physical_plan(&plan)

--- a/datafusion/core/tests/sql/offset.rs
+++ b/datafusion/core/tests/sql/offset.rs
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn csv_offset_without_limit() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 99";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    #[rustfmt::skip]
+        let expected = vec![
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| e  |",
+        "+----+"];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn csv_query_offset() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 2 LIMIT 2";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    #[rustfmt::skip]
+    let expected = vec![
+        "+----+", 
+        "| c1 |", 
+        "+----+", 
+        "| b  |", 
+        "| a  |", 
+        "+----+"];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn csv_query_offset_the_same_as_nbr_of_rows() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 1 OFFSET 100";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec!["++", "++"];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn csv_query_offset_bigger_than_nbr_of_rows() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 1 OFFSET 101";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec!["++", "++"];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -293,10 +293,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.set_expr_to_plan(set_expr, alias, ctes, outer_query_schema)?;
 
         let plan = self.order_by(plan, query.order_by)?;
-
         let plan: LogicalPlan = self.limit(plan, query.limit)?;
 
-        //make limit as offset's input will enable limit push down simply
+        // make limit as offset's input will enable limit push down simply.
         self.offset(plan, query.offset)
     }
 
@@ -4839,6 +4838,15 @@ mod tests {
         \n  Projection: #person.id\
         \n    Filter: #person.id > Int64(100)\
         \n      TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn test_offset_no_limit_no_filter() {
+        let sql = "SELECT id FROM person OFFSET 5;";
+        let expected = "Offset: 5\
+        \n  Projection: #person.id\
+        \n    TableScan: person projection=None";
         quick_test(sql, expected);
     }
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4842,15 +4842,6 @@ mod tests {
     }
 
     #[test]
-    fn test_offset_no_limit_no_filter() {
-        let sql = "SELECT id FROM person OFFSET 5;";
-        let expected = "Offset: 5\
-        \n  Projection: #person.id\
-        \n    TableScan: person projection=None";
-        quick_test(sql, expected);
-    }
-
-    #[test]
     fn test_offset_after_limit() {
         let sql = "select id from person where person.id > 100 LIMIT 5 OFFSET 3;";
         let expected = "Offset: 3\


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/2551

 # Rationale for this change

Support physical plan for `OFFSET`.
Tow test cases for `OFFSET` without `LIMIT` are still not working, which is related to `limit_push_down` https://github.com/apache/arrow-datafusion/issues/2624

# What changes are included in this PR?

Implement physical plan of `OFFSET`

# Are there any user-facing changes?

# Does this PR break compatibility with Ballista?