### PR TITLE
Fix Ballista link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ capable of parallel execution against partitioned data sources (CSV
 and Parquet) using threads.
 
 DataFusion also supports distributed query execution via the
-[Ballista](ballista/README.md) crate.
+[Ballista](https://github.com/apache/arrow-ballista/) crate.
 
 ## Use Cases
 


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

It looks like Ballista was recently moved to a separate repository and so the link needs to be updated.