### PR TITLE
try to reduce left/right/full join to inner join

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -25,8 +25,8 @@ use datafusion_expr::expr_rewriter::normalize_col_with_schemas;
 use datafusion_expr::logical_plan::{
     Analyze, CreateCatalog, CreateCatalogSchema,
     CreateExternalTable as PlanCreateExternalTable, CreateMemoryTable, CreateView,
-    DropTable, Explain, FileType, JoinType, LogicalPlan, LogicalPlanBuilder, PlanType,
-    ToStringifiedPlan,
+    DropTable, Explain, FileType, Join as HashJoin, JoinType, LogicalPlan,
+    LogicalPlanBuilder, PlanType, ToStringifiedPlan,
 };
 use datafusion_expr::utils::{
     can_hash, expand_qualified_wildcard, expand_wildcard, expr_as_column_expr,
@@ -783,6 +783,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
 
                 let filter_expr = self.sql_to_rex(predicate_expr, &join_schema, ctes)?;
+
+                // reduce outer joins
+                let plans = reduce_outer_joins(plans, &filter_expr)?;
 
                 // look for expressions of the form `<column> = <column>`
                 let mut possible_join_keys = vec![];
@@ -2582,6 +2585,230 @@ fn extract_join_keys(
             accum_filter.push(expr);
         }
     }
+}
+
+/// Recursively traversese expr, if expr returns false when
+/// any inputs are null, treats columns of both sides as nonnullable columns.
+///
+/// For and/or expr, extracts from all sub exprs and merges the columns.
+/// For or expr, if one of sub exprs returns true, discards all columns from or expr.
+/// For IS NOT NULL/NOT expr, always returns false for NULL input.
+///     extracts columns from these exprs.
+/// For all other exprs, fall through
+fn extract_nonnullable_columns(
+    expr: &Expr,
+    columns: &mut Vec<Column>,
+    top_level: bool,
+) -> Result<()> {
+    match expr {
+        Expr::Column(col) => {
+            columns.push(col.clone());
+            Ok(())
+        }
+        Expr::BinaryExpr { left, op, right } => match op {
+            // If one of the inputs are null for these operators, the results should be false.
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq => {
+                extract_nonnullable_columns(left, columns, false)?;
+                extract_nonnullable_columns(right, columns, false)
+            }
+            Operator::And => {
+                if !top_level {
+                    return Ok(());
+                }
+                extract_nonnullable_columns(left, columns, top_level)?;
+                extract_nonnullable_columns(right, columns, top_level)
+            }
+            Operator::Or => {
+                let mut left_nonnullable_cols: Vec<Column> = vec![];
+                let mut right_nonnullable_cols: Vec<Column> = vec![];
+
+                extract_nonnullable_columns(left, &mut left_nonnullable_cols, top_level)?;
+                extract_nonnullable_columns(
+                    right,
+                    &mut right_nonnullable_cols,
+                    top_level,
+                )?;
+
+                // for query: select *** from a left join b where b.c1 ... or b.c2 ...
+                // this can be reduced to inner join.
+                // for query: select *** from a left join b where a.c1 ... or b.c2 ...
+                // this can not be reduced.
+                // If columns of relation exist in both sub exprs, any columns of this relation
+                // can be added to non nullable columns.
+                if !left_nonnullable_cols.is_empty() && !right_nonnullable_cols.is_empty()
+                {
+                    for left_col in &left_nonnullable_cols {
+                        for right_col in &right_nonnullable_cols {
+                            if let (Some(l_rel), Some(r_rel)) =
+                                (&left_col.relation, &right_col.relation)
+                            {
+                                if l_rel == r_rel {
+                                    columns.push(left_col.clone());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        },
+        Expr::Not(arg) => extract_nonnullable_columns(arg, columns, false),
+        Expr::IsNotNull(arg) => {
+            if !top_level {
+                return Ok(());
+            }
+            extract_nonnullable_columns(arg, columns, false)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// try to reduce one outer join to inner join
+fn reduce_outer_join(
+    plan: &LogicalPlan,
+    nonnullable_cols: &Vec<Column>,
+) -> Result<Option<LogicalPlan>> {
+    match plan {
+        LogicalPlan::Join(join) => {
+            if join.join_type == JoinType::Left
+                || join.join_type == JoinType::Right
+                || join.join_type == JoinType::Full
+            {
+                let mut left_nonnullable = false;
+                let mut right_nonnullable = false;
+                for col in nonnullable_cols {
+                    if join.left.schema().field_from_column(col).is_ok() {
+                        left_nonnullable = true;
+                    }
+                    if join.right.schema().field_from_column(col).is_ok() {
+                        right_nonnullable = true;
+                    }
+                }
+                let mut new_join_type = join.join_type;
+                match join.join_type {
+                    JoinType::Left => {
+                        if right_nonnullable {
+                            new_join_type = JoinType::Inner;
+                        }
+                    }
+                    JoinType::Right => {
+                        if left_nonnullable {
+                            new_join_type = JoinType::Inner;
+                        }
+                    }
+                    JoinType::Full => {
+                        if left_nonnullable && right_nonnullable {
+                            new_join_type = JoinType::Inner;
+                        } else if left_nonnullable {
+                            new_join_type = JoinType::Left;
+                        } else if right_nonnullable {
+                            new_join_type = JoinType::Right;
+                        }
+                    }
+                    _ => {}
+                };
+                let left = reduce_outer_join(&join.left, nonnullable_cols)?;
+                let right = reduce_outer_join(&join.right, nonnullable_cols)?;
+                match (left, right) {
+                    (None, None) => {
+                        if new_join_type == join.join_type {
+                            return Ok(None);
+                        }
+                        return Ok(Some(LogicalPlan::Join(HashJoin {
+                            left: join.left.clone(),
+                            right: join.right.clone(),
+                            join_type: new_join_type,
+                            join_constraint: join.join_constraint,
+                            on: join.on.clone(),
+                            filter: join.filter.clone(),
+                            schema: join.schema.clone(),
+                            null_equals_null: join.null_equals_null,
+                        })));
+                    }
+                    (None, Some(right_plan)) => {
+                        return Ok(Some(LogicalPlan::Join(HashJoin {
+                            left: join.left.clone(),
+                            right: Arc::new(right_plan),
+                            join_type: new_join_type,
+                            join_constraint: join.join_constraint,
+                            on: join.on.clone(),
+                            filter: join.filter.clone(),
+                            schema: join.schema.clone(),
+                            null_equals_null: join.null_equals_null,
+                        })))
+                    }
+                    (Some(left_plan), None) => {
+                        return Ok(Some(LogicalPlan::Join(HashJoin {
+                            left: Arc::new(left_plan),
+                            right: join.right.clone(),
+                            join_type: new_join_type,
+                            join_constraint: join.join_constraint,
+                            on: join.on.clone(),
+                            filter: join.filter.clone(),
+                            schema: join.schema.clone(),
+                            null_equals_null: join.null_equals_null,
+                        })))
+                    }
+                    (Some(left_plan), Some(right_plan)) => {
+                        return Ok(Some(LogicalPlan::Join(HashJoin {
+                            left: Arc::new(left_plan),
+                            right: Arc::new(right_plan),
+                            join_type: new_join_type,
+                            join_constraint: join.join_constraint,
+                            on: join.on.clone(),
+                            filter: join.filter.clone(),
+                            schema: join.schema.clone(),
+                            null_equals_null: join.null_equals_null,
+                        })))
+                    }
+                }
+            };
+            Ok(None)
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Attempt to reduce outer joins to inner joins.
+/// for query: select ... from a left join b on ... where b.xx = 100;
+/// if b.xx is null, and b.xx = 100 returns false, filterd those null rows.
+/// Therefore, there is no need to produce null rows for output, we can use
+/// inner join instead of left join.
+///
+/// Generally, an outer join can be reduced to inner join if quals from where
+/// return false while any inputs are null and columns of those quals are come from
+/// nullable side of outer join.
+fn reduce_outer_joins(plans: Vec<LogicalPlan>, expr: &Expr) -> Result<Vec<LogicalPlan>> {
+    let mut nonnullable_cols: Vec<Column> = vec![];
+
+    // get all non nullable columns
+    extract_nonnullable_columns(expr, &mut nonnullable_cols, true)?;
+
+    // try to reduce outer join to inner join for each join plan
+    if !nonnullable_cols.is_empty() {
+        let mut new_plans = vec![];
+        for plan in plans {
+            let new_plan = reduce_outer_join(&plan, &nonnullable_cols)?;
+            match new_plan {
+                Some(new_plan) => {
+                    new_plans.push(new_plan);
+                }
+                None => {
+                    new_plans.push(plan);
+                }
+            }
+        }
+        return Ok(new_plans);
+    }
+
+    Ok(plans)
 }
 
 /// Extract join keys from a WHERE clause


### PR DESCRIPTION
 # Rationale for this change
try to reduce left/right/full join to inner join

for query: select ... from a left join b on ... where b.xx = 100;
if b.xx is null, and b.xx = 100 returns false, filterd those null rows.
Therefore, there is no need to produce null rows for output, we can use
inner join instead of left join.

Generally, right join/full join can also be reduced to inner join according to these rules.

# What changes are included in this PR?
add reduce_outer_plan to try to reduce left/right/full join to inner join in src/planner.rs
