### PR TITLE
WIP: Update prost/tonic

### DIFF
--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -39,7 +39,7 @@ async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"
 num_cpus = "1.13.0"
-prost = "0.10"
+prost = "0.11"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.82"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -43,4 +43,4 @@ prost = "0.11"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.82"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
-tonic = "0.7"
+tonic = "0.8"

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -43,7 +43,7 @@ datafusion-common = { path = "../common", version = "10.0.0" }
 datafusion-expr = { path = "../expr", version = "10.0.0" }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }
-prost = "0.10"
+prost = "0.11"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -53,4 +53,4 @@ tokio = "1.18"
 
 [build-dependencies]
 pbjson-build = { version = "0.3", optional = true }
-prost-build = { version = "0.10" }
+prost-build = { version = "0.11" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -41,8 +41,8 @@ arrow = { version = "19.0.0" }
 datafusion = { path = "../core", version = "10.0.0" }
 datafusion-common = { path = "../common", version = "10.0.0" }
 datafusion-expr = { path = "../expr", version = "10.0.0" }
-pbjson = { version = "0.3", optional = true }
-pbjson-types = { version = "0.3", optional = true }
+pbjson = { version = "0.4", optional = true }
+pbjson-types = { version = "0.4", optional = true }
 prost = "0.11"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
@@ -52,5 +52,5 @@ doc-comment = "0.3"
 tokio = "1.18"
 
 [build-dependencies]
-pbjson-build = { version = "0.3", optional = true }
+pbjson-build = { version = "0.4", optional = true }
 prost-build = { version = "0.11" }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3028.

# Rationale for this change

Keep up with the Joneses.

# What changes are included in this PR?

All the dependabot upgrades aside from arrow-flight, which has been merged but not released yet.

# Are there any user-facing changes?

Shouldn't be!