### PR TITLE
MINOR: Remove uses of TryClone for Parquet 

### DIFF
--- a/datafusion/core/benches/parquet_query_sql.rs
+++ b/datafusion/core/benches/parquet_query_sql.rs
@@ -159,8 +159,8 @@ fn generate_file() -> NamedTempFile {
         .set_max_row_group_size(ROW_GROUP_SIZE)
         .build();
 
-    let file = named_file.as_file().try_clone().unwrap();
-    let mut writer = ArrowWriter::try_new(file, schema, Some(properties)).unwrap();
+    let mut writer =
+        ArrowWriter::try_new(&mut named_file, schema, Some(properties)).unwrap();
 
     for _ in 0..NUM_BATCHES {
         let batch = generate_batch();

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -438,14 +438,12 @@ pub(crate) mod test_util {
         let files: Vec<_> = batches
             .into_iter()
             .map(|batch| {
-                let output = tempfile::NamedTempFile::new().expect("creating temp file");
+                let mut output = NamedTempFile::new().expect("creating temp file");
 
                 let props = WriterProperties::builder().build();
-                let file: std::fs::File = (*output.as_file())
-                    .try_clone()
-                    .expect("cloning file descriptor");
-                let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props))
-                    .expect("creating writer");
+                let mut writer =
+                    ArrowWriter::try_new(&mut output, batch.schema(), Some(props))
+                        .expect("creating writer");
 
                 writer.write(&batch).expect("Writing batch");
                 writer.close().unwrap();

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -606,11 +606,8 @@ pub async fn plan_to_parquet(
                 let filename = format!("part-{}.parquet", i);
                 let path = fs_path.join(&filename);
                 let file = fs::File::create(path)?;
-                let mut writer = ArrowWriter::try_new(
-                    file.try_clone().unwrap(),
-                    plan.schema(),
-                    writer_properties.clone(),
-                )?;
+                let mut writer =
+                    ArrowWriter::try_new(file, plan.schema(), writer_properties.clone())?;
                 let task_ctx = Arc::new(TaskContext::from(state));
                 let stream = plan.execute(i, task_ctx)?;
                 let handle: tokio::task::JoinHandle<Result<()>> =

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -638,7 +638,7 @@ impl ContextWithParquet {
 
 /// Create a test parquet file with varioud data types
 async fn make_test_file(scenario: Scenario) -> NamedTempFile {
-    let output_file = tempfile::Builder::new()
+    let mut output_file = tempfile::Builder::new()
         .prefix("parquet_pruning")
         .suffix(".parquet")
         .tempfile()
@@ -685,15 +685,7 @@ async fn make_test_file(scenario: Scenario) -> NamedTempFile {
 
     let schema = batches[0].schema();
 
-    let mut writer = ArrowWriter::try_new(
-        output_file
-            .as_file()
-            .try_clone()
-            .expect("cloning file descriptor"),
-        schema,
-        Some(props),
-    )
-    .unwrap();
+    let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
 
     for batch in batches {
         writer.write(&batch).expect("writing batch");

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -200,9 +200,7 @@ async fn schema_merge_ignores_metadata() {
             let filename = format!("part-{}.parquet", i);
             let path = table_path.join(&filename);
             let file = fs::File::create(path).unwrap();
-            let mut writer =
-                ArrowWriter::try_new(file.try_clone().unwrap(), schema.clone(), None)
-                    .unwrap();
+            let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
 
             // create mock record batch
             let ids = Arc::new(Int32Array::from_slice(&[i as i32]));


### PR DESCRIPTION
Some of these were never strictly necessary, but with https://github.com/apache/arrow-rs/pull/1719 now none of them are necessary :tada: