### PR TITLE
Add `DataFrame::with_column_renamed`

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -1228,7 +1228,7 @@ mod tests {
             ])?
             .limit(None, Some(1))?;
 
-        let df_results = &df.collect().await?;
+        let df_results = df.collect().await?;
         assert_batches_sorted_eq!(
             vec![
                 "+----+----+-----+----+----+-----+",
@@ -1251,7 +1251,7 @@ mod tests {
             format!("{:?}", df_renamed.to_logical_plan()?)
         );
 
-        let df_results = &df_renamed.collect().await?;
+        let df_results = df_renamed.collect().await?;
 
         assert_batches_sorted_eq!(
             vec![


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/2919

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Convenient to be able to rename columns without applying a full projection manually

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `with_column_renamed` with tests

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->