### PR TITLE
Correct schema nullability declaration in tests

### DIFF
--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -272,7 +272,7 @@ fn paths_to_batch(
     let mut fields = vec![
         Field::new(FILE_PATH_COLUMN_NAME, DataType::Utf8, false),
         Field::new(FILE_SIZE_COLUMN_NAME, DataType::UInt64, false),
-        Field::new(FILE_MODIFIED_COLUMN_NAME, DataType::Date64, false),
+        Field::new(FILE_MODIFIED_COLUMN_NAME, DataType::Date64, true),
     ];
     for pn in table_partition_cols {
         fields.push(Field::new(pn, DataType::Utf8, false));

--- a/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
@@ -276,8 +276,8 @@ mod tests {
     /// Mock data using a MemoryExec which has an exact count statistic
     fn mock_data() -> Result<Arc<MemoryExec>> {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
         ]));
 
         let batch = RecordBatch::try_new(

--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -2388,8 +2388,8 @@ mod tests {
             },
         ];
         let intermediate_schema = Schema::new(vec![
-            Field::new("c", DataType::Int32, false),
-            Field::new("c", DataType::Int32, false),
+            Field::new("c", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
         ]);
         let filter_expression = Arc::new(BinaryExpr::new(
             Arc::new(Column::new("c", 0)),

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -231,8 +231,8 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
-            Field::new("c", DataType::Int32, false),
-            Field::new("d", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+            Field::new("d", DataType::Int32, false),
         ]));
 
         let batch = RecordBatch::try_new(

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -336,8 +336,8 @@ mod tests {
         let b: ArrayRef = Arc::new(Int32Array::from(vec![Some(4), Some(5), Some(6)]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
 
@@ -359,8 +359,8 @@ mod tests {
         let b: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
 
@@ -384,8 +384,8 @@ mod tests {
         let d = Arc::new(Float64Array::from(vec![4.4_f64, 5.5_f64, 9.9_f64]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Float64, false),
-            Field::new("b", DataType::Float64, false),
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
         ]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
@@ -419,8 +419,8 @@ mod tests {
         let d = Arc::new(Float64Array::from(vec![None]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Float64, false),
-            Field::new("b", DataType::Float64, false),
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
         ]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -511,8 +511,8 @@ mod tests {
         let b: ArrayRef = Arc::new(Int32Array::from(vec![Some(4), Some(5), Some(6)]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
 
@@ -534,8 +534,8 @@ mod tests {
         let b: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
 
@@ -559,8 +559,8 @@ mod tests {
         let d = Arc::new(Float64Array::from(vec![4.4_f64, 5.5_f64, 6.6_f64]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Float64, false),
-            Field::new("b", DataType::Float64, false),
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
         ]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
@@ -594,8 +594,8 @@ mod tests {
         let d = Arc::new(Float64Array::from(vec![None]));
 
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Float64, false),
-            Field::new("b", DataType::Float64, false),
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
         ]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;

--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn stddev_i32_all_nulls() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
-        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a])?;
 
         let agg = Arc::new(Stddev::new(
@@ -395,7 +395,7 @@ mod tests {
         let a = Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
         let b = Arc::new(Float64Array::from(vec![None]));
 
-        let schema = Schema::new(vec![Field::new("a", DataType::Float64, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64, true)]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a])?;
         let batch2 = RecordBatch::try_new(Arc::new(schema.clone()), vec![b])?;

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -199,7 +199,7 @@ mod tests {
 
     macro_rules! generic_test_sum_distinct {
         ($ARRAY:expr, $DATATYPE:expr, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $DATATYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $DATATYPE, true)]);
 
             let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![$ARRAY])?;
 

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn variance_i32_all_nulls() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
-        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a])?;
 
         let agg = Arc::new(Variance::new(
@@ -476,7 +476,7 @@ mod tests {
         let a = Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
         let b = Arc::new(Float64Array::from(vec![None]));
 
-        let schema = Schema::new(vec![Field::new("a", DataType::Float64, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64, true)]);
 
         let batch1 = RecordBatch::try_new(Arc::new(schema.clone()), vec![a])?;
         let batch2 = RecordBatch::try_new(Arc::new(schema.clone()), vec![b])?;

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -2113,8 +2113,8 @@ mod tests {
     /// b: [true, NULL, false, true, NULL, false, true,  NULL,  false]
     fn bool_test_arrays() -> (SchemaRef, ArrayRef, ArrayRef) {
         let schema = Schema::new(vec![
-            Field::new("a", DataType::Boolean, false),
-            Field::new("b", DataType::Boolean, false),
+            Field::new("a", DataType::Boolean, true),
+            Field::new("b", DataType::Boolean, true),
         ]);
         let a: BooleanArray = [
             Some(true),
@@ -2147,7 +2147,7 @@ mod tests {
 
     /// Returns (schema, BooleanArray) with [true, NULL, false]
     fn scalar_bool_test_array() -> (SchemaRef, ArrayRef) {
-        let schema = Schema::new(vec![Field::new("a", DataType::Boolean, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Boolean, true)]);
         let a: BooleanArray = vec![Some(true), None, Some(false)].iter().collect();
         (Arc::new(schema), Arc::new(a))
     }

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -177,7 +177,7 @@ mod tests {
     // 5. verify that the resulting values are downcastable and correct
     macro_rules! generic_decimal_to_other_test_cast {
         ($DECIMAL_ARRAY:ident, $A_TYPE:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr,$CAST_OPTIONS:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $A_TYPE, true)]);
             let batch = RecordBatch::try_new(
                 Arc::new(schema.clone()),
                 vec![Arc::new($DECIMAL_ARRAY)],
@@ -225,7 +225,7 @@ mod tests {
     // 5. verify that the resulting values are downcastable and correct
     macro_rules! generic_test_cast {
         ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr, $CAST_OPTIONS:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $A_TYPE, true)]);
             let a = $A_ARRAY::from($A_VEC);
             let batch =
                 RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn literal_i32() -> Result<()> {
         // create an arbitrary record bacth
-        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
         let a = Int32Array::from(vec![Some(1), None, Some(3), Some(4), Some(5)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -100,7 +100,7 @@ pub(crate) mod tests {
     #[macro_export]
     macro_rules! generic_test_op {
         ($ARRAY:expr, $DATATYPE:expr, $OP:ident, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $DATATYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $DATATYPE, true)]);
 
             let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![$ARRAY])?;
 
@@ -123,8 +123,8 @@ pub(crate) mod tests {
     macro_rules! generic_test_op2 {
         ($ARRAY1:expr, $ARRAY2:expr, $DATATYPE1:expr, $DATATYPE2:expr, $OP:ident, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
             let schema = Schema::new(vec![
-                Field::new("a", $DATATYPE1, false),
-                Field::new("b", $DATATYPE2, false),
+                Field::new("a", $DATATYPE1, true),
+                Field::new("b", $DATATYPE2, true),
             ]);
             let batch =
                 RecordBatch::try_new(Arc::new(schema.clone()), vec![$ARRAY1, $ARRAY2])?;

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -138,7 +138,7 @@ mod tests {
     // 5. verify that the resulting values are downcastable and correct
     macro_rules! generic_decimal_to_other_test_cast {
         ($DECIMAL_ARRAY:ident, $A_TYPE:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $A_TYPE, true)]);
             let batch = RecordBatch::try_new(
                 Arc::new(schema.clone()),
                 vec![Arc::new($DECIMAL_ARRAY)],
@@ -185,7 +185,7 @@ mod tests {
     // 5. verify that the resulting values are downcastable and correct
     macro_rules! generic_test_cast {
         ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
-            let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
+            let schema = Schema::new(vec![Field::new("a", $A_TYPE, true)]);
             let a = $A_ARRAY::from($A_VEC);
             let batch =
                 RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;

--- a/datafusion/physical-expr/src/window/row_number.rs
+++ b/datafusion/physical-expr/src/window/row_number.rs
@@ -93,7 +93,7 @@ mod tests {
         let arr: ArrayRef = Arc::new(BooleanArray::from(vec![
             None, None, None, None, None, None, None, None,
         ]));
-        let schema = Schema::new(vec![Field::new("arr", DataType::Boolean, false)]);
+        let schema = Schema::new(vec![Field::new("arr", DataType::Boolean, true)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![arr])?;
         let row_number = RowNumber::new("row_number".to_owned());
         let result = row_number.create_evaluator(&batch)?.evaluate(vec![0..8])?;


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/pull/2778

 # Rationale for this change

https://github.com/apache/arrow-rs/issues/1888 (added in `arrow 17.0.0`) added validation to `RecordBatch` if the schema's declared nullability is different than its actual nullability it throws a runtime error. 

# What changes are included in this PR?
Correct declared schema nullability in DataFusion tests .

There are no tests in this PR -- they are covered in https://github.com/apache/arrow-datafusion/pull/2778

# Are there any user-facing changes?
No, it is a test only change