### PR TITLE
Fix `AggregateStatistics` optimization so it doesn't change output type

### DIFF
--- a/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
@@ -305,13 +305,14 @@ mod tests {
         let plan = Arc::new(plan) as _;
         let optimized = AggregateStatistics::new().optimize(Arc::clone(&plan), &conf)?;
 
-
         // A ProjectionExec is a sign that the count optimization was applied
         assert!(optimized.as_any().is::<ProjectionExec>());
 
         // run both the optimized and nonoptimized plan
-        let optimized_result = common::collect(optimized.execute(0, session_ctx.task_ctx())?).await?;
-        let nonoptimized_result = common::collect(plan.execute(0, session_ctx.task_ctx())?).await?;
+        let optimized_result =
+            common::collect(optimized.execute(0, session_ctx.task_ctx())?).await?;
+        let nonoptimized_result =
+            common::collect(plan.execute(0, session_ctx.task_ctx())?).await?;
         assert_eq!(optimized_result.len(), nonoptimized_result.len());
 
         //  and validate the results are the same and expected
@@ -324,7 +325,7 @@ mod tests {
         Ok(())
     }
 
-    fn check_batch(batch: RecordBatch, agg: &TestAggregate){
+    fn check_batch(batch: RecordBatch, agg: &TestAggregate) {
         let schema = batch.schema();
         let fields = schema.fields();
         assert_eq!(fields.len(), 1);

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{Int32Array, PrimitiveArray, UInt64Array};
+use arrow::array::{Int32Array, Int64Array, PrimitiveArray};
 use arrow::compute::kernels::aggregate;
 use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
@@ -284,12 +284,12 @@ async fn optimizers_catch_all_statistics() {
 
     let expected = RecordBatch::try_new(
         Arc::new(Schema::new(vec![
-            Field::new("COUNT(UInt8(1))", DataType::UInt64, false),
+            Field::new("COUNT(UInt8(1))", DataType::Int64, false),
             Field::new("MIN(test.c1)", DataType::Int32, false),
             Field::new("MAX(test.c1)", DataType::Int32, false),
         ])),
         vec![
-            Arc::new(UInt64Array::from_slice(&[4])),
+            Arc::new(Int64Array::from_slice(&[4])),
             Arc::new(Int32Array::from_slice(&[1])),
             Arc::new(Int32Array::from_slice(&[100])),
         ],

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -26,10 +26,14 @@ use crate::logical_plan::{
 };
 use crate::{Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder};
 use datafusion_common::{
-    Column, DFField, DFSchema, DFSchemaRef, DataFusionError, Result,
+    Column, DFField, DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
+
+///  The value to which `COUNT(*)` is expanded to in
+///  `COUNT(<constant>)` expressions
+pub const COUNT_STAR_EXPANSION: ScalarValue = ScalarValue::UInt8(Some(1));
 
 /// Recursively walk a list of expression trees, collecting the unique set of columns
 /// referenced in the expression

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -30,7 +30,7 @@ use datafusion_expr::logical_plan::{
 };
 use datafusion_expr::utils::{
     expand_qualified_wildcard, expand_wildcard, expr_as_column_expr, expr_to_columns,
-    find_aggregate_exprs, find_column_exprs, find_window_exprs,
+    find_aggregate_exprs, find_column_exprs, find_window_exprs, COUNT_STAR_EXPANSION,
 };
 use datafusion_expr::{
     and, col, lit, AggregateFunction, AggregateUDF, Expr, Operator, ScalarUDF,
@@ -2197,14 +2197,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         schema: &DFSchema,
     ) -> Result<(AggregateFunction, Vec<Expr>)> {
         let args = match fun {
+            // Special case rewrite COUNT(*) to COUNT(constant)
             AggregateFunction::Count => function
                 .args
                 .into_iter()
                 .map(|a| match a {
                     FunctionArg::Unnamed(FunctionArgExpr::Expr(SQLExpr::Value(
                         Value::Number(_, _),
-                    ))) => Ok(lit(1_u8)),
-                    FunctionArg::Unnamed(FunctionArgExpr::Wildcard) => Ok(lit(1_u8)),
+                    ))) => Ok(Expr::Literal(COUNT_STAR_EXPANSION.clone())),
+                    FunctionArg::Unnamed(FunctionArgExpr::Wildcard) => {
+                        Ok(Expr::Literal(COUNT_STAR_EXPANSION.clone()))
+                    }
                     _ => self.sql_fn_arg_to_logical_expr(a, schema, &mut HashMap::new()),
                 })
                 .collect::<Result<Vec<Expr>>>()?,


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/2673

 # Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/2673 -- the optimizer pass is changing input types.

# What changes are included in this PR?
1. Fix bug
2. New Regresion test
3. Give some constants related to `COUNT(*)` expansion symbolic names to improve readability

# Are there any user-facing changes?
less bugs

# Does this PR break compatibility with Ballista?
No