### PR TITLE
Combine all comparison coercion rules

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1746,8 +1746,6 @@ mod tests {
     async fn errors() -> Result<()> {
         let bool_expr = col("c1").eq(col("c1"));
         let cases = vec![
-            // utf8 < u32
-            col("c1").lt(col("c2")),
             // utf8 AND utf8
             col("c1").and(col("c1")),
             // u8 AND u8

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -25,7 +25,7 @@ use arrow::compute::{and, eq_dyn, is_null, not, or, or_kleene};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{DataFusionError, Result};
-use datafusion_expr::binary_rule::comparison_eq_coercion;
+use datafusion_expr::binary_rule::comparison_coercion;
 use datafusion_expr::ColumnarValue;
 
 type WhenThen = (Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>);
@@ -350,7 +350,7 @@ fn get_case_common_type(
             None => None,
             // TODO: now just use the `equal` coercion rule for case when. If find the issue, and
             // refactor again.
-            Some(left_type) => comparison_eq_coercion(&left_type, right_type),
+            Some(left_type) => comparison_coercion(&left_type, right_type),
         })
 }
 

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use arrow::datatypes::{DataType, Schema};
 use datafusion_common::{DFSchema, DataFusionError, Result, ScalarValue};
-use datafusion_expr::binary_rule::comparison_eq_coercion;
+use datafusion_expr::binary_rule::comparison_coercion;
 use datafusion_expr::{Expr, Operator};
 use std::sync::Arc;
 
@@ -354,7 +354,7 @@ fn get_coerce_type(expr_type: &DataType, list_type: &[DataType]) -> Option<DataT
             match left {
                 None => None,
                 // TODO refactor a framework to do the data type coercion
-                Some(left_type) => comparison_eq_coercion(&left_type, right_type),
+                Some(left_type) => comparison_coercion(&left_type, right_type),
             }
         })
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2890

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It is confusing when we different coercion rules for different comparison operators

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make rules consistent across all comparison operators

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, when comparing numeric and string expressions with `>`, `<`, `>=`, and `<=` we will now convert the numerics to strings (just like we were already doing for `=` and `!=`) instead of failing

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->