### PR TITLE
Fix nullability calculation for `CASE` expressions

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -170,7 +170,6 @@ impl ExprSchemable for Expr {
                 } else if let Some(e) = else_expr {
                     e.nullable(input_schema)
                 } else {
-                    println!("AAL IN none else expr");
                     // CASE produces NULL if there is no `else` expr
                     // (aka when none of the `when_then_exprs` match)
                     Ok(true)

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -170,7 +170,10 @@ impl ExprSchemable for Expr {
                 } else if let Some(e) = else_expr {
                     e.nullable(input_schema)
                 } else {
-                    Ok(false)
+                    println!("AAL IN none else expr");
+                    // CASE produces NULL if there is no `else` expr
+                    // (aka when none of the `when_then_exprs` match)
+                    Ok(true)
                 }
             }
             Expr::Cast { expr, .. } => expr.nullable(input_schema),

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -243,7 +243,9 @@ impl PhysicalExpr for CaseExpr {
         } else if let Some(e) = &self.else_expr {
             e.nullable(input_schema)
         } else {
-            Ok(false)
+            // CASE produces NULL if there is no `else` expr
+            // (aka when none of the `when_then_exprs` match)
+            Ok(true)
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/pull/2778

 # Rationale for this change

https://github.com/apache/arrow-rs/issues/1888 (added in `arrow 17.0.0`) added validation to `RecordBatch` if the schema's declared nullability is different than its actual nullability it throws a runtime error. 

# What changes are included in this PR?
Correct declared schema nullability calculation for `CASE` expressions

There are no tests in this PR -- they are covered in https://github.com/apache/arrow-datafusion/pull/2778

# Are there any user-facing changes?
Yes the output schema  calculation for CASE expressions