### PR TITLE
Update README.md to add CnosDB into the Known Uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here are some of the projects known to use DataFusion:
 - [Ballista](https://github.com/apache/arrow-ballista) Distributed SQL Query Engine
 - [Blaze](https://github.com/blaze-init/blaze) Spark accelerator with DataFusion at its core
 - [Cloudfuse Buzz](https://github.com/cloudfuse-io/buzz-rust)
+- [CnosDB](https://github.com/cnosdb/cnosdb) Open Source Distributed Time Series Database
 - [Cube Store](https://github.com/cube-js/cube.js/tree/master/rust)
 - [datafusion-tui](https://github.com/datafusion-contrib/datafusion-tui) Text UI for DataFusion
 - [delta-rs](https://github.com/delta-io/delta-rs) Native Rust implementation of Delta Lake


### PR DESCRIPTION
Update README.md to add CnosDB into the Known Uses. 
CnosDB is a Open Source Distributed Time Series Database which use arrow-datafusion.

# Which issue does this PR close?
No issue.
 # Rationale for this change
CnosDB use arrow-datafusion as its query engine, so it's good to add the CnosDB into the Known Uses.
# What changes are included in this PR?
Only Docs changes.
# Are there any user-facing changes?
No.