### PR TITLE
Adds optional serde support to datafusion-proto

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
           CARGO_TARGET_DIR: "/github/home/target"
       - name: Check Workspace builds with all features
         run: |
-          cargo check --workspace --benches --features avro,jit,scheduler
+          cargo check --workspace --benches --features avro,jit,scheduler,json
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"
@@ -121,7 +121,7 @@ jobs:
         run: |
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
-          cargo test --features avro,jit,scheduler
+          cargo test --features avro,jit,scheduler,json
           # test datafusion-sql examples
           cargo run --example sql
           # test datafusion examples

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -41,11 +41,11 @@ arrow = { version = "18.0.0" }
 datafusion = { path = "../core", version = "10.0.0" }
 datafusion-common = { path = "../common", version = "10.0.0" }
 datafusion-expr = { path = "../expr", version = "10.0.0" }
+pbjson = { version = "0.3", optional = true }
+pbjson-types = { version = "0.3", optional = true }
 prost = "0.10"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-pbjson = { version = "0.3", optional = true }
-pbjson-types = { version = "0.3", optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-json = ["pbjson", "pbjson-build", "serde"]
+json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
 arrow = { version = "18.0.0" }
@@ -43,13 +43,13 @@ datafusion-common = { path = "../common", version = "10.0.0" }
 datafusion-expr = { path = "../expr", version = "10.0.0" }
 prost = "0.10"
 serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
 tokio = "1.18"
-serde_json = "1.0"
 
 [build-dependencies]
 tonic-build = { version = "0.7" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-serde = ["pbjson", "pbjson-build", "dep:serde"]
+json = ["pbjson", "pbjson-build", "serde"]
 
 [dependencies]
 arrow = { version = "18.0.0" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -52,5 +52,5 @@ doc-comment = "0.3"
 tokio = "1.18"
 
 [build-dependencies]
-tonic-build = { version = "0.7" }
 pbjson-build = { version = "0.3", optional = true }
+prost-build = { version = "0.7" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-keywords = [ "arrow", "query", "sql" ]
+keywords = ["arrow", "query", "sql"]
 edition = "2021"
 rust-version = "1.58"
 
@@ -33,6 +33,8 @@ name = "datafusion_proto"
 path = "src/lib.rs"
 
 [features]
+default = []
+serde = ["pbjson", "pbjson-build", "dep:serde"]
 
 [dependencies]
 arrow = { version = "18.0.0" }
@@ -40,11 +42,15 @@ datafusion = { path = "../core", version = "10.0.0" }
 datafusion-common = { path = "../common", version = "10.0.0" }
 datafusion-expr = { path = "../expr", version = "10.0.0" }
 prost = "0.10"
-
+serde = { version = "1.0", optional = true }
+pbjson = { version = "0.3", optional = true }
+pbjson-types = { version = "0.3", optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
 tokio = "1.18"
+serde_json = "1.0"
 
 [build-dependencies]
 tonic-build = { version = "0.7" }
+pbjson-build = { version = "0.3", optional = true }

--- a/datafusion/proto/build.rs
+++ b/datafusion/proto/build.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "json")]
 fn build() -> Result<(), String> {
     let descriptor_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
         .join("proto_descriptor.bin");
@@ -50,7 +50,7 @@ fn build() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(feature = "serde"))]
+#[cfg(not(feature = "json"))]
 fn build() -> Result<(), String> {
     tonic_build::configure()
         .compile(&["proto/datafusion.proto"], &["proto"])

--- a/datafusion/proto/build.rs
+++ b/datafusion/proto/build.rs
@@ -33,11 +33,11 @@ fn build() -> Result<(), String> {
     let descriptor_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
         .join("proto_descriptor.bin");
 
-    tonic_build::configure()
+    prost_build::Config::new()
         .file_descriptor_set_path(&descriptor_path)
-        .compile_well_known_types(true)
+        .compile_well_known_types()
         .extern_path(".google.protobuf", "::pbjson_types")
-        .compile(&["proto/datafusion.proto"], &["proto"])
+        .compile_protos(&["proto/datafusion.proto"], &["proto"])
         .map_err(|e| format!("protobuf compilation failed: {}", e))?;
 
     let descriptor_set = std::fs::read(descriptor_path).unwrap();
@@ -52,7 +52,7 @@ fn build() -> Result<(), String> {
 
 #[cfg(not(feature = "json"))]
 fn build() -> Result<(), String> {
-    tonic_build::configure()
-        .compile(&["proto/datafusion.proto"], &["proto"])
+    prost_build::Config::new()
+        .compile_protos(&["proto/datafusion.proto"], &["proto"])
         .map_err(|e| format!("protobuf compilation failed: {}", e))
 }

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -24,7 +24,7 @@ use datafusion_common::DataFusionError;
 pub mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/datafusion.rs"));
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "json")]
     include!(concat!(env!("OUT_DIR"), "/datafusion.serde.rs"));
 }
 
@@ -78,15 +78,15 @@ mod roundtrip_tests {
     use std::fmt::Formatter;
     use std::sync::Arc;
 
-    #[cfg(feature = "serde")]
-    fn roundtrip_serde_test(proto: &protobuf::LogicalExprNode) {
+    #[cfg(feature = "json")]
+    fn roundtrip_json_test(proto: &protobuf::LogicalExprNode) {
         let string = serde_json::to_string(proto).unwrap();
         let back: protobuf::LogicalExprNode = serde_json::from_str(&string).unwrap();
         assert_eq!(proto, &back);
     }
 
-    #[cfg(not(feature = "serde"))]
-    fn roundtrip_serde_test(_proto: &protobuf::LogicalExprNode) {}
+    #[cfg(not(feature = "json"))]
+    fn roundtrip_json_test(_proto: &protobuf::LogicalExprNode) {}
 
     // Given a DataFusion logical Expr, convert it to protobuf and back, using debug formatting to test
     // equality.
@@ -103,7 +103,7 @@ mod roundtrip_tests {
             format!("{:?}", round_trip)
         );
 
-        roundtrip_serde_test(&proto);
+        roundtrip_json_test(&proto);
     }
 
     fn new_box_field(name: &str, dt: DataType, nullable: bool) -> Box<Field> {

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -23,6 +23,9 @@ use datafusion_common::DataFusionError;
 #[allow(clippy::all)]
 pub mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/datafusion.rs"));
+
+    #[cfg(feature = "serde")]
+    include!(concat!(env!("OUT_DIR"), "/datafusion.serde.rs"));
 }
 
 pub mod bytes;
@@ -75,19 +78,32 @@ mod roundtrip_tests {
     use std::fmt::Formatter;
     use std::sync::Arc;
 
+    #[cfg(feature = "serde")]
+    fn roundtrip_serde_test(proto: &protobuf::LogicalExprNode) {
+        let string = serde_json::to_string(proto).unwrap();
+        let back: protobuf::LogicalExprNode = serde_json::from_str(&string).unwrap();
+        assert_eq!(proto, &back);
+    }
+
+    #[cfg(not(feature = "serde"))]
+    fn roundtrip_serde_test(_proto: &protobuf::LogicalExprNode) {}
+
     // Given a DataFusion logical Expr, convert it to protobuf and back, using debug formatting to test
     // equality.
-    macro_rules! roundtrip_expr_test {
-        ($initial_struct:ident, $ctx:ident) => {
-            let proto: protobuf::LogicalExprNode = (&$initial_struct).try_into().unwrap();
+    fn roundtrip_expr_test<T, E>(initial_struct: T, ctx: SessionContext)
+    where
+        for<'a> &'a T: TryInto<protobuf::LogicalExprNode, Error = E> + Debug,
+        E: Debug,
+    {
+        let proto: protobuf::LogicalExprNode = (&initial_struct).try_into().unwrap();
+        let round_trip: Expr = parse_expr(&proto, &ctx).unwrap();
 
-            let round_trip: Expr = parse_expr(&proto, &$ctx).unwrap();
+        assert_eq!(
+            format!("{:?}", &initial_struct),
+            format!("{:?}", round_trip)
+        );
 
-            assert_eq!(
-                format!("{:?}", $initial_struct),
-                format!("{:?}", round_trip)
-            );
-        };
+        roundtrip_serde_test(&proto);
     }
 
     fn new_box_field(name: &str, dt: DataType, nullable: bool) -> Box<Field> {
@@ -807,7 +823,7 @@ mod roundtrip_tests {
         let test_expr = Expr::Not(Box::new(lit(1.0_f32)));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -815,7 +831,7 @@ mod roundtrip_tests {
         let test_expr = Expr::IsNull(Box::new(col("id")));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -823,7 +839,7 @@ mod roundtrip_tests {
         let test_expr = Expr::IsNotNull(Box::new(col("id")));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -836,7 +852,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -848,7 +864,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -859,7 +875,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -871,7 +887,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -879,7 +895,7 @@ mod roundtrip_tests {
         let test_expr = Expr::Negative(Box::new(lit(1.0_f32)));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -891,7 +907,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -899,7 +915,7 @@ mod roundtrip_tests {
         let test_expr = Expr::Wildcard;
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -909,7 +925,7 @@ mod roundtrip_tests {
             args: vec![col("col")],
         };
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -921,7 +937,7 @@ mod roundtrip_tests {
         };
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -975,7 +991,7 @@ mod roundtrip_tests {
         let mut ctx = SessionContext::new();
         ctx.register_udaf(dummy_agg);
 
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -1000,7 +1016,7 @@ mod roundtrip_tests {
         let mut ctx = SessionContext::new();
         ctx.register_udf(udf);
 
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -1012,7 +1028,7 @@ mod roundtrip_tests {
         ]));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -1020,7 +1036,7 @@ mod roundtrip_tests {
         let test_expr = Expr::GroupingSet(GroupingSet::Rollup(vec![col("a"), col("b")]));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 
     #[test]
@@ -1028,6 +1044,6 @@ mod roundtrip_tests {
         let test_expr = Expr::GroupingSet(GroupingSet::Cube(vec![col("a"), col("b")]));
 
         let ctx = SessionContext::new();
-        roundtrip_expr_test!(test_expr, ctx);
+        roundtrip_expr_test(test_expr, ctx);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2889

 # Rationale for this change

This provides a way to serialize the datafusion-proto messages to any serde serializer, e.g. JSON, based on the protobuf [JSON specification](https://developers.google.com/protocol-buffers/docs/proto3#json). 

# What changes are included in this PR?

Uses pbjson to auto-generate the serde implementations for the protobuf messages. Full disclosure: I am the primary author and maintainer of this crate.

# Are there any user-facing changes?

No