### PR TITLE
change result type of count/count_distinct from uint64 to int64

### DIFF
--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -238,8 +238,8 @@ mod tests {
             .build()?;
 
         // Should work
-        let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT test.b) [COUNT(DISTINCT test.b):UInt64;N]\
-                            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):UInt64;N]\
+        let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT test.b) [COUNT(DISTINCT test.b):Int64;N]\
+                            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):Int64;N]\
                             \n    Aggregate: groupBy=[[#test.b AS alias1]], aggr=[[]] [alias1:UInt32]\
                             \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
@@ -255,8 +255,8 @@ mod tests {
             .aggregate(Vec::<Expr>::new(), vec![count_distinct(lit(2) * col("b"))])?
             .build()?;
 
-        let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT Int32(2) * test.b) [COUNT(DISTINCT Int32(2) * test.b):UInt64;N]\
-                            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):UInt64;N]\
+        let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT Int32(2) * test.b) [COUNT(DISTINCT Int32(2) * test.b):Int64;N]\
+                            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):Int64;N]\
                             \n    Aggregate: groupBy=[[Int32(2) * #test.b AS alias1]], aggr=[[]] [alias1:Int32]\
                             \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
@@ -273,8 +273,8 @@ mod tests {
             .build()?;
 
         // Should work
-        let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):UInt64;N]\
-                            \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1)]] [a:UInt32, COUNT(alias1):UInt64;N]\
+        let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):Int64;N]\
+                            \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1)]] [a:UInt32, COUNT(alias1):Int64;N]\
                             \n    Aggregate: groupBy=[[#test.a, #test.b AS alias1]], aggr=[[]] [a:UInt32, alias1:UInt32]\
                             \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
@@ -294,7 +294,7 @@ mod tests {
             .build()?;
 
         // Do nothing
-        let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(DISTINCT #test.c)]] [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, COUNT(DISTINCT test.c):UInt64;N]\
+        let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(DISTINCT #test.c)]] [a:UInt32, COUNT(DISTINCT test.b):Int64;N, COUNT(DISTINCT test.c):Int64;N]\
                             \n  TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
@@ -319,8 +319,8 @@ mod tests {
             )?
             .build()?;
         // Should work
-        let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b), #MAX(alias1) AS MAX(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, MAX(DISTINCT test.b):UInt32;N]\
-                            \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1), MAX(#alias1)]] [a:UInt32, COUNT(alias1):UInt64;N, MAX(alias1):UInt32;N]\
+        let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b), #MAX(alias1) AS MAX(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):Int64;N, MAX(DISTINCT test.b):UInt32;N]\
+                            \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1), MAX(#alias1)]] [a:UInt32, COUNT(alias1):Int64;N, MAX(alias1):UInt32;N]\
                             \n    Aggregate: groupBy=[[#test.a, #test.b AS alias1]], aggr=[[]] [a:UInt32, alias1:UInt32]\
                             \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
@@ -340,7 +340,7 @@ mod tests {
             .build()?;
 
         // Do nothing
-        let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(#test.c)]] [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, COUNT(test.c):UInt64;N]\
+        let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(#test.c)]] [a:UInt32, COUNT(DISTINCT test.b):Int64;N, COUNT(test.c):Int64;N]\
                             \n  TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);

--- a/datafusion/core/src/physical_plan/windows/mod.rs
+++ b/datafusion/core/src/physical_plan/windows/mod.rs
@@ -219,7 +219,7 @@ mod tests {
 
         // c3 is small int
 
-        let count: &UInt64Array = as_primitive_array(&columns[0]);
+        let count: &Int64Array = as_primitive_array(&columns[0]);
         assert_eq!(count.value(0), 100);
         assert_eq!(count.value(99), 100);
 

--- a/datafusion/core/tests/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/provider_filter_pushdown.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{as_primitive_array, Int32Builder, UInt64Array};
+use arrow::array::{as_primitive_array, Int32Builder, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -170,7 +170,7 @@ impl TableProvider for CustomProvider {
     }
 }
 
-async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()> {
+async fn assert_provider_row_count(value: i64, expected_count: i64) -> Result<()> {
     let provider = CustomProvider {
         zero_batch: create_batch(0, 10)?,
         one_batch: create_batch(1, 5)?,
@@ -183,7 +183,7 @@ async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()
         .aggregate(vec![], vec![count(col("flag"))])?;
 
     let results = df.collect().await?;
-    let result_col: &UInt64Array = as_primitive_array(results[0].column(0));
+    let result_col: &Int64Array = as_primitive_array(results[0].column(0));
     assert_eq!(result_col.value(0), expected_count);
 
     ctx.register_table("data", Arc::new(provider))?;
@@ -193,7 +193,7 @@ async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()
         .collect()
         .await?;
 
-    let sql_result_col: &UInt64Array = as_primitive_array(sql_results[0].column(0));
+    let sql_result_col: &Int64Array = as_primitive_array(sql_results[0].column(0));
     assert_eq!(sql_result_col.value(0), expected_count);
 
     Ok(())

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -146,9 +146,8 @@ pub fn return_type(
     let coerced_data_types = coerce_types(fun, input_expr_types, &signature(fun))?;
 
     match fun {
-        // TODO If the datafusion is compatible with PostgreSQL, the returned data type should be INT64.
         AggregateFunction::Count | AggregateFunction::ApproxDistinct => {
-            Ok(DataType::UInt64)
+            Ok(DataType::Int64)
         }
         AggregateFunction::Max | AggregateFunction::Min => {
             // For min and max agg function, the returned type is same as input type.

--- a/datafusion/expr/src/window_function.rs
+++ b/datafusion/expr/src/window_function.rs
@@ -227,10 +227,10 @@ mod tests {
     fn test_count_return_type() -> Result<()> {
         let fun = WindowFunction::from_str("count")?;
         let observed = return_type(&fun, &[DataType::Utf8])?;
-        assert_eq!(DataType::UInt64, observed);
+        assert_eq!(DataType::Int64, observed);
 
         let observed = return_type(&fun, &[DataType::UInt64])?;
-        assert_eq!(DataType::UInt64, observed);
+        assert_eq!(DataType::Int64, observed);
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -304,7 +304,7 @@ mod tests {
                         assert!(result_agg_phy_exprs.as_any().is::<Count>());
                         assert_eq!("c1", result_agg_phy_exprs.name());
                         assert_eq!(
-                            Field::new("c1", DataType::UInt64, true),
+                            Field::new("c1", DataType::Int64, true),
                             result_agg_phy_exprs.field().unwrap()
                         );
                     }
@@ -347,7 +347,7 @@ mod tests {
                         assert!(result_distinct.as_any().is::<DistinctCount>());
                         assert_eq!("c1", result_distinct.name());
                         assert_eq!(
-                            Field::new("c1", DataType::UInt64, true),
+                            Field::new("c1", DataType::Int64, true),
                             result_distinct.field().unwrap()
                         );
                     }
@@ -954,14 +954,14 @@ mod tests {
     #[test]
     fn test_count_return_type() -> Result<()> {
         let observed = return_type(&AggregateFunction::Count, &[DataType::Utf8])?;
-        assert_eq!(DataType::UInt64, observed);
+        assert_eq!(DataType::Int64, observed);
 
         let observed = return_type(&AggregateFunction::Count, &[DataType::Int8])?;
-        assert_eq!(DataType::UInt64, observed);
+        assert_eq!(DataType::Int64, observed);
 
         let observed =
             return_type(&AggregateFunction::Count, &[DataType::Decimal(28, 13)])?;
-        assert_eq!(DataType::UInt64, observed);
+        assert_eq!(DataType::Int64, observed);
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -218,7 +218,7 @@ impl Accumulator for DistinctCountAccumulator {
 
     fn evaluate(&self) -> Result<ScalarValue> {
         match &self.count_data_type {
-            DataType::UInt64 => Ok(ScalarValue::UInt64(Some(self.values.len() as u64))),
+            DataType::Int64 => Ok(ScalarValue::Int64(Some(self.values.len() as i64))),
             t => Err(DataFusionError::Internal(format!(
                 "Invalid data type {:?} for count distinct aggregation",
                 t
@@ -317,7 +317,7 @@ mod tests {
 
             assert_eq!(states.len(), 1);
             assert_eq!(state_vec, vec![Some(1), Some(2), Some(3)]);
-            assert_eq!(result, ScalarValue::UInt64(Some(3)));
+            assert_eq!(result, ScalarValue::Int64(Some(3)));
 
             Ok(())
         }};
@@ -344,7 +344,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![],
             String::from("__col_name__"),
-            DataType::UInt64,
+            DataType::Int64,
         );
 
         let mut accum = agg.create_accumulator()?;
@@ -361,7 +361,7 @@ mod tests {
             data_types.to_vec(),
             vec![],
             String::from("__col_name__"),
-            DataType::UInt64,
+            DataType::Int64,
         );
 
         let mut accum = agg.create_accumulator()?;
@@ -393,7 +393,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![],
             String::from("__col_name__"),
-            DataType::UInt64,
+            DataType::Int64,
         );
 
         let mut accum = agg.create_accumulator()?;
@@ -466,7 +466,7 @@ mod tests {
                 ]
             );
             assert!(state_vec[nan_idx].unwrap_or_default().is_nan());
-            assert_eq!(result, ScalarValue::UInt64(Some(8)));
+            assert_eq!(result, ScalarValue::Int64(Some(8)));
 
             Ok(())
         }};
@@ -524,17 +524,17 @@ mod tests {
 
     #[test]
     fn count_distinct_update_batch_boolean() -> Result<()> {
-        let get_count = |data: BooleanArray| -> Result<(Vec<Option<bool>>, u64)> {
+        let get_count = |data: BooleanArray| -> Result<(Vec<Option<bool>>, i64)> {
             let arrays = vec![Arc::new(data) as ArrayRef];
             let (states, result) = run_update_batch(&arrays)?;
             let mut state_vec = state_to_vec!(&states[0], Boolean, bool).unwrap();
             state_vec.sort();
             let count = match result {
-                ScalarValue::UInt64(c) => c.ok_or_else(|| {
+                ScalarValue::Int64(c) => c.ok_or_else(|| {
                     DataFusionError::Internal("Found None count".to_string())
                 }),
                 scalar => Err(DataFusionError::Internal(format!(
-                    "Found non Uint64 scalar value from count: {}",
+                    "Found non int64 scalar value from count: {}",
                     scalar
                 ))),
             }?;
@@ -587,7 +587,7 @@ mod tests {
 
         assert_eq!(states.len(), 1);
         assert_eq!(state_to_vec!(&states[0], Int32, i32), Some(vec![]));
-        assert_eq!(result, ScalarValue::UInt64(Some(0)));
+        assert_eq!(result, ScalarValue::Int64(Some(0)));
 
         Ok(())
     }
@@ -600,7 +600,7 @@ mod tests {
 
         assert_eq!(states.len(), 1);
         assert_eq!(state_to_vec!(&states[0], Int32, i32), Some(vec![]));
-        assert_eq!(result, ScalarValue::UInt64(Some(0)));
+        assert_eq!(result, ScalarValue::Int64(Some(0)));
 
         Ok(())
     }
@@ -623,7 +623,7 @@ mod tests {
             vec![(Some(1_i8), Some(3_i16)), (Some(2_i8), Some(4_i16))]
         );
 
-        assert_eq!(result, ScalarValue::UInt64(Some(2)));
+        assert_eq!(result, ScalarValue::Int64(Some(2)));
 
         Ok(())
     }
@@ -658,7 +658,7 @@ mod tests {
                 (Some(5_i32), Some(1_u64)),
             ]
         );
-        assert_eq!(result, ScalarValue::UInt64(Some(5)));
+        assert_eq!(result, ScalarValue::Int64(Some(5)));
 
         Ok(())
     }
@@ -690,7 +690,7 @@ mod tests {
             vec![(Some(-2_i32), Some(5_u64)), (Some(-1_i32), Some(5_u64))]
         );
 
-        assert_eq!(result, ScalarValue::UInt64(Some(2)));
+        assert_eq!(result, ScalarValue::Int64(Some(2)));
 
         Ok(())
     }
@@ -730,7 +730,7 @@ mod tests {
             ]
         );
 
-        assert_eq!(result, ScalarValue::UInt64(Some(5)));
+        assert_eq!(result, ScalarValue::Int64(Some(5)));
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2635
From the #2635, the result type of count is `uint64` and this is not compatible with PG and other db system.

This pr just convert the result type from `uint64` to `int64`

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Does this PR break compatibility with Ballista?

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->