### PR TITLE
Support multiple paths for ListingTableScanNode

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -93,7 +93,7 @@ message AvroFormat {}
 
 message ListingTableScanNode {
   string table_name = 1;
-  string path = 2;
+  repeated string paths = 2;
   string file_extension = 3;
   ProjectionColumns projection = 4;
   datafusion.Schema schema = 5;


### PR DESCRIPTION
# Which issue does this PR close?


Closes #2768.

 # Rationale for this change
Sometimes like in ballista we need pass multi-path in `ListingTableScanNode `, like in spark
https://github.com/apache/spark/blob/a8a765b3f302c078cb9519c4a17912cd38b9680c/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala#L36-L43
```
trait FileIndex {


  /**
   * Returns the list of root input paths from which the catalog will get files. There may be a
   * single root path from which partitions are discovered, or individual partitions may be
   * specified by each path.
   */
  def rootPaths: Seq[Path]
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->