### PR TITLE
MINOR: re-export sqlparser from datafusion-sql crate

### DIFF
--- a/datafusion/sql/examples/sql.rs
+++ b/datafusion/sql/examples/sql.rs
@@ -22,9 +22,9 @@ use datafusion_expr::{
 };
 use datafusion_sql::{
     planner::{ContextProvider, SqlToRel},
+    sqlparser::{dialect::GenericDialect, parser::Parser},
     TableReference,
 };
-use sqlparser::{dialect::GenericDialect, parser::Parser};
 use std::{collections::HashMap, sync::Arc};
 
 fn main() {

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -23,4 +23,5 @@ pub mod planner;
 mod table_reference;
 pub mod utils;
 
+pub use sqlparser;
 pub use table_reference::{ResolvedTableReference, TableReference};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Users of datafusion-sql often run into confusing Rust errors when updating the datafusion-sql version and not using the correct sqlparser version.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Re-export sqlparser so datafusion-sql users do not need to explicitly add it as a dependency.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->