### PR TITLE
Fix clippy warnings with toolchain 1.63

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -295,7 +295,7 @@ mod test {
     #[allow(clippy::try_err)]
     fn return_arrow_error() -> arrow::error::Result<()> {
         // Expect the '?' to work
-        let _foo = Err(DataFusionError::Plan("foo".to_string()))?;
+        Err(DataFusionError::Plan("foo".to_string()))?;
         Ok(())
     }
 
@@ -304,7 +304,7 @@ mod test {
     #[allow(clippy::try_err)]
     fn return_datafusion_error() -> crate::error::Result<()> {
         // Expect the '?' to work
-        let _bar = Err(ArrowError::SchemaError("bar".to_string()))?;
+        Err(ArrowError::SchemaError("bar".to_string()))?;
         Ok(())
     }
 }

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -544,10 +544,10 @@ impl ScalarValue {
         if precision <= DECIMAL_MAX_PRECISION && scale <= precision {
             return Ok(ScalarValue::Decimal128(Some(value), precision, scale));
         }
-        return Err(DataFusionError::Internal(format!(
+        Err(DataFusionError::Internal(format!(
             "Can not new a decimal type ScalarValue for precision {} and scale {}",
             precision, scale
-        )));
+        )))
     }
     /// Getter for the `DataType` of the value
     pub fn get_datatype(&self) -> DataType {

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -532,14 +532,11 @@ fn rewrite_expr_to_prunable(
             };
         }
 
-        _ => {
-            return Err(DataFusionError::Plan(format!(
-                "column expression {:?} is not supported",
-                column_expr
-            )))
-        }
+        _ => Err(DataFusionError::Plan(format!(
+            "column expression {:?} is not supported",
+            column_expr
+        ))),
     }
-    // Ok((column_expr.clone(), op, scalar_expr.clone()))
 }
 
 fn is_compare_op(op: Operator) -> bool {
@@ -784,7 +781,7 @@ fn build_statistics_expr(expr_builder: &mut PruningExpressionBuilder) -> Result<
     Ok(statistics_expr)
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum StatisticsType {
     Min,
     Max,

--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -176,7 +176,7 @@ impl HashJoinMetrics {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Partitioning mode to use for hash join
 pub enum PartitionMode {
     /// Left/right children are partitioned using the left and right keys

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -91,7 +91,7 @@ pub use self::planner::PhysicalPlanner;
 /// Fields are optional and can be inexact because the sources
 /// sometimes provide approximate estimates for performance reasons
 /// and the transformations output are not always predictable.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Statistics {
     /// The number of table rows
     pub num_rows: Option<usize>,
@@ -105,7 +105,7 @@ pub struct Statistics {
     pub is_exact: bool,
 }
 /// This table statistics are estimates about column
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ColumnStatistics {
     /// Number of null values on column
     pub null_count: Option<usize>,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -64,6 +64,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use log::{debug, trace};
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::sync::Arc;
 
 fn create_function_physical_name(
@@ -111,13 +112,13 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
         } => {
             let mut name = "CASE ".to_string();
             if let Some(e) = expr {
-                name += &format!("{:?} ", e);
+                let _ = write!(name, "{:?} ", e);
             }
             for (w, t) in when_then_expr {
-                name += &format!("WHEN {:?} THEN {:?} ", w, t);
+                let _ = write!(name, "WHEN {:?} THEN {:?} ", w, t);
             }
             if let Some(e) = else_expr {
-                name += &format!("ELSE {:?} ", e);
+                let _ = write!(name, "ELSE {:?} ", e);
             }
             name += "END";
             Ok(name)

--- a/datafusion/core/src/physical_plan/sorts/cursor.rs
+++ b/datafusion/core/src/physical_plan/sorts/cursor.rs
@@ -52,7 +52,7 @@ pub struct SortKeyCursor {
     sort_options: Arc<Vec<SortOptions>>,
 }
 
-impl<'a> std::fmt::Debug for SortKeyCursor {
+impl std::fmt::Debug for SortKeyCursor {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("SortKeyCursor")
             .field("sort_columns", &self.sort_columns)

--- a/datafusion/data-access/src/lib.rs
+++ b/datafusion/data-access/src/lib.rs
@@ -34,7 +34,7 @@ pub enum ListEntry {
 }
 
 /// The path and size of the file.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SizedFile {
     /// Path of the file. It is relative to the current object
     /// store (it does not specify the `xx://` scheme).
@@ -46,7 +46,7 @@ pub struct SizedFile {
 /// Description of a file as returned by the listing command of a
 /// given object store. The resulting path is relative to the
 /// object store that generated it.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileMeta {
     /// The path and size of the file.
     pub sized_file: SizedFile,

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -31,6 +31,7 @@ use datafusion_common::Column;
 use datafusion_common::{DFSchema, Result};
 use datafusion_common::{DataFusionError, ScalarValue};
 use std::fmt;
+use std::fmt::Write;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::ops::Not;
 use std::sync::Arc;
@@ -715,16 +716,16 @@ fn create_name(e: &Expr, input_schema: &DFSchema) -> Result<String> {
             let mut name = "CASE ".to_string();
             if let Some(e) = expr {
                 let e = create_name(e, input_schema)?;
-                name += &format!("{} ", e);
+                let _ = write!(name, "{} ", e);
             }
             for (w, t) in when_then_expr {
                 let when = create_name(w, input_schema)?;
                 let then = create_name(t, input_schema)?;
-                name += &format!("WHEN {} THEN {} ", when, then);
+                let _ = write!(name, "WHEN {} THEN {} ", when, then);
             }
             if let Some(e) = else_expr {
                 let e = create_name(e, input_schema)?;
-                name += &format!("ELSE {} ", e);
+                let _ = write!(name, "ELSE {} ", e);
             }
             name += "END";
             Ok(name)

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -620,7 +620,7 @@ impl LogicalPlan {
         struct Wrapper<'a>(&'a LogicalPlan);
         impl<'a> fmt::Display for Wrapper<'a> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                match &*self.0 {
+                match self.0 {
                     LogicalPlan::EmptyRelation(_) => write!(f, "EmptyRelation"),
                     LogicalPlan::Values(Values { ref values, .. }) => {
                         let str_values: Vec<_> = values
@@ -1098,7 +1098,7 @@ pub struct CreateView {
 }
 
 /// Types of files to parse as DataFrames
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileType {
     /// Newline-delimited JSON
     NdJson,
@@ -1273,7 +1273,7 @@ pub enum Partitioning {
 
 /// Represents which type of plan, when storing multiple
 /// for use in EXPLAIN plans
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlanType {
     /// The initial LogicalPlan provided to DataFusion
     InitialLogicalPlan,
@@ -1313,7 +1313,7 @@ impl fmt::Display for PlanType {
 }
 
 /// Represents some sort of execution plan, in String form
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::rc_buffer)]
 pub struct StringifiedPlan {
     /// An identifier of what type of plan this string represents

--- a/datafusion/expr/src/table_source.rs
+++ b/datafusion/expr/src/table_source.rs
@@ -23,7 +23,7 @@ use std::any::Any;
 
 /// Indicates whether and how a filter expression can be handled by a
 /// TableProvider for table scans.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TableProviderFilterPushDown {
     /// The expression cannot be used by the provider.
     Unsupported,
@@ -39,7 +39,7 @@ pub enum TableProviderFilterPushDown {
 }
 
 /// Indicates the type of this table for metadata/catalog purposes.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TableType {
     /// An ordinary physical table.
     Base,

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -30,6 +30,7 @@ use datafusion_expr::{
     Expr, ExprSchemable,
 };
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::sync::Arc;
 
 /// A map from expression's identifier to tuple including
@@ -424,17 +425,17 @@ impl ExprIdentifierVisitor<'_> {
             }
             Expr::Cast { data_type, .. } => {
                 desc.push_str("Cast-");
-                desc.push_str(&format!("{:?}", data_type));
+                let _ = write!(desc, "{:?}", data_type);
             }
             Expr::TryCast { data_type, .. } => {
                 desc.push_str("TryCast-");
-                desc.push_str(&format!("{:?}", data_type));
+                let _ = write!(desc, "{:?}", data_type);
             }
             Expr::Sort {
                 asc, nulls_first, ..
             } => {
                 desc.push_str("Sort-");
-                desc.push_str(&format!("{}{}", asc, nulls_first));
+                let _ = write!(desc, "{}{}", asc, nulls_first);
             }
             Expr::ScalarFunction { fun, .. } => {
                 desc.push_str("ScalarFunction-");
@@ -449,7 +450,7 @@ impl ExprIdentifierVisitor<'_> {
             } => {
                 desc.push_str("WindowFunction-");
                 desc.push_str(&fun.to_string());
-                desc.push_str(&format!("{:?}", window_frame));
+                let _ = write!(desc, "{:?}", window_frame);
             }
             Expr::AggregateFunction { fun, distinct, .. } => {
                 desc.push_str("AggregateFunction-");

--- a/datafusion/optimizer/src/limit_push_down.rs
+++ b/datafusion/optimizer/src/limit_push_down.rs
@@ -278,7 +278,7 @@ fn generate_push_down_join(
         null_equals_null,
     }) = join
     {
-        return Ok(LogicalPlan::Join(Join {
+        Ok(LogicalPlan::Join(Join {
             left: Arc::new(limit_push_down(
                 _optimizer,
                 Ancestor::FromLimit {
@@ -303,7 +303,7 @@ fn generate_push_down_join(
             join_constraint: *join_constraint,
             schema: schema.clone(),
             null_equals_null: *null_equals_null,
-        }));
+        }))
     } else {
         Err(DataFusionError::Internal(format!(
             "{:?} must be join type",

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -278,12 +278,10 @@ impl ApproxPercentileAccumulator {
                     .filter_map(|v| v.try_as_f64().transpose())
                     .collect::<Result<Vec<_>>>()?)
             }
-            e => {
-                return Err(DataFusionError::Internal(format!(
-                    "APPROX_PERCENTILE_CONT is not expected to receive the type {:?}",
-                    e
-                )));
-            }
+            e => Err(DataFusionError::Internal(format!(
+                "APPROX_PERCENTILE_CONT is not expected to receive the type {:?}",
+                e
+            ))),
         }
     }
 }

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -96,12 +96,10 @@ impl TryIntoOrderedF64 for ScalarValue {
             ScalarValue::UInt32(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
             ScalarValue::UInt64(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
 
-            got => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Support for 'TryIntoOrderedF64' for data type {} is not implemented",
-                    got
-                )))
-            }
+            got => Err(DataFusionError::NotImplemented(format!(
+                "Support for 'TryIntoOrderedF64' for data type {} is not implemented",
+                got
+            ))),
         }
     }
 }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1246,22 +1246,22 @@ impl BinaryExpr {
                 if left_data_type == &DataType::Boolean {
                     boolean_op!(left, right, and_kleene)
                 } else {
-                    return Err(DataFusionError::Internal(format!(
+                    Err(DataFusionError::Internal(format!(
                         "Cannot evaluate binary expression {:?} with types {:?} and {:?}",
                         self.op,
                         left.data_type(),
                         right.data_type()
-                    )));
+                    )))
                 }
             }
             Operator::Or => {
                 if left_data_type == &DataType::Boolean {
                     boolean_op!(left, right, or_kleene)
                 } else {
-                    return Err(DataFusionError::Internal(format!(
+                    Err(DataFusionError::Internal(format!(
                         "Cannot evaluate binary expression {:?} with types {:?} and {:?}",
                         self.op, left_data_type, right_data_type
-                    )));
+                    )))
                 }
             }
             Operator::RegexMatch => {

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -504,13 +504,11 @@ impl PhysicalExpr for InListExpr {
                         .unwrap();
                     set_contains_with_negated!(array, set, self.negated)
                 }
-                datatype => {
-                    return Result::Err(DataFusionError::NotImplemented(format!(
-                        "InSet does not support datatype {:?}.",
-                        datatype
-                    )))
-                }
-            };
+                datatype => Result::Err(DataFusionError::NotImplemented(format!(
+                    "InSet does not support datatype {:?}.",
+                    datatype
+                ))),
+            }
         } else {
             let list_values = self
                 .list

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -76,7 +76,7 @@ fn scatter(mask: &BooleanArray, truthy: &dyn Array) -> Result<ArrayRef> {
     // (SlicesIterator doesn't respect nulls)
     let mask = and_kleene(mask, &is_not_null(mask)?)?;
 
-    let mut mutable = MutableArrayData::new(vec![&*truthy], true, mask.len());
+    let mut mutable = MutableArrayData::new(vec![truthy], true, mask.len());
 
     // the SlicesIterator slices only the true values. So the gaps left by this iterator we need to
     // fill with falsy values

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -49,7 +49,7 @@ fn parse_file_type(s: &str) -> Result<FileType, ParserError> {
 }
 
 /// DataFusion extension DDL for `CREATE EXTERNAL TABLE`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateExternalTable {
     /// Table name
     pub name: String,
@@ -70,7 +70,7 @@ pub struct CreateExternalTable {
 }
 
 /// DataFusion extension DDL for `DESCRIBE TABLE`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DescribeTable {
     /// Table name
     pub table_name: String,
@@ -79,7 +79,7 @@ pub struct DescribeTable {
 /// DataFusion Statement representations.
 ///
 /// Tokens parsed by `DFParser` are converted into these values.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
     /// ANSI SQL AST node
     Statement(Box<SQLStatement>),

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -737,11 +737,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 // sqlparser-rs encodes AS t as an empty list of column alias
                 Ok(plan)
             } else if columns_alias.len() != plan.schema().fields().len() {
-                return Err(DataFusionError::Plan(format!(
+                Err(DataFusionError::Plan(format!(
                     "Source table contains {} columns but only {} names given as column alias",
                     plan.schema().fields().len(),
                     columns_alias.len(),
-                )));
+                )))
             } else {
                 Ok(LogicalPlanBuilder::from(plan.clone())
                     .project_with_alias(

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -448,19 +448,17 @@ pub(crate) fn make_decimal_type(
     scale: Option<u64>,
 ) -> Result<DataType> {
     match (precision, scale) {
-        (None, _) | (_, None) => {
-            return Err(DataFusionError::Internal(format!(
-                "Decimal(precision, scale) must both be specified, got ({:?}, {:?})",
-                precision, scale
-            )));
-        }
+        (None, _) | (_, None) => Err(DataFusionError::Internal(format!(
+            "Decimal(precision, scale) must both be specified, got ({:?}, {:?})",
+            precision, scale
+        ))),
         (Some(p), Some(s)) => {
             // Arrow decimal is i128 meaning 38 maximum decimal digits
             if (p as usize) > DECIMAL_MAX_PRECISION || s > p {
-                return Err(DataFusionError::Internal(format!(
+                Err(DataFusionError::Internal(format!(
                     "For decimal(precision, scale) precision must be less than or equal to 38 and scale can't be greater than precision. Got ({}, {})",
                     p, s
-                )));
+                )))
             } else {
                 Ok(DataType::Decimal(p as usize, s as usize))
             }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I got these clippy lints after updating my rust toolchain to 1.63.

Most warnings come from these rules:

https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

I'm not sure whether the second rule `format_push_string` is acceptable so I split it into another commit.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix clippy warnings.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

no