### PR TITLE
Use concat_elements_utf8 from arrow rather than custom kernel

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -49,9 +49,8 @@ use arrow::compute::kernels::comparison::{
 };
 
 use adapter::{eq_dyn, gt_dyn, gt_eq_dyn, lt_dyn, lt_eq_dyn, neq_dyn};
-use kernels::{
-    bitwise_and, bitwise_and_scalar, bitwise_or, bitwise_or_scalar, string_concat,
-};
+use arrow::compute::kernels::concat_elements::concat_elements_utf8;
+use kernels::{bitwise_and, bitwise_and_scalar, bitwise_or, bitwise_or_scalar};
 use kernels_arrow::{
     add_decimal, add_decimal_scalar, divide_decimal, divide_decimal_scalar,
     eq_decimal_scalar, gt_decimal_scalar, gt_eq_decimal_scalar, is_distinct_from,
@@ -851,7 +850,9 @@ impl BinaryExpr {
             }
             Operator::BitwiseAnd => bitwise_and(left, right),
             Operator::BitwiseOr => bitwise_or(left, right),
-            Operator::StringConcat => string_concat(left, right),
+            Operator::StringConcat => {
+                binary_string_array_op!(left, right, concat_elements)
+            }
         }
     }
 }

--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -167,25 +167,3 @@ pub(crate) fn bitwise_or_scalar(
     };
     Some(result)
 }
-
-/// Concat lhs and rhs String Array, any `NULL` exists on lhs or rhs will come out result `NULL`
-/// 1. 'a' || 'b' || 32 = 'ab32'
-/// 2. 'a' || NULL = NULL
-pub(crate) fn string_concat(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
-    let left_array = left.as_any().downcast_ref::<StringArray>().unwrap();
-    let right_array = right.as_any().downcast_ref::<StringArray>().unwrap();
-    let result = (0..left.len())
-        .into_iter()
-        .map(|i| {
-            if left.is_null(i) || right.is_null(i) {
-                None
-            } else {
-                let mut owned_string: String = "".to_owned();
-                owned_string.push_str(left_array.value(i));
-                owned_string.push_str(right_array.value(i));
-                Some(owned_string)
-            }
-        })
-        .collect::<StringArray>();
-    Ok(Arc::new(result) as ArrayRef)
-}


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/1474

 # Rationale for this change
I noticed https://github.com/apache/arrow-datafusion/pull/3026#discussion_r937996173 that datafusion is not yet using the great `concat_elements` kernel added by @ismailmaj  in https://github.com/apache/arrow-rs/pull/1720

# What changes are included in this PR?
Use arrow kernel, remove custom datafusion one

# Are there any user-facing changes?
No