### PR TITLE
Prune unused dependencies from datafusion-proto

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -36,16 +36,15 @@ path = "src/lib.rs"
 
 [dependencies]
 arrow = { version = "14.0.0" }
-async-trait = "0.1"
 datafusion = { path = "../core", version = "8.0.0" }
 datafusion-common = { path = "../common", version = "8.0.0" }
-datafusion-data-access = { path = "../data-access", version = "8.0.0" }
 datafusion-expr = { path = "../expr", version = "8.0.0" }
 prost = "0.10"
-tokio = "1.18"
+
 
 [dev-dependencies]
 doc-comment = "0.3"
+tokio = "1.18"
 
 [build-dependencies]
 tonic-build = { version = "0.7" }


### PR DESCRIPTION
These were added in #2639 but don't appear to be being used