### PR TITLE
Improve formatting of logical plans containing subqueries

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -46,4 +46,3 @@ ordered-float = "3.0"
 parquet = { version = "18.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = "0.18"
-serde_json = "1.0.82"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -46,3 +46,4 @@ ordered-float = "3.0"
 parquet = { version = "18.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = "0.18"
+serde_json = "1.0.82"

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -484,6 +484,23 @@ impl std::fmt::Display for Expr {
                 /// List of expressions to feed to the functions as arguments
                 ref args,
             } => fmt_function(f, &fun.to_string(), false, args, true),
+            Expr::Exists { negated, .. } => {
+                if *negated {
+                    write!(f, "NOT EXISTS (<subquery>)")
+                } else {
+                    write!(f, "EXISTS (<subquery>)")
+                }
+            }
+            Expr::InSubquery { negated, .. } => {
+                if *negated {
+                    write!(f, "NOT IN (<subquery>)")
+                } else {
+                    write!(f, "IN (<subquery>)")
+                }
+            }
+            Expr::ScalarSubquery(_) => {
+                write!(f, "(<subquery>)")
+            }
             _ => write!(f, "{:?}", self),
         }
     }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1217,11 +1217,13 @@ mod tests {
             .filter(exists(Arc::new(subquery)))?
             .build()?;
 
-        let expected = "Filter: EXISTS (\
-            Subquery: Filter: #foo.a = #bar.a\
-            \n  Projection: #foo.a\
-            \n    TableScan: foo)\
-        \n  Projection: #bar.a\n    TableScan: bar";
+        let expected = "Filter: EXISTS (<subquery>)\
+        \n  Subquery:\
+        \n    Filter: #foo.a = #bar.a\
+        \n      Projection: #foo.a\
+        \n        TableScan: foo\
+        \n  Projection: #bar.a\
+        \n    TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
 
         Ok(())
@@ -1243,9 +1245,11 @@ mod tests {
             .filter(in_subquery(col("a"), Arc::new(subquery)))?
             .build()?;
 
-        let expected = "Filter: #bar.a IN (Subquery: Filter: #foo.a = #bar.a\
-        \n  Projection: #foo.a\
-        \n    TableScan: foo)\
+        let expected = "Filter: #bar.a IN (<subquery>)\
+        \n  Subquery:\
+        \n    Filter: #foo.a = #bar.a\
+        \n      Projection: #foo.a\
+        \n        TableScan: foo\
         \n  Projection: #bar.a\
         \n    TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
@@ -1268,10 +1272,12 @@ mod tests {
             .project(vec![scalar_subquery(Arc::new(subquery))])?
             .build()?;
 
-        let expected = "Projection: (Subquery: Filter: #foo.a = #bar.a\
-                \n  Projection: #foo.b\
-                \n    TableScan: foo)\
-            \n  TableScan: bar";
+        let expected = "Projection: (<subquery>)\
+        \n  Subquery:\
+        \n    Filter: #foo.a = #bar.a\
+        \n      Projection: #foo.b\
+        \n        TableScan: foo\
+        \n  TableScan: bar";
         assert_eq!(expected, format!("{:?}", outer_query));
 
         Ok(())

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -489,8 +489,8 @@ impl LogicalPlan {
     fn collect_subqueries(&self, expr: &Expr, sub: &mut Vec<Arc<LogicalPlan>>) {
         match expr {
             Expr::BinaryExpr { left, right, .. } => {
-                self.collect_subqueries(&left, sub);
-                self.collect_subqueries(&right, sub);
+                self.collect_subqueries(left, sub);
+                self.collect_subqueries(right, sub);
             }
             Expr::Exists { subquery, .. } => {
                 sub.push(Arc::new(LogicalPlan::Subquery(subquery.clone())));

--- a/datafusion/optimizer/src/filter_push_down.rs
+++ b/datafusion/optimizer/src/filter_push_down.rs
@@ -2072,7 +2072,10 @@ mod tests {
 
         // filter on col b in subquery
         let expected_before = "\
-        Filter: #b IN (Subquery: Projection: #sq.c\n  TableScan: sq)\
+        Filter: #b IN (<subquery>)\
+        \n  Subquery:\
+        \n    Projection: #sq.c\
+        \n      TableScan: sq\
         \n  Projection: #test.a AS b, #test.c\
         \n    TableScan: test";
         assert_eq!(format!("{:?}", plan), expected_before);
@@ -2080,7 +2083,10 @@ mod tests {
         // rewrite filter col b to test.a
         let expected_after = "\
         Projection: #test.a AS b, #test.c\
-        \n  Filter: #test.a IN (Subquery: Projection: #sq.c\n  TableScan: sq)\
+        \n  Filter: #test.a IN (<subquery>)\
+        \n    Subquery:\
+        \n      Projection: #sq.c\
+        \n        TableScan: sq\
         \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected_after);
 

--- a/datafusion/optimizer/src/limit_push_down.rs
+++ b/datafusion/optimizer/src/limit_push_down.rs
@@ -676,9 +676,11 @@ mod test {
 
         // Limit pushdown Not supported in sub_query
         let expected = "Limit: skip=10, fetch=100\
-        \n  Filter: EXISTS (Subquery: Filter: #test1.a = #test1.a\
-        \n  Projection: #test1.a\
-        \n    TableScan: test1)\
+        \n  Filter: EXISTS (<subquery>)\
+        \n    Subquery:\
+        \n      Filter: #test1.a = #test1.a\
+        \n        Projection: #test1.a\
+        \n          TableScan: test1\
         \n    Projection: #test2.a\
         \n      TableScan: test2";
 
@@ -705,9 +707,11 @@ mod test {
 
         // Limit pushdown Not supported in sub_query
         let expected = "Limit: skip=10, fetch=100\
-        \n  Filter: EXISTS (Subquery: Filter: #test1.a = #test1.a\
-        \n  Projection: #test1.a\
-        \n    TableScan: test1)\
+        \n  Filter: EXISTS (<subquery>)\
+        \n    Subquery:\
+        \n      Filter: #test1.a = #test1.a\
+        \n        Projection: #test1.a\
+        \n          TableScan: test1\
         \n    Projection: #test2.a\
         \n      TableScan: test2";
 

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -328,9 +328,10 @@ mod tests {
             .build()?;
 
         let expected = "Projection: #test.b [b:UInt32]\
-        \n  Filter: #test.a = UInt32(1) AND #test.b < UInt32(30) OR #test.c IN (\
-        Subquery: Projection: #sq.c\
-        \n  TableScan: sq) [a:UInt32, b:UInt32, c:UInt32]\
+        \n  Filter: #test.a = UInt32(1) AND #test.b < UInt32(30) OR #test.c IN (<subquery>) [a:UInt32, b:UInt32, c:UInt32]\
+        \n    Subquery: [c:UInt32]\
+        \n      Projection: #sq.c [c:UInt32]\
+        \n        TableScan: sq [a:UInt32, b:UInt32, c:UInt32]\
         \n    TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
@@ -352,9 +353,13 @@ mod tests {
             .build()?;
 
         let expected = "Projection: #test.b [b:UInt32]\
-        \n  Filter: #test.a = UInt32(1) OR #test.b IN (Subquery: Projection: #sq1.c\
-            \n  TableScan: sq1) AND #test.c IN (Subquery: Projection: #sq2.c\
-            \n  TableScan: sq2) [a:UInt32, b:UInt32, c:UInt32]\
+        \n  Filter: #test.a = UInt32(1) OR #test.b IN (<subquery>) AND #test.c IN (<subquery>) [a:UInt32, b:UInt32, c:UInt32]\
+        \n    Subquery: [c:UInt32]\
+        \n      Projection: #sq1.c [c:UInt32]\
+        \n        TableScan: sq1 [a:UInt32, b:UInt32, c:UInt32]\
+        \n    Subquery: [c:UInt32]\
+        \n      Projection: #sq2.c [c:UInt32]\
+        \n        TableScan: sq2 [a:UInt32, b:UInt32, c:UInt32]\
         \n    TableScan: test [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_eq(&plan, expected);
@@ -405,9 +410,9 @@ mod tests {
             .build()?;
 
         let expected = "Projection: #wrapped.b [b:UInt32]\
-        \n  Filter: #wrapped.b < UInt32(30) OR #wrapped.c IN (\
-        Subquery: Projection: #sq_outer.c\
-        \n  TableScan: sq_outer) [b:UInt32, c:UInt32]\
+        \n  Filter: #wrapped.b < UInt32(30) OR #wrapped.c IN (<subquery>) [b:UInt32, c:UInt32]\
+        \n    Subquery: [c:UInt32]\n      Projection: #sq_outer.c [c:UInt32]\
+        \n        TableScan: sq_outer [a:UInt32, b:UInt32, c:UInt32]\
         \n    Projection: #test.b, #test.c, alias=wrapped [b:UInt32, c:UInt32]\
         \n      Semi Join: #test.c = #sq_inner.c [a:UInt32, b:UInt32, c:UInt32]\
         \n        TableScan: test [a:UInt32, b:UInt32, c:UInt32]\

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4799,7 +4799,7 @@ mod tests {
         \n            TableScan: person\
         \n    TableScan: person";
 
-        quick_test(sql, &expected)
+        quick_test(sql, expected)
     }
 
     #[tokio::test]

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4665,7 +4665,7 @@ mod tests {
         \n          TableScan: person\
         \n    SubqueryAlias: p\
         \n      TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4691,7 +4691,7 @@ mod tests {
         \n      TableScan: person\
         \n      SubqueryAlias: p\
         \n        TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4709,7 +4709,7 @@ mod tests {
         \n          TableScan: person\
         \n    SubqueryAlias: p\
         \n      TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4724,7 +4724,7 @@ mod tests {
         \n        TableScan: person\
         \n    SubqueryAlias: p\
         \n      TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4740,7 +4740,7 @@ mod tests {
         \n          TableScan: person\
         \n    SubqueryAlias: p\
         \n      TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4755,7 +4755,7 @@ mod tests {
         \n          TableScan: person\
         \n  SubqueryAlias: p\
         \n    TableScan: person";
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[test]
@@ -4781,7 +4781,7 @@ mod tests {
         \n      TableScan: j1\
         \n      TableScan: j2";
 
-        quick_test(sql, &expected);
+        quick_test(sql, expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2898

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## Before:

```
Projection: #employee_csv.id
  Filter: #employee_csv.state IN (Subquery: TableScan: employee_csv projection=[state])
    TableScan: employee_csv projection=[id, state]
```

## After

```
Projection: #employee_csv.id
  Filter: #employee_csv.state IN (<subquery>)
    Subquery:
      TableScan: employee_csv projection=[state]
    TableScan: employee_csv projection=[id, state]
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- IndentVisitor visits all inputs, including subqueries
- Subquery expressions no longer display their subqueries

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, plans look different

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->