### PR TITLE
to_timestamp align with postgresql

### DIFF
--- a/datafusion/core/src/logical_plan/mod.rs
+++ b/datafusion/core/src/logical_plan/mod.rs
@@ -54,7 +54,7 @@ pub use datafusion_expr::{
     nullif, octet_length, or, power, random, regexp_match, regexp_replace, repeat,
     replace, reverse, right, round, rpad, rtrim, scalar_subquery, sha224, sha256, sha384,
     sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
-    to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, translate, trim,
+    to_timestamp_micros, to_timestamp_millis, to_timestamp_nanos, to_timestamp_seconds, translate, trim,
     trunc, unalias, upper, when, Expr, ExprSchemable, Literal, Operator,
 };
 pub use datafusion_optimizer::expr_simplifier::{ExprSimplifiable, SimplifyInfo};

--- a/datafusion/core/src/logical_plan/mod.rs
+++ b/datafusion/core/src/logical_plan/mod.rs
@@ -54,7 +54,7 @@ pub use datafusion_expr::{
     nullif, octet_length, or, power, random, regexp_match, regexp_replace, repeat,
     replace, reverse, right, round, rpad, rtrim, scalar_subquery, sha224, sha256, sha384,
     sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, sum, tan, to_hex,
-    to_timestamp_micros, to_timestamp_millis, to_timestamp_nanos, to_timestamp_seconds, translate, trim,
-    trunc, unalias, upper, when, Expr, ExprSchemable, Literal, Operator,
+    to_timestamp_micros, to_timestamp_millis, to_timestamp_nanos, to_timestamp_seconds,
+    translate, trim, trunc, unalias, upper, when, Expr, ExprSchemable, Literal, Operator,
 };
 pub use datafusion_optimizer::expr_simplifier::{ExprSimplifiable, SimplifyInfo};

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -49,7 +49,6 @@ async fn query_cast_timestamp() -> Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn query_cast_timestamp_seconds() -> Result<()> {
     let ctx = SessionContext::new();
@@ -80,7 +79,6 @@ async fn query_cast_timestamp_seconds() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
-
 
 #[tokio::test]
 async fn query_cast_timestamp_millis() -> Result<()> {
@@ -178,10 +176,6 @@ async fn query_cast_timestamp_nanos() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
-
-
-
-
 
 #[tokio::test]
 async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
@@ -298,7 +292,6 @@ async fn query_cast_timestamp_millis_to_others() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
-
     // Original column is millis, convert to nanos and check timestamp
     let sql = "SELECT to_timestamp_nanos(ts) FROM ts_millis LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -314,7 +307,6 @@ async fn query_cast_timestamp_millis_to_others() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
-
 
 #[tokio::test]
 async fn query_cast_timestamp_micros_to_others() -> Result<()> {
@@ -338,7 +330,6 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
-
     // Original column is micros, convert to seconds and check timestamp
     let sql = "SELECT to_timestamp_seconds(ts) FROM ts_micros LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -353,7 +344,6 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
-
     // Original column is micros, convert to millis and check timestamp
     let sql = "SELECT to_timestamp_millis(ts) FROM ts_micros LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -367,7 +357,6 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
         "+---------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
-
 
     // Original column is micros, convert to nanos and check timestamp
     let sql = "SELECT to_timestamp_nanos(ts) FROM ts_micros LIMIT 3";
@@ -385,12 +374,10 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
     let ctx = SessionContext::new();
     ctx.register_table("ts_nanos", make_timestamp_nano_table()?)?;
-
 
     // Original column is nanos, convert to seconds via to_timestamp and check timestamp
     let sql = "SELECT to_timestamp(ts) FROM ts_nanos LIMIT 3";
@@ -405,7 +392,6 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
         "+--------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
-
 
     // Original column is nanos, convert to seconds and check timestamp
     let sql = "SELECT to_timestamp_seconds(ts) FROM ts_nanos LIMIT 3";
@@ -451,11 +437,8 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
-    
-
     Ok(())
 }
-
 
 #[tokio::test]
 async fn query_cast_timestamp_from_unixtime() -> Result<()> {
@@ -488,16 +471,10 @@ async fn query_cast_timestamp_from_unixtime() -> Result<()> {
     Ok(())
 }
 
-
-
-
 #[tokio::test]
 async fn to_timestamp() -> Result<()> {
     let ctx = SessionContext::new();
-    ctx.register_table(
-        "ts_data",
-        make_timestamp_table::<TimestampSecondType>()?,
-    )?;
+    ctx.register_table("ts_data", make_timestamp_table::<TimestampSecondType>()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp('2020-09-08T12:00:00+00:00')";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -513,14 +490,10 @@ async fn to_timestamp() -> Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn to_timestamp_seconds() -> Result<()> {
     let ctx = SessionContext::new();
-    ctx.register_table(
-        "ts_data",
-        make_timestamp_table::<TimestampSecondType>()?,
-    )?;
+    ctx.register_table("ts_data", make_timestamp_table::<TimestampSecondType>()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_seconds('2020-09-08T12:00:00+00:00')";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -584,7 +557,7 @@ async fn to_timestamp_nanos() -> Result<()> {
     let ctx = SessionContext::new();
     ctx.register_table(
         "ts_data",
-        make_timestamp_table::<TimestampNanosecondType>()?
+        make_timestamp_table::<TimestampNanosecondType>()?,
     )?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_nanos('2020-09-08T12:00:00+00:00')";
@@ -600,7 +573,6 @@ async fn to_timestamp_nanos() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
-
 
 #[tokio::test]
 async fn from_unixtime() -> Result<()> {

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -233,7 +233,7 @@ async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
     assert_batches_eq!(expected, &actual);
 
     // Original column is sconds, convert to nanos and check timestamp
-    let sql = "SELECT to_timestam_nanos(ts) FROM ts_secs LIMIT 3";
+    let sql = "SELECT to_timestamp_nanos(ts) FROM ts_secs LIMIT 3";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+------------------------------+",
@@ -1217,11 +1217,11 @@ async fn cast_to_timestamp_twice() -> Result<()> {
     let results = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
-        "+-------------------------------+",
-        "| totimestamp(a.a)              |",
-        "+-------------------------------+",
-        "| 1970-01-01 00:00:00.000000001 |",
-        "+-------------------------------+",
+        "+---------------------+",
+        "| totimestamp(a.a)    |",
+        "+---------------------+",
+        "| 1970-01-01 00:00:01 |",
+        "+---------------------+",
     ];
 
     assert_batches_eq!(expected, &results);
@@ -1283,6 +1283,26 @@ async fn cast_to_timestamp_micros_twice() -> Result<()> {
         "+----------------------------+",
         "| 1970-01-01 00:00:00.000001 |",
         "+----------------------------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cast_to_timestamp_nanos_twice() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select to_timestamp_nanos(a) from (select to_timestamp_nanos(1) as a)A;";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+-------------------------------+",
+        "| totimestampnanos(a.a)         |",
+        "+-------------------------------+",
+        "| 1970-01-01 00:00:00.000000001 |",
+        "+-------------------------------+",
     ];
 
     assert_batches_eq!(expected, &results);

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -150,6 +150,8 @@ pub enum BuiltinScalarFunction {
     ToTimestampMicros,
     /// to_timestamp_seconds
     ToTimestampSeconds,
+    /// to_timestamp_nanos
+    ToTimestampNanos,
     /// from_unixtime
     FromUnixtime,
     ///now
@@ -239,6 +241,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ToTimestampMillis => Volatility::Immutable,
             BuiltinScalarFunction::ToTimestampMicros => Volatility::Immutable,
             BuiltinScalarFunction::ToTimestampSeconds => Volatility::Immutable,
+            BuiltinScalarFunction::ToTimestampNanos => Volatility::Immutable,
             BuiltinScalarFunction::Translate => Volatility::Immutable,
             BuiltinScalarFunction::Trim => Volatility::Immutable,
             BuiltinScalarFunction::Upper => Volatility::Immutable,
@@ -334,6 +337,7 @@ impl FromStr for BuiltinScalarFunction {
             "to_timestamp_millis" => BuiltinScalarFunction::ToTimestampMillis,
             "to_timestamp_micros" => BuiltinScalarFunction::ToTimestampMicros,
             "to_timestamp_seconds" => BuiltinScalarFunction::ToTimestampSeconds,
+            "to_timestamp_nanos" => BuiltinScalarFunction::ToTimestampNanos,
             "now" => BuiltinScalarFunction::Now,
             "translate" => BuiltinScalarFunction::Translate,
             "trim" => BuiltinScalarFunction::Trim,

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -353,6 +353,7 @@ scalar_expr!(DateTrunc, date_trunc, part, date);
 scalar_expr!(ToTimestampMillis, to_timestamp_millis, date);
 scalar_expr!(ToTimestampMicros, to_timestamp_micros, date);
 scalar_expr!(ToTimestampSeconds, to_timestamp_seconds, date);
+scalar_expr!(ToTimestampNanos, to_timestamp_nanos, date);
 scalar_expr!(FromUnixtime, from_unixtime, unixtime);
 
 /// Returns an array of fixed size with each argument on it.

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -183,7 +183,7 @@ pub fn return_type(
             }
         }),
         BuiltinScalarFunction::ToTimestamp => {
-            Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
+            Ok(DataType::Timestamp(TimeUnit::Second, None))
         }
         BuiltinScalarFunction::ToTimestampMillis => {
             Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
@@ -193,6 +193,9 @@ pub fn return_type(
         }
         BuiltinScalarFunction::ToTimestampSeconds => {
             Ok(DataType::Timestamp(TimeUnit::Second, None))
+        }
+        BuiltinScalarFunction::ToTimestampNanos => {
+            Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
         }
         BuiltinScalarFunction::FromUnixtime => {
             Ok(DataType::Timestamp(TimeUnit::Second, None))
@@ -351,9 +354,14 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Utf8,
                 DataType::Int64,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
+<<<<<<< HEAD
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
+=======
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+>>>>>>> 544b0953 (to_timestamp using second instead of nano, add a new to_timestamp_nanos)
             ],
             fun.volatility(),
         ),
@@ -387,6 +395,17 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Utf8,
                 DataType::Int64,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Timestamp(TimeUnit::Second, None),
+            ],
+            fun.volatility(),
+        ),
+        BuiltinScalarFunction::ToTimestampNanos => Signature::uniform(
+            1,
+            vec![
+                DataType::Utf8,
+                DataType::Int64,
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -354,14 +354,9 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 DataType::Utf8,
                 DataType::Int64,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
-<<<<<<< HEAD
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),
-=======
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-                DataType::Timestamp(TimeUnit::Microsecond, None),
->>>>>>> 544b0953 (to_timestamp using second instead of nano, add a new to_timestamp_nanos)
             ],
             fun.volatility(),
         ),
@@ -406,6 +401,7 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
             vec![
                 DataType::Utf8,
                 DataType::Int64,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Timestamp(TimeUnit::Second, None),

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -132,10 +132,19 @@ fn string_to_timestamp_nanos_shim(s: &str) -> Result<i64> {
 
 /// to_timestamp SQL function
 pub fn to_timestamp(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle::<TimestampSecondType, _, TimestampSecondType>(
+        args,
+        |s| string_to_timestamp_nanos_shim(s).map(|n| n / 1_000_000_000),
+        "to_timestamp",
+    )
+}
+
+/// to_timestamp_nanos SQL function
+pub fn to_timestamp_nanos(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle::<TimestampNanosecondType, _, TimestampNanosecondType>(
         args,
         string_to_timestamp_nanos_shim,
-        "to_timestamp",
+        "to_timestamp_nanos"
     )
 }
 

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -144,7 +144,7 @@ pub fn to_timestamp_nanos(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle::<TimestampNanosecondType, _, TimestampNanosecondType>(
         args,
         string_to_timestamp_nanos_shim,
-        "to_timestamp_nanos"
+        "to_timestamp_nanos",
     )
 }
 

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -86,7 +86,7 @@ pub fn create_physical_expr(
                 Ok(DataType::Utf8) => {
                     println!("jhere2");
                     datetime_expressions::to_timestamp
-                },
+                }
                 other => {
                     return Err(DataFusionError::Internal(format!(
                         "Unsupported data type {:?} for function to_timestamp",

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -78,12 +78,15 @@ pub fn create_physical_expr(
                     |col_values: &[ColumnarValue]| {
                         cast_column(
                             &col_values[0],
-                            &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                            &DataType::Timestamp(TimeUnit::Second, None),
                             &DEFAULT_DATAFUSION_CAST_OPTIONS,
                         )
                     }
                 }
-                Ok(DataType::Utf8) => datetime_expressions::to_timestamp,
+                Ok(DataType::Utf8) => {
+                    println!("jhere2");
+                    datetime_expressions::to_timestamp
+                },
                 other => {
                     return Err(DataFusionError::Internal(format!(
                         "Unsupported data type {:?} for function to_timestamp",
@@ -144,6 +147,26 @@ pub fn create_physical_expr(
                     }
                 }
                 Ok(DataType::Utf8) => datetime_expressions::to_timestamp_seconds,
+                other => {
+                    return Err(DataFusionError::Internal(format!(
+                        "Unsupported data type {:?} for function to_timestamp_seconds",
+                        other,
+                    )))
+                }
+            }
+        }),
+        BuiltinScalarFunction::ToTimestampNanos => Arc::new({
+            match coerced_phy_exprs[0].data_type(input_schema) {
+                Ok(DataType::Int64) | Ok(DataType::Timestamp(_, None)) => {
+                    |col_values: &[ColumnarValue]| {
+                        cast_column(
+                            &col_values[0],
+                            &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                            &DEFAULT_DATAFUSION_CAST_OPTIONS,
+                        )
+                    }
+                }
+                Ok(DataType::Utf8) => datetime_expressions::to_timestamp_nanos,
                 other => {
                     return Err(DataFusionError::Internal(format!(
                         "Unsupported data type {:?} for function to_timestamp_seconds",

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -440,6 +440,7 @@ enum ScalarFunction {
   StructFun=65;
   FromUnixtime=66;
   Atan2=67;
+  ToTimestampNanos=68;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -39,9 +39,10 @@ use datafusion_expr::{
     lower, lpad, ltrim, md5, now_expr, nullif, octet_length, power, random, regexp_match,
     regexp_replace, repeat, replace, reverse, right, round, rpad, rtrim, sha224, sha256,
     sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, tan,
-    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, to_timestamp_nanos, translate,
-    trim, trunc, upper, AggregateFunction, BuiltInWindowFunction, BuiltinScalarFunction,
-    Expr, Operator, WindowFrame, WindowFrameBound, WindowFrameUnits,
+    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_nanos,
+    to_timestamp_seconds, translate, trim, trunc, upper, AggregateFunction,
+    BuiltInWindowFunction, BuiltinScalarFunction, Expr, Operator, WindowFrame,
+    WindowFrameBound, WindowFrameUnits,
 };
 use std::sync::Arc;
 

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -39,7 +39,7 @@ use datafusion_expr::{
     lower, lpad, ltrim, md5, now_expr, nullif, octet_length, power, random, regexp_match,
     regexp_replace, repeat, replace, reverse, right, round, rpad, rtrim, sha224, sha256,
     sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, tan,
-    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, translate,
+    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, to_timestamp_nanos, translate,
     trim, trunc, upper, AggregateFunction, BuiltInWindowFunction, BuiltinScalarFunction,
     Expr, Operator, WindowFrame, WindowFrameBound, WindowFrameUnits,
 };
@@ -467,6 +467,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::ToHex => Self::ToHex,
             ScalarFunction::ToTimestampMicros => Self::ToTimestampMicros,
             ScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
+            ScalarFunction::ToTimestampNanos => Self::ToTimestampNanos,
             ScalarFunction::Now => Self::Now,
             ScalarFunction::Translate => Self::Translate,
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
@@ -1108,6 +1109,9 @@ pub fn parse_expr(
                 }
                 ScalarFunction::ToTimestampSeconds => {
                     Ok(to_timestamp_seconds(parse_expr(&args[0], registry)?))
+                }
+                ScalarFunction::ToTimestampNanos => {
+                    Ok(to_timestamp_nanos(parse_expr(&args[0], registry)?))
                 }
                 ScalarFunction::Now => Ok(now_expr(
                     args.to_owned()

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1117,6 +1117,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::ToHex => Self::ToHex,
             BuiltinScalarFunction::ToTimestampMicros => Self::ToTimestampMicros,
             BuiltinScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
+            BuiltinScalarFunction::ToTimestampNanos => Self::ToTimestampNanos,
             BuiltinScalarFunction::Now => Self::Now,
             BuiltinScalarFunction::Translate => Self::Translate,
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,

--- a/docs/source/user-guide/sql/datafusion-functions.md
+++ b/docs/source/user-guide/sql/datafusion-functions.md
@@ -21,9 +21,9 @@
 
 These SQL functions are specific to DataFusion, or they are well known and have functionality which is specific to DataFusion. Specifically, the `to_timestamp_xx()` functions exist due to Arrow's support for multiple timestamp resolutions.
 
-## `to_timestamp`
+## `to_timestamp_nanos`
 
-`to_timestamp()` is similar to the standard SQL function. It performs conversions to type `Timestamp(Nanoseconds, None)`, from:
+`to_timestamp_nanos()` is similar to the standard SQL function. It performs conversions to type `Timestamp(Nanoseconds, None)`, from:
 
 - Timestamp strings
   - `1997-01-31T09:26:56.123Z` # RCF3339
@@ -72,6 +72,22 @@ Note that `CAST(.. AS Timestamp)` converts to Timestamps with Nanosecond resolut
 ## `to_timestamp_seconds`
 
 `to_timestamp_seconds()` does conversions to type `Timestamp(Seconds, None)`, from:
+
+- Timestamp strings, the same as supported by the regular timestamp() function (except the output is a timestamp of secondseconds resolution)
+  - `1997-01-31T09:26:56.123Z` # RCF3339
+  - `1997-01-31T09:26:56.123-05:00` # RCF3339
+  - `1997-01-31 09:26:56.123-05:00` # close to RCF3339 but with a space er than T
+  - `1997-01-31T09:26:56.123` # close to RCF3339 but no timezone et specified
+  - `1997-01-31 09:26:56.123` # close to RCF3339 but uses a space and timezone offset
+  - `1997-01-31 09:26:56` # close to RCF3339, no fractional seconds
+- An Int64 array/column, values are seconds since Epoch UTC
+- Other Timestamp() columns or values
+
+Note that `CAST(.. AS Timestamp)` converts to Timestamps with Nanosecond resolution; this function is the only way to convert/cast to seconds resolution.
+
+## `to_timestamp`
+
+`to_timestamp()` does conversions to type `Timestamp(Seconds, None)`, from:
 
 - Timestamp strings, the same as supported by the regular timestamp() function (except the output is a timestamp of secondseconds resolution)
   - `1997-01-31T09:26:56.123Z` # RCF3339


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2979 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

original to_timestamp assume time unit is nanosecond. this pr is to change it to second based (to align with postgresql's to_timestamp)

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

```to_timestamp``` use seconds instead of nanoseconds. a new ```to_timestamp_nanos``` expression is added that has the same behavior as the original to_timestamp

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes. To migrate to new ```to_timestamp```. The original usage for ```to_timestamp(1_000_000_000)``` need to be modified to either ```to_timestamp(1)``` or ```to_timestamp_nanos(1_000_000_000)```

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
this pr has the breaking changes to puublic API: ```to_timestamp``` 