### PR TITLE
Remove redundant (and currently broken) RAT check

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,24 +19,6 @@ name: Dev
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint C++, Python, R, Rust, Docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          repository: apache/arrow
-          submodules: true
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Setup Archery
-        run: pip install -e dev/archery[lint]
-      - name: Lint
-        run: archery lint --rat
 
   rat:
     name: Release Audit Tool (RAT)


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3052
re #3045 

 # Rationale for this change
RAT is the license checker that ensures that all files in this repo have an appropriate license in the header

It turns out that datafusion CU runs *2* RAT checks:
1. `dev/scripts/run-rat.sh` (which is also what is run to verify the release when a tarball is created)
2. an "archery" based one left over from when we split DataFusion out of the main `arrow` repository. Its name gives you a hint it is crufty: `Lint C++, Python, R, Rust, Docker`

Since the checks are redundant and the archery one started failing in  https://github.com/apache/arrow-datafusion/issues/3052 I propose to remove the archery job

Note that "archery" is a python-based workflow tool used for t

# What changes are included in this PR?
Remove redundant and failing check "[Lint C++, Python, R, Rust, Docker](https://github.com/apache/arrow-datafusion/runs/7700921830?check_suite_focus=true#logs)"

# Are there any user-facing changes?
No