### PR TITLE
Rewrite subexpressions of InSubquery in rewrite_expression

### DIFF
--- a/datafusion/expr/src/expr_visitor.rs
+++ b/datafusion/expr/src/expr_visitor.rs
@@ -102,6 +102,7 @@ impl ExprVisitable for Expr {
             | Expr::Cast { expr, .. }
             | Expr::TryCast { expr, .. }
             | Expr::Sort { expr, .. }
+            | Expr::InSubquery { expr, .. }
             | Expr::GetIndexedField { expr, .. } => expr.accept(visitor),
             Expr::GroupingSet(GroupingSet::Rollup(exprs)) => exprs
                 .iter()
@@ -120,7 +121,6 @@ impl ExprVisitable for Expr {
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_)
             | Expr::Exists { .. }
-            | Expr::InSubquery { .. }
             | Expr::ScalarSubquery(_)
             | Expr::Wildcard
             | Expr::QualifiedWildcard { .. } => Ok(visitor),

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -281,10 +281,16 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
             list: list.clone(),
             negated: *negated,
         }),
+        Expr::InSubquery {
+            subquery, negated, ..
+        } => Ok(Expr::InSubquery {
+            expr: Box::new(expressions[0].clone()),
+            subquery: subquery.clone(),
+            negated: *negated,
+        }),
         Expr::Column(_)
         | Expr::Literal(_)
         | Expr::Exists { .. }
-        | Expr::InSubquery { .. }
         | Expr::ScalarSubquery(_)
         | Expr::ScalarVariable(_, _) => Ok(expr.clone()),
         Expr::Sort {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2736.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Looking at the expressions mentioned in #2725, I think the only one that needs fixing is `Expr::InSubquery`. `Exists` and `ScalarSubquery` both have subqueries but not subexpressions, and it looks like subqueries are currently treated as completely separate plans for the purposes of optimisation. I'm new to working on query engines (and rust, for that matter!) though so may be misinterpreting this.

I've modified `rewrite_expression` so `InSubquery` exprs use the subexpression passed in `expressions` rather than just returning a clone, and added a pushdown test with an `InSubquery` predicate which uses an aliased column.

Additionally, I noticed while I was creating the test case that `InSubquery` filters were not being pushed down at all. This was because the subexpressions of `InSubquery` were not being visited by `ExpressionVisitor`, so the column in `InSubquery` predicates was not found. Fixed with a simple modification to `expr_visitor.rs`. The test case I added covers this as well.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->