### PR TITLE
Allow setting of config options via environment variables

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -92,7 +92,7 @@ pub async fn main() -> Result<()> {
         env::set_current_dir(&p).unwrap();
     };
 
-    let mut session_config = SessionConfig::new().with_information_schema(true);
+    let mut session_config = SessionConfig::from_env().with_information_schema(true);
 
     if let Some(batch_size) = args.batch_size {
         session_config = session_config.with_batch_size(batch_size);

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -20,7 +20,7 @@
 use crate::error::{DataFusionError, Result};
 use arrow::{
     array::*,
-    compute::kernels::cast::cast,
+    compute::kernels::cast::{cast, cast_with_options, CastOptions},
     datatypes::{
         ArrowDictionaryKeyType, ArrowNativeType, DataType, Field, Float32Type,
         Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, IntervalUnit, TimeUnit,
@@ -1431,6 +1431,14 @@ impl ScalarValue {
                 )));
             }
         })
+    }
+
+    /// Try to parse `value` into a ScalarValue of type `target_type`
+    pub fn try_from_string(value: String, target_type: &DataType) -> Result<Self> {
+        let value = ScalarValue::Utf8(Some(value));
+        let cast_options = CastOptions { safe: false };
+        let cast_arr = cast_with_options(&value.to_array(), target_type, &cast_options)?;
+        ScalarValue::try_from_array(&cast_arr, 0)
     }
 
     fn eq_array_decimal(

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -17,9 +17,8 @@
 
 //! DataFusion Configuration Options
 
-use arrow::compute::kernels::cast;
 use arrow::datatypes::DataType;
-use datafusion_common::{Result, ScalarValue};
+use datafusion_common::ScalarValue;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::env;
@@ -161,14 +160,6 @@ impl BuiltInConfigs {
         }
         docs
     }
-}
-
-fn scalar_from_string(value: String, target_type: &DataType) -> Result<ScalarValue> {
-    let value = ScalarValue::Utf8(Some(value));
-    let cast_options = cast::CastOptions { safe: false };
-    let cast_arr =
-        cast::cast_with_options(&value.to_array(), target_type, &cast_options)?;
-    ScalarValue::try_from_array(&cast_arr, 0)
 }
 
 /// Configuration options struct. This can contain values for built-in and custom options

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -245,7 +245,6 @@ impl ConfigOptions {
 #[cfg(test)]
 mod test {
     use crate::config::{BuiltInConfigs, ConfigOptions};
-    use std::env;
 
     #[test]
     fn docs() {
@@ -265,6 +264,7 @@ mod test {
     fn get_then_set() {
         let mut config = ConfigOptions::new();
         let config_key = "datafusion.optimizer.filter_null_join_keys";
+        assert!(!config.get_bool(config_key));
         config.set_bool(config_key, true);
         assert!(config.get_bool(config_key));
     }
@@ -275,25 +275,5 @@ mod test {
         let invalid_key = "not.valid";
         assert!(config.get(invalid_key).is_none());
         assert!(!config.get_bool(invalid_key));
-    }
-
-    #[test]
-    fn get_from_env() {
-        let bool_config_key = "datafusion.optimizer.filter_null_join_keys";
-        let bool_env_key = "DATAFUSION_OPTIMIZER_FILTER_NULL_JOIN_KEYS";
-        env::set_var(bool_env_key, "true");
-        let int_config_key = "datafusion.execution.batch_size";
-        let int_env_key = "DATAFUSION_EXECUTION_BATCH_SIZE";
-        env::set_var(int_env_key, "4096");
-        let invalid_config_key = "datafusion.execution.coalesce_target_batch_size";
-        let invalid_env_key = "DATAFUSION_EXECUTION_COALESCE_TARGET_BATCH_SIZE";
-        env::set_var(invalid_env_key, "abc");
-        let config = ConfigOptions::new();
-        env::remove_var(bool_env_key);
-        env::remove_var(int_env_key);
-        env::remove_var(invalid_env_key);
-        assert!(config.get_bool(bool_config_key));
-        assert_eq!(config.get_u64(int_config_key), 4096);
-        assert_eq!(config.get_u64(invalid_config_key), 4096); // set to its default value
     }
 }

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -270,7 +270,6 @@ mod test {
     fn get_then_set() {
         let mut config = ConfigOptions::new();
         let config_key = "datafusion.optimizer.filter_null_join_keys";
-        assert!(!config.get_bool(config_key));
         config.set_bool(config_key, true);
         assert!(config.get_bool(config_key));
     }

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -181,6 +181,17 @@ impl ConfigOptions {
         let mut options = HashMap::new();
         let built_in = BuiltInConfigs::new();
         for config_def in &built_in.config_definitions {
+            options.insert(config_def.key.clone(), config_def.default_value.clone());
+        }
+        Self { options }
+    }
+
+    /// Create new ConfigOptions struct, taking values from environment variables where possible.
+    /// For example, setting DATAFUSION_EXECUTION_BATCH_SIZE to control `datafusion.execution.batch_size`.
+    pub fn from_env() -> Self {
+        let mut options = HashMap::new();
+        let built_in = BuiltInConfigs::new();
+        for config_def in &built_in.config_definitions {
             let config_value = {
                 let mut env_key = config_def.key.replace('.', "_");
                 env_key.make_ascii_uppercase();

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -168,7 +168,7 @@ fn scalar_from_string(value: String, target_type: &DataType) -> Result<ScalarVal
     let cast_options = cast::CastOptions { safe: false };
     let cast_arr =
         cast::cast_with_options(&value.to_array(), target_type, &cast_options)?;
-    Ok(ScalarValue::try_from_array(&cast_arr, 0)?)
+    ScalarValue::try_from_array(&cast_arr, 0)
 }
 
 /// Configuration options struct. This can contain values for built-in and custom options
@@ -190,7 +190,7 @@ impl ConfigOptions {
         let built_in = BuiltInConfigs::new();
         for config_def in &built_in.config_definitions {
             let config_value = {
-                let mut env_key = config_def.key.replace(".", "_");
+                let mut env_key = config_def.key.replace('.', "_");
                 env_key.make_ascii_uppercase();
                 match env::var(env_key) {
                     Ok(value) => match scalar_from_string(value, &config_def.data_type) {

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -185,12 +185,15 @@ impl ConfigOptions {
                 let mut env_key = config_def.key.replace('.', "_");
                 env_key.make_ascii_uppercase();
                 match env::var(&env_key) {
-                    Ok(value) => match ScalarValue::try_from_string(value.clone(), &config_def.data_type) {
+                    Ok(value) => match ScalarValue::try_from_string(
+                        value.clone(),
+                        &config_def.data_type,
+                    ) {
                         Ok(parsed) => parsed,
                         Err(_) => {
                             warn!("Warning: could not parse environment variable {}={} to type {}.", env_key, value, config_def.data_type);
                             config_def.default_value.clone()
-                        },
+                        }
                     },
                     Err(_) => config_def.default_value.clone(),
                 }

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1043,9 +1043,10 @@ impl SessionConfig {
 
     /// Create an execution config with config options read from the environment
     pub fn from_env() -> Self {
-        let mut config = Self::default();
-        config.config_options = ConfigOptions::from_env();
-        config
+        Self {
+            config_options: ConfigOptions::from_env(),
+            ..Default::default()
+        }
     }
 
     /// Set a configuration option

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1041,6 +1041,22 @@ impl SessionConfig {
         Default::default()
     }
 
+    /// Create an execution config with config options read from the environment
+    pub fn from_env() -> Self {
+        Self {
+            target_partitions: num_cpus::get(),
+            default_catalog: DEFAULT_CATALOG.to_owned(),
+            default_schema: DEFAULT_SCHEMA.to_owned(),
+            create_default_catalog_and_schema: true,
+            information_schema: false,
+            repartition_joins: true,
+            repartition_aggregations: true,
+            repartition_windows: true,
+            parquet_pruning: true,
+            config_options: ConfigOptions::from_env(),
+        }
+    }
+
     /// Set a configuration option
     pub fn set(mut self, key: &str, value: ScalarValue) -> Self {
         self.config_options.set(key, value);

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1043,18 +1043,9 @@ impl SessionConfig {
 
     /// Create an execution config with config options read from the environment
     pub fn from_env() -> Self {
-        Self {
-            target_partitions: num_cpus::get(),
-            default_catalog: DEFAULT_CATALOG.to_owned(),
-            default_schema: DEFAULT_SCHEMA.to_owned(),
-            create_default_catalog_and_schema: true,
-            information_schema: false,
-            repartition_joins: true,
-            repartition_aggregations: true,
-            repartition_windows: true,
-            parquet_pruning: true,
-            config_options: ConfigOptions::from_env(),
-        }
+        let mut config = Self::default();
+        config.config_options = ConfigOptions::from_env();
+        config
     }
 
     /// Set a configuration option

--- a/datafusion/core/tests/config_from_env.rs
+++ b/datafusion/core/tests/config_from_env.rs
@@ -23,7 +23,7 @@ fn get_config_bool_from_env() {
     let config_key = "datafusion.optimizer.filter_null_join_keys";
     let env_key = "DATAFUSION_OPTIMIZER_FILTER_NULL_JOIN_KEYS";
     env::set_var(env_key, "true");
-    let config = ConfigOptions::new();
+    let config = ConfigOptions::from_env();
     env::remove_var(env_key);
     assert!(config.get_bool(config_key));
 }
@@ -33,7 +33,7 @@ fn get_config_int_from_env() {
     let config_key = "datafusion.execution.batch_size";
     let env_key = "DATAFUSION_EXECUTION_BATCH_SIZE";
     env::set_var(env_key, "4096");
-    let config = ConfigOptions::new();
+    let config = ConfigOptions::from_env();
     env::remove_var(env_key);
     assert_eq!(config.get_u64(config_key), 4096);
 }
@@ -43,7 +43,7 @@ fn get_config_int_from_env_invalid() {
     let config_key = "datafusion.execution.coalesce_target_batch_size";
     let env_key = "DATAFUSION_EXECUTION_COALESCE_TARGET_BATCH_SIZE";
     env::set_var(env_key, "abc");
-    let config = ConfigOptions::new();
+    let config = ConfigOptions::from_env();
     env::remove_var(env_key);
     assert_eq!(config.get_u64(config_key), 4096); // set to its default value
 }

--- a/datafusion/core/tests/config_from_env.rs
+++ b/datafusion/core/tests/config_from_env.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::config::ConfigOptions;
+use std::env;
+
+#[test]
+fn get_config_bool_from_env() {
+    let config_key = "datafusion.optimizer.filter_null_join_keys";
+    let env_key = "DATAFUSION_OPTIMIZER_FILTER_NULL_JOIN_KEYS";
+    env::set_var(env_key, "true");
+    let config = ConfigOptions::new();
+    env::remove_var(env_key);
+    assert!(config.get_bool(config_key));
+}
+
+#[test]
+fn get_config_int_from_env() {
+    let config_key = "datafusion.execution.batch_size";
+    let env_key = "DATAFUSION_EXECUTION_BATCH_SIZE";
+    env::set_var(env_key, "4096");
+    let config = ConfigOptions::new();
+    env::remove_var(env_key);
+    assert_eq!(config.get_u64(config_key), 4096);
+}
+
+#[test]
+fn get_config_int_from_env_invalid() {
+    let config_key = "datafusion.execution.coalesce_target_batch_size";
+    let env_key = "DATAFUSION_EXECUTION_COALESCE_TARGET_BATCH_SIZE";
+    env::set_var(env_key, "abc");
+    let config = ConfigOptions::new();
+    env::remove_var(env_key);
+    assert_eq!(config.get_u64(config_key), 4096); // set to its default value
+}

--- a/dev/update_config_docs.sh
+++ b/dev/update_config_docs.sh
@@ -57,11 +57,12 @@ Instead, edit dev/update_config_docs.sh or the docstrings in datafusion/core/src
 
 The following configuration options can be passed to `SessionConfig` to control various aspects of query execution.
 
-As well as setting them directly on a `SessionConfig`, these options may also be set via environment variables.
+For applications which do not expose `SessionConfig`, like `datafusion-cli`, these options may also be set via environment variables.
+To construct a session with options from the environment, use `SessionConfig::from_env`.
 The name of the environment variable is the option's key, transformed to uppercase and with periods replaced with underscores.
 For example, to configure `datafusion.execution.batch_size` you would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable.
 Values are parsed according to the [same rules used in casts from Utf8](https://docs.rs/arrow/latest/arrow/compute/kernels/cast/fn.cast.html).
-If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead.
+If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead and a warning emitted.
 Environment variables are read during `SessionConfig` initialisation so they must be set beforehand and will not affect running sessions.
 
 EOF

--- a/dev/update_config_docs.sh
+++ b/dev/update_config_docs.sh
@@ -57,6 +57,13 @@ Instead, edit dev/update_config_docs.sh or the docstrings in datafusion/core/src
 
 The following configuration options can be passed to `SessionConfig` to control various aspects of query execution.
 
+As well as setting them directly on a `SessionConfig`, these options may also be set via environment variables.
+The name of the environment variable is the option's key, transformed to uppercase and with periods replaced with underscores.
+For example, to configure `datafusion.execution.batch_size` you would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable.
+Values are parsed according to the [same rules used in casts from Utf8](https://docs.rs/arrow/latest/arrow/compute/kernels/cast/fn.cast.html).
+If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead.
+Environment variables are read during `SessionConfig` initialisation so they must be set beforehand and will not affect running sessions.
+
 EOF
 
 echo "Running CLI and inserting docs table"

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -27,6 +27,13 @@ Instead, edit dev/update_config_docs.sh or the docstrings in datafusion/core/src
 
 The following configuration options can be passed to `SessionConfig` to control various aspects of query execution.
 
+As well as setting them directly on a `SessionConfig`, these options may also be set via environment variables.
+The name of the environment variable is the option's key, transformed to uppercase and with periods replaced with underscores.
+For example, to configure `datafusion.execution.batch_size` you would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable.
+Values are parsed according to the [same rules used in casts from Utf8](https://docs.rs/arrow/latest/arrow/compute/kernels/cast/fn.cast.html).
+If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead.
+Environment variables are read during `SessionConfig` initialisation so they must be set beforehand and will not affect running sessions.
+
 | key                                             | type    | default | description                                                                                                                                                                                                                                                                                                                                                   |
 | ----------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | datafusion.execution.batch_size                 | UInt64  | 8192    | Default batch size while creating new batches, it's especially useful for buffer-in-memory batches since creating tiny batches would results in too much metadata memory consumption.                                                                                                                                                                         |

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -27,11 +27,12 @@ Instead, edit dev/update_config_docs.sh or the docstrings in datafusion/core/src
 
 The following configuration options can be passed to `SessionConfig` to control various aspects of query execution.
 
-As well as setting them directly on a `SessionConfig`, these options may also be set via environment variables.
+For applications which do not expose `SessionConfig`, like `datafusion-cli`, these options may also be set via environment variables.
+To construct a session with options from the environment, use `SessionConfig::from_env`.
 The name of the environment variable is the option's key, transformed to uppercase and with periods replaced with underscores.
 For example, to configure `datafusion.execution.batch_size` you would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable.
 Values are parsed according to the [same rules used in casts from Utf8](https://docs.rs/arrow/latest/arrow/compute/kernels/cast/fn.cast.html).
-If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead.
+If the value in the environment variable cannot be cast to the type of the configuration option, the default value will be used instead and a warning emitted.
 Environment variables are read during `SessionConfig` initialisation so they must be set beforehand and will not affect running sessions.
 
 | key                                             | type    | default | description                                                                                                                                                                                                                                                                                                                                                   |


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2776 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

During `ConfigOptions::new`, scan the environment for datafusion config options and try to cast them to the appropriate type.

I'm unsure exactly what the behaviour should be if someone passes an uncastable value in an env var. At the moment we use the default value and silently ignore the env var, but this could be confusing for people. Would it be better to just panic?

Another worry is that the unit test for this necessarily sets environment variables, which may interfere with other tests which are running concurrently and cause flakiness. I've removed any danger of this from `config.rs` but I guess it could theoretically happen for any test. Would it be safer to `#[ignore]` the `get_from_env` test and rely on running it manually if/when changes are made to this code specifically?

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->