### PR TITLE
Fix the ci

### DIFF
--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -144,6 +144,7 @@ impl BuiltInConfigs {
 
     /// Generate documentation that can be included int he user guide
     pub fn generate_config_markdown() -> String {
+        use std::fmt::Write as _;
         let configs = Self::new();
         let mut docs = "| key | type | default | description |\n".to_string();
         docs += "|-----|------|---------|-------------|\n";
@@ -152,8 +153,9 @@ impl BuiltInConfigs {
             .iter()
             .sorted_by_key(|c| c.key.as_str())
         {
-            docs += &format!(
-                "| {} | {} | {} | {} |\n",
+            let _ = writeln!(
+                &mut docs,
+                "| {} | {} | {} | {} |",
                 config.key, config.data_type, config.default_value, config.description
             );
         }


### PR DESCRIPTION
# Which issue does this PR close?
NA

 # Rationale for this change
Looks like clippy is failing on PRs -- for example: https://github.com/apache/arrow-datafusion/runs/7146009434?check_suite_focus=true

Likely due to a new rust version being released: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1620-2022-06-30

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->