### PR TITLE
Export arrow-flight feature

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -42,6 +42,7 @@ path = "src/lib.rs"
 avro = ["avro-rs", "num-traits", "datafusion-common/avro"]
 crypto_expressions = ["datafusion-physical-expr/crypto_expressions"]
 default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
+flight = ["arrow-flight"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = []
 # Used to enable JIT code generation
@@ -56,6 +57,7 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 arrow = { version = "14.0.0", features = ["prettyprint"] }
+arrow-flight = { version = "14.0.0", optional = true }
 async-trait = "0.1.41"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 chrono = { version = "0.4", default-features = false }

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -224,6 +224,8 @@ pub mod variable;
 
 // re-export dependencies from arrow-rs to minimise version maintenance for crate users
 pub use arrow;
+#[cfg(feature = "flight")]
+pub use arrow_flight;
 pub use parquet;
 
 // re-export DataFusion crates


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

I don't particularly like this, but this will allow Ballista to automatically pick up the compatible version of arrow-flight to use with the version of arrow used by DataFusion. Alternative suggestions welcome...

# What changes are included in this PR?

Adds a new `flight` feature to `datafusion` that enables a re-export of a compatible arrow_flight version

# Are there any user-facing changes?

No

# Does this PR break compatibility with Ballista?

No