### PR TITLE
Add metadata_size_hint for optimistic fetching of parquet metadata

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -582,7 +582,9 @@ mod tests {
         let format = ParquetFormat::default().with_metadata_size_hint(9);
         let schema = format.infer_schema(&store, &meta).await.unwrap();
 
-        fetch_parquet_metadata(store.as_ref(), &meta[0], Some(9)).await.expect("error reading metadata with hint");
+        fetch_parquet_metadata(store.as_ref(), &meta[0], Some(9))
+            .await
+            .expect("error reading metadata with hint");
 
         let stats =
             fetch_statistics(store.as_ref(), schema.clone(), &meta[0], Some(9)).await?;
@@ -598,7 +600,9 @@ mod tests {
         let format = ParquetFormat::default().with_metadata_size_hint(size_hint);
         let schema = format.infer_schema(&store, &meta).await.unwrap();
 
-        fetch_parquet_metadata(store.as_ref(), &meta[0], Some(size_hint)).await.expect("error reading metadata with hint");
+        fetch_parquet_metadata(store.as_ref(), &meta[0], Some(size_hint))
+            .await
+            .expect("error reading metadata with hint");
 
         let stats =
             fetch_statistics(store.as_ref(), schema.clone(), &meta[0], Some(size_hint))

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -327,6 +327,8 @@ pub(crate) async fn fetch_parquet_metadata(
         )));
     }
 
+    // If a size hint is provided, read more than the minimum size 
+    // to try and avoid a second fetch.
     let footer_start = if let Some(size_hint) = size_hint {
         meta.size - size_hint
     } else {

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -352,6 +352,7 @@ pub(crate) async fn fetch_parquet_metadata(
         )));
     }
 
+    // Did not fetch the entire file metadata in the initial read, need to make a second request
     if length > suffix_len - 8 {
         let metadata_start = meta.size - length - 8;
         let remaining_metadata = store

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -706,6 +706,7 @@ mod tests {
             .await
             .expect("error reading metadata with hint");
 
+        // ensure the requests were coalesced into a single request
         assert_eq!(store.request_count(), 1);
 
         let format = ParquetFormat::default().with_metadata_size_hint(size_hint);

--- a/datafusion/core/src/physical_optimizer/repartition.rs
+++ b/datafusion/core/src/physical_optimizer/repartition.rs
@@ -271,6 +271,7 @@ mod tests {
                 table_partition_cols: vec![],
             },
             None,
+            None,
         ))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
Related to https://github.com/apache/arrow-rs/issues/2110

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add a configurable size hint to `ParquetFormat` to allow fetching metadata without multiple seeks. This is not set by default. If it is configured, the `ParquetFileReader` will read `metadata_size_hint` bytes from the end of the parquet file and then fetch additional data only if the metadata is more than `metadata_size_hint` 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Both `ParquetFormat` and `ParquetExec` can not take an optional `metadata_size_hint`. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->