### PR TITLE
fix: union schema fix

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -838,7 +838,7 @@ pub fn project_with_column_index_alias(
         .map(|(i, e)| match e {
             ignore_alias @ Expr::Alias { .. } => ignore_alias,
             ignore_col @ Expr::Column { .. } => ignore_col,
-            x => x.alias(format!("column{}", i).as_str()),
+            x => x.alias(schema.field(i).name()),
         })
         .collect::<Vec<_>>();
     Ok(LogicalPlan::Projection(Projection {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3946,9 +3946,9 @@ mod tests {
     fn union_values_with_no_alias() {
         let sql = "SELECT 1, 2 UNION ALL SELECT 3, 4";
         let expected = "Union\
-            \n  Projection: Int64(1) AS column0, Int64(2) AS column1\
+            \n  Projection: Int64(1) AS Int64(1), Int64(2) AS Int64(2)\
             \n    EmptyRelation\
-            \n  Projection: Int64(3) AS column0, Int64(4) AS column1\
+            \n  Projection: Int64(3) AS Int64(1), Int64(4) AS Int64(2)\
             \n    EmptyRelation";
         quick_test(sql, expected);
     }


### PR DESCRIPTION
# Which issue does this PR close?
Not exists

# Rationale for this change
For now, Union Inputs Projections can have different schemas (because of forcing changing alias name to "column{}"). In case you want to recreate Union from these Inputs, you can catch an exception, because of different schemas.

# What changes are included in this PR?
* Fix Union Inputs Schemas

# Are there any user-facing changes?
No

Hello! I am an employee of Cube.js. We do post-processing of logical plan in our project and in some cases, we unwrap Union and build it back. And we catch an exception because of wrong schemas.

