### PR TITLE
Support pluggable async executor in physical plan execution

### DIFF
--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -75,7 +75,7 @@ impl MemTable {
             .map(|part_i| {
                 let context1 = context.clone();
                 let exec = exec.clone();
-                tokio::spawn(async move {
+                context.async_executor().execute(async move {
                     let stream = exec.execute(part_i, context1.clone())?;
                     common::collect(stream).await
                 })

--- a/datafusion/core/src/execution/async_executor.rs
+++ b/datafusion/core/src/execution/async_executor.rs
@@ -1,0 +1,27 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+
+pub trait AsyncExecutor {
+    type Output<T>;
+
+    fn execute<F>(&self, future: F) -> Self::Output<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+}
+
+pub struct DefaultExecutor;
+
+impl AsyncExecutor for DefaultExecutor {
+    type Output<T> = JoinHandle<T>;
+
+    fn execute<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::spawn(future)
+    }
+}

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -79,6 +79,7 @@ use crate::physical_optimizer::coalesce_batches::CoalesceBatches;
 use crate::physical_optimizer::merge_exec::AddCoalescePartitionsExec;
 use crate::physical_optimizer::repartition::Repartition;
 
+use crate::execution::async_executor::{AsyncExecutor, DefaultExecutor};
 use crate::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use crate::logical_plan::plan::Explain;
 use crate::physical_plan::file_format::{plan_to_csv, plan_to_json, plan_to_parquet};
@@ -1514,6 +1515,8 @@ pub struct TaskContext {
     aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     /// Runtime environment associated with this task context
     runtime: Arc<RuntimeEnv>,
+    /// Async executor allows to specific which asynchronous executor should be used
+    async_executor: Arc<Box<dyn AsyncExecutor>>,
 }
 
 impl TaskContext {
@@ -1533,6 +1536,7 @@ impl TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
+            async_executor: Arc::new(Box::new(DefaultExecutor {})),
         }
     }
 
@@ -1586,6 +1590,10 @@ impl TaskContext {
     pub fn runtime_env(&self) -> Arc<RuntimeEnv> {
         self.runtime.clone()
     }
+
+    pub fn async_executor(&self) -> Arc<Box<dyn AsyncExecutor>> {
+        Arc::clone(&self.async_executor)
+    }
 }
 
 /// Create a new task context instance from SessionContext
@@ -1608,6 +1616,7 @@ impl From<&SessionContext> for TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
+            async_executor: Arc::new(Box::new(DefaultExecutor {})),
         }
     }
 }
@@ -1627,6 +1636,7 @@ impl From<&SessionState> for TaskContext {
             scalar_functions,
             aggregate_functions,
             runtime,
+            async_executor: Arc::new(Box::new(DefaultExecutor {})),
         }
     }
 }

--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -22,6 +22,7 @@ pub mod disk_manager;
 pub mod memory_manager;
 pub mod options;
 pub mod runtime_env;
+pub mod async_executor;
 
 pub use disk_manager::DiskManager;
 pub use memory_manager::{

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![feature(generic_associated_types)]
 #![warn(missing_docs, clippy::needless_borrow)]
 
 //! [DataFusion](https://github.com/apache/arrow-datafusion)

--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -178,7 +178,7 @@ pub(crate) fn spawn_execution(
     partition: usize,
     context: Arc<TaskContext>,
 ) -> JoinHandle<()> {
-    tokio::spawn(async move {
+    context.async_executor().execute(async move {
         let mut stream = match input.execute(partition, context) {
             Err(e) => {
                 // If send fails, plan being torn

--- a/datafusion/core/src/physical_plan/repartition.rs
+++ b/datafusion/core/src/physical_plan/repartition.rs
@@ -337,7 +337,7 @@ impl ExecutionPlan for RepartitionExec {
                 let r_metrics = RepartitionMetrics::new(i, partition, &self.metrics);
 
                 let input_task: JoinHandle<Result<()>> =
-                    tokio::spawn(Self::pull_from_input(
+                    context.async_executor().execute(Self::pull_from_input(
                         self.input.clone(),
                         i,
                         txs.clone(),
@@ -348,7 +348,7 @@ impl ExecutionPlan for RepartitionExec {
 
                 // In a separate task, wait for each input to be done
                 // (and pass along any errors, including panic!s)
-                let join_handle = tokio::spawn(Self::wait_for_task(
+                let join_handle = context.async_executor().execute(Self::wait_for_task(
                     AbortOnDropSingle::new(input_task),
                     txs,
                 ));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1478.

 # Rationale for this change
In current, datafusion couples tokio, users need to customized the async executor in some performance sensitive cases. Therefore, we add an interface which names `AsyncExecutor`, replace all `tokio::spawn` to `AsyncExecutor::execute`, to make async executor replacable.

# What changes are included in this PR?
- `generic_associated_types` feature required in `datafusion::core` (we could discussed about this change requirement later)
- add `async_executor.rs` file into `datafusion/core/src/execution`, which includes:
  - `AsyncExecutor` trait
  - `DefaultExecutor` bases on Tokio
- add `async_executor` attribute to `TaskContext`
- replace all `tokio::spawn` to `AsyncExecutor::execute`

This PR does not contain the user interface of customized async executor, it only provides the neccesary pre-changes, because I am not sure about the most user friendly way of it.

# Are there any user-facing changes?
No, there are not. We use Tokio runtime as the default executor in any currently cases.

# Does this PR break compatibility with Ballista?
I am not sure, but probably not.