### PR TITLE
Make LogicalPlan::Union be consistent with other plans

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -277,7 +277,9 @@ impl LogicalPlan {
             LogicalPlan::Subquery(Subquery { subquery, .. }) => vec![subquery],
             LogicalPlan::SubqueryAlias(SubqueryAlias { input, .. }) => vec![input],
             LogicalPlan::Extension(extension) => extension.node.inputs(),
-            LogicalPlan::Union(Union { inputs, .. }) => inputs.iter().collect(),
+            LogicalPlan::Union(Union { inputs, .. }) => {
+                inputs.iter().map(|arc| arc.as_ref()).collect()
+            }
             LogicalPlan::Distinct(Distinct { input }) => vec![input],
             LogicalPlan::Explain(explain) => vec![&explain.plan],
             LogicalPlan::Analyze(analyze) => vec![&analyze.input],
@@ -1072,7 +1074,7 @@ pub struct Repartition {
 #[derive(Clone)]
 pub struct Union {
     /// Inputs to merge
-    pub inputs: Vec<LogicalPlan>,
+    pub inputs: Vec<Arc<LogicalPlan>>,
     /// Union schema. Should be the same for all inputs.
     pub schema: DFSchemaRef,
     /// Union output relation alias

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -476,7 +476,7 @@ pub fn from_plan(
         })),
         LogicalPlan::Union(Union { schema, alias, .. }) => {
             Ok(LogicalPlan::Union(Union {
-                inputs: inputs.to_vec(),
+                inputs: inputs.iter().cloned().map(Arc::new).collect(),
                 schema: schema.clone(),
                 alias: alias.clone(),
             }))

--- a/datafusion/optimizer/src/limit_push_down.rs
+++ b/datafusion/optimizer/src/limit_push_down.rs
@@ -192,7 +192,7 @@ fn limit_push_down(
             let new_inputs = inputs
                 .iter()
                 .map(|x| {
-                    Ok(LogicalPlan::Limit(Limit {
+                    Ok(Arc::new(LogicalPlan::Limit(Limit {
                         skip: None,
                         fetch: Some(ancestor_fetch),
                         input: Arc::new(limit_push_down(
@@ -204,7 +204,7 @@ fn limit_push_down(
                             x,
                             _optimizer_config,
                         )?),
-                    }))
+                    })))
                 })
                 .collect::<Result<_>>()?;
             Ok(LogicalPlan::Union(Union {

--- a/datafusion/optimizer/src/projection_push_down.rs
+++ b/datafusion/optimizer/src/projection_push_down.rs
@@ -454,7 +454,7 @@ fn optimize_plan(
                 schema.metadata().clone(),
             )?;
             Ok(LogicalPlan::Union(Union {
-                inputs: new_inputs,
+                inputs: new_inputs.iter().cloned().map(Arc::new).collect(),
                 schema: Arc::new(new_schema),
                 alias: alias.clone(),
             }))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2816.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Union should contain Vec<Arc<LogicalPlan>> instead


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->