### PR TITLE
feat: support double quoted literal strings for dialects(such as mysql,bigquery,spark)

### DIFF
--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -1210,3 +1210,39 @@ async fn unprojected_filter() {
     ];
     assert_batches_sorted_eq!(expected, &results);
 }
+
+#[tokio::test]
+async fn case_sensitive_in_default_dialect() {
+    let int32_array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+    let schema = Schema::new(vec![Field::new("INT32", DataType::Int32, false)]);
+    let batch =
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(int32_array)]).unwrap();
+
+    let ctx = SessionContext::new();
+    let table = MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap();
+    ctx.register_table("t", Arc::new(table)).unwrap();
+
+    {
+        let sql = "select \"int32\" from t";
+        let plan = ctx.create_logical_plan(sql);
+        assert!(plan.is_err());
+    }
+
+    {
+        let sql = "select \"INT32\" from t";
+        let actual = execute_to_batches(&ctx, sql).await;
+
+        let expected = vec![
+            "+-------+",
+            "| INT32 |",
+            "+-------+",
+            "| 1     |",
+            "| 2     |",
+            "| 3     |",
+            "| 4     |",
+            "| 5     |",
+            "+-------+",
+        ];
+        assert_batches_eq!(expected, &actual);
+    }
+}

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4870,11 +4870,11 @@ mod tests {
         let dialect = &MySqlDialect {};
         let single_quoted_res = format!(
             "{:?}",
-            logical_plan_with_dialect("SELECT \"1\"", dialect).unwrap()
+            logical_plan_with_dialect("SELECT '1'", dialect).unwrap()
         );
         let double_quoted_res = format!(
             "{:?}",
-            logical_plan_with_dialect("SELECT '1'", dialect).unwrap()
+            logical_plan_with_dialect("SELECT \"1\"", dialect).unwrap()
         );
         assert_eq!(single_quoted_res, double_quoted_res);
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3055.

 # Rationale for this change
See #3055.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->