### PR TITLE
feat: Add support for TIME literal values

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -986,6 +986,26 @@ async fn sub_interval_day() -> Result<()> {
 }
 
 #[tokio::test]
+async fn cast_string_to_time() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select time '08:09:10.123456789' as time;";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+--------------------+",
+        "| time               |",
+        "+--------------------+",
+        "| 08:09:10.123456789 |",
+        "+--------------------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn cast_to_timestamp_twice() -> Result<()> {
     let ctx = SessionContext::new();
 

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -986,23 +986,41 @@ async fn sub_interval_day() -> Result<()> {
 }
 
 #[tokio::test]
-async fn cast_string_to_time() -> Result<()> {
+async fn cast_string_to_time() {
     let ctx = SessionContext::new();
 
-    let sql = "select time '08:09:10.123456789' as time;";
+    let sql = "select \
+        time '08:09:10.123456789' as time_nano, \
+        time '13:14:15.123456'    as time_micro,\
+        time '13:14:15.123'       as time_milli,\
+        time '13:14:15'           as time;";
     let results = execute_to_batches(&ctx, sql).await;
 
     let expected = vec![
-        "+--------------------+",
-        "| time               |",
-        "+--------------------+",
-        "| 08:09:10.123456789 |",
-        "+--------------------+",
+        "+--------------------+-----------------+--------------+----------+",
+        "| time_nano          | time_micro      | time_milli   | time     |",
+        "+--------------------+-----------------+--------------+----------+",
+        "| 08:09:10.123456789 | 13:14:15.123456 | 13:14:15.123 | 13:14:15 |",
+        "+--------------------+-----------------+--------------+----------+",
     ];
-
     assert_batches_eq!(expected, &results);
 
-    Ok(())
+    // Fallible cases
+
+    let sql = "SELECT TIME 'not a time' as time;";
+    let result = try_execute_to_batches(&ctx, sql).await;
+    assert_eq!(
+        result.err().unwrap().to_string(),
+        "Arrow error: Cast error: Cannot cast string 'not a time' to value of Time64(Nanosecond) type"
+    );
+
+    // An invalid time
+    let sql = "SELECT TIME '24:01:02' as time;";
+    let result = try_execute_to_batches(&ctx, sql).await;
+    assert_eq!(
+        result.err().unwrap().to_string(),
+        "Arrow error: Cast error: Cannot cast string '24:01:02' to value of Time64(Nanosecond) type"
+    );
 }
 
 #[tokio::test]

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4359,19 +4359,19 @@ mod tests {
     }
 
     #[test]
-    fn select_typedstring() {
-        let sql = "SELECT date '2020-12-10' AS date FROM person";
+    fn select_typed_date_string() {
+        let sql = "SELECT date '2020-12-10' AS date";
         let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32) AS date\
-            \n  TableScan: person";
+            \n  EmptyRelation";
         quick_test(sql, expected);
     }
 
     #[test]
-    fn select_typedstring_time() {
-        let sql = "SELECT TIME '08:09:10.123' AS time FROM person";
+    fn select_typed_time_string() {
+        let sql = "SELECT TIME '08:09:10.123' AS time";
         let expected =
             "Projection: CAST(Utf8(\"08:09:10.123\") AS Time64(Nanosecond)) AS time\
-            \n  TableScan: person";
+            \n  EmptyRelation";
         quick_test(sql, expected);
     }
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -496,7 +496,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLDataType::Double => Ok(DataType::Float64),
             SQLDataType::Boolean => Ok(DataType::Boolean),
             SQLDataType::Date => Ok(DataType::Date32),
-            SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
+            SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Nanosecond)),
             SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "The SQL data type {:?} is not implemented",
@@ -2561,6 +2561,7 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> Result<DataType> {
         | SQLDataType::String => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         SQLDataType::Date => Ok(DataType::Date32),
+        SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Nanosecond)),
         SQLDataType::Decimal(precision, scale) => make_decimal_type(*precision, *scale),
         SQLDataType::Binary(_) => Ok(DataType::Binary),
         SQLDataType::Bytea => Ok(DataType::Binary),
@@ -4361,6 +4362,15 @@ mod tests {
     fn select_typedstring() {
         let sql = "SELECT date '2020-12-10' AS date FROM person";
         let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32) AS date\
+            \n  TableScan: person";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_typedstring_time() {
+        let sql = "SELECT TIME '08:09:10.123' AS time FROM person";
+        let expected =
+            "Projection: CAST(Utf8(\"08:09:10.123\") AS Time64(Nanosecond)) AS time\
             \n  TableScan: person";
         quick_test(sql, expected);
     }


### PR DESCRIPTION
This PR teaches DataFusion how to interpret `TIME` literals. These values are stored as nanoseconds from midnight using a `Time64(Nanosecond)`.

# Which issue does this PR close?

Closes #2883.

 # Rationale for this change

I adjusted the precision of `TIME` to `nanosecond`, which is different from the draft PR #2884 by @andygrove. The rationale for choosing `Nanosecond` is that PostgreSQL `TIME` requires [microsecond precision](https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-DATETIME-TABLE). Microsecond precision requires the `Time64(_)` type, so it seems safe to increase the precision to Nanosecond with no additional memory requirements.

# What changes are included in this PR?

Add support for `TIME` literals

# Are there any user-facing changes?

This PR teaches DataFusion about `TIME` literals and therefore documentation would need to be revised. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->