### PR TITLE
Fix `ScalarValue::isNull` calculation

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -625,32 +625,36 @@ impl ScalarValue {
 
     /// whether this value is null or not.
     pub fn is_null(&self) -> bool {
-        matches!(
-            *self,
-            ScalarValue::Null
-                | ScalarValue::Boolean(None)
-                | ScalarValue::UInt8(None)
-                | ScalarValue::UInt16(None)
-                | ScalarValue::UInt32(None)
-                | ScalarValue::UInt64(None)
-                | ScalarValue::Int8(None)
-                | ScalarValue::Int16(None)
-                | ScalarValue::Int32(None)
-                | ScalarValue::Int64(None)
-                | ScalarValue::Float32(None)
-                | ScalarValue::Float64(None)
-                | ScalarValue::Date32(None)
-                | ScalarValue::Date64(None)
-                | ScalarValue::Utf8(None)
-                | ScalarValue::LargeUtf8(None)
-                | ScalarValue::List(None, _)
-                | ScalarValue::TimestampSecond(None, _)
-                | ScalarValue::TimestampMillisecond(None, _)
-                | ScalarValue::TimestampMicrosecond(None, _)
-                | ScalarValue::TimestampNanosecond(None, _)
-                | ScalarValue::Struct(None, _)
-                | ScalarValue::Decimal128(None, _, _) // For decimal type, the value is null means ScalarValue::Decimal128 is null.
-        )
+        match self {
+            ScalarValue::Boolean(v) => v.is_none(),
+            ScalarValue::Null => true,
+            ScalarValue::Float32(v) => v.is_none(),
+            ScalarValue::Float64(v) => v.is_none(),
+            ScalarValue::Decimal128(v, _, _) => v.is_none(),
+            ScalarValue::Int8(v) => v.is_none(),
+            ScalarValue::Int16(v) => v.is_none(),
+            ScalarValue::Int32(v) => v.is_none(),
+            ScalarValue::Int64(v) => v.is_none(),
+            ScalarValue::UInt8(v) => v.is_none(),
+            ScalarValue::UInt16(v) => v.is_none(),
+            ScalarValue::UInt32(v) => v.is_none(),
+            ScalarValue::UInt64(v) => v.is_none(),
+            ScalarValue::Utf8(v) => v.is_none(),
+            ScalarValue::LargeUtf8(v) => v.is_none(),
+            ScalarValue::Binary(v) => v.is_none(),
+            ScalarValue::LargeBinary(v) => v.is_none(),
+            ScalarValue::List(v, _) => v.is_none(),
+            ScalarValue::Date32(v) => v.is_none(),
+            ScalarValue::Date64(v) => v.is_none(),
+            ScalarValue::TimestampSecond(v, _) => v.is_none(),
+            ScalarValue::TimestampMillisecond(v, _) => v.is_none(),
+            ScalarValue::TimestampMicrosecond(v, _) => v.is_none(),
+            ScalarValue::TimestampNanosecond(v, _) => v.is_none(),
+            ScalarValue::IntervalYearMonth(v) => v.is_none(),
+            ScalarValue::IntervalDayTime(v) => v.is_none(),
+            ScalarValue::IntervalMonthDayNano(v) => v.is_none(),
+            ScalarValue::Struct(v, _) => v.is_none(),
+        }
     }
 
     /// Converts a scalar value into an 1-row array.


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/pull/2778

 # Rationale for this change

https://github.com/apache/arrow-rs/issues/1888 (added in `arrow 17.0.0`) added validation to `RecordBatch` if the schema's declared nullability is different than its actual nullability it throws a runtime error. 

# What changes are included in this PR?
Correct `ScalarValue::isNull`

There are no additional tests in this PR -- they are covered in https://github.com/apache/arrow-datafusion/pull/2778

# Are there any user-facing changes?
More accurate schema calculations