### PR TITLE
minor: update minimal rust version to 1.62, matching arrow-rs

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow", "query", "sql"]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_common"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -31,7 +31,7 @@ include = [
     "Cargo.toml",
 ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "datafusion", "logical", "plan", "expressions" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_expr"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow", "query", "sql" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_jit"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "datafusion", "query", "optimizer" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_optimizer"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow", "query", "sql" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_physical_expr"

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow", "query", "sql"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_proto"

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow", "query", "sql" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_row"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "datafusion", "sql", "parser", "planner" ]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.62"
 
 [lib]
 name = "datafusion_sql"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
DataFusion wouldn't compile with 1.61 due to change in arrow-rs using total_cmp() function that's stable only in 1.62.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
updates minimal rust version across all the cargo tomls

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->