### PR TITLE
Remove `ExecutionProps` dependency from `OptimizerRule`

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1271,7 +1271,7 @@ impl SessionState {
             optimizer: Optimizer::new(vec![
                 // Simplify expressions first to maximize the chance
                 // of applying other optimizations
-                Arc::new(SimplifyExpressions::new(ExecutionProps::new())),
+                Arc::new(SimplifyExpressions::new()),
                 Arc::new(SubqueryFilterToJoin::new()),
                 Arc::new(EliminateFilter::new()),
                 Arc::new(CommonSubexprEliminate::new()),
@@ -1376,7 +1376,9 @@ impl SessionState {
 
     /// Optimizes the logical plan by applying optimizer rules.
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
-        let optimizer_config = OptimizerConfig::default();
+        let mut optimizer_config = OptimizerConfig::default();
+        optimizer_config.query_execution_start_time =
+            self.execution_props.query_execution_start_time;
 
         if let LogicalPlan::Explain(e) = plan {
             let mut stringified_plans = e.stringified_plans.clone();

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1376,7 +1376,7 @@ impl SessionState {
 
     /// Optimizes the logical plan by applying optimizer rules.
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
-        let mut optimizer_config = OptimizerConfig::default();
+        let mut optimizer_config = OptimizerConfig::new();
         optimizer_config.query_execution_start_time =
             self.execution_props.query_execution_start_time;
 

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -18,7 +18,6 @@
 //! Eliminate common sub-expression.
 
 use crate::error::Result;
-use crate::execution::context::ExecutionProps;
 use crate::logical_plan::plan::{Filter, Projection, Window};
 use crate::logical_plan::{
     col,
@@ -26,6 +25,7 @@ use crate::logical_plan::{
     DFField, DFSchema, Expr, ExprRewritable, ExprRewriter, ExprSchemable, ExprVisitable,
     ExpressionVisitor, LogicalPlan, Recursion, RewriteRecursion,
 };
+use crate::optimizer::optimizer::OptimizerConfig;
 use crate::optimizer::optimizer::OptimizerRule;
 use arrow::datatypes::DataType;
 use datafusion_expr::expr::GroupingSet;
@@ -60,9 +60,9 @@ impl OptimizerRule for CommonSubexprEliminate {
     fn optimize(
         &self,
         plan: &LogicalPlan,
-        execution_props: &ExecutionProps,
+        optimizer_config: &OptimizerConfig,
     ) -> Result<LogicalPlan> {
-        optimize(plan, execution_props)
+        optimize(plan, optimizer_config)
     }
 
     fn name(&self) -> &str {
@@ -83,7 +83,10 @@ impl CommonSubexprEliminate {
     }
 }
 
-fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<LogicalPlan> {
+fn optimize(
+    plan: &LogicalPlan,
+    optimizer_config: &OptimizerConfig,
+) -> Result<LogicalPlan> {
     let mut expr_set = ExprSet::new();
 
     match plan {
@@ -101,7 +104,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
                 input,
                 &mut expr_set,
                 schema,
-                execution_props,
+                optimizer_config,
             )?;
 
             Ok(LogicalPlan::Projection(Projection {
@@ -135,7 +138,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
                 input,
                 &mut expr_set,
                 input.schema(),
-                execution_props,
+                optimizer_config,
             )?;
 
             Ok(LogicalPlan::Filter(Filter {
@@ -156,7 +159,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
                 input,
                 &mut expr_set,
                 schema,
-                execution_props,
+                optimizer_config,
             )?;
 
             Ok(LogicalPlan::Window(Window {
@@ -180,7 +183,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
                 input,
                 &mut expr_set,
                 schema,
-                execution_props,
+                optimizer_config,
             )?;
             // note the reversed pop order.
             let new_aggr_expr = new_expr.pop().unwrap();
@@ -202,7 +205,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
                 input,
                 &mut expr_set,
                 input.schema(),
-                execution_props,
+                optimizer_config,
             )?;
 
             Ok(LogicalPlan::Sort(Sort {
@@ -235,7 +238,7 @@ fn optimize(plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<Logi
             let inputs = plan.inputs();
             let new_inputs = inputs
                 .iter()
-                .map(|input_plan| optimize(input_plan, execution_props))
+                .map(|input_plan| optimize(input_plan, optimizer_config))
                 .collect::<Result<Vec<_>>>()?;
 
             from_plan(plan, &expr, &new_inputs)
@@ -302,7 +305,7 @@ fn rewrite_expr(
     input: &LogicalPlan,
     expr_set: &mut ExprSet,
     schema: &DFSchema,
-    execution_props: &ExecutionProps,
+    optimizer_config: &OptimizerConfig,
 ) -> Result<(Vec<Vec<Expr>>, LogicalPlan)> {
     let mut affected_id = HashSet::<Identifier>::new();
 
@@ -327,7 +330,7 @@ fn rewrite_expr(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let mut new_input = optimize(input, execution_props)?;
+    let mut new_input = optimize(input, optimizer_config)?;
     if !affected_id.is_empty() {
         new_input = build_project_plan(new_input, affected_id, expr_set)?;
     }
@@ -702,7 +705,7 @@ mod test {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let optimizer = CommonSubexprEliminate {};
         let optimized_plan = optimizer
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &OptimizerConfig::new())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/eliminate_filter.rs
+++ b/datafusion/core/src/optimizer/eliminate_filter.rs
@@ -27,7 +27,7 @@ use crate::logical_plan::plan::Filter;
 use crate::logical_plan::{EmptyRelation, LogicalPlan};
 use crate::optimizer::optimizer::OptimizerRule;
 
-use crate::execution::context::ExecutionProps;
+use crate::optimizer::optimizer::OptimizerConfig;
 
 /// Optimization rule that elimanate the scalar value (true/false) filter with an [LogicalPlan::EmptyRelation]
 #[derive(Default)]
@@ -44,7 +44,7 @@ impl OptimizerRule for EliminateFilter {
     fn optimize(
         &self,
         plan: &LogicalPlan,
-        execution_props: &ExecutionProps,
+        optimizer_config: &OptimizerConfig,
     ) -> Result<LogicalPlan> {
         match plan {
             LogicalPlan::Filter(Filter {
@@ -65,7 +65,7 @@ impl OptimizerRule for EliminateFilter {
                 let inputs = plan.inputs();
                 let new_inputs = inputs
                     .iter()
-                    .map(|plan| self.optimize(plan, execution_props))
+                    .map(|plan| self.optimize(plan, optimizer_config))
                     .collect::<Result<Vec<_>>>()?;
 
                 from_plan(plan, &plan.expressions(), &new_inputs)
@@ -88,7 +88,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = EliminateFilter::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &OptimizerConfig::new())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -14,10 +14,8 @@
 
 //! Filter Push Down optimizer rule ensures that filters are applied as early as possible in the plan
 
-use crate::{
-    execution::context::ExecutionProps,
-    optimizer::{optimizer::OptimizerRule, utils},
-};
+use crate::optimizer::optimizer::OptimizerConfig;
+use crate::optimizer::{optimizer::OptimizerRule, utils};
 use datafusion_common::{Column, DFSchema, Result};
 use datafusion_expr::{
     col,
@@ -530,7 +528,7 @@ impl OptimizerRule for FilterPushDown {
         "filter_push_down"
     }
 
-    fn optimize(&self, plan: &LogicalPlan, _: &ExecutionProps) -> Result<LogicalPlan> {
+    fn optimize(&self, plan: &LogicalPlan, _: &OptimizerConfig) -> Result<LogicalPlan> {
         optimize(plan, State::default())
     }
 }
@@ -578,7 +576,7 @@ mod tests {
 
     fn optimize_plan(plan: &LogicalPlan) -> LogicalPlan {
         let rule = FilterPushDown::new();
-        rule.optimize(plan, &ExecutionProps::new())
+        rule.optimize(plan, &OptimizerConfig::new())
             .expect("failed to optimize plan")
     }
 

--- a/datafusion/core/src/optimizer/optimizer.rs
+++ b/datafusion/core/src/optimizer/optimizer.rs
@@ -55,8 +55,11 @@ impl OptimizerConfig {
             query_execution_start_time: chrono::Utc::now(),
         }
     }
+}
+
+impl Default for OptimizerConfig {
     /// Create optimizer config
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self::new()
     }
 }

--- a/datafusion/core/src/optimizer/optimizer.rs
+++ b/datafusion/core/src/optimizer/optimizer.rs
@@ -17,6 +17,7 @@
 
 //! Query optimizer traits
 
+use chrono::{DateTime, Utc};
 use std::sync::Arc;
 
 use log::{debug, trace};
@@ -41,16 +42,22 @@ pub trait OptimizerRule {
 
 /// Placeholder for optimizer configuration options
 #[derive(Debug)]
-pub struct OptimizerConfig {}
+pub struct OptimizerConfig {
+    /// Query execution start time that can be used to rewrite expressions such as `now()`
+    /// to use a literal value instead
+    pub query_execution_start_time: DateTime<Utc>,
+}
 
 impl OptimizerConfig {
     /// Create optimizer config
     pub fn new() -> Self {
-        Self {}
+        Self {
+            query_execution_start_time: chrono::Utc::now(),
+        }
     }
     /// Create optimizer config
     pub fn default() -> Self {
-        Self {}
+        Self::new()
     }
 }
 
@@ -78,9 +85,6 @@ impl Optimizer {
     where
         F: FnMut(&LogicalPlan, &dyn OptimizerRule),
     {
-        //TODO fix this regression
-        //let optimizer_config = optimizer_config.start_execution();
-
         let mut new_plan = plan.clone();
         debug!("Input logical plan:\n{}\n", plan.display_indent());
         trace!("Full input logical plan:\n{:?}", plan);

--- a/datafusion/core/src/optimizer/optimizer.rs
+++ b/datafusion/core/src/optimizer/optimizer.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use log::{debug, trace};
 
 use crate::error::Result;
-use crate::execution::context::ExecutionProps;
 use crate::logical_plan::LogicalPlan;
 
 /// `OptimizerRule` transforms one ['LogicalPlan'] into another which
@@ -33,11 +32,26 @@ pub trait OptimizerRule {
     fn optimize(
         &self,
         plan: &LogicalPlan,
-        execution_props: &ExecutionProps,
+        optimizer_config: &OptimizerConfig,
     ) -> Result<LogicalPlan>;
 
     /// A human readable name for this optimizer rule
     fn name(&self) -> &str;
+}
+
+/// Placeholder for optimizer configuration options
+#[derive(Debug)]
+pub struct OptimizerConfig {}
+
+impl OptimizerConfig {
+    /// Create optimizer config
+    pub fn new() -> Self {
+        Self {}
+    }
+    /// Create optimizer config
+    pub fn default() -> Self {
+        Self {}
+    }
 }
 
 /// A rule-based optimizer.
@@ -58,19 +72,20 @@ impl Optimizer {
     pub fn optimize<F>(
         &self,
         plan: &LogicalPlan,
-        execution_props: &mut ExecutionProps,
+        optimizer_config: &OptimizerConfig,
         mut observer: F,
     ) -> Result<LogicalPlan>
     where
         F: FnMut(&LogicalPlan, &dyn OptimizerRule),
     {
-        let execution_props = execution_props.start_execution();
+        //TODO fix this regression
+        //let optimizer_config = optimizer_config.start_execution();
 
         let mut new_plan = plan.clone();
         debug!("Input logical plan:\n{}\n", plan.display_indent());
         trace!("Full input logical plan:\n{:?}", plan);
         for rule in &self.rules {
-            new_plan = rule.optimize(&new_plan, execution_props)?;
+            new_plan = rule.optimize(&new_plan, optimizer_config)?;
             observer(&new_plan, rule.as_ref());
         }
         debug!("Optimized logical plan:\n{}\n", new_plan.display_indent());

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -1750,7 +1750,7 @@ mod tests {
 
     // expect optimizing will result in an error, returning the error string
     fn get_optimized_plan_err(plan: &LogicalPlan, date_time: &DateTime<Utc>) -> String {
-        let mut config = OptimizerConfig::default();
+        let mut config = OptimizerConfig::new();
         config.query_execution_start_time = *date_time;
         let rule = SimplifyExpressions::new();
 
@@ -1765,7 +1765,7 @@ mod tests {
         plan: &LogicalPlan,
         date_time: &DateTime<Utc>,
     ) -> String {
-        let mut config = OptimizerConfig::default();
+        let mut config = OptimizerConfig::new();
         config.query_execution_start_time = *date_time;
         let rule = SimplifyExpressions::new();
 

--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -18,10 +18,10 @@
 //! single distinct to group by optimizer rule
 
 use crate::error::Result;
-use crate::execution::context::ExecutionProps;
 use crate::logical_plan::plan::{Aggregate, Projection};
 use crate::logical_plan::ExprSchemable;
 use crate::logical_plan::{col, DFSchema, Expr, LogicalPlan};
+use crate::optimizer::optimizer::OptimizerConfig;
 use crate::optimizer::optimizer::OptimizerRule;
 use datafusion_expr::utils::{columnize_expr, from_plan};
 use hashbrown::HashSet;
@@ -188,7 +188,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
     fn optimize(
         &self,
         plan: &LogicalPlan,
-        _execution_props: &ExecutionProps,
+        _optimizer_config: &OptimizerConfig,
     ) -> Result<LogicalPlan> {
         optimize(plan)
     }
@@ -207,7 +207,7 @@ mod tests {
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = SingleDistinctToGroupBy::new();
         let optimized_plan = rule
-            .optimize(plan, &ExecutionProps::new())
+            .optimize(plan, &OptimizerConfig::new())
             .expect("failed to optimize plan");
         let formatted_plan = format!("{}", optimized_plan.display_indent_schema());
         assert_eq!(formatted_plan, expected);

--- a/datafusion/core/src/optimizer/utils.rs
+++ b/datafusion/core/src/optimizer/utils.rs
@@ -18,7 +18,7 @@
 //! Collection of utility functions that are leveraged by the query optimizer rules
 
 use super::optimizer::OptimizerRule;
-use crate::execution::context::ExecutionProps;
+use crate::optimizer::optimizer::OptimizerConfig;
 use datafusion_expr::logical_plan::Filter;
 
 use crate::error::{DataFusionError, Result};
@@ -42,13 +42,13 @@ const WINDOW_SORT_MARKER: &str = "__DATAFUSION_WINDOW_SORT__";
 pub fn optimize_children(
     optimizer: &impl OptimizerRule,
     plan: &LogicalPlan,
-    execution_props: &ExecutionProps,
+    optimizer_config: &OptimizerConfig,
 ) -> Result<LogicalPlan> {
     let new_exprs = plan.expressions();
     let new_inputs = plan
         .inputs()
         .into_iter()
-        .map(|plan| optimizer.optimize(plan, execution_props))
+        .map(|plan| optimizer.optimize(plan, optimizer_config))
         .collect::<Result<Vec<_>>>()?;
 
     from_plan(plan, &new_exprs, &new_inputs)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2614

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- Logical optimizer rules should not depend on anything related to physical plans or execution
- I am working on moving logical optimizer rules to their own crate so this is a step towards that

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- `OptimizerRule` trait no longer references `ExecutionProps`
- `OptimizerRule` trait now references `OptimizerConfig` instead, which contains the one value (query start time) that it was previously getting from `ExecutionProps`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes if they are using this API

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Does this PR break compatibility with Ballista?

TBD

<!--
The CI checks will attempt to build [arrow-ballista](https://github.com/apache/arrow-ballista) against this PR. If 
this check fails then it indicates that this PR makes a breaking change to the DataFusion API.

If possible, try to make the change in a way that is not a breaking API change. For example, if code has moved 
 around, try adding `pub use` from the original location to preserve the current API.

If it is not possible to avoid a breaking change (such as when adding enum variants) then follow this process:

- Make a corresponding PR against `arrow-ballista` with the changes required there
- Update `dev/build-arrow-ballista.sh` to clone the appropriate `arrow-ballista` repo & branch
- Merge this PR when CI passes
- Merge the Ballista PR
- Create a new PR here to reset `dev/build-arrow-ballista.sh` to point to `arrow-ballista` master again

_If you would like to help improve this process, please see https://github.com/apache/arrow-datafusion/issues/2583_
-->