### PR TITLE
Simplify `approx_median` implementation

### DIFF
--- a/datafusion/core/tests/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe_functions.rs
@@ -33,6 +33,7 @@ use datafusion::prelude::*;
 use datafusion::execution::context::SessionContext;
 
 use datafusion::assert_batches_eq;
+use datafusion_expr::approx_median;
 
 fn create_test_table() -> Result<Arc<DataFrame>> {
     let schema = Arc::new(Schema::new(vec![
@@ -148,6 +149,26 @@ async fn test_fn_btrim_with_chars() -> Result<()> {
     ];
 
     assert_fn_batches!(expr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fn_approx_median() -> Result<()> {
+    let expr = approx_median(col("b"));
+
+    let expected = vec![
+        "+----------------------+",
+        "| APPROXMEDIAN(test.b) |",
+        "+----------------------+",
+        "| 10                   |",
+        "+----------------------+",
+    ];
+
+    let df = create_test_table()?;
+    let batches = df.aggregate(vec![], vec![expr]).unwrap().collect().await?;
+
+    assert_batches_eq!(expected, &batches);
 
     Ok(())
 }

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -166,6 +166,15 @@ pub fn approx_distinct(expr: Expr) -> Expr {
     }
 }
 
+/// Calculate an approximation of the median for `expr`.
+pub fn approx_median(expr: Expr) -> Expr {
+    Expr::AggregateFunction {
+        fun: aggregate_function::AggregateFunction::ApproxMedian,
+        distinct: false,
+        args: vec![expr],
+    }
+}
+
 /// Calculate an approximation of the specified `percentile` for `expr`.
 pub fn approx_percentile_cont(expr: Expr, percentile: Expr) -> Expr {
     Expr::AggregateFunction {

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -244,11 +244,11 @@ pub fn create_aggregate_expr(
             ));
         }
         (AggregateFunction::ApproxMedian, false) => {
-            Arc::new(expressions::ApproxMedian::new(
+            Arc::new(expressions::ApproxMedian::try_new(
                 coerced_phy_exprs[0].clone(),
                 name,
                 return_type,
-            ))
+            )?)
         }
         (AggregateFunction::ApproxMedian, true) => {
             return Err(DataFusionError::NotImplemented(

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -43,7 +43,6 @@ use datafusion_expr::{
 };
 use hashbrown::HashMap;
 use std::collections::HashSet;
-use std::iter;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{convert::TryInto, vec};
@@ -2180,18 +2179,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     _ => self.sql_fn_arg_to_logical_expr(a, schema, &mut HashMap::new()),
                 })
                 .collect::<Result<Vec<Expr>>>()?,
-            AggregateFunction::ApproxMedian => function
-                .args
-                .into_iter()
-                .map(|a| self.sql_fn_arg_to_logical_expr(a, schema, &mut HashMap::new()))
-                .chain(iter::once(Ok(lit(0.5_f64))))
-                .collect::<Result<Vec<Expr>>>()?,
             _ => self.function_args_to_expr(function.args, schema)?,
-        };
-
-        let fun = match fun {
-            AggregateFunction::ApproxMedian => AggregateFunction::ApproxPercentileCont,
-            _ => fun,
         };
 
         Ok((fun, args))
@@ -3564,8 +3552,8 @@ mod tests {
     #[test]
     fn select_approx_median() {
         let sql = "SELECT approx_median(age) FROM person";
-        let expected = "Projection: #APPROXPERCENTILECONT(person.age,Float64(0.5))\
-                        \n  Aggregate: groupBy=[[]], aggr=[[APPROXPERCENTILECONT(#person.age, Float64(0.5))]]\
+        let expected = "Projection: #APPROXMEDIAN(person.age)\
+                        \n  Aggregate: groupBy=[[]], aggr=[[APPROXMEDIAN(#person.age)]]\
                         \n    TableScan: person";
         quick_test(sql, expected);
     }
@@ -4357,8 +4345,8 @@ mod tests {
         let sql =
             "SELECT order_id, APPROX_MEDIAN(qty) OVER(PARTITION BY order_id) from orders";
         let expected = "\
-        Projection: #orders.order_id, #APPROXPERCENTILECONT(orders.qty,Float64(0.5)) PARTITION BY [#orders.order_id]\
-        \n  WindowAggr: windowExpr=[[APPROXPERCENTILECONT(#orders.qty, Float64(0.5)) PARTITION BY [#orders.order_id]]]\
+        Projection: #orders.order_id, #APPROXMEDIAN(orders.qty) PARTITION BY [#orders.order_id]\
+        \n  WindowAggr: windowExpr=[[APPROXMEDIAN(#orders.qty) PARTITION BY [#orders.order_id]]]\
         \n    TableScan: orders";
         quick_test(sql, expected);
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/3063

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I started down this rabbit hole when trying to expose `ApproxMedian` in Python and found that it called `unimplemented!` in its accumulator. DataFusion supports `approx_median` in SQL because the SQL query planner translates `approx_median(expr)` to `approx_percentile_cont(expr, 0.5)`.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Implement `ApproxMedian` (by delegating to `ApproxPercentileCont`)
- Add `pub fn approx_median` so that it is now possible to use this from DataFrames
- Remove the logic from the SQL query planner that was translating these functions
- Add a new test
- Update some existing test because the plan now correctly shows `APPROXMEDIAN` instead of `APPROXPERCENTILECONT`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes - the plans look different

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->