### PR TITLE
Remove Ballista related lines from Dockerfile

### DIFF
--- a/datafusion-cli/Dockerfile
+++ b/datafusion-cli/Dockerfile
@@ -21,8 +21,6 @@ COPY ./datafusion /usr/src/datafusion
 
 COPY ./datafusion-cli /usr/src/datafusion-cli
 
-COPY ./ballista /usr/src/ballista
-
 WORKDIR /usr/src/datafusion-cli
 
 RUN rustup component add rustfmt


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2691.

 # Rationale for this change

Ballista is now maintained in a separate repository and is not needed to build datafusion-cli.

# Are there any user-facing changes?

No