### PR TITLE
fix `RowWriter`  index out of bounds error

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -1281,7 +1281,7 @@ mod tests {
                 Arc::new(arrow::array::StringArray::from(vec![
                     Some("2a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
                     Some("3a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800"),
-                ])),
+                ]))
             ],
         )?;
 
@@ -1297,10 +1297,6 @@ mod tests {
             test
         GROUP BY
             column_1"#;
-
-        // let df = ctx.sql("SELECT * FROM test").await.unwrap();
-        // df.show_limit(10).await.unwrap();
-        // dbg!(df.schema());
 
         let df = ctx.sql(sql).await.unwrap();
         df.show_limit(10).await.unwrap();

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -1266,4 +1266,45 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn row_writer_resize_test() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![arrow::datatypes::Field::new(
+            "column_1",
+            DataType::Utf8,
+            false,
+        )]));
+
+        let data = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec![
+                    Some("2a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+                    Some("3a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800"),
+                ])),
+            ],
+        )?;
+
+        let table = crate::datasource::MemTable::try_new(schema, vec![vec![data]])?;
+
+        let ctx = SessionContext::new();
+        ctx.register_table("test", Arc::new(table))?;
+
+        let sql = r#"
+        SELECT 
+            COUNT(1)
+        FROM 
+            test
+        GROUP BY
+            column_1"#;
+
+        // let df = ctx.sql("SELECT * FROM test").await.unwrap();
+        // df.show_limit(10).await.unwrap();
+        // dbg!(df.schema());
+
+        let df = ctx.sql(sql).await.unwrap();
+        df.show_limit(10).await.unwrap();
+
+        Ok(())
+    }
 }

--- a/datafusion/row/src/writer.rs
+++ b/datafusion/row/src/writer.rs
@@ -350,7 +350,6 @@ pub(crate) fn write_field_utf8(
     let s = from.value(row_idx);
     let new_width = to.current_width() + s.as_bytes().len();
     if new_width > to.data.len() {
-        // double the capacity to avoid repeated resize
         to.data.resize(max(to.data.capacity(), new_width), 0);
     }
     to.set_utf8(col_idx, s);
@@ -366,7 +365,6 @@ pub(crate) fn write_field_binary(
     let s = from.value(row_idx);
     let new_width = to.current_width() + s.len();
     if new_width > to.data.len() {
-        // double the capacity to avoid repeated resize
         to.data.resize(max(to.data.capacity(), new_width), 0);
     }
     to.set_binary(col_idx, s);

--- a/datafusion/row/src/writer.rs
+++ b/datafusion/row/src/writer.rs
@@ -256,7 +256,7 @@ impl RowWriter {
     pub(crate) fn end_padding(&mut self) {
         let payload_width = self.current_width();
         self.row_width = round_upto_power_of_2(payload_width, 8);
-        if self.data.capacity() < self.row_width {
+        if self.data.len() < self.row_width {
             self.data.resize(self.row_width, 0);
         }
     }
@@ -351,7 +351,7 @@ pub(crate) fn write_field_utf8(
     let new_width = to.current_width() + s.as_bytes().len();
     if new_width > to.data.len() {
         // double the capacity to avoid repeated resize
-        to.data.resize(max(to.data.capacity() * 2, new_width), 0);
+        to.data.resize(max(to.data.capacity(), new_width), 0);
     }
     to.set_utf8(col_idx, s);
 }
@@ -365,9 +365,9 @@ pub(crate) fn write_field_binary(
     let from = from.as_any().downcast_ref::<BinaryArray>().unwrap();
     let s = from.value(row_idx);
     let new_width = to.current_width() + s.len();
-    if new_width > to.data.capacity() {
+    if new_width > to.data.len() {
         // double the capacity to avoid repeated resize
-        to.data.resize(max(to.data.capacity() * 2, new_width), 0);
+        to.data.resize(max(to.data.capacity(), new_width), 0);
     }
     to.set_binary(col_idx, s);
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2910 #2963 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The weird bug was reported, it can be reproduced locally in `row_writer_resize_test`, the reason being when the column is not nullable then 1 extra byte added to initial offset, and this breaks the buffer resize logic, causing out of range issues on `        self.data[varlena_offset..varlena_offset + size].copy_from_slice(bytes);
`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->