### PR TITLE
feat: Enable typed strings expressions for VALUES clause

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1613,12 +1613,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                 &schema,
                                 &mut HashMap::new(),
                             ),
-                        SQLExpr::TypedString {
-                            ref data_type,
-                            ref value,
-                        } => Ok(Expr::Cast {
-                            expr: Box::new(lit(&**value)),
-                            data_type: convert_data_type(data_type)?,
+                        SQLExpr::TypedString { data_type, value } => Ok(Expr::Cast {
+                            expr: Box::new(lit(value)),
+                            data_type: convert_data_type(&data_type)?,
                         }),
                         other => Err(DataFusionError::NotImplemented(format!(
                             "Unsupported value {:?} in a values list expression",
@@ -1816,11 +1813,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }),
 
             SQLExpr::TypedString {
-                ref data_type,
-                ref value,
+                data_type,
+                value,
             } => Ok(Expr::Cast {
-                expr: Box::new(lit(&**value)),
-                data_type: convert_data_type(data_type)?,
+                expr: Box::new(lit(value)),
+                data_type: convert_data_type(&data_type)?,
             }),
 
             SQLExpr::IsNull(expr) => Ok(Expr::IsNull(Box::new(

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1613,6 +1613,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                 &schema,
                                 &mut HashMap::new(),
                             ),
+                        SQLExpr::TypedString {
+                            ref data_type,
+                            ref value,
+                        } => Ok(Expr::Cast {
+                            expr: Box::new(lit(&**value)),
+                            data_type: convert_data_type(data_type)?,
+                        }),
                         other => Err(DataFusionError::NotImplemented(format!(
                             "Unsupported value {:?} in a values list expression",
                             other
@@ -3244,6 +3251,17 @@ mod tests {
             "Projection: #MIN(person.age) AS a, #MIN(person.age) AS b\
              \n  Aggregate: groupBy=[[]], aggr=[[MIN(#person.age)]]\
              \n    TableScan: person",
+        );
+    }
+
+    #[test]
+    fn select_from_typed_string_values() {
+        quick_test(
+            "SELECT col1, col2 FROM (VALUES (TIMESTAMP '2021-06-10 17:01:00Z', DATE '2004-04-09')) as t (col1, col2)",
+            "Projection: #t.col1, #t.col2\
+            \n  Projection: #t.column1 AS col1, #t.column2 AS col2, alias=t\
+            \n    Projection: #column1, #column2, alias=t\
+            \n      Values: (CAST(Utf8(\"2021-06-10 17:01:00Z\") AS Timestamp(Nanosecond, None)), CAST(Utf8(\"2004-04-09\") AS Date32))",
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3017.

# What changes are included in this PR?

Support for transforming typed string literal expressions to `CAST` expressions in a `VALUES` clause.

# Are there any user-facing changes?

This extends the supported expressions in a `VALUES` list clause.