### PR TITLE
add session option 'datafusion.explain.logical_plan'. when set to true, the explain statement will only print logical plans.

### DIFF
--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -27,6 +27,9 @@ use std::env;
 /// Configuration option "datafusion.optimizer.filter_null_join_keys"
 pub const OPT_FILTER_NULL_JOIN_KEYS: &str = "datafusion.optimizer.filter_null_join_keys";
 
+/// Configuration option "datafusion.explain.logical_plan"
+pub const OPT_EXPLAIN_LOGICAL_PLAN_ONLY: &str = "datafusion.explain.logical_plan";
+
 /// Configuration option "datafusion.execution.batch_size"
 pub const OPT_BATCH_SIZE: &str = "datafusion.execution.batch_size";
 
@@ -117,6 +120,11 @@ impl BuiltInConfigs {
                 a nullable and non-nullable column to filter out nulls on the nullable side. This \
                 filter can add additional overhead when the file format does not fully support \
                 predicate push down.",
+                false,
+            ),
+            ConfigDefinition::new_bool(
+                OPT_EXPLAIN_LOGICAL_PLAN_ONLY,
+                "When set to true, the explain statement will only print logical plans.",
                 false,
             ),
             ConfigDefinition::new_u64(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2894 

 # Rationale for this change
Add session option 'datafusion.explain.logical_plan'. 
when set to true, the explain statement will only print logical plans. We can set environment variable DATAFUSION_EXPLAIN_LOGICAL_PLAN to make this value take effect.

For example:
explain select count(*) from (values ('a', 1, 100), ('a', 2, 150)) as t (c1,c2,c3);

+--------------+----------------------------------------------------------------------------------+
| plan_type    | plan                                                                             |
+--------------+----------------------------------------------------------------------------------+
| logical_plan | Projection: #COUNT(UInt8(1))                                                     |
|              |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]                              |
|              |     Values: (Utf8("a"), Int64(1), Int64(100)), (Utf8("a"), Int64(2), Int64(150)) |
+--------------+----------------------------------------------------------------------------------+

# What changes are included in this PR?
add session option 'datafusion.explain.logical_plan'. in datafusion/core/src/config.rs
use this option to control the output of explain statement in datafusion/core/src/physical_plan/planner.rs