### PR TITLE
Fix data type calculation for `CaseExpr` s with `NULLs`

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -146,6 +146,72 @@ async fn case_when_else_with_null_contant() -> Result<()> {
 }
 
 #[tokio::test]
+async fn case_expr_with_null() -> Result<()> {
+    let ctx = SessionContext::new();
+    let sql = "select case when b is null then null else b end from (select a,b from (values (1,null),(2,3)) as t (a,b)) a;";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+------------------------------------------------+",
+        "| CASE WHEN #a.b IS NULL THEN NULL ELSE #a.b END |",
+        "+------------------------------------------------+",
+        "|                                                |",
+        "| 3                                              |",
+        "+------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "select case when b is null then null else b end from (select a,b from (values (1,1),(2,3)) as t (a,b)) a;";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+------------------------------------------------+",
+        "| CASE WHEN #a.b IS NULL THEN NULL ELSE #a.b END |",
+        "+------------------------------------------------+",
+        "| 1                                              |",
+        "| 3                                              |",
+        "+------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn case_expr_with_nulls() -> Result<()> {
+    let ctx = SessionContext::new();
+    let sql = "select case when b is null then null when b < 3 then null when b >=3 then b + 1 else b end from (select a,b from (values (1,null),(1,2),(2,3)) as t (a,b)) a";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+--------------------------------------------------------------------------------------------------------------------------+",
+        "| CASE WHEN #a.b IS NULL THEN NULL WHEN #a.b < Int64(3) THEN NULL WHEN #a.b >= Int64(3) THEN #a.b + Int64(1) ELSE #a.b END |",
+        "+--------------------------------------------------------------------------------------------------------------------------+",
+        "|                                                                                                                          |",
+        "|                                                                                                                          |",
+        "| 4                                                                                                                        |",
+        "+--------------------------------------------------------------------------------------------------------------------------+"
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "select case b when 1 then null when 2 then null when 3 then b + 1 else b end from (select a,b from (values (1,null),(1,2),(2,3)) as t (a,b)) a;";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+------------------------------------------------------------------------------------------------------------+",
+        "| CASE #a.b WHEN Int64(1) THEN NULL WHEN Int64(2) THEN NULL WHEN Int64(3) THEN #a.b + Int64(1) ELSE #a.b END |",
+        "+------------------------------------------------------------------------------------------------------------+",
+        "|                                                                                                            |",
+        "|                                                                                                            |",
+        "| 4                                                                                                          |",
+        "+------------------------------------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_not() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
 

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -117,7 +117,7 @@ impl CaseExpr {
     ///     [ELSE result]
     /// END
     fn case_when_with_expr(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
-        let return_type = self.when_then_expr[0].1.data_type(&batch.schema())?;
+        let return_type = self.data_type(&*batch.schema())?;
         let expr = self.expr.as_ref().unwrap();
         let base_value = expr.evaluate(batch)?;
         let base_value = base_value.into_array(batch.num_rows());
@@ -138,7 +138,12 @@ impl CaseExpr {
             let then_value = self.when_then_expr[i]
                 .1
                 .evaluate_selection(batch, &when_match)?;
-            let then_value = then_value.into_array(batch.num_rows());
+            let then_value = match then_value {
+                ColumnarValue::Scalar(value) if value.is_null() => {
+                    new_null_array(&return_type, batch.num_rows())
+                }
+                _ => then_value.into_array(batch.num_rows()),
+            };
 
             current_value =
                 zip(&when_match, then_value.as_ref(), current_value.as_ref())?;
@@ -169,7 +174,7 @@ impl CaseExpr {
     ///      [ELSE result]
     /// END
     fn case_when_no_expr(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
-        let return_type = self.when_then_expr[0].1.data_type(&batch.schema())?;
+        let return_type = self.data_type(&*batch.schema())?;
 
         // start with nulls as default output
         let mut current_value = new_null_array(&return_type, batch.num_rows());
@@ -195,7 +200,12 @@ impl CaseExpr {
             let then_value = self.when_then_expr[i]
                 .1
                 .evaluate_selection(batch, when_value)?;
-            let then_value = then_value.into_array(batch.num_rows());
+            let then_value = match then_value {
+                ColumnarValue::Scalar(value) if value.is_null() => {
+                    new_null_array(&return_type, batch.num_rows())
+                }
+                _ => then_value.into_array(batch.num_rows()),
+            };
 
             current_value = zip(when_value, then_value.as_ref(), current_value.as_ref())?;
 
@@ -228,7 +238,23 @@ impl PhysicalExpr for CaseExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        self.when_then_expr[0].1.data_type(input_schema)
+        // since all then results have the same data type, we can choose any one as the
+        // return data type except for the null.
+        let mut data_type = DataType::Null;
+        for i in 0..self.when_then_expr.len() {
+            data_type = self.when_then_expr[i].1.data_type(input_schema)?;
+            if !data_type.equals_datatype(&DataType::Null) {
+                break;
+            }
+        }
+        // if all then results are null, we use data type of else expr instead if possible.
+        if data_type.equals_datatype(&DataType::Null) {
+            if let Some(e) = &self.else_expr {
+                data_type = e.data_type(input_schema)?;
+            }
+        }
+
+        Ok(data_type)
     }
 
     fn nullable(&self, input_schema: &Schema) -> Result<bool> {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2798 

# Rationale for this change
use non-null then/else expr 's data type as return data type for CaseExpr.

For this query:  select case when b is null then null else b end from (select a,b from (values (1,null),(2,3)) as t (a,b)) a;

We use data type of else expr(b) as return data type.

For this query:  select case when b is null then null when b >= 3 then b + 1 else b end from (select a,b from (values (1,null),(2,3)) as t (a,b)) a;

We use data type of then expr(b + 1 ) as return data type.

# What changes are included in this PR?
modify data_type function of CaseExpr in datafusion/physical-expr/src/expressions/case.rs
