### PR TITLE
Bump arrow2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", rev = "v0.10.0" }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2.git", rev = "v0.10.1" }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", rev = "v0.12.0" }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2.git", rev = "v0.13.2" }

--- a/ballista-examples/Cargo.toml
+++ b/ballista-examples/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 [dependencies]
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0"}
-prost = "0.9"
-tonic = "0.6"
+prost = "0.10"
+tonic = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,19 +35,19 @@ async-trait = "0.1.41"
 futures = "0.3"
 hashbrown = "0.12"
 log = "0.4"
-prost = "0.9"
-prost-types = "0.9"
+prost = "0.10"
+prost-types = "0.10"
 serde = {version = "1", features = ["derive"]}
 sqlparser = "0.15"
 tokio = "1.0"
-tonic = "0.6"
+tonic = "0.7"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 parse_arg = "0.1.3"
 
-arrow-format = { version = "0.4", features = ["flight-data", "flight-service"] }
-arrow = { package = "arrow2", version="0.10", features = ["io_ipc", "io_flight"] }
+arrow-format = { version = "0.6", features = ["flight-data", "flight-service"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_ipc", "io_flight"] }
 
 datafusion = { path = "../../../datafusion", version = "7.0.0" }
 datafusion-proto = { path = "../../../datafusion-proto", version = "7.0.0" }
@@ -58,4 +58,4 @@ parking_lot = "0.12"
 tempfile = "3"
 
 [build-dependencies]
-tonic-build = { version = "0.6" }
+tonic-build = { version = "0.7" }

--- a/ballista/rust/core/src/client.rs
+++ b/ballista/rust/core/src/client.rs
@@ -34,7 +34,7 @@ use arrow_format::flight::data::{FlightData, Ticket};
 use arrow_format::flight::service::flight_service_client::FlightServiceClient;
 use datafusion::arrow::{
     datatypes::SchemaRef,
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use datafusion::field_util::SchemaExt;
 use datafusion::physical_plan::RecordBatchStream;

--- a/ballista/rust/core/src/error.rs
+++ b/ballista/rust/core/src/error.rs
@@ -23,7 +23,7 @@ use std::{
     io, result,
 };
 
-use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::error::Error as ArrowError;
 use datafusion::error::DataFusionError;
 use sqlparser::parser;
 

--- a/ballista/rust/core/src/memory_stream.rs
+++ b/ballista/rust/core/src/memory_stream.rs
@@ -1,1 +1,16 @@
-
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -29,8 +29,8 @@ edition = "2018"
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-arrow-format = { version = "0.4", features = ["flight-data", "flight-service"] }
-arrow = { package = "arrow2", version="0.10", features = ["io_ipc"] }
+arrow-format = { version = "0.6", features = ["flight-data", "flight-service"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_ipc"] }
 anyhow = "1"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.6.0" }
@@ -43,7 +43,7 @@ snmalloc-rs = {version = "0.2", optional = true}
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = "0.6"
+tonic = "0.7"
 uuid = { version = "0.8", features = ["v4"] }
 hyper = "0.14.4"
 parking_lot = "0.12"

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -62,7 +62,7 @@ pub async fn poll_loop<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         // to avoid going in sleep mode between polling
         let mut active_job = false;
 
-        let poll_work_result: anyhow::Result<
+        let poll_work_result: Result<
             tonic::Response<PollWorkResult>,
             tonic::Status,
         > = scheduler

--- a/ballista/rust/executor/src/execution_loop.rs
+++ b/ballista/rust/executor/src/execution_loop.rs
@@ -62,16 +62,14 @@ pub async fn poll_loop<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         // to avoid going in sleep mode between polling
         let mut active_job = false;
 
-        let poll_work_result: Result<
-            tonic::Response<PollWorkResult>,
-            tonic::Status,
-        > = scheduler
-            .poll_work(PollWorkParams {
-                metadata: Some(executor.metadata.clone()),
-                can_accept_task: available_tasks_slots.load(Ordering::SeqCst) > 0,
-                task_status,
-            })
-            .await;
+        let poll_work_result: Result<tonic::Response<PollWorkResult>, tonic::Status> =
+            scheduler
+                .poll_work(PollWorkParams {
+                    metadata: Some(executor.metadata.clone()),
+                    can_accept_task: available_tasks_slots.load(Ordering::SeqCst) > 0,
+                    task_status,
+                })
+                .await;
 
         let task_status_sender = task_status_sender.clone();
 

--- a/ballista/rust/executor/src/flight_service.rs
+++ b/ballista/rust/executor/src/flight_service.rs
@@ -35,7 +35,7 @@ use arrow_format::flight::data::{
 };
 use arrow_format::flight::service::flight_service_server::FlightService;
 use datafusion::arrow::{
-    error::ArrowError, io::ipc::read::FileReader, io::ipc::write::WriteOptions,
+    error::Error as ArrowError, io::ipc::read::FileReader, io::ipc::write::WriteOptions,
 };
 use futures::{Stream, StreamExt};
 use log::{info, warn};

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -44,13 +44,13 @@ http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
 parse_arg = "0.1.3"
-prost = "0.9"
+prost = "0.10"
 rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
-tonic = "0.6"
+tonic = "0.7"
 tower = { version = "0.4" }
 warp = "0.3"
 parking_lot = "0.12"
@@ -62,7 +62,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]
 configure_me_codegen = "0.4.1"
-tonic-build = { version = "0.6" }
+tonic-build = { version = "0.7" }
 
 [package.metadata.configure_me.bin]
 scheduler = "scheduler_config_spec.toml"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,7 +32,8 @@ simd = ["datafusion/simd"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-arrow = { package = "arrow2", version="0.10", features = ["io_csv", "io_json", "io_parquet", "io_parquet_compression", "io_ipc", "io_print", "ahash", "compute_merge_sort", "compute", "regex"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_csv", "io_json", "io_parquet", "io_parquet_compression", "io_ipc", "io_print", "ahash", "compute_merge_sort", "compute", "regex"] }
+parquet2 = "0.13"
 datafusion = { path = "../datafusion" }
 ballista = { path = "../ballista/rust/client" }
 structopt = { version = "0.3", default-features = false }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -19,6 +19,7 @@
 
 use arrow::array::ArrayRef;
 use arrow::chunk::Chunk;
+use datafusion::arrow::io::print;
 use futures::future::join_all;
 use rand::prelude::*;
 use std::ops::Div;
@@ -30,7 +31,6 @@ use std::{
     sync::Arc,
     time::{Instant, SystemTime},
 };
-use datafusion::arrow::io::print;
 
 use datafusion::datasource::{
     listing::{ListingOptions, ListingTable},
@@ -51,7 +51,7 @@ use datafusion::{
     datasource::file_format::parquet::ParquetFormat, record_batch::RecordBatch,
 };
 
-use arrow::io::parquet::write::{CompressionOptions, Version, WriteOptions};
+use arrow::io::parquet::write::Version;
 use ballista::prelude::{
     BallistaConfig, BallistaContext, BALLISTA_DEFAULT_SHUFFLE_PARTITIONS,
 };

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -30,7 +30,6 @@ use std::{
     sync::Arc,
     time::{Instant, SystemTime},
 };
-
 use datafusion::arrow::io::print;
 
 use datafusion::datasource::{
@@ -52,7 +51,7 @@ use datafusion::{
     datasource::file_format::parquet::ParquetFormat, record_batch::RecordBatch,
 };
 
-use arrow::io::parquet::write::{Compression, Version, WriteOptions};
+use arrow::io::parquet::write::{CompressionOptions, Version, WriteOptions};
 use ballista::prelude::{
     BallistaConfig, BallistaContext, BALLISTA_DEFAULT_SHUFFLE_PARTITIONS,
 };
@@ -665,24 +664,7 @@ async fn convert_tbl(opt: ConvertOpt) -> Result<()> {
         match opt.file_format.as_str() {
             "csv" => ctx.write_csv(csv, output_path).await?,
             "parquet" => {
-                let compression = match opt.compression.as_str() {
-                    "none" => Compression::Uncompressed,
-                    "snappy" => Compression::Snappy,
-                    "brotli" => Compression::Brotli,
-                    "gzip" => Compression::Gzip,
-                    "lz4" => Compression::Lz4,
-                    "lz0" => Compression::Lzo,
-                    "zstd" => Compression::Zstd,
-                    other => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Invalid compression format: {}",
-                            other
-                        )))
-                    }
-                };
-
-                let options = WriteOptions {
-                    compression,
+                let options = parquet2::write::WriteOptions {
                     write_statistics: false,
                     version: Version::V1,
                 };

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "3", features = ["derive", "cargo"] }
 rustyline = "9.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 datafusion = { path = "../datafusion", version = "7.0.0" }
-arrow = { package = "arrow2", version="0.10", features = ["io_print"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_print"] }
 ballista = { path = "../ballista/rust/client", version = "0.6.0", optional=true }
 env_logger = "0.9"
 mimalloc = { version = "*", default-features = false }

--- a/datafusion-common/Cargo.toml
+++ b/datafusion-common/Cargo.toml
@@ -37,8 +37,8 @@ pyarrow = ["pyo3"]
 jit = ["cranelift-module"]
 
 [dependencies]
-arrow = { package = "arrow2", version = "0.10", default-features = false }
-parquet = { package = "parquet2", version = "0.10", default_features = false, features = ["stream"], optional = true }
+arrow = { package = "arrow2", version = "0.12.0", default-features = false }
+parquet = { package = "parquet2", version = "0.13", default_features = false, optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = "0.15"
 ordered-float = "2.10"

--- a/datafusion-common/src/error.rs
+++ b/datafusion-common/src/error.rs
@@ -22,13 +22,13 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;
 
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 #[cfg(feature = "avro")]
 use avro_rs::Error as AvroError;
 #[cfg(feature = "jit")]
 use cranelift_module::ModuleError;
 #[cfg(feature = "parquet")]
-use parquet::error::ParquetError;
+use parquet::error::Error as ParquetError;
 use sqlparser::parser::ParserError;
 
 /// Result type for operations that could result in an [DataFusionError]
@@ -181,7 +181,7 @@ impl error::Error for DataFusionError {}
 #[cfg(test)]
 mod test {
     use crate::error::DataFusionError;
-    use arrow::error::ArrowError;
+    use arrow::error::Error as ArrowError;
 
     #[test]
     fn arrow_error_to_datafusion() {

--- a/datafusion-common/src/field_util.rs
+++ b/datafusion-common/src/field_util.rs
@@ -19,7 +19,7 @@
 
 use arrow::array::{ArrayRef, StructArray};
 use arrow::datatypes::{DataType, Field, Metadata, Schema};
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 

--- a/datafusion-common/src/record_batch.rs
+++ b/datafusion-common/src/record_batch.rs
@@ -23,7 +23,7 @@ use arrow::array::*;
 use arrow::chunk::Chunk;
 use arrow::compute::filter::{build_filter, filter};
 use arrow::datatypes::*;
-use arrow::error::{ArrowError, Result};
+use arrow::error::{Error as ArrowError, Result};
 
 /// A two-dimensional dataset with a number of
 /// columns ([`Array`]) and rows and defined [`Schema`](crate::datatypes::Schema).

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,11 +34,11 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-format = { version = "0.4", features = ["flight-service", "flight-data"] }
-arrow = { package = "arrow2", version="0.10", features = ["io_ipc", "io_flight"] }
+arrow-format = { version = "0.6", features = ["flight-service", "flight-data"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_ipc", "io_flight"] }
 datafusion = { path = "../datafusion" }
-prost = "0.9"
-tonic = "0.6"
+prost = "0.10"
+tonic = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/datafusion-expr/Cargo.toml
+++ b/datafusion-expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
-arrow = { package = "arrow2", version = "0.10", default-features = false }
+arrow = { package = "arrow2", version = "0.12", default-features = false }
 sqlparser = "0.15"
 ahash = { version = "0.7", default-features = false }

--- a/datafusion-physical-expr/Cargo.toml
+++ b/datafusion-physical-expr/Cargo.toml
@@ -41,7 +41,7 @@ unicode_expressions = ["unicode-segmentation"]
 [dependencies]
 datafusion-common = { path = "../datafusion-common", version = "7.0.0" }
 datafusion-expr = { path = "../datafusion-expr", version = "7.0.0" }
-arrow = { package = "arrow2", version = "0.10" }
+arrow = { package = "arrow2", version = "0.12" }
 paste = "^1.0"
 ahash = { version = "0.7", default-features = false }
 ordered-float = "2.10"

--- a/datafusion-physical-expr/src/arrow_temporal_util.rs
+++ b/datafusion-physical-expr/src/arrow_temporal_util.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::error::{ArrowError, Result};
+use arrow::error::{Error as ArrowError, Result};
 use chrono::{prelude::*, LocalResult};
 
 /// Accepts a string in RFC3339 / ISO8601 standard format and some

--- a/datafusion-physical-expr/src/expressions/binary.rs
+++ b/datafusion-physical-expr/src/expressions/binary.rs
@@ -936,7 +936,7 @@ mod tests {
     use crate::expressions::{col, lit};
     use crate::test_util::create_decimal_array;
     use arrow::datatypes::{Field, SchemaRef};
-    use arrow::error::ArrowError;
+    use arrow::error::Error as ArrowError;
     use datafusion_common::field_util::SchemaExt;
 
     // TODO add iter for decimal array

--- a/datafusion-physical-expr/src/regex_expressions.rs
+++ b/datafusion-physical-expr/src/regex_expressions.rs
@@ -28,7 +28,7 @@ use std::any::type_name;
 use std::sync::Arc;
 
 use arrow::array::*;
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 
 use datafusion_common::{DataFusionError, Result};
 

--- a/datafusion-physical-expr/src/test_util.rs
+++ b/datafusion-physical-expr/src/test_util.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use arrow::datatypes::DataType;
 
 #[cfg(test)]

--- a/datafusion-proto/Cargo.toml
+++ b/datafusion-proto/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 
 [dependencies]
 datafusion = { path = "../datafusion", version = "7.0.0" }
-prost = "0.9"
+prost = "0.10"
 
 [build-dependencies]
-tonic-build = { version = "0.6" }
+tonic-build = { version = "0.7" }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -60,7 +60,7 @@ datafusion-jit = { path = "../datafusion-jit", version = "7.0.0", optional = tru
 datafusion-physical-expr = { path = "../datafusion-physical-expr", version = "7.0.0" }
 ahash = { version = "0.7", default-features = false }
 hashbrown = { version = "0.12", features = ["raw"] }
-parquet = { package = "parquet2", version = "0.10", default_features = false, features = ["stream"] }
+parquet = { package = "parquet2", version = "0.13", default_features = false }
 sqlparser = "0.15"
 paste = "^1.0"
 num_cpus = "1.13.0"
@@ -86,7 +86,7 @@ comfy-table = { version = "5.0", default-features = false }
 
 [dependencies.arrow]
 package = "arrow2"
-version="0.10"
+version="0.12"
 features = ["io_csv", "io_json", "io_parquet", "io_parquet_compression", "io_ipc", "ahash", "compute"]
 
 [dev-dependencies]

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -93,7 +93,7 @@ features = ["io_csv", "io_json", "io_parquet", "io_parquet_compression", "io_ipc
 criterion = "0.3"
 doc-comment = "0.3"
 fuzz-utils = { path = "fuzz-utils" }
-parquet-format-async-temp = "0.2"
+parquet-format-async-temp = "0.3"
 
 [[bench]]
 name = "aggregate_query_sql"

--- a/datafusion/benches/parquet_query_sql.rs
+++ b/datafusion/benches/parquet_query_sql.rs
@@ -29,7 +29,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::prelude::ExecutionContext;
 use datafusion_common::field_util::SchemaExt;
 use datafusion_common::record_batch::RecordBatch;
-use parquet::compression::Compression;
+use parquet::compression::{Compression, CompressionOptions};
 use parquet::encoding::Encoding;
 use parquet::write::Version;
 use rand::distributions::uniform::SampleUniform;
@@ -153,7 +153,7 @@ fn generate_file() -> NamedTempFile {
 
     let options = arrow::io::parquet::write::WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V2,
     };
 
@@ -172,12 +172,11 @@ fn generate_file() -> NamedTempFile {
             iter.into_iter(),
             schema.as_ref(),
             options,
-            vec![Encoding::Plain].repeat(schema.fields().len()),
+            vec![vec![Encoding::Plain]].repeat(schema.fields().len()),
         )
         .unwrap();
         for rg in row_groups {
-            let (group, len) = rg.unwrap();
-            writer.write(group, len).unwrap();
+            writer.write(rg.unwrap()).unwrap();
         }
     }
     let (_total_size, mut w) = writer.end(None).unwrap();

--- a/datafusion/fuzz-utils/Cargo.toml
+++ b/datafusion/fuzz-utils/Cargo.toml
@@ -24,6 +24,6 @@ edition = "2021"
 
 [dependencies]
 datafusion-common = { path = "../../datafusion-common", version = "^7.0.0" }
-arrow = { package = "arrow2", version="0.10", features = ["io_print"] }
+arrow = { package = "arrow2", version="0.12", features = ["io_print"] }
 rand = "0.8"
 env_logger = "0.9.0"

--- a/datafusion/src/dataframe.rs
+++ b/datafusion/src/dataframe.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 
 use crate::physical_plan::SendableRecordBatchStream;
 use async_trait::async_trait;
-use parquet::write::WriteOptions;
 
 /// DataFrame represents a logical set of rows with the same named columns.
 /// Similar to a [Pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) or
@@ -414,6 +413,6 @@ pub trait DataFrame: Send + Sync {
     async fn write_parquet(
         &self,
         path: &str,
-        writer_properties: Option<WriteOptions>,
+        writer_properties: Option<arrow::io::parquet::write::WriteOptions>,
     ) -> Result<()>;
 }

--- a/datafusion/src/datasource/memory.rs
+++ b/datafusion/src/datasource/memory.rs
@@ -165,7 +165,7 @@ mod tests {
 
     use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Field, Schema};
-    use arrow::error::ArrowError;
+    use arrow::error::Error as ArrowError;
     use std::collections::BTreeMap;
 
     #[tokio::test]

--- a/datafusion/src/execution/context.rs
+++ b/datafusion/src/execution/context.rs
@@ -89,7 +89,6 @@ use crate::variable::{VarProvider, VarType};
 use crate::{dataframe::DataFrame, physical_plan::udaf::AggregateUDF};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use parquet::write::WriteOptions;
 
 use super::{
     disk_manager::DiskManagerConfig,
@@ -723,7 +722,7 @@ impl ExecutionContext {
         &self,
         plan: Arc<dyn ExecutionPlan>,
         path: impl AsRef<str>,
-        writer_properties: WriteOptions,
+        writer_properties: arrow::io::parquet::write::WriteOptions,
     ) -> Result<()> {
         plan_to_parquet(self, plan, path, Some(writer_properties)).await
     }

--- a/datafusion/src/execution/dataframe_impl.rs
+++ b/datafusion/src/execution/dataframe_impl.rs
@@ -20,7 +20,6 @@
 use async_trait::async_trait;
 use datafusion_common::field_util::{FieldExt, SchemaExt};
 use parking_lot::Mutex;
-use parquet::write::WriteOptions;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -327,7 +326,7 @@ impl DataFrame for DataFrameImpl {
     async fn write_parquet(
         &self,
         path: &str,
-        writer_properties: Option<WriteOptions>,
+        writer_properties: Option<arrow::io::parquet::write::WriteOptions>,
     ) -> Result<()> {
         let plan = self.create_physical_plan().await?;
         let state = self.ctx_state.lock().clone();

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(assert_matches)]
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/datafusion/src/lib.rs
+++ b/datafusion/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(assert_matches)]
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/datafusion/src/physical_plan/common.rs
+++ b/datafusion/src/physical_plan/common.rs
@@ -26,7 +26,7 @@ use crate::record_batch::RecordBatch;
 use arrow::compute::aggregate::estimated_bytes_size;
 use arrow::compute::concatenate::concatenate;
 use arrow::datatypes::{Schema, SchemaRef};
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 use arrow::error::Result as ArrowResult;
 use arrow::io::ipc::write::{FileWriter, WriteOptions};
 use datafusion_common::field_util::SchemaExt;

--- a/datafusion/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/src/physical_plan/file_format/file_stream.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use arrow::{
     datatypes::SchemaRef,
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use datafusion_common::record_batch::RecordBatch;
 use futures::Stream;

--- a/datafusion/src/physical_plan/file_format/mod.rs
+++ b/datafusion/src/physical_plan/file_format/mod.rs
@@ -28,7 +28,7 @@ pub use self::parquet::ParquetExec;
 use arrow::{
     array::{ArrayRef, DictionaryArray},
     datatypes::{DataType, Field, Schema, SchemaRef},
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 pub use avro::AvroExec;
 pub(crate) use csv::plan_to_csv;

--- a/datafusion/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/src/physical_plan/file_format/parquet.rs
@@ -634,7 +634,6 @@ pub async fn plan_to_parquet(
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
     use crate::datasource::{
         file_format::{parquet::ParquetFormat, FileFormat},
         object_store::local::{
@@ -1102,7 +1101,6 @@ mod tests {
         let batch = results.next().await.unwrap();
         // invalid file should produce an error to that effect
         let error = batch.unwrap_err();
-        assert_matches!(error, arrow::error::Error::External(..));
         assert_contains!(
             error.to_string(),
             "External error: IO error"

--- a/datafusion/src/physical_plan/functions.rs
+++ b/datafusion/src/physical_plan/functions.rs
@@ -42,7 +42,7 @@ use crate::{
     scalar::ScalarValue,
 };
 use arrow::array::{Array, PrimitiveArray, Utf8Array};
-use arrow::error::{ArrowError, Result as ArrowResult};
+use arrow::error::{Error as ArrowError, Result as ArrowResult};
 use arrow::types::{NativeType, Offset};
 use arrow::{
     array::ArrayRef,
@@ -740,9 +740,9 @@ where
         .windows(2)
         .map(|offset| op(offset[1] - offset[0]));
 
-    let values = arrow::buffer::Buffer::from_trusted_len_iter(values);
+    let values = arrow::buffer::Buffer::from_iter(values);
 
-    let data_type = if O::is_large() {
+    let data_type = if O::IS_LARGE {
         DataType::Int64
     } else {
         DataType::Int32

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -42,7 +42,7 @@ use arrow::compute::{concatenate, take};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::{
     array::Array,
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use arrow::{array::ArrayRef, compute::cast};
 use hashbrown::raw::RawTable;

--- a/datafusion/src/physical_plan/metrics/baseline.rs
+++ b/datafusion/src/physical_plan/metrics/baseline.rs
@@ -20,7 +20,7 @@
 use std::task::Poll;
 
 use super::{Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, Time, Timestamp};
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 use datafusion_common::record_batch::RecordBatch;
 
 /// Helper for creating and tracking common "baseline" metrics for

--- a/datafusion/src/physical_plan/metrics/tracker.rs
+++ b/datafusion/src/physical_plan/metrics/tracker.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use crate::record_batch::RecordBatch;
-use arrow::error::ArrowError;
+use arrow::error::Error as ArrowError;
 
 /// Simplified version of tracking memory consumer,
 /// see also: [`Tracking`](crate::execution::memory_manager::ConsumerType::Tracking)

--- a/datafusion/src/physical_plan/repartition.rs
+++ b/datafusion/src/physical_plan/repartition.rs
@@ -522,7 +522,7 @@ mod tests {
     };
     use arrow::array::{ArrayRef, Utf8Array};
     use arrow::datatypes::{DataType, Field, Schema};
-    use arrow::error::ArrowError;
+    use arrow::error::Error as ArrowError;
     use datafusion_common::field_util::SchemaExt;
     use datafusion_common::record_batch::RecordBatch;
     use futures::FutureExt;

--- a/datafusion/src/physical_plan/sort.rs
+++ b/datafusion/src/physical_plan/sort.rs
@@ -1,1 +1,16 @@
-
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -34,7 +34,7 @@ use arrow::array::growable::make_growable;
 use arrow::{
     compute::sort::SortOptions,
     datatypes::SchemaRef,
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use async_trait::async_trait;
 use datafusion_common::field_util::SchemaExt;

--- a/datafusion/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/src/physical_plan/windows/window_agg_exec.rs
@@ -32,7 +32,7 @@ use crate::record_batch::RecordBatch;
 use arrow::{
     array::ArrayRef,
     datatypes::{Schema, SchemaRef},
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use async_trait::async_trait;
 use datafusion_common::field_util::SchemaExt;

--- a/datafusion/src/test/exec.rs
+++ b/datafusion/src/test/exec.rs
@@ -29,7 +29,7 @@ use tokio::sync::Barrier;
 use crate::record_batch::RecordBatch;
 use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
-    error::{ArrowError, Result as ArrowResult},
+    error::{Error as ArrowError, Result as ArrowResult},
 };
 use datafusion_common::field_util::SchemaExt;
 use futures::Stream;
@@ -239,7 +239,7 @@ impl ExecutionPlan for MockExec {
 }
 
 fn clone_error(e: &ArrowError) -> ArrowError {
-    use ArrowError::*;
+    use arrow::error::Error::InvalidArgumentError;
     match e {
         InvalidArgumentError(msg) => InvalidArgumentError(msg.to_string()),
         _ => unimplemented!(),

--- a/datafusion/tests/parquet_pruning.rs
+++ b/datafusion/tests/parquet_pruning.rs
@@ -628,14 +628,14 @@ async fn make_test_file(scenario: Scenario) -> NamedTempFile {
         write_statistics: true,
         version: Version::V1,
     };
-    let encodings: Vec<Vec<Encoding>> = schema // TODO(hl):
+    let encodings: Vec<Vec<Encoding>> = schema
         .fields()
         .iter()
         .map(|field| {
             if let DataType::Dictionary(_, _, _) = field.data_type() {
-                vec![Encoding::RleDictionary] // TODO(hl):
+                vec![Encoding::RleDictionary]
             } else {
-                vec![Encoding::Plain] // TODO(hl):
+                vec![Encoding::Plain]
             }
         })
         .collect();

--- a/datafusion/tests/sql_integration.rs
+++ b/datafusion/tests/sql_integration.rs
@@ -1,1 +1,16 @@
-
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/datafusion/tests/user_defined_plan.rs
+++ b/datafusion/tests/user_defined_plan.rs
@@ -63,7 +63,7 @@ use futures::{Stream, StreamExt};
 use arrow::{
     array::{Int64Array, Utf8Array},
     datatypes::SchemaRef,
-    error::ArrowError,
+    error::Error as ArrowError,
 };
 use datafusion::record_batch::RecordBatch;
 use datafusion::{


### PR DESCRIPTION
# Which issue does this PR close?
Closes #2709.

 # Rationale for this change

Current branch `arrow2` is still using arrow2 version `v0.10` and falls far behind the latest version `v0.12`

# What changes are included in this PR?

Dependencies upgraded: 
- arrow2: `v0.10` ->  `v0.12`
- parquet2: `v0.12` -> `v0.13`
- arrow-format: `0.4`->`0.6`
- prost: `0.9` -> `0.10 `
- prost-types: `0.9` -> `0.10`
- tonic: 0.6 -> `0.7`
- topic-build: `0.6` -> `0.7`

API change: 

- `arrow2::error::ArrowError` -> `arrow2::error::Error`
- arrow2 FileWriter now accepts `Vec<Vec<Encoding>>` instead of `Vec<Encoding>` and `transverse` can be used to create encodings from schema with a customized mapping.
- arrow2 `RowGroupMetadata` no longer as a `column(usize)` method to fetch column metadata at given index, instead, it provides a `columns()` method that returns a column slice.
- `datafusion::dataframe::DataFrame::write_parquet` method now accepts `arrow::io::parquet::write::WriteOptions` instead of `parquet::write::WriteOptions`
- some other minor changes.


# Are there any user-facing changes?
Yes, please refer to previous section for full API change list.
But I think it's rather easy for users of `arrow2` branch to adapt to these changes.

# About tests
Some tests are failling in current arrow2 branch, so I'm not going to fix all failing tests in this PR, instead I'll make sure no more unit test fails. I'd be happy to fix all failing tests after this PR is merged so I don't have to fix them twice :)
