### PR TITLE
Derive Hash for JoinType

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -937,7 +937,7 @@ impl ToStringifiedPlan for LogicalPlan {
 }
 
 /// Join type
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum JoinType {
     /// Inner Join
     Inner,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2971.

 # Rationale for this change
The optimizer framework I'm working on requires this, see https://github.com/datafusion-contrib/datafusion-dolomite/issues/3


# What changes are included in this PR?
Derive `Hash` trait for `JoinType`.


# Are there any user-facing changes?
No.
