### PR TITLE
tablescan projection readability fix

### DIFF
--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -1224,7 +1224,7 @@ mod tests {
 
         let expected = "Projection: #employee_csv.id\
         \n  Filter: #employee_csv.state = Utf8(\"CO\")\
-        \n    TableScan: employee_csv projection=Some([0, 3])";
+        \n    TableScan: employee_csv projection=[id, state]";
 
         assert_eq!(expected, format!("{:?}", plan));
 
@@ -1259,7 +1259,7 @@ mod tests {
 
         let expected = "Projection: #employee_csv.state, #total_salary\
         \n  Aggregate: groupBy=[[#employee_csv.state]], aggr=[[SUM(#employee_csv.salary) AS total_salary]]\
-        \n    TableScan: employee_csv projection=Some([3, 4])";
+        \n    TableScan: employee_csv projection=[state, salary]";
 
         assert_eq!(expected, format!("{:?}", plan));
 
@@ -1288,7 +1288,7 @@ mod tests {
         .build()?;
 
         let expected = "Sort: #employee_csv.state ASC NULLS FIRST, #employee_csv.salary DESC NULLS LAST\
-        \n  TableScan: employee_csv projection=Some([3, 4])";
+        \n  TableScan: employee_csv projection=[state, salary]";
 
         assert_eq!(expected, format!("{:?}", plan));
 
@@ -1308,8 +1308,8 @@ mod tests {
         // id column should only show up once in projection
         let expected = "Projection: #t1.id, #t1.first_name, #t1.last_name, #t1.state, #t1.salary, #t2.first_name, #t2.last_name, #t2.state, #t2.salary\
         \n  Inner Join: Using #t1.id = #t2.id\
-        \n    TableScan: t1 projection=None\
-        \n    TableScan: t2 projection=None";
+        \n    TableScan: t1\
+        \n    TableScan: t2";
 
         assert_eq!(expected, format!("{:?}", plan));
 
@@ -1332,10 +1332,10 @@ mod tests {
 
         // output has only one union
         let expected = "Union\
-        \n  TableScan: employee_csv projection=Some([3, 4])\
-        \n  TableScan: employee_csv projection=Some([3, 4])\
-        \n  TableScan: employee_csv projection=Some([3, 4])\
-        \n  TableScan: employee_csv projection=Some([3, 4])";
+        \n  TableScan: employee_csv projection=[state, salary]\
+        \n  TableScan: employee_csv projection=[state, salary]\
+        \n  TableScan: employee_csv projection=[state, salary]\
+        \n  TableScan: employee_csv projection=[state, salary]";
 
         assert_eq!(expected, format!("{:?}", plan));
 
@@ -1360,8 +1360,8 @@ mod tests {
         let expected = "Filter: EXISTS (\
             Subquery: Filter: #foo.a = #bar.a\
             \n  Projection: #foo.a\
-            \n    TableScan: foo projection=None)\
-        \n  Projection: #bar.a\n    TableScan: bar projection=None";
+            \n    TableScan: foo)\
+        \n  Projection: #bar.a\n    TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
 
         Ok(())
@@ -1385,9 +1385,9 @@ mod tests {
 
         let expected = "Filter: #bar.a IN (Subquery: Filter: #foo.a = #bar.a\
         \n  Projection: #foo.a\
-        \n    TableScan: foo projection=None)\
+        \n    TableScan: foo)\
         \n  Projection: #bar.a\
-        \n    TableScan: bar projection=None";
+        \n    TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
 
         Ok(())
@@ -1410,8 +1410,8 @@ mod tests {
 
         let expected = "Projection: (Subquery: Filter: #foo.a = #bar.a\
                 \n  Projection: #foo.b\
-                \n    TableScan: foo projection=None)\
-            \n  TableScan: bar projection=None";
+                \n    TableScan: foo)\
+            \n  TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
 
         Ok(())

--- a/datafusion/core/src/logical_plan/plan.rs
+++ b/datafusion/core/src/logical_plan/plan.rs
@@ -135,7 +135,7 @@ mod tests {
 
         let expected = "Projection: #employee_csv.id\
         \n  Filter: #employee_csv.state = Utf8(\"CO\")\
-        \n    TableScan: employee_csv projection=Some([0, 3])";
+        \n    TableScan: employee_csv projection=[id, state]";
 
         assert_eq!(expected, format!("{}", plan.display_indent()));
     }
@@ -146,7 +146,7 @@ mod tests {
 
         let expected = "Projection: #employee_csv.id [id:Int32]\
                         \n  Filter: #employee_csv.state = Utf8(\"CO\") [id:Int32, state:Utf8]\
-                        \n    TableScan: employee_csv projection=Some([0, 3]) [id:Int32, state:Utf8]";
+                        \n    TableScan: employee_csv projection=[id, state] [id:Int32, state:Utf8]";
 
         assert_eq!(expected, format!("{}", plan.display_indent_schema()));
     }
@@ -168,12 +168,12 @@ mod tests {
         );
         assert!(
             graphviz.contains(
-                r#"[shape=box label="TableScan: employee_csv projection=Some([0, 3])"]"#
+                r#"[shape=box label="TableScan: employee_csv projection=[id, state]"]"#
             ),
             "\n{}",
             plan.display_graphviz()
         );
-        assert!(graphviz.contains(r#"[shape=box label="TableScan: employee_csv projection=Some([0, 3])\nSchema: [id:Int32, state:Utf8]"]"#),
+        assert!(graphviz.contains(r#"[shape=box label="TableScan: employee_csv projection=[id, state]\nSchema: [id:Int32, state:Utf8]"]"#),
                 "\n{}", plan.display_graphviz());
         assert!(
             graphviz.contains(r#"// End DataFusion GraphViz Plan"#),

--- a/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
+++ b/datafusion/core/src/optimizer/common_subexpr_eliminate.rs
@@ -747,7 +747,7 @@ mod test {
 
         let expected = "Aggregate: groupBy=[[]], aggr=[[SUM(#BinaryExpr-*BinaryExpr--Column-test.bLiteral1Column-test.a AS test.a * Int32(1) - test.b), SUM(#BinaryExpr-*BinaryExpr--Column-test.bLiteral1Column-test.a AS test.a * Int32(1) - test.b * Int32(1) + #test.c)]]\
         \n  Projection: #test.a * Int32(1) - #test.b AS BinaryExpr-*BinaryExpr--Column-test.bLiteral1Column-test.a, #test.a, #test.b, #test.c\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -770,7 +770,7 @@ mod test {
 
         let expected = "Aggregate: groupBy=[[]], aggr=[[Int32(1) + #AggregateFunction-AVGfalseColumn-test.a AS AVG(test.a), Int32(1) - #AggregateFunction-AVGfalseColumn-test.a AS AVG(test.a)]]\
         \n  Projection: AVG(#test.a) AS AggregateFunction-AVGfalseColumn-test.a, #test.a, #test.b, #test.c\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -790,7 +790,7 @@ mod test {
 
         let expected = "Projection: #BinaryExpr-+Column-test.aLiteral1 AS Int32(1) + test.a AS first, #BinaryExpr-+Column-test.aLiteral1 AS Int32(1) + test.a AS second\
         \n  Projection: Int32(1) + #test.a AS BinaryExpr-+Column-test.aLiteral1, #test.a, #test.b, #test.c\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -809,7 +809,7 @@ mod test {
             .build()?;
 
         let expected = "Projection: Int32(1) + #test.a, #test.a + Int32(1)\
-        \n  TableScan: test projection=None";
+        \n  TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -827,7 +827,7 @@ mod test {
 
         let expected = "Projection: #Int32(1) + test.a\
         \n  Projection: Int32(1) + #test.a\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 

--- a/datafusion/core/src/optimizer/eliminate_filter.rs
+++ b/datafusion/core/src/optimizer/eliminate_filter.rs
@@ -137,7 +137,7 @@ mod tests {
         let expected = "Union\
             \n  EmptyRelation\
             \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
     }
 
@@ -155,7 +155,7 @@ mod tests {
             .unwrap();
 
         let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
-        \n  TableScan: test projection=None";
+        \n  TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
     }
 
@@ -182,9 +182,9 @@ mod tests {
         // Filter is removed
         let expected = "Union\
             \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
     }
 }

--- a/datafusion/core/src/optimizer/eliminate_limit.rs
+++ b/datafusion/core/src/optimizer/eliminate_limit.rs
@@ -124,7 +124,7 @@ mod tests {
         let expected = "Union\
             \n  EmptyRelation\
             \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b)]]\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
     }
 }

--- a/datafusion/core/src/optimizer/filter_push_down.rs
+++ b/datafusion/core/src/optimizer/filter_push_down.rs
@@ -630,7 +630,7 @@ mod tests {
         let expected = "\
             Projection: #test.a, #test.b\
             \n  Filter: #test.a = Int64(1)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -648,7 +648,7 @@ mod tests {
             Filter: #test.a = Int64(1)\
             \n  Limit: 10\
             \n    Projection: #test.a, #test.b\
-            \n      TableScan: test projection=None";
+            \n      TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -661,7 +661,7 @@ mod tests {
             .build()?;
         let expected = "\
             Filter: Int64(0) = Int64(1)\
-            \n  TableScan: test projection=None";
+            \n  TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -679,7 +679,7 @@ mod tests {
             Projection: #test.c, #test.b\
             \n  Projection: #test.a, #test.b, #test.c\
             \n    Filter: #test.a = Int64(1)\
-            \n      TableScan: test projection=None";
+            \n      TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -695,7 +695,7 @@ mod tests {
         let expected = "\
             Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b) AS total_salary]]\
             \n  Filter: #test.a > Int64(10)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -711,7 +711,7 @@ mod tests {
         let expected = "\
             Filter: #b > Int64(10)\
             \n  Aggregate: groupBy=[[#test.a]], aggr=[[SUM(#test.b) AS b]]\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -728,7 +728,7 @@ mod tests {
         let expected = "\
             Projection: #test.a AS b, #test.c\
             \n  Filter: #test.a = Int64(1)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -767,14 +767,14 @@ mod tests {
             "\
             Filter: #b = Int64(1)\
             \n  Projection: #test.a * Int32(2) + #test.c AS b, #test.c\
-            \n    TableScan: test projection=None"
+            \n    TableScan: test"
         );
 
         // filter is before projection
         let expected = "\
             Projection: #test.a * Int32(2) + #test.c AS b, #test.c\
             \n  Filter: #test.a * Int32(2) + #test.c = Int64(1)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -800,7 +800,7 @@ mod tests {
             Filter: #a = Int64(1)\
             \n  Projection: #b * Int32(3) AS a, #test.c\
             \n    Projection: #test.a * Int32(2) + #test.c AS b, #test.c\
-            \n      TableScan: test projection=None"
+            \n      TableScan: test"
         );
 
         // filter is before the projections
@@ -808,7 +808,7 @@ mod tests {
         Projection: #b * Int32(3) AS a, #test.c\
         \n  Projection: #test.a * Int32(2) + #test.c AS b, #test.c\
         \n    Filter: #test.a * Int32(2) + #test.c * Int32(3) = Int64(1)\
-        \n      TableScan: test projection=None";
+        \n      TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -834,7 +834,7 @@ mod tests {
             \n  Filter: #b > Int64(10)\
             \n    Aggregate: groupBy=[[#b]], aggr=[[SUM(#test.c)]]\
             \n      Projection: #test.a AS b, #test.c\
-            \n        TableScan: test projection=None"
+            \n        TableScan: test"
         );
 
         // filter is before the projections
@@ -843,7 +843,7 @@ mod tests {
         \n  Aggregate: groupBy=[[#b]], aggr=[[SUM(#test.c)]]\
         \n    Projection: #test.a AS b, #test.c\
         \n      Filter: #test.a > Int64(10)\
-        \n        TableScan: test projection=None";
+        \n        TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
 
         Ok(())
@@ -871,7 +871,7 @@ mod tests {
             Filter: #SUM(test.c) > Int64(10) AND #b > Int64(10) AND #SUM(test.c) < Int64(20)\
             \n  Aggregate: groupBy=[[#b]], aggr=[[SUM(#test.c)]]\
             \n    Projection: #test.a AS b, #test.c\
-            \n      TableScan: test projection=None"
+            \n      TableScan: test"
         );
 
         // filter is before the projections
@@ -880,7 +880,7 @@ mod tests {
         \n  Aggregate: groupBy=[[#b]], aggr=[[SUM(#test.c)]]\
         \n    Projection: #test.a AS b, #test.c\
         \n      Filter: #test.a > Int64(10)\
-        \n        TableScan: test projection=None";
+        \n        TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
 
         Ok(())
@@ -904,7 +904,7 @@ mod tests {
             \n    Limit: 10\
             \n      Limit: 20\
             \n        Projection: #test.a, #test.b\
-            \n          TableScan: test projection=None";
+            \n          TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -920,9 +920,9 @@ mod tests {
         let expected = "\
             Union\
             \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -941,9 +941,9 @@ mod tests {
         let expected = "\
             Union\
             \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n  Filter: #a = Int64(1)\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -969,7 +969,7 @@ mod tests {
              \n    Limit: 1\
              \n      Filter: #test.a <= Int64(1)\
              \n        Projection: #test.a\
-             \n          TableScan: test projection=None"
+             \n          TableScan: test"
         );
 
         let expected = "\
@@ -978,7 +978,7 @@ mod tests {
         \n    Limit: 1\
         \n      Projection: #test.a\
         \n        Filter: #test.a <= Int64(1)\
-        \n          TableScan: test projection=None";
+        \n          TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -1002,14 +1002,14 @@ mod tests {
             \n  Filter: #test.a >= Int64(1)\
             \n    Filter: #test.a <= Int64(1)\
             \n      Limit: 1\
-            \n        TableScan: test projection=None"
+            \n        TableScan: test"
         );
 
         let expected = "\
         Projection: #test.a\
         \n  Filter: #test.a >= Int64(1) AND #test.a <= Int64(1)\
         \n    Limit: 1\
-        \n      TableScan: test projection=None";
+        \n      TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -1029,7 +1029,7 @@ mod tests {
         let expected = "\
             TestUserDefined\
              \n  Filter: #test.a <= Int64(1)\
-             \n    TableScan: test projection=None";
+             \n    TableScan: test";
 
         // not part of the test
         assert_eq!(format!("{:?}", plan), expected);
@@ -1062,19 +1062,19 @@ mod tests {
             "\
             Filter: #test.a <= Int64(1)\
             \n  Inner Join: #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter sent to side before the join
         let expected = "\
         Inner Join: #test.a = #test2.a\
         \n  Filter: #test.a <= Int64(1)\
-        \n    TableScan: test projection=None\
+        \n    TableScan: test\
         \n  Projection: #test2.a\
         \n    Filter: #test2.a <= Int64(1)\
-        \n      TableScan: test2 projection=None";
+        \n      TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1103,19 +1103,19 @@ mod tests {
             "\
             Filter: #test.a <= Int64(1)\
             \n  Inner Join: Using #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter sent to side before the join
         let expected = "\
         Inner Join: Using #test.a = #test2.a\
         \n  Filter: #test.a <= Int64(1)\
-        \n    TableScan: test projection=None\
+        \n    TableScan: test\
         \n  Projection: #test2.a\
         \n    Filter: #test2.a <= Int64(1)\
-        \n      TableScan: test2 projection=None";
+        \n      TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1148,9 +1148,9 @@ mod tests {
             Filter: #test.c <= #test2.b\
             \n  Inner Join: #test.a = #test2.a\
             \n    Projection: #test.a, #test.c\
-            \n      TableScan: test projection=None\
+            \n      TableScan: test\
             \n    Projection: #test2.a, #test2.b\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // expected is equal: no push-down
@@ -1187,18 +1187,18 @@ mod tests {
             Filter: #test.b <= Int64(1)\
             \n  Inner Join: #test.a = #test2.a\
             \n    Projection: #test.a, #test.b\
-            \n      TableScan: test projection=None\
+            \n      TableScan: test\
             \n    Projection: #test2.a, #test2.c\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         let expected = "\
         Inner Join: #test.a = #test2.a\
         \n  Projection: #test.a, #test.b\
         \n    Filter: #test.b <= Int64(1)\
-        \n      TableScan: test projection=None\
+        \n      TableScan: test\
         \n  Projection: #test2.a, #test2.c\
-        \n    TableScan: test2 projection=None";
+        \n    TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1228,18 +1228,18 @@ mod tests {
             "\
             Filter: #test2.a <= Int64(1)\
             \n  Left Join: Using #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter not duplicated nor pushed down - i.e. noop
         let expected = "\
         Filter: #test2.a <= Int64(1)\
         \n  Left Join: Using #test.a = #test2.a\
-        \n    TableScan: test projection=None\
+        \n    TableScan: test\
         \n    Projection: #test2.a\
-        \n      TableScan: test2 projection=None";
+        \n      TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1269,18 +1269,18 @@ mod tests {
             "\
             Filter: #test.a <= Int64(1)\
             \n  Right Join: Using #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter not duplicated nor pushed down - i.e. noop
         let expected = "\
         Filter: #test.a <= Int64(1)\
         \n  Right Join: Using #test.a = #test2.a\
-        \n    TableScan: test projection=None\
+        \n    TableScan: test\
         \n    Projection: #test2.a\
-        \n      TableScan: test2 projection=None";
+        \n      TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1310,18 +1310,18 @@ mod tests {
             "\
             Filter: #test.a <= Int64(1)\
             \n  Left Join: Using #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter sent to left side of the join, not the right
         let expected = "\
         Left Join: Using #test.a = #test2.a\
         \n  Filter: #test.a <= Int64(1)\
-        \n    TableScan: test projection=None\
+        \n    TableScan: test\
         \n  Projection: #test2.a\
-        \n    TableScan: test2 projection=None";
+        \n    TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1351,18 +1351,18 @@ mod tests {
             "\
             Filter: #test2.a <= Int64(1)\
             \n  Right Join: Using #test.a = #test2.a\
-            \n    TableScan: test projection=None\
+            \n    TableScan: test\
             \n    Projection: #test2.a\
-            \n      TableScan: test2 projection=None"
+            \n      TableScan: test2"
         );
 
         // filter sent to right side of join, not duplicated to the left
         let expected = "\
         Right Join: Using #test.a = #test2.a\
-        \n  TableScan: test projection=None\
+        \n  TableScan: test\
         \n  Projection: #test2.a\
         \n    Filter: #test2.a <= Int64(1)\
-        \n      TableScan: test2 projection=None";
+        \n      TableScan: test2";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1435,7 +1435,7 @@ mod tests {
         let plan = table_scan_with_pushdown_provider(TableProviderFilterPushDown::Exact)?;
 
         let expected = "\
-        TableScan: test projection=None, full_filters=[#a = Int64(1)]";
+        TableScan: test, full_filters=[#a = Int64(1)]";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1447,7 +1447,7 @@ mod tests {
 
         let expected = "\
         Filter: #a = Int64(1)\
-        \n  TableScan: test projection=None, partial_filters=[#a = Int64(1)]";
+        \n  TableScan: test, partial_filters=[#a = Int64(1)]";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1461,7 +1461,7 @@ mod tests {
 
         let expected = "\
         Filter: #a = Int64(1)\
-        \n  TableScan: test projection=None, partial_filters=[#a = Int64(1)]";
+        \n  TableScan: test, partial_filters=[#a = Int64(1)]";
 
         // Optimizing the same plan multiple times should produce the same plan
         // each time.
@@ -1476,7 +1476,7 @@ mod tests {
 
         let expected = "\
         Filter: #a = Int64(1)\
-        \n  TableScan: test projection=None";
+        \n  TableScan: test";
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
     }
@@ -1505,7 +1505,7 @@ mod tests {
 
         let expected ="Projection: #a, #b\
             \n  Filter: #a = Int64(10) AND #b > Int64(11)\
-            \n    TableScan: test projection=Some([0]), partial_filters=[#a = Int64(10), #b > Int64(11)]";
+            \n    TableScan: test projection=[a], partial_filters=[#a = Int64(10), #b > Int64(11)]";
 
         assert_optimized_plan_eq(&plan, expected);
 

--- a/datafusion/core/src/optimizer/limit_push_down.rs
+++ b/datafusion/core/src/optimizer/limit_push_down.rs
@@ -190,7 +190,7 @@ mod test {
         // When it has a select
         let expected = "Limit: 1000\
         \n  Projection: #test.a\
-        \n    TableScan: test projection=None, limit=1000";
+        \n    TableScan: test, limit=1000";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -210,7 +210,7 @@ mod test {
         // This rule doesn't replace multiple limits
         let expected = "Limit: 10\
         \n  Limit: 10\
-        \n    TableScan: test projection=None, limit=10";
+        \n    TableScan: test, limit=10";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -229,7 +229,7 @@ mod test {
         // Limit should *not* push down aggregate node
         let expected = "Limit: 1000\
         \n  Aggregate: groupBy=[[#test.a]], aggr=[[MAX(#test.b)]]\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -249,9 +249,9 @@ mod test {
         let expected = "Limit: 1000\
         \n  Union\
         \n    Limit: 1000\
-        \n      TableScan: test projection=None, limit=1000\
+        \n      TableScan: test, limit=1000\
         \n    Limit: 1000\
-        \n      TableScan: test projection=None, limit=1000";
+        \n      TableScan: test, limit=1000";
 
         assert_optimized_plan_eq(&plan, expected);
 
@@ -272,7 +272,7 @@ mod test {
         let expected = "Limit: 10\
         \n  Aggregate: groupBy=[[#test.a]], aggr=[[MAX(#test.b)]]\
         \n    Limit: 1000\
-        \n      TableScan: test projection=None, limit=1000";
+        \n      TableScan: test, limit=1000";
 
         assert_optimized_plan_eq(&plan, expected);
 

--- a/datafusion/core/src/optimizer/simplify_expressions.rs
+++ b/datafusion/core/src/optimizer/simplify_expressions.rs
@@ -1538,7 +1538,7 @@ mod tests {
             "\
 	        Filter: #test.b > Int32(1) AS test.b > Int32(1) AND test.b > Int32(1)\
             \n  Projection: #test.a\
-            \n    TableScan: test projection=None",
+            \n    TableScan: test",
         );
     }
 
@@ -1562,7 +1562,7 @@ mod tests {
             "\
             Filter: #test.a > Int32(5) AND #test.b < Int32(6) AS test.a > Int32(5) AND test.b < Int32(6) AND test.a > Int32(5)\
             \n  Projection: #test.a, #test.b\
-	        \n    TableScan: test projection=None",
+	        \n    TableScan: test",
         );
     }
 
@@ -1583,7 +1583,7 @@ mod tests {
         Projection: #test.a\
         \n  Filter: NOT #test.c AS test.c = Boolean(false)\
         \n    Filter: #test.b AS test.b = Boolean(true)\
-        \n      TableScan: test projection=None";
+        \n      TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1608,7 +1608,7 @@ mod tests {
         \n  Limit: 1\
         \n    Filter: #test.c AS test.c != Boolean(false)\
         \n      Filter: NOT #test.b AS test.b != Boolean(true)\
-        \n        TableScan: test projection=None";
+        \n        TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1627,7 +1627,7 @@ mod tests {
         let expected = "\
         Projection: #test.a\
         \n  Filter: NOT #test.b AND #test.c AS test.b != Boolean(true) AND test.c = Boolean(true)\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1646,7 +1646,7 @@ mod tests {
         let expected = "\
         Projection: #test.a\
         \n  Filter: NOT #test.b OR NOT #test.c AS test.b != Boolean(true) OR test.c = Boolean(false)\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1665,7 +1665,7 @@ mod tests {
         let expected = "\
         Projection: #test.a\
         \n  Filter: #test.b AS NOT test.b = Boolean(false)\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1681,7 +1681,7 @@ mod tests {
 
         let expected = "\
         Projection: #test.a, #test.d, NOT #test.b AS test.b = Boolean(false)\
-        \n  TableScan: test projection=None";
+        \n  TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1706,7 +1706,7 @@ mod tests {
         let expected = "\
         Aggregate: groupBy=[[#test.a, #test.c]], aggr=[[MAX(#test.b) AS MAX(test.b = Boolean(true)), MIN(#test.b)]]\
         \n  Projection: #test.a, #test.c, #test.b\
-        \n    TableScan: test projection=None";
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(&plan, expected);
     }
@@ -1775,7 +1775,7 @@ mod tests {
             .unwrap();
 
         let expected = "Projection: TimestampNanosecond(1599566400000000000, None) AS totimestamp(Utf8(\"2020-09-08T12:00:00+00:00\"))\
-            \n  TableScan: test projection=None"
+            \n  TableScan: test"
             .to_string();
         let actual = get_optimized_plan_formatted(&plan, &Utc::now());
         assert_eq!(expected, actual);
@@ -1810,7 +1810,7 @@ mod tests {
             .unwrap();
 
         let expected = "Projection: Int32(0) AS CAST(Utf8(\"0\") AS Int32)\
-            \n  TableScan: test projection=None";
+            \n  TableScan: test";
         let actual = get_optimized_plan_formatted(&plan, &Utc::now());
         assert_eq!(expected, actual);
     }
@@ -1852,7 +1852,7 @@ mod tests {
         let actual = get_optimized_plan_formatted(&plan, &time);
         let expected = format!(
             "Projection: TimestampNanosecond({}, Some(\"UTC\")) AS now(), TimestampNanosecond({}, Some(\"UTC\")) AS t2\
-            \n  TableScan: test projection=None",
+            \n  TableScan: test",
             time.timestamp_nanos(),
             time.timestamp_nanos()
         );
@@ -1877,7 +1877,7 @@ mod tests {
         let actual = get_optimized_plan_formatted(&plan, &time);
         let expected =
             "Projection: NOT #test.a AS Boolean(true) OR Boolean(false) != test.a\
-                        \n  TableScan: test projection=None";
+                        \n  TableScan: test";
 
         assert_eq!(actual, expected);
     }
@@ -1902,7 +1902,7 @@ mod tests {
         // Note that constant folder runs and folds the entire
         // expression down to a single constant (true)
         let expected = "Filter: Boolean(true) AS CAST(now() AS Int64) < CAST(totimestamp(Utf8(\"2020-09-08T12:05:00+00:00\")) AS Int64) + Int32(50000)\
-                        \n  TableScan: test projection=None";
+                        \n  TableScan: test";
         let actual = get_optimized_plan_formatted(&plan, &time);
 
         assert_eq!(expected, actual);
@@ -1934,7 +1934,7 @@ mod tests {
         // Note that constant folder runs and folds the entire
         // expression down to a single constant (true)
         let expected = "Projection: Date32(\"18636\") AS CAST(totimestamp(Utf8(\"2020-09-08T12:05:00+00:00\")) AS Date32) + IntervalDayTime(\"123\")\
-            \n  TableScan: test projection=None";
+            \n  TableScan: test";
         let actual = get_optimized_plan_formatted(&plan, &time);
 
         assert_eq!(expected, actual);

--- a/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
+++ b/datafusion/core/src/optimizer/single_distinct_to_groupby.rs
@@ -222,8 +222,9 @@ mod tests {
             .build()?;
 
         // Do nothing
-        let expected = "Aggregate: groupBy=[[]], aggr=[[MAX(#test.b)]] [MAX(test.b):UInt32;N]\
-                            \n  TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+        let expected =
+            "Aggregate: groupBy=[[]], aggr=[[MAX(#test.b)]] [MAX(test.b):UInt32;N]\
+                            \n  TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -241,7 +242,7 @@ mod tests {
         let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT test.b) [COUNT(DISTINCT test.b):UInt64;N]\
                             \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):UInt64;N]\
                             \n    Aggregate: groupBy=[[#test.b AS alias1]], aggr=[[]] [alias1:UInt32]\
-                            \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n      TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -258,7 +259,7 @@ mod tests {
         let expected = "Projection: #COUNT(alias1) AS COUNT(DISTINCT Int32(2) * test.b) [COUNT(DISTINCT Int32(2) * test.b):UInt64;N]\
                             \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#alias1)]] [COUNT(alias1):UInt64;N]\
                             \n    Aggregate: groupBy=[[Int32(2) * #test.b AS alias1]], aggr=[[]] [alias1:Int32]\
-                            \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n      TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -276,7 +277,7 @@ mod tests {
         let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):UInt64;N]\
                             \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1)]] [a:UInt32, COUNT(alias1):UInt64;N]\
                             \n    Aggregate: groupBy=[[#test.a, #test.b AS alias1]], aggr=[[]] [a:UInt32, alias1:UInt32]\
-                            \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n      TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -295,7 +296,7 @@ mod tests {
 
         // Do nothing
         let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(DISTINCT #test.c)]] [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, COUNT(DISTINCT test.c):UInt64;N]\
-                            \n  TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n  TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -322,7 +323,7 @@ mod tests {
         let expected = "Projection: #test.a AS a, #COUNT(alias1) AS COUNT(DISTINCT test.b), #MAX(alias1) AS MAX(DISTINCT test.b) [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, MAX(DISTINCT test.b):UInt32;N]\
                             \n  Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(#alias1), MAX(#alias1)]] [a:UInt32, COUNT(alias1):UInt64;N, MAX(alias1):UInt32;N]\
                             \n    Aggregate: groupBy=[[#test.a, #test.b AS alias1]], aggr=[[]] [a:UInt32, alias1:UInt32]\
-                            \n      TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n      TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())
@@ -341,7 +342,7 @@ mod tests {
 
         // Do nothing
         let expected = "Aggregate: groupBy=[[#test.a]], aggr=[[COUNT(DISTINCT #test.b), COUNT(#test.c)]] [a:UInt32, COUNT(DISTINCT test.b):UInt64;N, COUNT(test.c):UInt64;N]\
-                            \n  TableScan: test projection=None [a:UInt32, b:UInt32, c:UInt32]";
+                            \n  TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
         Ok(())

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2571,7 +2571,7 @@ mod tests {
         quick_test(
             "SELECT *, first_name AS fn from person",
             "Projection: #person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀, #person.first_name AS fn\
-            \n  TableScan: person projection=None",
+            \n  TableScan: person",
         );
     }
 
@@ -2590,7 +2590,7 @@ mod tests {
                    FROM person WHERE state = 'CO'";
         let expected = "Projection: #person.id, #person.first_name, #person.last_name\
                         \n  Filter: #person.state = Utf8(\"CO\")\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2614,7 +2614,7 @@ mod tests {
                    FROM person WHERE NOT state";
         let expected = "Projection: #person.id, #person.first_name, #person.last_name\
                         \n  Filter: NOT #person.state\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2624,7 +2624,7 @@ mod tests {
                    FROM person WHERE state = 'CO' AND age >= 21 AND age <= 65";
         let expected = "Projection: #person.id, #person.first_name, #person.last_name\
             \n  Filter: #person.state = Utf8(\"CO\") AND #person.age >= Int64(21) AND #person.age <= Int64(65)\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2635,7 +2635,7 @@ mod tests {
 
         let expected = "Projection: #person.state\
             \n  Filter: #person.birth_date < CAST(Int64(158412331400600000) AS Timestamp(Nanosecond, None))\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -2647,7 +2647,7 @@ mod tests {
 
         let expected = "Projection: #person.state\
             \n  Filter: #person.birth_date < CAST(Utf8(\"2020-01-01\") AS Date32)\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -2669,7 +2669,7 @@ mod tests {
                         AND #person.age >= Int64(21) \
                         AND #person.age < Int64(65) \
                         AND #person.age <= Int64(65)\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2678,7 +2678,7 @@ mod tests {
         let sql = "SELECT state FROM person WHERE age BETWEEN 21 AND 65";
         let expected = "Projection: #person.state\
             \n  Filter: #person.age BETWEEN Int64(21) AND Int64(65)\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -2688,7 +2688,7 @@ mod tests {
         let sql = "SELECT state FROM person WHERE age NOT BETWEEN 21 AND 65";
         let expected = "Projection: #person.state\
             \n  Filter: #person.age NOT BETWEEN Int64(21) AND Int64(65)\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -2708,7 +2708,7 @@ mod tests {
                         \n    Projection: #a.fn1 AS fn2, #a.last_name, #a.birth_date, alias=b\
                         \n      Projection: #a.fn1, #a.last_name, #a.birth_date, #a.age, alias=a\
                         \n        Projection: #person.first_name AS fn1, #person.last_name, #person.birth_date, #person.age, alias=a\
-                        \n          TableScan: person projection=None";
+                        \n          TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2727,7 +2727,7 @@ mod tests {
                         \n    Projection: #a.fn1, #a.age, alias=a\
                         \n      Projection: #person.first_name AS fn1, #person.age, alias=a\
                         \n        Filter: #person.age > Int64(20)\
-                        \n          TableScan: person projection=None";
+                        \n          TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -2739,7 +2739,7 @@ mod tests {
         let expected = "Projection: #l.a, #l.b, #l.c\
                         \n  Projection: #l.l_item_id AS a, #l.l_description AS b, #l.price AS c, alias=l\
                         \n    SubqueryAlias: l\
-                        \n      TableScan: lineitem projection=None";
+                        \n      TableScan: lineitem";
         quick_test(sql, expected);
     }
 
@@ -2761,7 +2761,7 @@ mod tests {
                    HAVING age > 100 AND age < 200";
         let expected = "Projection: #person.id, #person.age\
                         \n  Filter: #person.age > Int64(100) AND #person.age < Int64(200)\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2809,7 +2809,7 @@ mod tests {
         let expected = "Projection: #MAX(person.age)\
                         \n  Filter: #MAX(person.age) < Int64(30)\
                         \n    Aggregate: groupBy=[[]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2821,7 +2821,7 @@ mod tests {
         let expected = "Projection: #MAX(person.age)\
                         \n  Filter: #MAX(person.first_name) > Utf8(\"M\")\
                         \n    Aggregate: groupBy=[[]], aggr=[[MAX(#person.age), MAX(#person.first_name)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2846,7 +2846,7 @@ mod tests {
         let expected = "Projection: #MAX(person.age) AS max_age\
                         \n  Filter: #MAX(person.age) < Int64(30)\
                         \n    Aggregate: groupBy=[[]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2858,7 +2858,7 @@ mod tests {
         let expected = "Projection: #MAX(person.age) AS max_age\
                         \n  Filter: #MAX(person.age) < Int64(30)\
                         \n    Aggregate: groupBy=[[]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2871,7 +2871,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #person.first_name = Utf8(\"M\")\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2886,7 +2886,7 @@ mod tests {
                         \n  Filter: #MAX(person.age) < Int64(100)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
                         \n      Filter: #person.id > Int64(5)\
-                        \n        TableScan: person projection=None";
+                        \n        TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2902,7 +2902,7 @@ mod tests {
                         \n  Filter: #MAX(person.age) < Int64(100)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
                         \n      Filter: #person.id > Int64(5) AND #person.age > Int64(18)\
-                        \n        TableScan: person projection=None";
+                        \n        TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2915,7 +2915,7 @@ mod tests {
         let expected = "Projection: #person.first_name AS fn, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(2) AND #person.first_name = Utf8(\"M\")\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2929,7 +2929,7 @@ mod tests {
         let expected = "Projection: #person.first_name AS fn, #MAX(person.age) AS max_age\
                         \n  Filter: #MAX(person.age) > Int64(2) AND #MAX(person.age) < Int64(5) AND #person.first_name = Utf8(\"M\") AND #person.first_name = Utf8(\"N\")\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2942,7 +2942,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(100)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2968,7 +2968,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(100) AND #MAX(person.age) < Int64(200)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2981,7 +2981,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(100) AND #MIN(person.id) < Int64(50)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age), MIN(#person.id)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -2995,7 +2995,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age) AS max_age\
                         \n  Filter: #MAX(person.age) > Int64(100)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3010,7 +3010,7 @@ mod tests {
             "Projection: #person.first_name, #MAX(person.age) + Int64(1) AS max_age_plus_one\
                         \n  Filter: #MAX(person.age) + Int64(1) > Int64(100)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3024,7 +3024,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(100) AND #MIN(person.id - Int64(2)) < Int64(50)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age), MIN(#person.id - Int64(2))]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3037,7 +3037,7 @@ mod tests {
         let expected = "Projection: #person.first_name, #MAX(person.age)\
                         \n  Filter: #MAX(person.age) > Int64(100) AND #COUNT(UInt8(1)) < Int64(50)\
                         \n    Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age), COUNT(UInt8(1))]]\
-                        \n      TableScan: person projection=None";
+                        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3045,7 +3045,7 @@ mod tests {
     fn select_binary_expr() {
         let sql = "SELECT age + salary from person";
         let expected = "Projection: #person.age + #person.salary\
-                        \n  TableScan: person projection=None";
+                        \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3053,7 +3053,7 @@ mod tests {
     fn select_binary_expr_nested() {
         let sql = "SELECT (age + salary)/2 from person";
         let expected = "Projection: #person.age + #person.salary / Int64(2)\
-                        \n  TableScan: person projection=None";
+                        \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3063,7 +3063,7 @@ mod tests {
             r#"SELECT * FROM person GROUP BY id, first_name, last_name, age, state, salary, birth_date, "😀""#,
             "Projection: #person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀\
              \n  Aggregate: groupBy=[[#person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀]], aggr=[[]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
         quick_test(
             "SELECT * FROM (SELECT first_name, last_name FROM person) AS a GROUP BY first_name, last_name",
@@ -3071,7 +3071,7 @@ mod tests {
              \n  Aggregate: groupBy=[[#a.first_name, #a.last_name]], aggr=[[]]\
              \n    Projection: #a.first_name, #a.last_name, alias=a\
              \n      Projection: #person.first_name, #person.last_name, alias=a\
-             \n        TableScan: person projection=None",
+             \n        TableScan: person",
         );
     }
 
@@ -3081,7 +3081,7 @@ mod tests {
             "SELECT MIN(age) FROM person",
             "Projection: #MIN(person.age)\
             \n  Aggregate: groupBy=[[]], aggr=[[MIN(#person.age)]]\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
     }
 
@@ -3091,7 +3091,7 @@ mod tests {
             "SELECT SUM(age) from person",
             "Projection: #SUM(person.age)\
             \n  Aggregate: groupBy=[[]], aggr=[[SUM(#person.age)]]\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
     }
 
@@ -3118,7 +3118,7 @@ mod tests {
             "SELECT MIN(age), MIN(age) AS a FROM person",
             "Projection: #MIN(person.age), #MIN(person.age) AS a\
              \n  Aggregate: groupBy=[[]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3128,7 +3128,7 @@ mod tests {
             "SELECT MIN(age) AS a, MIN(age) AS b FROM person",
             "Projection: #MIN(person.age) AS a, #MIN(person.age) AS b\
              \n  Aggregate: groupBy=[[]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3148,7 +3148,7 @@ mod tests {
             "SELECT state, MIN(age), MAX(age) FROM person GROUP BY state",
             "Projection: #person.state, #MIN(person.age), #MAX(person.age)\
             \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age), MAX(#person.age)]]\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
     }
 
@@ -3158,7 +3158,7 @@ mod tests {
             "SELECT state AS a, MIN(age) AS b FROM person GROUP BY state",
             "Projection: #person.state AS a, #MIN(person.age) AS b\
              \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3178,7 +3178,7 @@ mod tests {
             "SELECT MIN(age), MAX(age) FROM person GROUP BY state",
             "Projection: #MIN(person.age), #MAX(person.age)\
              \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age), MAX(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3236,7 +3236,7 @@ mod tests {
             "SELECT MAX(first_name) FROM person GROUP BY first_name",
             "Projection: #MAX(person.first_name)\
              \n  Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3246,13 +3246,13 @@ mod tests {
             "SELECT state, age AS b, COUNT(1) FROM person GROUP BY 1, 2",
             "Projection: #person.state, #person.age AS b, #COUNT(UInt8(1))\
              \n  Aggregate: groupBy=[[#person.state, #person.age]], aggr=[[COUNT(UInt8(1))]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
         quick_test(
             "SELECT state, age AS b, COUNT(1) FROM person GROUP BY 2, 1",
             "Projection: #person.state, #person.age AS b, #COUNT(UInt8(1))\
              \n  Aggregate: groupBy=[[#person.age, #person.state]], aggr=[[COUNT(UInt8(1))]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3279,7 +3279,7 @@ mod tests {
             "SELECT state AS a, MIN(age) AS b FROM person GROUP BY a",
             "Projection: #person.state AS a, #MIN(person.age) AS b\
              \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3299,7 +3299,7 @@ mod tests {
             "SELECT state, MIN(age), MIN(age) AS ma FROM person GROUP BY state",
             "Projection: #person.state, #MIN(person.age), #MIN(person.age) AS ma\
              \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         )
     }
 
@@ -3309,7 +3309,7 @@ mod tests {
             "SELECT MIN(first_name) FROM person GROUP BY age + 1",
             "Projection: #MIN(person.first_name)\
              \n  Aggregate: groupBy=[[#person.age + Int64(1)]], aggr=[[MIN(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3320,13 +3320,13 @@ mod tests {
             "SELECT age + 1, MIN(first_name) FROM person GROUP BY age + 1",
             "Projection: #person.age + Int64(1), #MIN(person.first_name)\
              \n  Aggregate: groupBy=[[#person.age + Int64(1)]], aggr=[[MIN(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
         quick_test(
             "SELECT MIN(first_name), age + 1 FROM person GROUP BY age + 1",
             "Projection: #MIN(person.first_name), #person.age + Int64(1)\
              \n  Aggregate: groupBy=[[#person.age + Int64(1)]], aggr=[[MIN(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3337,7 +3337,7 @@ mod tests {
             "SELECT ((age + 1) / 2) * (age + 1), MIN(first_name) FROM person GROUP BY age + 1",
             "Projection: #person.age + Int64(1) / Int64(2) * #person.age + Int64(1), #MIN(person.first_name)\
              \n  Aggregate: groupBy=[[#person.age + Int64(1)]], aggr=[[MIN(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3371,7 +3371,7 @@ mod tests {
             "SELECT state, MIN(age) < 10 FROM person GROUP BY state",
             "Projection: #person.state, #MIN(person.age) < Int64(10)\
              \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3381,7 +3381,7 @@ mod tests {
             "SELECT age + 1, MAX(first_name) FROM person GROUP BY age",
             "Projection: #person.age + Int64(1), #MAX(person.first_name)\
              \n  Aggregate: groupBy=[[#person.age]], aggr=[[MAX(#person.first_name)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3391,7 +3391,7 @@ mod tests {
             "SELECT age + MIN(salary) FROM person GROUP BY age",
             "Projection: #person.age + #MIN(person.salary)\
              \n  Aggregate: groupBy=[[#person.age]], aggr=[[MIN(#person.salary)]]\
-             \n    TableScan: person projection=None",
+             \n    TableScan: person",
         );
     }
 
@@ -3401,7 +3401,7 @@ mod tests {
             "SELECT state, MIN(age + 1) FROM person GROUP BY state",
             "Projection: #person.state, #MIN(person.age + Int64(1))\
             \n  Aggregate: groupBy=[[#person.state]], aggr=[[MIN(#person.age + Int64(1))]]\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
     }
 
@@ -3410,7 +3410,7 @@ mod tests {
         quick_test(
             "SELECT * from person",
             "Projection: #person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀\
-            \n  TableScan: person projection=None",
+            \n  TableScan: person",
         );
     }
 
@@ -3419,7 +3419,7 @@ mod tests {
         let sql = "SELECT COUNT(1) FROM person";
         let expected = "Projection: #COUNT(UInt8(1))\
                         \n  Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3428,7 +3428,7 @@ mod tests {
         let sql = "SELECT COUNT(id) FROM person";
         let expected = "Projection: #COUNT(person.id)\
                         \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#person.id)]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3437,7 +3437,7 @@ mod tests {
         let sql = "SELECT approx_median(age) FROM person";
         let expected = "Projection: #APPROXPERCENTILECONT(person.age,Float64(0.5))\
                         \n  Aggregate: groupBy=[[]], aggr=[[APPROXPERCENTILECONT(#person.age, Float64(0.5))]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3445,7 +3445,7 @@ mod tests {
     fn select_scalar_func() {
         let sql = "SELECT sqrt(age) FROM person";
         let expected = "Projection: sqrt(#person.age)\
-                        \n  TableScan: person projection=None";
+                        \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3453,7 +3453,7 @@ mod tests {
     fn select_aliased_scalar_func() {
         let sql = "SELECT sqrt(person.age) AS square_people FROM person";
         let expected = "Projection: sqrt(#person.age) AS square_people\
-                        \n  TableScan: person projection=None";
+                        \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3463,7 +3463,7 @@ mod tests {
                    FROM aggregate_test_100 WHERE c3/nullif(c4+c5, 0) > 0.1";
         let expected = "Projection: #aggregate_test_100.c3 / #aggregate_test_100.c4 + #aggregate_test_100.c5\
             \n  Filter: #aggregate_test_100.c3 / nullif(#aggregate_test_100.c4 + #aggregate_test_100.c5, Int64(0)) > Float64(0.1)\
-            \n    TableScan: aggregate_test_100 projection=None";
+            \n    TableScan: aggregate_test_100";
         quick_test(sql, expected);
     }
 
@@ -3472,7 +3472,7 @@ mod tests {
         let sql = "SELECT c3 FROM aggregate_test_100 WHERE c3 > -0.1 AND -c4 > 0";
         let expected = "Projection: #aggregate_test_100.c3\
             \n  Filter: #aggregate_test_100.c3 > Float64(-0.1) AND (- #aggregate_test_100.c4) > Int64(0)\
-            \n    TableScan: aggregate_test_100 projection=None";
+            \n    TableScan: aggregate_test_100";
         quick_test(sql, expected);
     }
 
@@ -3481,7 +3481,7 @@ mod tests {
         let sql = "SELECT c3 FROM aggregate_test_100 WHERE c3 > +0.1 AND +c4 > 0";
         let expected = "Projection: #aggregate_test_100.c3\
             \n  Filter: #aggregate_test_100.c3 > Float64(0.1) AND #aggregate_test_100.c4 > Int64(0)\
-            \n    TableScan: aggregate_test_100 projection=None";
+            \n    TableScan: aggregate_test_100";
         quick_test(sql, expected);
     }
 
@@ -3490,7 +3490,7 @@ mod tests {
         let sql = "SELECT id FROM person ORDER BY 1";
         let expected = "Sort: #person.id ASC NULLS LAST\
                         \n  Projection: #person.id\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3500,7 +3500,7 @@ mod tests {
         let sql = "SELECT id, state, age FROM person ORDER BY 1, 3";
         let expected = "Sort: #person.id ASC NULLS LAST, #person.age ASC NULLS LAST\
                         \n  Projection: #person.id, #person.state, #person.age\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3530,7 +3530,7 @@ mod tests {
         let sql = "SELECT id FROM person ORDER BY id";
         let expected = "Sort: #person.id ASC NULLS LAST\
                         \n  Projection: #person.id\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3539,7 +3539,7 @@ mod tests {
         let sql = "SELECT id FROM person ORDER BY id DESC";
         let expected = "Sort: #person.id DESC NULLS FIRST\
                         \n  Projection: #person.id\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3549,14 +3549,14 @@ mod tests {
             "SELECT id FROM person ORDER BY id DESC NULLS LAST",
             "Sort: #person.id DESC NULLS LAST\
             \n  Projection: #person.id\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
 
         quick_test(
             "SELECT id FROM person ORDER BY id NULLS LAST",
             "Sort: #person.id ASC NULLS LAST\
             \n  Projection: #person.id\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
         );
     }
 
@@ -3565,7 +3565,7 @@ mod tests {
         let sql = "SELECT state FROM person GROUP BY state";
         let expected = "Projection: #person.state\
                         \n  Aggregate: groupBy=[[#person.state]], aggr=[[]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3575,7 +3575,7 @@ mod tests {
         let sql = "SELECT MAX(age) FROM person GROUP BY state";
         let expected = "Projection: #MAX(person.age)\
                         \n  Aggregate: groupBy=[[#person.state]], aggr=[[MAX(#person.age)]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3585,7 +3585,7 @@ mod tests {
         let sql = "SELECT state, COUNT(*) FROM person GROUP BY state";
         let expected = "Projection: #person.state, #COUNT(UInt8(1))\
                         \n  Aggregate: groupBy=[[#person.state]], aggr=[[COUNT(UInt8(1))]]\
-                        \n    TableScan: person projection=None";
+                        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3596,7 +3596,7 @@ mod tests {
         let expected = "\
         Projection: #COUNT(person.state), #person.state\
         \n  Aggregate: groupBy=[[#person.state]], aggr=[[COUNT(#person.state)]]\
-        \n    TableScan: person projection=None";
+        \n    TableScan: person";
 
         quick_test(sql, expected);
     }
@@ -3606,7 +3606,7 @@ mod tests {
         let sql = "SELECT c1, MIN(c12) FROM aggregate_test_100 GROUP BY c1, c13";
         let expected = "Projection: #aggregate_test_100.c1, #MIN(aggregate_test_100.c12)\
                        \n  Aggregate: groupBy=[[#aggregate_test_100.c1, #aggregate_test_100.c13]], aggr=[[MIN(#aggregate_test_100.c12)]]\
-                       \n    TableScan: aggregate_test_100 projection=None";
+                       \n    TableScan: aggregate_test_100";
         quick_test(sql, expected);
     }
 
@@ -3660,8 +3660,8 @@ mod tests {
             ON id = customer_id";
         let expected = "Projection: #person.id, #orders.order_id\
         \n  Inner Join: #person.id = #orders.customer_id\
-        \n    TableScan: person projection=None\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: person\
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3674,8 +3674,8 @@ mod tests {
         let expected = "Projection: #person.id, #orders.order_id\
         \n  Filter: #orders.order_id > Int64(1)\
         \n    Inner Join: #person.id = #orders.customer_id\
-        \n      TableScan: person projection=None\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: person\
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3687,9 +3687,9 @@ mod tests {
             ON id = customer_id AND order_id > 1";
         let expected = "Projection: #person.id, #orders.order_id\
         \n  Left Join: #person.id = #orders.customer_id\
-        \n    TableScan: person projection=None\
+        \n    TableScan: person\
         \n    Filter: #orders.order_id > Int64(1)\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3702,8 +3702,8 @@ mod tests {
         let expected = "Projection: #person.id, #orders.order_id\
         \n  Right Join: #person.id = #orders.customer_id\
         \n    Filter: #person.id > Int64(1)\
-        \n      TableScan: person projection=None\
-        \n    TableScan: orders projection=None";
+        \n      TableScan: person\
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3715,8 +3715,8 @@ mod tests {
             ON person.id = orders.customer_id";
         let expected = "Projection: #person.id, #orders.order_id\
         \n  Inner Join: #person.id = #orders.customer_id\
-        \n    TableScan: person projection=None\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: person\
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3728,9 +3728,9 @@ mod tests {
             USING (id)";
         let expected = "Projection: #person.first_name, #person.id\
         \n  Inner Join: Using #person.id = #person2.id\
-        \n    TableScan: person projection=None\
+        \n    TableScan: person\
         \n    SubqueryAlias: person2\
-        \n      TableScan: person projection=None";
+        \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -3742,9 +3742,9 @@ mod tests {
             USING (l_item_id)";
         let expected = "Projection: #lineitem.l_item_id, #lineitem.l_description, #lineitem.price, #lineitem2.l_description, #lineitem2.price\
         \n  Inner Join: Using #lineitem.l_item_id = #lineitem2.l_item_id\
-        \n    TableScan: lineitem projection=None\
+        \n    TableScan: lineitem\
         \n    SubqueryAlias: lineitem2\
-        \n      TableScan: lineitem projection=None";
+        \n      TableScan: lineitem";
         quick_test(sql, expected);
     }
 
@@ -3758,9 +3758,9 @@ mod tests {
             "Projection: #person.id, #orders.order_id, #lineitem.l_description\
             \n  Inner Join: #orders.o_item_id = #lineitem.l_item_id\
             \n    Inner Join: #person.id = #orders.customer_id\
-            \n      TableScan: person projection=None\
-            \n      TableScan: orders projection=None\
-            \n    TableScan: lineitem projection=None";
+            \n      TableScan: person\
+            \n      TableScan: orders\
+            \n    TableScan: lineitem";
         quick_test(sql, expected);
     }
 
@@ -3771,7 +3771,7 @@ mod tests {
         WHERE delivered = false OR delivered = true";
         let expected = "Projection: #orders.order_id\
             \n  Filter: #orders.delivered = Boolean(false) OR #orders.delivered = Boolean(true)\
-            \n    TableScan: orders projection=None";
+            \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3780,9 +3780,9 @@ mod tests {
         let sql = "SELECT order_id from orders UNION ALL SELECT order_id FROM orders";
         let expected = "Union\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None\
+            \n    TableScan: orders\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None";
+            \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3794,13 +3794,13 @@ mod tests {
                     UNION ALL SELECT order_id FROM orders";
         let expected = "Union\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None\
+            \n    TableScan: orders\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None\
+            \n    TableScan: orders\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None\
+            \n    TableScan: orders\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None";
+            \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3809,9 +3809,9 @@ mod tests {
         let sql = "SELECT order_id from orders UNION ALL SELECT customer_id FROM orders";
         let expected = "Union\
             \n  Projection: #orders.order_id\
-            \n    TableScan: orders projection=None\
+            \n    TableScan: orders\
             \n  Projection: #orders.customer_id\
-            \n    TableScan: orders projection=None";
+            \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3845,7 +3845,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.order_id)\
         \n  WindowAggr: windowExpr=[[MAX(#orders.order_id)]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3855,7 +3855,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id AS oid, #MAX(orders.order_id) AS max_oid\
         \n  WindowAggr: windowExpr=[[MAX(#orders.order_id)]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3865,7 +3865,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id AS oid, #MAX(orders.order_id) AS max_oid, #MAX(orders.order_id) AS max_oid_dup\
         \n  WindowAggr: windowExpr=[[MAX(#orders.order_id)]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3876,7 +3876,7 @@ mod tests {
         Projection: #orders.order_id AS oid, #MAX(orders.order_id), #MAX(orders.order_id) ORDER BY [#orders.order_id ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.order_id)]]\
         \n    WindowAggr: windowExpr=[[MAX(#orders.order_id) ORDER BY [#orders.order_id ASC NULLS LAST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3886,7 +3886,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.qty * Float64(1.1))\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty * Float64(1.1))]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3897,7 +3897,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.qty), #MIN(orders.qty), #AVG(orders.qty)\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty), MIN(#orders.qty), AVG(#orders.qty)]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3916,7 +3916,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.qty) PARTITION BY [#orders.order_id]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) PARTITION BY [#orders.order_id]]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3939,7 +3939,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST], #MIN(orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST]]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3950,7 +3950,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING, #MIN(orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -3961,7 +3961,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] ROWS BETWEEN 3 PRECEDING AND CURRENT ROW, #MIN(orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] ROWS BETWEEN 3 PRECEDING AND CURRENT ROW]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4004,7 +4004,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] GROUPS BETWEEN 3 PRECEDING AND CURRENT ROW, #MIN(orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST] GROUPS BETWEEN 3 PRECEDING AND CURRENT ROW]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id DESC NULLS FIRST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4027,7 +4027,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST], #MIN(orders.qty) ORDER BY [#orders.order_id + Int64(1) ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST]]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id + Int64(1) ASC NULLS LAST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4052,7 +4052,7 @@ mod tests {
         \n  WindowAggr: windowExpr=[[SUM(#orders.qty)]]\
         \n    WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.qty ASC NULLS LAST, #orders.order_id ASC NULLS LAST]]]\
         \n      WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST, #orders.qty ASC NULLS LAST]]]\
-        \n        TableScan: orders projection=None";
+        \n        TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4077,7 +4077,7 @@ mod tests {
         \n  WindowAggr: windowExpr=[[SUM(#orders.qty)]]\
         \n    WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST]]]\
         \n      WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST, #orders.qty ASC NULLS LAST]]]\
-        \n        TableScan: orders projection=None";
+        \n        TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4106,7 +4106,7 @@ mod tests {
         \n    WindowAggr: windowExpr=[[SUM(#orders.qty)]]\
         \n      WindowAggr: windowExpr=[[MAX(#orders.qty) ORDER BY [#orders.qty ASC NULLS LAST, #orders.order_id ASC NULLS LAST]]]\
         \n        WindowAggr: windowExpr=[[MIN(#orders.qty) ORDER BY [#orders.order_id ASC NULLS LAST, #orders.qty ASC NULLS LAST]]]\
-        \n          TableScan: orders projection=None";
+        \n          TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4126,7 +4126,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.qty) PARTITION BY [#orders.order_id] ORDER BY [#orders.qty ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) PARTITION BY [#orders.order_id] ORDER BY [#orders.qty ASC NULLS LAST]]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4146,7 +4146,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #MAX(orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.qty ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.qty ASC NULLS LAST]]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4170,7 +4170,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.qty ASC NULLS LAST], #MIN(orders.qty) PARTITION BY [#orders.qty] ORDER BY [#orders.order_id ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MIN(#orders.qty) PARTITION BY [#orders.qty] ORDER BY [#orders.order_id ASC NULLS LAST]]]\
         \n    WindowAggr: windowExpr=[[MAX(#orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.qty ASC NULLS LAST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4193,7 +4193,7 @@ mod tests {
         Projection: #orders.order_id, #MAX(orders.qty) PARTITION BY [#orders.order_id] ORDER BY [#orders.qty ASC NULLS LAST], #MIN(orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.price ASC NULLS LAST]\
         \n  WindowAggr: windowExpr=[[MAX(#orders.qty) PARTITION BY [#orders.order_id] ORDER BY [#orders.qty ASC NULLS LAST]]]\
         \n    WindowAggr: windowExpr=[[MIN(#orders.qty) PARTITION BY [#orders.order_id, #orders.qty] ORDER BY [#orders.price ASC NULLS LAST]]]\
-        \n      TableScan: orders projection=None";
+        \n      TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4204,7 +4204,7 @@ mod tests {
         let expected = "\
         Projection: #orders.order_id, #APPROXPERCENTILECONT(orders.qty,Float64(0.5)) PARTITION BY [#orders.order_id]\
         \n  WindowAggr: windowExpr=[[APPROXPERCENTILECONT(#orders.qty, Float64(0.5)) PARTITION BY [#orders.order_id]]]\
-        \n    TableScan: orders projection=None";
+        \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4212,7 +4212,7 @@ mod tests {
     fn select_typedstring() {
         let sql = "SELECT date '2020-12-10' AS date FROM person";
         let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32) AS date\
-            \n  TableScan: person projection=None";
+            \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -4220,7 +4220,7 @@ mod tests {
     fn select_multibyte_column() {
         let sql = r#"SELECT "😀" FROM person"#;
         let expected = "Projection: #person.😀\
-            \n  TableScan: person projection=None";
+            \n  TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -4326,7 +4326,7 @@ mod tests {
     fn select_partially_qualified_column() {
         let sql = r#"SELECT person.first_name FROM public.person"#;
         let expected = "Projection: #public.person.first_name\
-            \n  TableScan: public.person projection=None";
+            \n  TableScan: public.person";
         quick_test(sql, expected);
     }
 
@@ -4336,9 +4336,9 @@ mod tests {
         let expected = "Projection: #person.id\
                                  \n  Inner Join: #lineitem.l_description = #orders.o_item_id\
                                  \n    Inner Join: #person.id = #lineitem.l_item_id\
-                                 \n      TableScan: person projection=None\
-                                 \n      TableScan: lineitem projection=None\
-                                 \n    TableScan: orders projection=None";
+                                 \n      TableScan: person\
+                                 \n      TableScan: lineitem\
+                                 \n    TableScan: orders";
         quick_test(sql, expected);
     }
 
@@ -4349,9 +4349,9 @@ mod tests {
                                     \n  Filter: #person.id = #person.age\
                                     \n    CrossJoin:\
                                     \n      CrossJoin:\
-                                    \n        TableScan: person projection=None\
-                                    \n        TableScan: orders projection=None\
-                                    \n      TableScan: lineitem projection=None";
+                                    \n        TableScan: person\
+                                    \n        TableScan: orders\
+                                    \n      TableScan: lineitem";
         quick_test(sql, expected);
     }
 
@@ -4361,9 +4361,9 @@ mod tests {
         let expected = "Projection: #peeps.id, #folks.first_name\
                                     \n  Inner Join: #peeps.id = #folks.id\
                                     \n    SubqueryAlias: peeps\
-                                    \n      TableScan: person projection=None\
+                                    \n      TableScan: person\
                                     \n    SubqueryAlias: folks\
-                                    \n      TableScan: person projection=None";
+                                    \n      TableScan: person";
         quick_test(sql, expected);
     }
 
@@ -4379,7 +4379,7 @@ mod tests {
     fn date_plus_interval_in_projection() {
         let sql = "select t_date32 + interval '5 days' FROM test";
         let expected = "Projection: #test.t_date32 + IntervalDayTime(\"21474836480\")\
-                            \n  TableScan: test projection=None";
+                            \n  TableScan: test";
         quick_test(sql, expected);
     }
 
@@ -4392,7 +4392,7 @@ mod tests {
         let expected =
             "Projection: #test.t_date64\
             \n  Filter: #test.t_date64 BETWEEN CAST(Utf8(\"1999-12-31\") AS Date32) AND CAST(Utf8(\"1999-12-31\") AS Date32) + IntervalDayTime(\"128849018880\")\
-            \n    TableScan: test projection=None";
+            \n    TableScan: test";
         quick_test(sql, expected);
     }
 
@@ -4405,13 +4405,13 @@ mod tests {
 
         let subquery_expected = "Subquery: Projection: #person.first_name\
         \n  Filter: #person.last_name = #p.last_name AND #person.state = #p.state\
-        \n    TableScan: person projection=None";
+        \n    TableScan: person";
 
         let expected = format!(
             "Projection: #p.id\
         \n  Filter: EXISTS ({})\
         \n    SubqueryAlias: p\
-        \n      TableScan: person projection=None",
+        \n      TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4430,17 +4430,17 @@ mod tests {
         let subquery_expected = "Subquery: Projection: #person.first_name\
         \n  Filter: #person.last_name = #p.last_name AND #person.state = #p.state\
         \n    Inner Join: #person.id = #p2.id\
-        \n      TableScan: person projection=None\
+        \n      TableScan: person\
         \n      SubqueryAlias: p2\
-        \n        TableScan: person projection=None";
+        \n        TableScan: person";
 
         let expected = format!(
             "Projection: #person.id\
             \n  Filter: EXISTS ({})\
             \n    Inner Join: #person.id = #p.id\
-            \n      TableScan: person projection=None\
+            \n      TableScan: person\
             \n      SubqueryAlias: p\
-            \n        TableScan: person projection=None",
+            \n        TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4456,13 +4456,13 @@ mod tests {
         let subquery_expected = "Subquery: Projection: #person.id, #person.first_name, \
         #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀\
             \n  Filter: #person.last_name = #p.last_name AND #person.state = #p.state\
-            \n    TableScan: person projection=None";
+            \n    TableScan: person";
 
         let expected = format!(
             "Projection: #p.id\
             \n  Filter: EXISTS ({})\
             \n    SubqueryAlias: p\
-            \n      TableScan: person projection=None",
+            \n      TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4474,13 +4474,13 @@ mod tests {
             (SELECT id FROM person)";
 
         let subquery_expected = "Subquery: Projection: #person.id\
-        \n  TableScan: person projection=None";
+        \n  TableScan: person";
 
         let expected = format!(
             "Projection: #p.id\
             \n  Filter: #p.id IN ({})\
             \n    SubqueryAlias: p\
-            \n      TableScan: person projection=None",
+            \n      TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4493,13 +4493,13 @@ mod tests {
 
         let subquery_expected = "Subquery: Projection: #person.id\
         \n  Filter: #person.last_name = #p.last_name AND #person.state = Utf8(\"CO\")\
-        \n    TableScan: person projection=None";
+        \n    TableScan: person";
 
         let expected = format!(
             "Projection: #p.id\
             \n  Filter: #p.id NOT IN ({})\
             \n    SubqueryAlias: p\
-            \n      TableScan: person projection=None",
+            \n      TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4512,12 +4512,12 @@ mod tests {
         let subquery_expected = "Subquery: Projection: #MAX(person.id)\
         \n  Aggregate: groupBy=[[]], aggr=[[MAX(#person.id)]]\
         \n    Filter: #person.last_name = #p.last_name\
-        \n      TableScan: person projection=None";
+        \n      TableScan: person";
 
         let expected = format!(
             "Projection: #p.id, ({})\
             \n  SubqueryAlias: p\
-            \n    TableScan: person projection=None",
+            \n    TableScan: person",
             subquery_expected
         );
         quick_test(sql, &expected);
@@ -4532,11 +4532,11 @@ mod tests {
         let subquery = "Subquery: Projection: #cte.id, #cte.first_name, #cte.last_name, #cte.age, #cte.state, #cte.salary, #cte.birth_date, #cte.😀\
         \n  Filter: #cte.id = #person.id\
         \n    Projection: #person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀, alias=cte\
-        \n      TableScan: person projection=None";
+        \n      TableScan: person";
 
         let expected = format!("Projection: #person.id, #person.first_name, #person.last_name, #person.age, #person.state, #person.salary, #person.birth_date, #person.😀\
         \n  Filter: EXISTS ({})\
-        \n    TableScan: person projection=None", subquery);
+        \n    TableScan: person", subquery);
 
         quick_test(sql, &expected)
     }

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -226,7 +226,7 @@ async fn custom_source_dataframe() -> Result<()> {
 
     let expected = format!(
         "Projection: #{}.c2\
-        \n  TableScan: {} projection=Some([1])",
+        \n  TableScan: {} projection=[c2]",
         UNNAMED_TABLE, UNNAMED_TABLE
     );
     assert_eq!(format!("{:?}", optimized_plan), expected);

--- a/datafusion/core/tests/sql/avro.rs
+++ b/datafusion/core/tests/sql/avro.rs
@@ -145,7 +145,7 @@ async fn avro_explain() {
             "logical_plan",
             "Projection: #COUNT(UInt8(1))\
             \n  Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
-            \n    TableScan: alltypes_plain projection=Some([0])",
+            \n    TableScan: alltypes_plain projection=[0]",
         ],
         vec![
             "physical_plan",

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -194,7 +194,7 @@ async fn csv_explain_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
-        "      TableScan: aggregate_test_100 projection=None [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
+        "      TableScan: aggregate_test_100 [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -209,7 +209,7 @@ async fn csv_explain_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=None",
+        "      TableScan: aggregate_test_100",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -231,7 +231,7 @@ async fn csv_explain_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=None\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -242,7 +242,7 @@ async fn csv_explain_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=None\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -269,7 +269,7 @@ async fn csv_explain_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32]",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
+        "      TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -284,7 +284,7 @@ async fn csv_explain_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
+        "      TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -306,7 +306,7 @@ async fn csv_explain_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -317,7 +317,7 @@ async fn csv_explain_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -392,7 +392,7 @@ async fn csv_explain_verbose_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
-        "      TableScan: aggregate_test_100 projection=None [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
+        "      TableScan: aggregate_test_100 [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -407,7 +407,7 @@ async fn csv_explain_verbose_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=None",
+        "      TableScan: aggregate_test_100",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -429,7 +429,7 @@ async fn csv_explain_verbose_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=None\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -440,7 +440,7 @@ async fn csv_explain_verbose_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=None\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100\\nSchema: [c1:Utf8, c2:Int32, c3:Int16, c4:Int16, c5:Int32, c6:Int64, c7:Int16, c8:Int32, c9:Int64, c10:Utf8, c11:Float32, c12:Float64, c13:Utf8]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -467,7 +467,7 @@ async fn csv_explain_verbose_plans() {
         "Explain [plan_type:Utf8, plan:Utf8]",
         "  Projection: #aggregate_test_100.c1 [c1:Utf8]",
         "    Filter: #aggregate_test_100.c2 > Int64(10) [c1:Utf8, c2:Int32]",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
+        "      TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)] [c1:Utf8, c2:Int32]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -482,7 +482,7 @@ async fn csv_explain_verbose_plans() {
         "Explain",
         "  Projection: #aggregate_test_100.c1",
         "    Filter: #aggregate_test_100.c2 > Int64(10)",
-        "      TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
+        "      TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]",
     ];
     let formatted = plan.display_indent().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -504,7 +504,7 @@ async fn csv_explain_verbose_plans() {
         "    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]",
         "    4[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\"]",
         "    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
+        "    5[shape=box label=\"TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]\"]",
         "    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "  subgraph cluster_6",
@@ -515,7 +515,7 @@ async fn csv_explain_verbose_plans() {
         "    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]",
         "    9[shape=box label=\"Filter: #aggregate_test_100.c2 > Int64(10)\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]",
-        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
+        "    10[shape=box label=\"TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]\\nSchema: [c1:Utf8, c2:Int32]\"]",
         "    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]",
         "  }",
         "}",
@@ -628,12 +628,12 @@ order by
     \n      Inner Join: #customer.c_nationkey = #nation.n_nationkey\
     \n        Inner Join: #orders.o_orderkey = #lineitem.l_orderkey\
     \n          Inner Join: #customer.c_custkey = #orders.o_custkey\
-    \n            TableScan: customer projection=Some([0, 1, 2, 3, 4, 5, 7])\
+    \n            TableScan: customer projection=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment]\
     \n            Filter: #orders.o_orderdate >= Date32(\"8674\") AND #orders.o_orderdate < Date32(\"8766\")\
-    \n              TableScan: orders projection=Some([0, 1, 4]), partial_filters=[#orders.o_orderdate >= Date32(\"8674\"), #orders.o_orderdate < Date32(\"8766\")]\
+    \n              TableScan: orders projection=[o_orderkey, o_custkey, o_orderdate], partial_filters=[#orders.o_orderdate >= Date32(\"8674\"), #orders.o_orderdate < Date32(\"8766\")]\
     \n          Filter: #lineitem.l_returnflag = Utf8(\"R\")\
-    \n            TableScan: lineitem projection=Some([0, 5, 6, 8]), partial_filters=[#lineitem.l_returnflag = Utf8(\"R\")]\
-    \n        TableScan: nation projection=Some([0, 1])";
+    \n            TableScan: lineitem projection=[l_orderkey, l_extendedprice, l_discount, l_returnflag], partial_filters=[#lineitem.l_returnflag = Utf8(\"R\")]\
+    \n        TableScan: nation projection=[n_nationkey, n_name]";
     assert_eq!(format!("{:?}", plan.unwrap()), expected);
 
     Ok(())
@@ -753,7 +753,7 @@ async fn csv_explain() {
             "logical_plan",
             "Projection: #aggregate_test_100.c1\
              \n  Filter: #aggregate_test_100.c2 > Int64(10)\
-             \n    TableScan: aggregate_test_100 projection=Some([0, 1]), partial_filters=[#aggregate_test_100.c2 > Int64(10)]"
+             \n    TableScan: aggregate_test_100 projection=[c1, c2], partial_filters=[#aggregate_test_100.c2 > Int64(10)]"
         ],
         vec!["physical_plan",
              "ProjectionExec: expr=[c1@0 as c1]\

--- a/datafusion/core/tests/sql/json.rs
+++ b/datafusion/core/tests/sql/json.rs
@@ -87,7 +87,7 @@ async fn json_explain() {
             "logical_plan",
             "Projection: #COUNT(UInt8(1))\
             \n  Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
-            \n    TableScan: t1 projection=Some([0])",
+            \n    TableScan: t1 projection=[a]",
         ],
         vec![
             "physical_plan",

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -180,7 +180,7 @@ async fn projection_on_table_scan() -> Result<()> {
     }
 
     let expected = "Projection: #test.c2\
-                    \n  TableScan: test projection=Some([1])";
+                    \n  TableScan: test projection=[c2]";
     assert_eq!(format!("{:?}", optimized_plan), expected);
 
     let physical_plan = ctx.create_physical_plan(&optimized_plan).await?;
@@ -254,7 +254,7 @@ async fn projection_on_memory_scan() -> Result<()> {
 
     let expected = format!(
         "Projection: #{}.b\
-         \n  TableScan: {} projection=Some([1])",
+         \n  TableScan: {} projection=[b]",
         UNNAMED_TABLE, UNNAMED_TABLE
     );
     assert_eq!(format!("{:?}", optimized_plan), expected);

--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -92,7 +92,7 @@ async fn scalar_udf() -> Result<()> {
 
     assert_eq!(
         format!("{:?}", plan),
-        "Projection: #t.a, #t.b, my_add(#t.a, #t.b)\n  TableScan: t projection=Some([0, 1])"
+        "Projection: #t.a, #t.b, my_add(#t.a, #t.b)\n  TableScan: t projection=[a, b]"
     );
 
     let plan = ctx.optimize(&plan)?;

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -46,7 +46,7 @@
 //! | logical_plan | Limit: 3                               |
 //! |              |   Sort: #revenue DESC NULLS FIRST      |
 //! |              |     Projection: #customer_id, #revenue |
-//! |              |       TableScan: sales projection=None |
+//! |              |       TableScan: sales |
 //! +--------------+----------------------------------------+
 //! ```
 //!
@@ -218,7 +218,7 @@ async fn topk_plan() -> Result<()> {
     let mut expected = vec![
         "| logical_plan after topk                               | TopK: k=3                                                                     |",
         "|                                                       |   Projection: #sales.customer_id, #sales.revenue                              |",
-        "|                                                       |     TableScan: sales projection=Some([0, 1])                                  |",
+        "|                                                       |     TableScan: sales projection=[customer_id,revenue]                                  |",
     ].join("\n");
 
     let explain_query = format!("EXPLAIN VERBOSE {}", QUERY);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2697 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Improve readability for Table scans. Provide column name instead of column index.

`TableScan a projection=[col1,col2]` instead of `TableScan a projection=[0,1]`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->