### PR TITLE
Add public API for GlobalLimitExec and LocalLimitExec

### DIFF
--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -70,6 +70,21 @@ impl GlobalLimitExec {
             metrics: ExecutionPlanMetricsSet::new(),
         }
     }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Number of rows to skip before fetch
+    pub fn skip(&self) -> Option<&usize> {
+        self.skip.as_ref()
+    }
+
+    /// Maximum number of rows to fetch
+    pub fn fetch(&self) -> Option<&usize> {
+        self.fetch.as_ref()
+    }
 }
 
 impl ExecutionPlan for GlobalLimitExec {
@@ -230,6 +245,16 @@ impl LocalLimitExec {
             fetch,
             metrics: ExecutionPlanMetricsSet::new(),
         }
+    }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Maximum number of rows to fetch
+    pub fn fetch(&self) -> usize {
+        self.fetch
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2720

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Query engines such as Ballista rely on being able to inspect DataFusion physical plans so that they can transform them or serialize them. A recent PR (https://github.com/apache/arrow-datafusion/pull/2694) removed part of the public API for the limit exec operators.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add public API back and update it

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->