### PR TITLE
feat: async extension planner

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -964,15 +964,14 @@ impl DefaultPhysicalPlanner {
                         .try_collect::<Vec<_>>()
                         .await?;
 
-
                     let mut maybe_plan = None;
-                    for planner in &self.extension_planners{
-                        if maybe_plan.is_some(){
+                    for planner in &self.extension_planners {
+                        if maybe_plan.is_some() {
                             break;
                         }
 
-                    let logical_input = e.node.inputs();
-                        let plan =  planner.plan_extension(
+                        let logical_input = e.node.inputs();
+                        let plan = planner.plan_extension(
                             self,
                             e.node.as_ref(),
                             &logical_input,
@@ -980,7 +979,7 @@ impl DefaultPhysicalPlanner {
                             session_state,
                         );
                         let plan = plan.await;
-                        if plan.is_err(){
+                        if plan.is_err() {
                             continue;
                         }
                         maybe_plan = plan.unwrap();

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -296,7 +296,7 @@ pub trait ExtensionPlanner {
     async fn plan_extension(
         &self,
         planner: &(dyn PhysicalPlanner),
-        node: &(dyn UserDefinedLogicalNode + Send + Sync),
+        node: &(dyn UserDefinedLogicalNode),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         session_state: &SessionState,
@@ -1728,7 +1728,7 @@ mod tests {
             &self,
             _exprs: &[Expr],
             _inputs: &[LogicalPlan],
-        ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        ) -> Arc<dyn UserDefinedLogicalNode> {
             unimplemented!("NoOp");
         }
     }
@@ -1806,7 +1806,7 @@ mod tests {
         async fn plan_extension(
             &self,
             _planner: &(dyn PhysicalPlanner),
-            _node: &(dyn UserDefinedLogicalNode + Send + Sync),
+            _node: &(dyn UserDefinedLogicalNode),
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],
             _session_state: &SessionState,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -255,7 +255,7 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
 /// Physical query planner that converts a `LogicalPlan` to an
 /// `ExecutionPlan` suitable for execution.
 #[async_trait]
-pub trait PhysicalPlanner {
+pub trait PhysicalPlanner: Send + Sync {
     /// Create a physical plan from a logical plan
     async fn create_physical_plan(
         &self,
@@ -295,7 +295,7 @@ pub trait ExtensionPlanner {
     /// [`ExtensionPlanner`].
     async fn plan_extension(
         &self,
-        planner: &(dyn PhysicalPlanner + Send + Sync),
+        planner: &(dyn PhysicalPlanner),
         node: &(dyn UserDefinedLogicalNode + Send + Sync),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
@@ -1805,7 +1805,7 @@ mod tests {
         /// Create a physical plan for an extension node
         async fn plan_extension(
             &self,
-            _planner: &(dyn PhysicalPlanner + Send + Sync),
+            _planner: &(dyn PhysicalPlanner),
             _node: &(dyn UserDefinedLogicalNode + Send + Sync),
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -281,6 +281,7 @@ pub trait PhysicalPlanner {
 }
 
 /// This trait exposes the ability to plan an [`ExecutionPlan`] out of a [`LogicalPlan`].
+#[async_trait]
 pub trait ExtensionPlanner {
     /// Create a physical plan for a [`UserDefinedLogicalNode`].
     ///
@@ -292,10 +293,10 @@ pub trait ExtensionPlanner {
     /// Returns `None` when the planner does not know how to plan the
     /// `node` and wants to delegate the planning to another
     /// [`ExtensionPlanner`].
-    fn plan_extension(
+    async fn plan_extension(
         &self,
-        planner: &dyn PhysicalPlanner,
-        node: &dyn UserDefinedLogicalNode,
+        planner: &(dyn PhysicalPlanner + Send + Sync),
+        node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         session_state: &SessionState,
@@ -963,22 +964,28 @@ impl DefaultPhysicalPlanner {
                         .try_collect::<Vec<_>>()
                         .await?;
 
-                    let maybe_plan = self.extension_planners.iter().try_fold(
-                        None,
-                        |maybe_plan, planner| {
-                            if let Some(plan) = maybe_plan {
-                                Ok(Some(plan))
-                            } else {
-                                planner.plan_extension(
-                                    self,
-                                    e.node.as_ref(),
-                                    &e.node.inputs(),
-                                    &physical_inputs,
-                                    session_state,
-                                )
-                            }
-                        },
-                    )?;
+
+                    let mut maybe_plan = None;
+                    for planner in &self.extension_planners{
+                        if maybe_plan.is_some(){
+                            break;
+                        }
+
+                    let logical_input = e.node.inputs();
+                        let plan =  planner.plan_extension(
+                            self,
+                            e.node.clone(),
+                            &logical_input,
+                            &physical_inputs,
+                            session_state,
+                        );
+                        let plan = plan.await;
+                        if plan.is_err(){
+                            continue;
+                        }
+                        maybe_plan = plan.unwrap();
+                    }
+
                     let plan = maybe_plan.ok_or_else(|| DataFusionError::Plan(format!(
                         "No installed planner was able to convert the custom node to an execution plan: {:?}", e.node
                     )))?;
@@ -1793,12 +1800,13 @@ mod tests {
     //  the logical plan node.
     struct BadExtensionPlanner {}
 
+    #[async_trait]
     impl ExtensionPlanner for BadExtensionPlanner {
         /// Create a physical plan for an extension node
-        fn plan_extension(
+        async fn plan_extension(
             &self,
-            _planner: &dyn PhysicalPlanner,
-            _node: &dyn UserDefinedLogicalNode,
+            _planner: &(dyn PhysicalPlanner + Send + Sync),
+            _node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],
             _session_state: &SessionState,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -295,8 +295,8 @@ pub trait ExtensionPlanner {
     /// [`ExtensionPlanner`].
     async fn plan_extension(
         &self,
-        planner: &(dyn PhysicalPlanner),
-        node: &(dyn UserDefinedLogicalNode),
+        planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         session_state: &SessionState,
@@ -1805,8 +1805,8 @@ mod tests {
         /// Create a physical plan for an extension node
         async fn plan_extension(
             &self,
-            _planner: &(dyn PhysicalPlanner),
-            _node: &(dyn UserDefinedLogicalNode),
+            _planner: &dyn PhysicalPlanner,
+            _node: &dyn UserDefinedLogicalNode,
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],
             _session_state: &SessionState,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -296,7 +296,7 @@ pub trait ExtensionPlanner {
     async fn plan_extension(
         &self,
         planner: &(dyn PhysicalPlanner + Send + Sync),
-        node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
+        node: &(dyn UserDefinedLogicalNode + Send + Sync),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         session_state: &SessionState,
@@ -974,7 +974,7 @@ impl DefaultPhysicalPlanner {
                     let logical_input = e.node.inputs();
                         let plan =  planner.plan_extension(
                             self,
-                            e.node.clone(),
+                            e.node.as_ref(),
                             &logical_input,
                             &physical_inputs,
                             session_state,
@@ -1806,7 +1806,7 @@ mod tests {
         async fn plan_extension(
             &self,
             _planner: &(dyn PhysicalPlanner + Send + Sync),
-            _node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
+            _node: &(dyn UserDefinedLogicalNode + Send + Sync),
             _logical_inputs: &[&LogicalPlan],
             _physical_inputs: &[Arc<dyn ExecutionPlan>],
             _session_state: &SessionState,

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -381,12 +381,13 @@ impl UserDefinedLogicalNode for TopKPlanNode {
 /// Physical planner for TopK nodes
 struct TopKPlanner {}
 
+#[async_trait]
 impl ExtensionPlanner for TopKPlanner {
     /// Create a physical plan for an extension node
-    fn plan_extension(
+    async fn plan_extension(
         &self,
-        _planner: &dyn PhysicalPlanner,
-        node: &dyn UserDefinedLogicalNode,
+        _planner: &(dyn PhysicalPlanner+Send+Sync),
+        node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         _session_state: &SessionState,

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -387,7 +387,7 @@ impl ExtensionPlanner for TopKPlanner {
     async fn plan_extension(
         &self,
         _planner: &(dyn PhysicalPlanner + Send + Sync),
-        node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
+        node: &(dyn UserDefinedLogicalNode + Send + Sync),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         _session_state: &SessionState,

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -386,7 +386,7 @@ impl ExtensionPlanner for TopKPlanner {
     /// Create a physical plan for an extension node
     async fn plan_extension(
         &self,
-        _planner: &(dyn PhysicalPlanner + Send + Sync),
+        _planner: &(dyn PhysicalPlanner),
         node: &(dyn UserDefinedLogicalNode + Send + Sync),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -386,8 +386,8 @@ impl ExtensionPlanner for TopKPlanner {
     /// Create a physical plan for an extension node
     async fn plan_extension(
         &self,
-        _planner: &(dyn PhysicalPlanner),
-        node: &(dyn UserDefinedLogicalNode),
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         _session_state: &SessionState,

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -367,7 +367,7 @@ impl UserDefinedLogicalNode for TopKPlanNode {
         &self,
         exprs: &[Expr],
         inputs: &[LogicalPlan],
-    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+    ) -> Arc<dyn UserDefinedLogicalNode> {
         assert_eq!(inputs.len(), 1, "input size inconsistent");
         assert_eq!(exprs.len(), 1, "expression size inconsistent");
         Arc::new(TopKPlanNode {
@@ -387,7 +387,7 @@ impl ExtensionPlanner for TopKPlanner {
     async fn plan_extension(
         &self,
         _planner: &(dyn PhysicalPlanner),
-        node: &(dyn UserDefinedLogicalNode + Send + Sync),
+        node: &(dyn UserDefinedLogicalNode),
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         _session_state: &SessionState,

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -386,7 +386,7 @@ impl ExtensionPlanner for TopKPlanner {
     /// Create a physical plan for an extension node
     async fn plan_extension(
         &self,
-        _planner: &(dyn PhysicalPlanner+Send+Sync),
+        _planner: &(dyn PhysicalPlanner + Send + Sync),
         node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -26,7 +26,7 @@ use std::{any::Any, collections::HashSet, fmt, sync::Arc};
 /// See the example in
 /// [user_defined_plan.rs](../../tests/user_defined_plan.rs) for an
 /// example of how to use this extension API
-pub trait UserDefinedLogicalNode: fmt::Debug {
+pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     /// Return a reference to self as Any, to support dynamic downcasting
     fn as_any(&self) -> &dyn Any;
 
@@ -76,5 +76,5 @@ pub trait UserDefinedLogicalNode: fmt::Debug {
         &self,
         exprs: &[Expr],
         inputs: &[LogicalPlan],
-    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync>;
+    ) -> Arc<dyn UserDefinedLogicalNode>;
 }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1161,7 +1161,7 @@ pub struct Analyze {
 #[derive(Clone)]
 pub struct Extension {
     /// The runtime extension operator
-    pub node: Arc<dyn UserDefinedLogicalNode + Send + Sync>,
+    pub node: Arc<dyn UserDefinedLogicalNode>,
 }
 
 /// Produces the first `n` tuples from its input and discards the rest.

--- a/datafusion/optimizer/src/test/user_defined.rs
+++ b/datafusion/optimizer/src/test/user_defined.rs
@@ -69,7 +69,7 @@ impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
         &self,
         exprs: &[Expr],
         inputs: &[LogicalPlan],
-    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+    ) -> Arc<dyn UserDefinedLogicalNode> {
         assert_eq!(inputs.len(), 1, "input size inconsistent");
         assert_eq!(exprs.len(), 0, "expression size inconsistent");
         Arc::new(TestUserDefinedPlanNode {

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -190,7 +190,7 @@ mod roundtrip_tests {
             &self,
             exprs: &[Expr],
             inputs: &[LogicalPlan],
-        ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        ) -> Arc<dyn UserDefinedLogicalNode> {
             assert_eq!(inputs.len(), 1, "input size inconsistent");
             assert_eq!(exprs.len(), 1, "expression size inconsistent");
             Arc::new(TopKPlanNode {


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2749 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`PhysicalPlanner::create_physical_plan()` is an async function.  I suppose `ExtensionPlanner::plan_extension()` should also be async (in my understanding they are the same in some aspect?).

In fact I encounter a scenario that needs to call async function in `ExtensionPlanner::plan_extension()`. I'll review my use case and provide a more concrete example tomorrow.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change `ExtensionPlanner::plan_extension()` to an async function

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes. 
- `ExtensionPlanner` becomes an async trait.
- `PhysicalPlanner` and `UserDefinedLogicalNode` now will request `Send` and `Sync` markers.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->