### PR TITLE
Fix release verification script by not overriding `ARROW_TEST_DATA` or `PARQUET_TEST_DATA`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -121,11 +121,9 @@ test_source_distribution() {
   rustup component add rustfmt --toolchain stable
   cargo fmt --all -- --check
 
-  # Clone testing repositories if not cloned already
-  git clone https://github.com/apache/arrow-testing.git arrow-testing-data
-  git clone https://github.com/apache/parquet-testing.git parquet-testing-data
-  export ARROW_TEST_DATA=$PWD/arrow-testing-data/data
-  export PARQUET_TEST_DATA=$PWD/parquet-testing-data/data
+  # Clone testing repositories into the expected location
+  git clone https://github.com/apache/arrow-testing.git testing
+  git clone https://github.com/apache/parquet-testing.git parquet-testing
 
   cargo build
   cargo test --all


### PR DESCRIPTION
# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/2916
Fixes https://github.com/apache/arrow-datafusion/issues/2719

 # Rationale for this change
Some people have been seeing the `verify_release_candidate.sh` script fail when verifying arrow releases. The failures are due to paths into the "testing data" which are not properly normalized

# What changes are included in this PR?

1. Change the script to check out `arrow-testing` and `parquet-testing` into the standard location (`datafusion/testing` and `datafusion/parquet-testing`, respectively) as the submodules so the normal path finding logic can kick in

Note here is an example of the contents that are in the tarball (note the presence of `testing` and `parquet-testing`), though they are empty.

```shell
ls /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-10.0.0.XXXXX.s39Dslgg/apache-arrow-datafusion-10.0.0
CHANGELOG.md         README.md            dev/                 rustfmt.toml
CODE_OF_CONDUCT.md   benchmarks/          docs/                target/
CONTRIBUTING.md      ci/                  header               test-rustup/
Cargo.lock           conbench/            integration-tests/   testing/
Cargo.toml           datafusion/          parquet-testing/
LICENSE.txt          datafusion-cli/      pre-commit.sh*
NOTICE.txt           datafusion-examples/ python/
```


# Are there any user-facing changes?
Hopefully the verify script works on subsequent releases

# Testing

Note that I don't normally have the test environment set:

```shell
(arrow_dev) alamb@MacBook-Pro-8:~/Software/arrow-datafusion$ env | grep ARROW_TEST_DATA
(arrow_dev) alamb@MacBook-Pro-8:~/Software/arrow-datafusion$ env | grep PARQUET_TEST_DATA
```

Prior to this change, running:
```shell
./dev/release/verify-release-candidate.sh 10.0.0 1
```

Would fail for me locally (with the same diff reported by @nevi-me in https://github.com/apache/arrow-datafusion/issues/2916). With this change, the same command passes