### PR TITLE
MINOR: Remove reference to docker image that is no longer available

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -61,37 +61,6 @@ The benchmark program also supports CSV and Parquet input file formats and a uti
 cargo run --release --bin tpch -- convert --input ./data --output /mnt/tpch-parquet --format parquet
 ```
 
-This utility does not yet provide support for changing the number of partitions when performing the conversion. Another
-option is to use the following Docker image to perform the conversion from `tbl` files to CSV or Parquet.
-
-```bash
-docker run -it ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT
-  -h, --help   Show help message
-
-Subcommand: convert-tpch
-  -i, --input  <arg>
-      --input-format  <arg>
-  -o, --output  <arg>
-      --output-format  <arg>
-  -p, --partitions  <arg>
-  -h, --help                   Show help message
-```
-
-Note that it is necessary to mount volumes into the Docker container as appropriate so that the file conversion process
-can access files on the host system.
-
-Here is a full example that assumes that data is stored in the `/mnt` path on the host system.
-
-```bash
-docker run -v /mnt:/mnt -it ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT \
-  convert-tpch \
-  --input /mnt/tpch/csv \
-  --input-format tbl \
-  --output /mnt/tpch/parquet \
-  --output-format parquet \
-  --partitions 64
-```
-
 ## Expected output
 
 The result of query 1 should produce the following output when executed against the SF=1 dataset.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Documentation refers to `ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT` image that no longer exists.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove some docs.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->