### PR TITLE
feat: Support `week`, `decade`, `century` for Interval literal

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -692,6 +692,14 @@ async fn test_interval_expressions() -> Result<()> {
         "0 years 0 mons 1 days 0 hours 0 mins 0.00 secs"
     );
     test_expression!(
+        "interval '1 week'",
+        "0 years 0 mons 7 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '2 weeks'",
+        "0 years 0 mons 14 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
         "interval '1 day 1'",
         "0 years 0 mons 1 days 0 hours 0 mins 1.00 secs"
     );
@@ -768,6 +776,18 @@ async fn test_interval_expressions() -> Result<()> {
     test_expression!(
         "interval '1 year'",
         "1 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 decade'",
+        "10 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 decade'",
+        "10 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
+    );
+    test_expression!(
+        "interval '1 century'",
+        "100 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
     );
     test_expression!(
         "interval '2 year'",

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -782,8 +782,8 @@ async fn test_interval_expressions() -> Result<()> {
         "10 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
     );
     test_expression!(
-        "interval '1 decade'",
-        "10 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
+        "interval '2 decades'",
+        "20 years 0 mons 0 days 0 hours 0 mins 0.00 secs"
     );
     test_expression!(
         "interval '1 century'",

--- a/datafusion/sql/src/interval.rs
+++ b/datafusion/sql/src/interval.rs
@@ -64,17 +64,28 @@ pub(crate) fn parse_interval(leading_field: &str, value: &str) -> Result<ScalarV
             }
 
             match interval_type.to_lowercase().as_str() {
-                "year" => Ok(align_interval_parts(interval_period * 12_f32, 0.0, 0.0)),
-                "month" => Ok(align_interval_parts(interval_period, 0.0, 0.0)),
+                "century" | "centuries" => {
+                    Ok(align_interval_parts(interval_period * 1200_f32, 0.0, 0.0))
+                }
+                "decade" | "decades" => {
+                    Ok(align_interval_parts(interval_period * 120_f32, 0.0, 0.0))
+                }
+                "year" | "years" => {
+                    Ok(align_interval_parts(interval_period * 12_f32, 0.0, 0.0))
+                }
+                "month" | "months" => Ok(align_interval_parts(interval_period, 0.0, 0.0)),
+                "week" | "weeks" => {
+                    Ok(align_interval_parts(0.0, interval_period * 7_f32, 0.0))
+                }
                 "day" | "days" => Ok(align_interval_parts(0.0, interval_period, 0.0)),
                 "hour" | "hours" => {
                     Ok((0, 0, interval_period * SECONDS_PER_HOUR * MILLIS_PER_SECOND))
                 }
-                "minutes" | "minute" => {
+                "minute" | "minutes" => {
                     Ok((0, 0, interval_period * 60_f32 * MILLIS_PER_SECOND))
                 }
-                "seconds" | "second" => Ok((0, 0, interval_period * MILLIS_PER_SECOND)),
-                "milliseconds" | "millisecond" => Ok((0, 0, interval_period)),
+                "second" | "seconds" => Ok((0, 0, interval_period * MILLIS_PER_SECOND)),
+                "millisecond" | "milliseconds" => Ok((0, 0, interval_period)),
                 _ => Err(DataFusionError::NotImplemented(format!(
                     "Invalid input syntax for type interval: {:?}",
                     value

--- a/datafusion/sql/src/interval.rs
+++ b/datafusion/sql/src/interval.rs
@@ -184,10 +184,10 @@ mod test {
         );
 
         assert_contains!(
-            parse_interval("months", "1 years 1 month")
+            parse_interval("months", "1 centurys 1 month")
                 .unwrap_err()
                 .to_string(),
-            r#"Invalid input syntax for type interval: "1 years 1 month""#
+            r#"Invalid input syntax for type interval: "1 centurys 1 month""#
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

A lot of BIs uses `<date expr> + INTERVAL '1 week'`. This PR introduces support for parsing new types for intervals: `week`, `decades` and `century`. (last two were added to be similar with Postgres behaviour)

<img width="852" alt="image" src="https://user-images.githubusercontent.com/572096/182922725-ed1a6314-de30-4e65-bbf5-27d257193081.png">

# Are there any user-facing changes?

New functionality without breaking changes.