### PR TITLE
fix: check redundant fields while building projection plan

### DIFF
--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -270,7 +270,7 @@ fn build_project_plan(
     let mut fields = vec![];
     let mut fields_set = HashSet::new();
 
-    for id in affected_id.clone() {
+    for id in affected_id {
         let (expr, _, data_type) = expr_set.get(&id).unwrap();
         // todo: check `nullable`
         let field = DFField::new(None, &id, data_type.clone(), true);

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -261,10 +261,6 @@ fn to_arrays(
 }
 
 /// Build the "intermediate" projection plan that evaluates the extracted common expressions.
-///
-/// This projection plan will merge all fields in the `input.schema()` into its own schema.
-/// Redundant project fields are expected to be removed in other optimize phase (like
-/// `projection_push_down`).
 fn build_project_plan(
     input: LogicalPlan,
     affected_id: HashSet<Identifier>,
@@ -272,18 +268,24 @@ fn build_project_plan(
 ) -> Result<LogicalPlan> {
     let mut project_exprs = vec![];
     let mut fields = vec![];
+    let mut fields_set = HashSet::new();
 
-    for id in affected_id {
+    for id in affected_id.clone() {
         let (expr, _, data_type) = expr_set.get(&id).unwrap();
         // todo: check `nullable`
-        fields.push(DFField::new(None, &id, data_type.clone(), true));
+        let field = DFField::new(None, &id, data_type.clone(), true);
+        fields_set.insert(field.name().to_owned());
+        fields.push(field);
         project_exprs.push(expr.clone().alias(&id));
     }
 
-    fields.extend_from_slice(input.schema().fields());
-    input.schema().fields().iter().for_each(|field| {
-        project_exprs.push(Expr::Column(field.qualified_column()));
-    });
+    for field in input.schema().fields() {
+        if !fields_set.contains(field.name()) {
+            fields_set.insert(field.name().to_owned());
+            fields.push(field.clone());
+            project_exprs.push(Expr::Column(field.qualified_column()));
+        }
+    }
 
     let mut schema = DFSchema::new_with_metadata(fields, HashMap::new())?;
     schema.merge(input.schema());

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -94,7 +94,7 @@ impl Optimizer {
             observer(&new_plan, rule.as_ref());
         }
         debug!("Optimized logical plan:\n{}\n", new_plan.display_indent());
-        trace!("Full Optimized logical plan:\n {:?}", plan);
+        trace!("Full Optimized logical plan:\n {:?}", new_plan);
         Ok(new_plan)
     }
 }


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2712 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

CSE optimizer used to produce schemas with redundant fields, and dependents on other rules to handle them:
>This projection plan will merge all fields in the `input.schema()` into its own schema. Redundant project fields are expected to be removed in other optimize phase (like `projection_push_down`).



# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

CSE optimizer will now check redundant fields while building the intermediate projection plan.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No