### PR TITLE
Upgrade to arrow 20.0.0 (but no change to object_store), including `prost`, and `tonic`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc --version
       - name: Cache Cargo
         uses: actions/cache@v3
         with:
@@ -94,6 +104,7 @@ jobs:
           rust-version: ${{ matrix.rust }}
       - name: Run tests
         run: |
+          export PATH=$PATH:$HOME/d/protoc/bin
           cargo test --features avro,jit,scheduler,json
           # test datafusion-sql examples
           cargo run --example sql
@@ -159,17 +170,65 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
 
-  windows-and-macos:
-    name: Test on ${{ matrix.os }} Rust ${{ matrix.rust }}
+  windows:
+    name: Test on Windows Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest]
         rust: [stable]
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-win64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc.exe --version
+      # TODO: this won't cache anything, which is expensive. Setup this action
+      # with a OS-dependent path.
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
+      - name: Run tests
+        shell: bash
+        run: |
+          export PATH=$PATH:$HOME/d/protoc/bin
+          cargo test
+        env:
+          # do not produce debug symbols to keep memory usage down
+          RUSTFLAGS: "-C debuginfo=0"
+
+  macos:
+    name: Test on MacOS Rust ${{ matrix.rust }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-osx-x86_64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc --version
       # TODO: this won't cache anything, which is expensive. Setup this action
       # with a OS-dependent path.
       - name: Setup Rust toolchain
@@ -250,6 +309,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc --version
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -263,6 +332,7 @@ jobs:
           key: cargo-coverage-cache3-
       - name: Run coverage
         run: |
+          export PATH=$PATH:$HOME/d/protoc/bin
           rustup toolchain install stable
           rustup default stable
           cargo install --version 0.20.1 cargo-tarpaulin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ list to help you get started.
 
 This section describes how you can get started at developing DataFusion.
 
+### Windows setup
+
+```shell
+wget https://az792536.vo.msecnd.net/vms/VMBuild_20190311/VirtualBox/MSEdge/MSEdge.Win10.VirtualBox.zip
+choco install -y git rustup.install visualcpp-build-tools clion-ide
+git-bash.exe
+cargo build
+```
+
 ### Bootstrap environment
 
 DataFusion is written in Rust and it uses a standard rust toolkit:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This section describes how you can get started at developing DataFusion.
 
 ```shell
 wget https://az792536.vo.msecnd.net/vms/VMBuild_20190311/VirtualBox/MSEdge/MSEdge.Win10.VirtualBox.zip
-choco install -y git rustup.install visualcpp-build-tools clion-ide
+choco install -y git rustup.install visualcpp-build-tools
 git-bash.exe
 cargo build
 ```

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,7 +32,7 @@ simd = ["datafusion/simd"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-datafusion = { path = "../datafusion/core" }
+datafusion = { path = "../datafusion/core", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,7 +32,7 @@ simd = ["datafusion/simd"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-datafusion = { path = "../datafusion/core", features = [], optional = false }
+datafusion = { path = "../datafusion/core" }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -29,9 +29,9 @@ rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow = { version = "20.0.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../datafusion/core", features = [], optional = false }
+datafusion = { path = "../datafusion/core", version = "10.0.0" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -29,9 +29,9 @@ rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]
-arrow = { version = "19.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../datafusion/core", version = "10.0.0" }
+datafusion = { path = "../datafusion/core", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,9 +34,9 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow-flight = { version = "20.0.0" }
 async-trait = "0.1.41"
-datafusion = { path = "../datafusion/core", features = [], optional = false }
+datafusion = { path = "../datafusion/core" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,13 +34,13 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { version = "19.0.0" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 async-trait = "0.1.41"
-datafusion = { path = "../datafusion/core" }
+datafusion = { path = "../datafusion/core", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
-prost = "0.10"
+prost = "0.11.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.82"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
-tonic = "0.7"
+tonic = "0.8"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,12 +39,12 @@ pyarrow = ["pyo3"]
 
 [dependencies]
 apache-avro = { version = "0.14", features = ["snappy"], optional = true }
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.86.1", optional = true }
 object_store = { version = "0.3", optional = true }
 ordered-float = "3.0"
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow"], optional = true }
+parquet = { version = "20.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 serde_json = "1.0"
 sqlparser = "0.20"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,11 +39,12 @@ pyarrow = ["pyo3"]
 
 [dependencies]
 apache-avro = { version = "0.14", features = ["snappy"], optional = true }
-arrow = { version = "19.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.86.1", optional = true }
-object_store = { version = "0.3", optional = true }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = true }
 ordered-float = "3.0"
-parquet = { version = "19.0.0", features = ["arrow"], optional = true }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 serde_json = "1.0"
 sqlparser = "0.20"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -42,7 +42,7 @@ apache-avro = { version = "0.14", features = ["snappy"], optional = true }
 arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.86.1", optional = true }
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = true }
+object_store = { version = "0.3", optional = true }
 ordered-float = "3.0"
 parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }

--- a/datafusion/common/src/from_slice.rs
+++ b/datafusion/common/src/from_slice.rs
@@ -69,7 +69,7 @@ where
             offsets.push(length_so_far);
             values.extend_from_slice(s);
         }
-        let array_data = ArrayData::builder(Self::get_data_type())
+        let array_data = ArrayData::builder(Self::DATA_TYPE)
             .len(slice.len())
             .add_buffer(Buffer::from_slice_ref(&offsets))
             .add_buffer(Buffer::from_slice_ref(&values));

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -56,17 +56,17 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 apache-avro = { version = "0.14", optional = true }
-arrow = { version = "19.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
 async-trait = "0.1.41"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "10.0.0", features = ["parquet", "object_store"] }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
-datafusion-jit = { path = "../jit", version = "10.0.0", optional = true }
-datafusion-optimizer = { path = "../optimizer", version = "10.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "10.0.0" }
-datafusion-row = { path = "../row", version = "10.0.0" }
-datafusion-sql = { path = "../sql", version = "10.0.0" }
+datafusion-common = { path = "../common", features = ["parquet", "object_store"], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
+datafusion-jit = { path = "../jit", features = [], optional = true }
+datafusion-optimizer = { path = "../optimizer", features = [], optional = false }
+datafusion-physical-expr = { path = "../physical-expr", features = [], optional = false }
+datafusion-row = { path = "../row", features = [], optional = false }
+datafusion-sql = { path = "../sql", features = [], optional = false }
 futures = "0.3"
 glob = "0.3.0"
 hashbrown = { version = "0.12", features = ["raw"] }
@@ -75,10 +75,10 @@ lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
-object_store = "0.3.0"
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 ordered-float = "3.0"
 parking_lot = "0.12"
-parquet = { version = "19.0.0", features = ["arrow", "async"] }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow", "async"], optional = false }
 paste = "^1.0"
 pin-project-lite = "^0.2.7"
 pyo3 = { version = "0.16", optional = true }
@@ -98,7 +98,7 @@ csv = "1.1.6"
 ctor = "0.1.22"
 doc-comment = "0.3"
 env_logger = "0.9"
-fuzz-utils = { path = "fuzz-utils" }
+fuzz-utils = { path = "fuzz-utils", features = [], optional = false }
 
 [[bench]]
 harness = false

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -56,17 +56,17 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 apache-avro = { version = "0.14", optional = true }
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", features = ["parquet", "object_store"], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
-datafusion-jit = { path = "../jit", features = [], optional = true }
-datafusion-optimizer = { path = "../optimizer", features = [], optional = false }
-datafusion-physical-expr = { path = "../physical-expr", features = [], optional = false }
-datafusion-row = { path = "../row", features = [], optional = false }
-datafusion-sql = { path = "../sql", features = [], optional = false }
+datafusion-common = { path = "../common", version = "10.0.0", features = ["parquet", "object_store"] }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
+datafusion-jit = { path = "../jit", version = "10.0.0", optional = true }
+datafusion-optimizer = { path = "../optimizer", version = "10.0.0" }
+datafusion-physical-expr = { path = "../physical-expr", version = "10.0.0" }
+datafusion-row = { path = "../row", version = "10.0.0" }
+datafusion-sql = { path = "../sql", version = "10.0.0" }
 futures = "0.3"
 glob = "0.3.0"
 hashbrown = { version = "0.12", features = ["raw"] }
@@ -78,7 +78,7 @@ num_cpus = "1.13.0"
 object_store = "0.3.0"
 ordered-float = "3.0"
 parking_lot = "0.12"
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow", "async"], optional = false }
+parquet = { version = "20.0.0", features = ["arrow", "async"] }
 paste = "^1.0"
 pin-project-lite = "^0.2.7"
 pyo3 = { version = "0.16", optional = true }
@@ -98,7 +98,7 @@ csv = "1.1.6"
 ctor = "0.1.22"
 doc-comment = "0.3"
 env_logger = "0.9"
-fuzz-utils = { path = "fuzz-utils", features = [], optional = false }
+fuzz-utils = { path = "fuzz-utils" }
 
 [[bench]]
 harness = false

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -75,7 +75,7 @@ lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+object_store = "0.3.0"
 ordered-float = "3.0"
 parking_lot = "0.12"
 parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["arrow", "async"], optional = false }

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { version = "19.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -101,12 +101,10 @@ impl<'a, R: Read> AvroArrowArrayReader<'a, R> {
                     "Failed to parse avro value: {:?}",
                     e
                 ))),
-                other => {
-                    return Err(ArrowError::ParseError(format!(
-                        "Row needs to be of type object, got: {:?}",
-                        other
-                    )))
-                }
+                other => Err(ArrowError::ParseError(format!(
+                    "Row needs to be of type object, got: {:?}",
+                    other
+                ))),
             })
             .collect::<ArrowResult<Vec<Vec<(String, Value)>>>>()?;
         if rows.is_empty() {

--- a/datafusion/core/src/avro_to_arrow/schema.rs
+++ b/datafusion/core/src/avro_to_arrow/schema.rs
@@ -141,7 +141,7 @@ fn schema_to_field_with_props(
         AvroSchema::Fixed { size, .. } => DataType::FixedSizeBinary(*size as i32),
         AvroSchema::Decimal {
             precision, scale, ..
-        } => DataType::Decimal(*precision, *scale),
+        } => DataType::Decimal128(*precision, *scale),
         AvroSchema::Uuid => DataType::FixedSizeBinary(16),
         AvroSchema::Date => DataType::Date32,
         AvroSchema::TimeMillis => DataType::Time32(TimeUnit::Millisecond),
@@ -217,7 +217,7 @@ fn default_field_name(dt: &DataType) -> &str {
         DataType::Union(_, _, _) => "union",
         DataType::Dictionary(_, _) => "map",
         DataType::Map(_, _) => unimplemented!("Map support not implemented"),
-        DataType::Decimal(_, _) => "decimal",
+        DataType::Decimal128(_, _) => "decimal",
         DataType::Decimal256(_, _) => "decimal",
     }
 }

--- a/datafusion/core/src/catalog/information_schema.rs
+++ b/datafusion/core/src/catalog/information_schema.rs
@@ -508,7 +508,7 @@ impl InformationSchemaColumnsBuilder {
             Float32 => (Some(24), Some(2), None),
             // Numbers from postgres `double` type
             Float64 => (Some(24), Some(2), None),
-            Decimal(precision, scale) => {
+            Decimal128(precision, scale) => {
                 (Some(*precision as u64), Some(10), Some(*scale as u64))
             }
             _ => (None, None, None),

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -231,20 +231,16 @@ mod tests {
         projection: Option<Vec<usize>>,
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let store_root = env!("CARGO_MANIFEST_DIR");
         let filename = "tests/jsons/2.json";
         let format = JsonFormat::default();
-        scan_format(&format, store_root, filename, projection, limit).await
+        scan_format(&format, ".", filename, projection, limit).await
     }
 
     #[tokio::test]
     async fn infer_schema_with_limit() {
         let store = Arc::new(LocalFileSystem::new()) as _;
+        let filename = "tests/jsons/schema_infer_limit.json";
         let format = JsonFormat::default().with_schema_infer_max_rec(Some(3));
-
-        let store_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        let filename = store_root.join("tests/jsons/schema_infer_limit.json");
-        let filename = filename.to_str().expect("Unable to get path!");
 
         let file_schema = format
             .infer_schema(&store, &[local_unpartitioned_file(filename)])

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -133,7 +133,6 @@ mod tests {
     use arrow::array::Int64Array;
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
-    use object_store::path::Path;
 
     use super::*;
     use crate::physical_plan::collect;

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -133,6 +133,7 @@ mod tests {
     use arrow::array::Int64Array;
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
+    use object_store::path::Path;
 
     use super::*;
     use crate::physical_plan::collect;
@@ -231,16 +232,20 @@ mod tests {
         projection: Option<Vec<usize>>,
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let store_root = env!("CARGO_MANIFEST_DIR");
         let filename = "tests/jsons/2.json";
         let format = JsonFormat::default();
-        scan_format(&format, ".", filename, projection, limit).await
+        scan_format(&format, store_root, filename, projection, limit).await
     }
 
     #[tokio::test]
     async fn infer_schema_with_limit() {
         let store = Arc::new(LocalFileSystem::new()) as _;
-        let filename = "tests/jsons/schema_infer_limit.json";
         let format = JsonFormat::default().with_schema_infer_max_rec(Some(3));
+
+        let store_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let filename = store_root.join("tests/jsons/schema_infer_limit.json");
+        let filename = filename.to_str().expect("Unable to get path!");
 
         let file_schema = format
             .infer_schema(&store, &[local_unpartitioned_file(filename)])

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -575,8 +575,7 @@ mod tests {
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
-    use object_store::{GetResult, ListResult, MultipartId};
-    use tokio::io::AsyncWrite;
+    use object_store::{GetResult, ListResult};
 
     #[tokio::test]
     async fn read_merged_batches() -> Result<()> {
@@ -647,22 +646,6 @@ mod tests {
     #[async_trait]
     impl ObjectStore for RequestCountingObjectStore {
         async fn put(&self, _location: &Path, _bytes: Bytes) -> object_store::Result<()> {
-            Err(object_store::Error::NotImplemented)
-        }
-
-        async fn put_multipart(
-            &self,
-            _location: &Path,
-        ) -> object_store::Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)>
-        {
-            Err(object_store::Error::NotImplemented)
-        }
-
-        async fn abort_multipart(
-            &self,
-            _location: &Path,
-            _multipart_id: &MultipartId,
-        ) -> object_store::Result<()> {
             Err(object_store::Error::NotImplemented)
         }
 

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -800,7 +800,7 @@ mod tests {
     use crate::from_slice::FromSlice;
     use crate::logical_plan::{col, lit};
     use crate::{assert_batches_eq, physical_optimizer::pruning::StatisticsType};
-    use arrow::array::Decimal128Array;
+    use arrow::array::{BasicDecimalArray, Decimal128Array};
     use arrow::{
         array::{BinaryArray, Int32Array, Int64Array, StringArray},
         datatypes::{DataType, TimeUnit},
@@ -1515,7 +1515,7 @@ mod tests {
         // decimal(9,2)
         let schema = Arc::new(Schema::new(vec![Field::new(
             "s1",
-            DataType::Decimal(9, 2),
+            DataType::Decimal128(9, 2),
             true,
         )]));
         // s1 > 5
@@ -1537,7 +1537,7 @@ mod tests {
         // decimal(18,2)
         let schema = Arc::new(Schema::new(vec![Field::new(
             "s1",
-            DataType::Decimal(18, 2),
+            DataType::Decimal128(18, 2),
             true,
         )]));
         // s1 > 5
@@ -1559,7 +1559,7 @@ mod tests {
         // decimal(23,2)
         let schema = Arc::new(Schema::new(vec![Field::new(
             "s1",
-            DataType::Decimal(23, 2),
+            DataType::Decimal128(23, 2),
             true,
         )]));
         // s1 > 5

--- a/datafusion/core/src/physical_plan/file_format/chunked_store.rs
+++ b/datafusion/core/src/physical_plan/file_format/chunked_store.rs
@@ -20,12 +20,11 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use object_store::path::Path;
+use object_store::Result;
 use object_store::{GetResult, ListResult, ObjectMeta, ObjectStore};
-use object_store::{MultipartId, Result};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::sync::Arc;
-use tokio::io::AsyncWrite;
 
 /// Wraps a [`ObjectStore`] and makes its get response return chunks
 ///
@@ -52,21 +51,6 @@ impl Display for ChunkedStore {
 impl ObjectStore for ChunkedStore {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.inner.put(location, bytes).await
-    }
-
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        self.inner.put_multipart(location).await
-    }
-
-    async fn abort_multipart(
-        &self,
-        location: &Path,
-        multipart_id: &MultipartId,
-    ) -> Result<()> {
-        self.inner.abort_multipart(location, multipart_id).await
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {

--- a/datafusion/core/src/physical_plan/file_format/chunked_store.rs
+++ b/datafusion/core/src/physical_plan/file_format/chunked_store.rs
@@ -20,11 +20,12 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use object_store::path::Path;
-use object_store::Result;
 use object_store::{GetResult, ListResult, ObjectMeta, ObjectStore};
+use object_store::{MultipartId, Result};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::sync::Arc;
+use tokio::io::AsyncWrite;
 
 /// Wraps a [`ObjectStore`] and makes its get response return chunks
 ///
@@ -51,6 +52,21 @@ impl Display for ChunkedStore {
 impl ObjectStore for ChunkedStore {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.inner.put(location, bytes).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn abort_multipart(
+        &self,
+        location: &Path,
+        multipart_id: &MultipartId,
+    ) -> Result<()> {
+        self.inner.abort_multipart(location, multipart_id).await
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -257,8 +257,7 @@ mod tests {
         let store_url = ObjectStoreUrl::local_filesystem();
         let store = ctx.runtime_env().object_store(&store_url).unwrap();
 
-        let store_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let path = store_root.join(TEST_DATA_BASE).join("1.json");
+        let path = format!("{}/1.json", TEST_DATA_BASE);
         let meta = local_unpartitioned_file(path);
         let schema = JsonFormat::default()
             .infer_schema(&store, &[meta.clone()])

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -257,7 +257,8 @@ mod tests {
         let store_url = ObjectStoreUrl::local_filesystem();
         let store = ctx.runtime_env().object_store(&store_url).unwrap();
 
-        let path = format!("{}/1.json", TEST_DATA_BASE);
+        let store_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let path = store_root.join(TEST_DATA_BASE).join("1.json");
         let meta = local_unpartitioned_file(path);
         let schema = JsonFormat::default()
             .infer_schema(&store, &[meta.clone()])

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -425,7 +425,7 @@ macro_rules! get_statistic {
             ParquetStatistics::Int32(s) => {
                 match $target_arrow_type {
                     // int32 to decimal with the precision and scale
-                    Some(DataType::Decimal(precision, scale)) => {
+                    Some(DataType::Decimal128(precision, scale)) => {
                         Some(ScalarValue::Decimal128(
                             Some(*s.$func() as i128),
                             precision,
@@ -438,7 +438,7 @@ macro_rules! get_statistic {
             ParquetStatistics::Int64(s) => {
                 match $target_arrow_type {
                     // int64 to decimal with the precision and scale
-                    Some(DataType::Decimal(precision, scale)) => {
+                    Some(DataType::Decimal128(precision, scale)) => {
                         Some(ScalarValue::Decimal128(
                             Some(*s.$func() as i128),
                             precision,
@@ -463,7 +463,7 @@ macro_rules! get_statistic {
             ParquetStatistics::FixedLenByteArray(s) => {
                 match $target_arrow_type {
                     // just support the decimal data type
-                    Some(DataType::Decimal(precision, scale)) => {
+                    Some(DataType::Decimal128(precision, scale)) => {
                         Some(ScalarValue::Decimal128(
                             Some(from_bytes_to_i128(s.$bytes_func())),
                             precision,
@@ -535,10 +535,10 @@ fn parquet_to_arrow_decimal_type(parquet_column: &ColumnDescriptor) -> Option<Da
     let type_ptr = parquet_column.self_type_ptr();
     match type_ptr.get_basic_info().logical_type() {
         Some(LogicalType::Decimal { scale, precision }) => {
-            Some(DataType::Decimal(precision as usize, scale as usize))
+            Some(DataType::Decimal128(precision as usize, scale as usize))
         }
         _ => match type_ptr.get_basic_info().converted_type() {
-            ConvertedType::DECIMAL => Some(DataType::Decimal(
+            ConvertedType::DECIMAL => Some(DataType::Decimal128(
                 type_ptr.get_precision() as usize,
                 type_ptr.get_scale() as usize,
             )),
@@ -1239,7 +1239,8 @@ mod tests {
     async fn parquet_exec_with_error() -> Result<()> {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
-        let location = Path::from_filesystem_path(".")
+        let store_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let location = Path::from_filesystem_path(store_root)
             .unwrap()
             .child("invalid.parquet");
 
@@ -1475,7 +1476,8 @@ mod tests {
 
         // INT32: c1 > 5, the c1 is decimal(9,2)
         let expr = col("c1").gt(lit(ScalarValue::Decimal128(Some(500), 9, 2)));
-        let schema = Schema::new(vec![Field::new("c1", DataType::Decimal(9, 2), false)]);
+        let schema =
+            Schema::new(vec![Field::new("c1", DataType::Decimal128(9, 2), false)]);
         let schema_descr = get_test_schema_descr(vec![(
             "c1",
             PhysicalType::INT32,
@@ -1516,7 +1518,8 @@ mod tests {
         // INT32: c1 > 5, but parquet decimal type has different precision or scale to arrow decimal
         // The decimal of arrow is decimal(5,2), the decimal of parquet is decimal(9,0)
         let expr = col("c1").gt(lit(ScalarValue::Decimal128(Some(500), 5, 2)));
-        let schema = Schema::new(vec![Field::new("c1", DataType::Decimal(5, 2), false)]);
+        let schema =
+            Schema::new(vec![Field::new("c1", DataType::Decimal128(5, 2), false)]);
         // The decimal of parquet is decimal(9,0)
         let schema_descr = get_test_schema_descr(vec![(
             "c1",
@@ -1568,7 +1571,8 @@ mod tests {
 
         // INT64: c1 < 5, the c1 is decimal(18,2)
         let expr = col("c1").lt(lit(ScalarValue::Decimal128(Some(500), 18, 2)));
-        let schema = Schema::new(vec![Field::new("c1", DataType::Decimal(18, 2), false)]);
+        let schema =
+            Schema::new(vec![Field::new("c1", DataType::Decimal128(18, 2), false)]);
         let schema_descr = get_test_schema_descr(vec![(
             "c1",
             PhysicalType::INT64,
@@ -1607,7 +1611,8 @@ mod tests {
         // FIXED_LENGTH_BYTE_ARRAY: c1 = 100, the c1 is decimal(28,2)
         // the type of parquet is decimal(18,2)
         let expr = col("c1").eq(lit(ScalarValue::Decimal128(Some(100000), 28, 3)));
-        let schema = Schema::new(vec![Field::new("c1", DataType::Decimal(18, 3), false)]);
+        let schema =
+            Schema::new(vec![Field::new("c1", DataType::Decimal128(18, 3), false)]);
         let schema_descr = get_test_schema_descr(vec![(
             "c1",
             PhysicalType::FIXED_LEN_BYTE_ARRAY,

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1239,8 +1239,7 @@ mod tests {
     async fn parquet_exec_with_error() -> Result<()> {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
-        let store_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        let location = Path::from_filesystem_path(store_root)
+        let location = Path::from_filesystem_path(".")
             .unwrap()
             .child("invalid.parquet");
 

--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -1098,8 +1098,8 @@ fn equal_rows(
             DataType::LargeUtf8 => {
                 equal_rows_elem!(LargeStringArray, l, r, left, right, null_equals_null)
             }
-            DataType::Decimal(_, lscale) => match r.data_type() {
-                DataType::Decimal(_, rscale) => {
+            DataType::Decimal128(_, lscale) => match r.data_type() {
+                DataType::Decimal128(_, rscale) => {
                     if lscale == rscale {
                         equal_rows_elem!(
                             Decimal128Array,

--- a/datafusion/core/src/physical_plan/hash_utils.rs
+++ b/datafusion/core/src/physical_plan/hash_utils.rs
@@ -336,7 +336,7 @@ pub fn create_hashes<'a>(
             DataType::Null => {
                 hash_null(random_state, hashes_buffer, multi_col);
             }
-            DataType::Decimal(_, _) => {
+            DataType::Decimal128(_, _) => {
                 hash_decimal128(col, random_state, hashes_buffer, multi_col);
             }
             DataType::UInt8 => {

--- a/datafusion/core/src/physical_plan/repartition.rs
+++ b/datafusion/core/src/physical_plan/repartition.rs
@@ -933,7 +933,7 @@ mod tests {
         let items_set: HashSet<&str> = items_vec.iter().copied().collect();
         assert_eq!(items_vec.len(), items_set.len());
         let source_str_set: HashSet<&str> =
-            (&["foo", "bar", "frob", "baz", "goo", "gar", "grob", "gaz"])
+            ["foo", "bar", "frob", "baz", "goo", "gar", "grob", "gaz"]
                 .iter()
                 .copied()
                 .collect();

--- a/datafusion/core/src/physical_plan/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/sort_merge_join.rs
@@ -1098,7 +1098,7 @@ fn compare_join_arrays(
             DataType::Float64 => compare_value!(Float64Array),
             DataType::Utf8 => compare_value!(StringArray),
             DataType::LargeUtf8 => compare_value!(LargeStringArray),
-            DataType::Decimal(..) => compare_value!(Decimal128Array),
+            DataType::Decimal128(..) => compare_value!(Decimal128Array),
             DataType::Timestamp(time_unit, None) => match time_unit {
                 TimeUnit::Second => compare_value!(TimestampSecondArray),
                 TimeUnit::Millisecond => compare_value!(TimestampMillisecondArray),
@@ -1164,7 +1164,7 @@ fn is_join_arrays_equal(
             DataType::Float64 => compare_value!(Float64Array),
             DataType::Utf8 => compare_value!(StringArray),
             DataType::LargeUtf8 => compare_value!(LargeStringArray),
-            DataType::Decimal(..) => compare_value!(Decimal128Array),
+            DataType::Decimal128(..) => compare_value!(Decimal128Array),
             DataType::Timestamp(time_unit, None) => match time_unit {
                 TimeUnit::Second => compare_value!(TimestampSecondArray),
                 TimeUnit::Millisecond => compare_value!(TimestampMillisecondArray),

--- a/datafusion/core/src/scheduler/plan.rs
+++ b/datafusion/core/src/scheduler/plan.rs
@@ -29,7 +29,7 @@ use crate::scheduler::pipeline::{
 };
 
 /// Identifies the [`Pipeline`] within the [`PipelinePlan`] to route output to
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutputLink {
     /// The index of the [`Pipeline`] in [`PipelinePlan`] to route output to
     pub pipeline: usize,

--- a/datafusion/core/src/scheduler/task.rs
+++ b/datafusion/core/src/scheduler/task.rs
@@ -137,7 +137,7 @@ impl Task {
         let partition = self.waker.partition;
 
         let waker = futures::task::waker_ref(&self.waker);
-        let mut cx = Context::from_waker(&*waker);
+        let mut cx = Context::from_waker(&waker);
 
         let pipelines = &self.context.pipelines;
         let routable = &pipelines[node];

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -223,7 +223,6 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
     let dir = env!("CARGO_MANIFEST_DIR");
 
     let pb = PathBuf::from(dir).join(submodule_data);
-    let pb = pb.canonicalize()?;
     if pb.is_dir() {
         Ok(pb)
     } else {
@@ -326,9 +325,9 @@ mod tests {
     #[test]
     fn test_data_dir() {
         let udf_env = "get_data_dir";
-        let cwd = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let cwd = env::current_dir().unwrap();
 
-        let existing_pb = cwd.join("..").canonicalize().unwrap();
+        let existing_pb = cwd.join("..");
         let existing = existing_pb.display().to_string();
         let existing_str = existing.as_str();
 

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -223,6 +223,7 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
     let dir = env!("CARGO_MANIFEST_DIR");
 
     let pb = PathBuf::from(dir).join(submodule_data);
+    let pb = pb.canonicalize()?;
     if pb.is_dir() {
         Ok(pb)
     } else {
@@ -325,9 +326,9 @@ mod tests {
     #[test]
     fn test_data_dir() {
         let udf_env = "get_data_dir";
-        let cwd = env::current_dir().unwrap();
+        let cwd = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
 
-        let existing_pb = cwd.join("..");
+        let existing_pb = cwd.join("..").canonicalize().unwrap();
         let existing = existing_pb.display().to_string();
         let existing_str = existing.as_str();
 

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -20,7 +20,7 @@
 //! expected.
 use std::sync::Arc;
 
-use arrow::array::Decimal128Array;
+use arrow::array::{BasicDecimalArray, Decimal128Array};
 use arrow::{
     array::{
         Array, ArrayRef, Date32Array, Date64Array, Float64Array, Int32Array, StringArray,
@@ -881,7 +881,7 @@ fn make_f64_batch(v: Vec<f64>) -> RecordBatch {
 fn make_decimal_batch(v: Vec<i128>, precision: usize, scale: usize) -> RecordBatch {
     let schema = Arc::new(Schema::new(vec![Field::new(
         "decimal_col",
-        DataType::Decimal(precision, scale),
+        DataType::Decimal128(precision, scale),
         true,
     )]));
     let array = Arc::new(

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -40,7 +40,10 @@ use datafusion::{
 use datafusion_common::ScalarValue;
 use futures::stream::BoxStream;
 use futures::{stream, StreamExt};
-use object_store::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore};
+use object_store::{
+    path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
+};
+use tokio::io::AsyncWrite;
 
 #[tokio::test]
 async fn parquet_distinct_partition_col() -> Result<()> {
@@ -513,6 +516,21 @@ impl MirroringObjectStore {
 #[async_trait]
 impl ObjectStore for MirroringObjectStore {
     async fn put(&self, _location: &Path, _bytes: Bytes) -> object_store::Result<()> {
+        unimplemented!()
+    }
+
+    async fn put_multipart(
+        &self,
+        _location: &Path,
+    ) -> object_store::Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        unimplemented!()
+    }
+
+    async fn abort_multipart(
+        &self,
+        _location: &Path,
+        _multipart_id: &MultipartId,
+    ) -> object_store::Result<()> {
         unimplemented!()
     }
 

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -40,10 +40,7 @@ use datafusion::{
 use datafusion_common::ScalarValue;
 use futures::stream::BoxStream;
 use futures::{stream, StreamExt};
-use object_store::{
-    path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
-};
-use tokio::io::AsyncWrite;
+use object_store::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore};
 
 #[tokio::test]
 async fn parquet_distinct_partition_col() -> Result<()> {
@@ -516,21 +513,6 @@ impl MirroringObjectStore {
 #[async_trait]
 impl ObjectStore for MirroringObjectStore {
     async fn put(&self, _location: &Path, _bytes: Bytes) -> object_store::Result<()> {
-        unimplemented!()
-    }
-
-    async fn put_multipart(
-        &self,
-        _location: &Path,
-    ) -> object_store::Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        unimplemented!()
-    }
-
-    async fn abort_multipart(
-        &self,
-        _location: &Path,
-        _multipart_id: &MultipartId,
-    ) -> object_store::Result<()> {
         unimplemented!()
     }
 

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -1472,7 +1472,7 @@ async fn aggregate_decimal_min() -> Result<()> {
         "+-----------------+",
     ];
     assert_eq!(
-        &DataType::Decimal(10, 3),
+        &DataType::Decimal128(10, 3),
         result[0].schema().field(0).data_type()
     );
     assert_batches_sorted_eq!(expected, &result);
@@ -1496,7 +1496,7 @@ async fn aggregate_decimal_max() -> Result<()> {
         "+-----------------+",
     ];
     assert_eq!(
-        &DataType::Decimal(10, 3),
+        &DataType::Decimal128(10, 3),
         result[0].schema().field(0).data_type()
     );
     assert_batches_sorted_eq!(expected, &result);
@@ -1519,7 +1519,7 @@ async fn aggregate_decimal_sum() -> Result<()> {
         "+-----------------+",
     ];
     assert_eq!(
-        &DataType::Decimal(20, 3),
+        &DataType::Decimal128(20, 3),
         result[0].schema().field(0).data_type()
     );
     assert_batches_sorted_eq!(expected, &result);
@@ -1542,7 +1542,7 @@ async fn aggregate_decimal_avg() -> Result<()> {
         "+-----------------+",
     ];
     assert_eq!(
-        &DataType::Decimal(14, 7),
+        &DataType::Decimal128(14, 7),
         result[0].schema().field(0).data_type()
     );
     assert_batches_sorted_eq!(expected, &result);

--- a/datafusion/core/tests/sql/decimal.rs
+++ b/datafusion/core/tests/sql/decimal.rs
@@ -23,45 +23,45 @@ async fn decimal_cast() -> Result<()> {
     let sql = "select cast(1.23 as decimal(10,4))";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 4),
+        &DataType::Decimal128(10, 4),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
-        "+---------------------------------------+",
-        "| CAST(Float64(1.23) AS Decimal(10, 4)) |",
-        "+---------------------------------------+",
-        "| 1.2300                                |",
-        "+---------------------------------------+",
+        "+------------------------------------------+",
+        "| CAST(Float64(1.23) AS Decimal128(10, 4)) |",
+        "+------------------------------------------+",
+        "| 1.2300                                   |",
+        "+------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
 
     let sql = "select cast(cast(1.23 as decimal(10,3)) as decimal(10,4))";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 4),
+        &DataType::Decimal128(10, 4),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
-        "+---------------------------------------------------------------+",
-        "| CAST(CAST(Float64(1.23) AS Decimal(10, 3)) AS Decimal(10, 4)) |",
-        "+---------------------------------------------------------------+",
-        "| 1.2300                                                        |",
-        "+---------------------------------------------------------------+",
+        "+---------------------------------------------------------------------+",
+        "| CAST(CAST(Float64(1.23) AS Decimal128(10, 3)) AS Decimal128(10, 4)) |",
+        "+---------------------------------------------------------------------+",
+        "| 1.2300                                                              |",
+        "+---------------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
 
     let sql = "select cast(1.2345 as decimal(24,2))";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(24, 2),
+        &DataType::Decimal128(24, 2),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
-        "+-----------------------------------------+",
-        "| CAST(Float64(1.2345) AS Decimal(24, 2)) |",
-        "+-----------------------------------------+",
-        "| 1.23                                    |",
-        "+-----------------------------------------+",
+        "+--------------------------------------------+",
+        "| CAST(Float64(1.2345) AS Decimal128(24, 2)) |",
+        "+--------------------------------------------+",
+        "| 1.23                                       |",
+        "+--------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
 
@@ -75,7 +75,7 @@ async fn decimal_by_sql() -> Result<()> {
     let sql = "SELECT c1 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -110,7 +110,7 @@ async fn decimal_by_filter() -> Result<()> {
     let sql = "select c1 from decimal_simple where c1 > 0.000030";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -133,11 +133,11 @@ async fn decimal_by_filter() -> Result<()> {
     let sql = "select * from decimal_simple where c1 > c5";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     assert_eq!(
-        &DataType::Decimal(12, 7),
+        &DataType::Decimal128(12, 7),
         actual[0].schema().field(4).data_type()
     );
     let expected = vec![
@@ -161,7 +161,7 @@ async fn decimal_agg_function() -> Result<()> {
     let sql = "select min(c1) from decimal_simple where c4=false";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -176,7 +176,7 @@ async fn decimal_agg_function() -> Result<()> {
     let sql = "select max(c1) from decimal_simple where c4=false";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -193,7 +193,7 @@ async fn decimal_agg_function() -> Result<()> {
     let actual = execute_to_batches(&ctx, sql).await;
     // inferred precision is 10+10
     assert_eq!(
-        &DataType::Decimal(20, 6),
+        &DataType::Decimal128(20, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -211,7 +211,7 @@ async fn decimal_agg_function() -> Result<()> {
     let sql = "select avg(c1) from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(14, 10),
+        &DataType::Decimal128(14, 10),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -234,7 +234,7 @@ async fn decimal_logic_op() -> Result<()> {
     let sql = "select * from decimal_simple where c1=CAST(0.00002 as Decimal(10,8))";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -274,7 +274,7 @@ async fn decimal_logic_op() -> Result<()> {
     let sql = "select * from decimal_simple where 0.00002 > c1";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -290,7 +290,7 @@ async fn decimal_logic_op() -> Result<()> {
     let sql = "select * from decimal_simple where c1 <= 0.00002";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -308,7 +308,7 @@ async fn decimal_logic_op() -> Result<()> {
     let sql = "select * from decimal_simple where c1 > 0.00002";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -335,7 +335,7 @@ async fn decimal_logic_op() -> Result<()> {
     let sql = "select * from decimal_simple where c1 >= 0.00002";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -372,7 +372,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let actual = execute_to_batches(&ctx, sql).await;
     // array decimal(10,6) +  scalar decimal(20,0) => decimal(21,6)
     assert_eq!(
-        &DataType::Decimal(27, 6),
+        &DataType::Decimal128(27, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -401,7 +401,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1+c5 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(13, 7),
+        &DataType::Decimal128(13, 7),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -430,7 +430,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1-1 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(27, 6),
+        &DataType::Decimal128(27, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -459,7 +459,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1-c5 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(13, 7),
+        &DataType::Decimal128(13, 7),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -488,7 +488,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1*20 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(31, 6),
+        &DataType::Decimal128(31, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -517,7 +517,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1*c5 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(23, 13),
+        &DataType::Decimal128(23, 13),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -546,36 +546,36 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c1/cast(0.00001 as decimal(5,5)) from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(21, 12),
+        &DataType::Decimal128(21, 12),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
-        "+-------------------------------------------------------------+",
-        "| decimal_simple.c1 / CAST(Float64(0.00001) AS Decimal(5, 5)) |",
-        "+-------------------------------------------------------------+",
-        "| 1.000000000000                                              |",
-        "| 2.000000000000                                              |",
-        "| 2.000000000000                                              |",
-        "| 3.000000000000                                              |",
-        "| 3.000000000000                                              |",
-        "| 3.000000000000                                              |",
-        "| 4.000000000000                                              |",
-        "| 4.000000000000                                              |",
-        "| 4.000000000000                                              |",
-        "| 4.000000000000                                              |",
-        "| 5.000000000000                                              |",
-        "| 5.000000000000                                              |",
-        "| 5.000000000000                                              |",
-        "| 5.000000000000                                              |",
-        "| 5.000000000000                                              |",
-        "+-------------------------------------------------------------+",
+        "+----------------------------------------------------------------+",
+        "| decimal_simple.c1 / CAST(Float64(0.00001) AS Decimal128(5, 5)) |",
+        "+----------------------------------------------------------------+",
+        "| 1.000000000000                                                 |",
+        "| 2.000000000000                                                 |",
+        "| 2.000000000000                                                 |",
+        "| 3.000000000000                                                 |",
+        "| 3.000000000000                                                 |",
+        "| 3.000000000000                                                 |",
+        "| 4.000000000000                                                 |",
+        "| 4.000000000000                                                 |",
+        "| 4.000000000000                                                 |",
+        "| 4.000000000000                                                 |",
+        "| 5.000000000000                                                 |",
+        "| 5.000000000000                                                 |",
+        "| 5.000000000000                                                 |",
+        "| 5.000000000000                                                 |",
+        "| 5.000000000000                                                 |",
+        "+----------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
 
     let sql = "select c1/c5 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(30, 19),
+        &DataType::Decimal128(30, 19),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -605,36 +605,36 @@ async fn decimal_arithmetic_op() -> Result<()> {
     let sql = "select c5%cast(0.00001 as decimal(5,5)) from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(7, 7),
+        &DataType::Decimal128(7, 7),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
-        "+-------------------------------------------------------------+",
-        "| decimal_simple.c5 % CAST(Float64(0.00001) AS Decimal(5, 5)) |",
-        "+-------------------------------------------------------------+",
-        "| 0.0000040                                                   |",
-        "| 0.0000050                                                   |",
-        "| 0.0000090                                                   |",
-        "| 0.0000020                                                   |",
-        "| 0.0000050                                                   |",
-        "| 0.0000010                                                   |",
-        "| 0.0000040                                                   |",
-        "| 0.0000000                                                   |",
-        "| 0.0000000                                                   |",
-        "| 0.0000040                                                   |",
-        "| 0.0000020                                                   |",
-        "| 0.0000080                                                   |",
-        "| 0.0000030                                                   |",
-        "| 0.0000080                                                   |",
-        "| 0.0000000                                                   |",
-        "+-------------------------------------------------------------+",
+        "+----------------------------------------------------------------+",
+        "| decimal_simple.c5 % CAST(Float64(0.00001) AS Decimal128(5, 5)) |",
+        "+----------------------------------------------------------------+",
+        "| 0.0000040                                                      |",
+        "| 0.0000050                                                      |",
+        "| 0.0000090                                                      |",
+        "| 0.0000020                                                      |",
+        "| 0.0000050                                                      |",
+        "| 0.0000010                                                      |",
+        "| 0.0000040                                                      |",
+        "| 0.0000000                                                      |",
+        "| 0.0000000                                                      |",
+        "| 0.0000040                                                      |",
+        "| 0.0000020                                                      |",
+        "| 0.0000080                                                      |",
+        "| 0.0000030                                                      |",
+        "| 0.0000080                                                      |",
+        "| 0.0000000                                                      |",
+        "+----------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
 
     let sql = "select c1%c5 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(11, 7),
+        &DataType::Decimal128(11, 7),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -670,7 +670,7 @@ async fn decimal_sort() -> Result<()> {
     let sql = "select * from decimal_simple where c1 >= 0.00004 order by c1";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -693,7 +693,7 @@ async fn decimal_sort() -> Result<()> {
     let sql = "select * from decimal_simple where c1 >= 0.00004 order by c1 desc";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -716,7 +716,7 @@ async fn decimal_sort() -> Result<()> {
     let sql = "select * from decimal_simple where c1 < 0.00003 order by c1 desc,c4";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(0).data_type()
     );
     let expected = vec![
@@ -740,7 +740,7 @@ async fn decimal_group_function() -> Result<()> {
     let sql = "select count(*),c1 from decimal_simple group by c1 order by c1";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(1).data_type()
     );
     let expected = vec![
@@ -759,7 +759,7 @@ async fn decimal_group_function() -> Result<()> {
     let sql = "select count(*),c1,c4 from decimal_simple group by c1,c4 order by c1,c4";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
-        &DataType::Decimal(10, 6),
+        &DataType::Decimal128(10, 6),
         actual[0].schema().field(1).data_type()
     );
     let expected = vec![

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -43,8 +43,9 @@ async fn test_cast_expressions_error() -> Result<()> {
     match result {
         Ok(_) => panic!("expected error"),
         Err(e) => {
-            assert_contains!(e.to_string(),
-                             "Cast error: Cannot cast string 'c' to value of arrow::datatypes::types::Int32Type type"
+            assert_contains!(
+                e.to_string(),
+                "Cannot cast string 'c' to value of Int32 type"
             );
         }
     }

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -1265,10 +1265,10 @@ async fn hash_join_with_date32() -> Result<()> {
     let plan = state.optimize(&plan)?;
     let expected = vec![
         "Explain [plan_type:Utf8, plan:Utf8]",
-        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "    Inner Join: #t1.c1 = #t2.c1 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "    Inner Join: #t1.c1 = #t2.c1 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -1307,10 +1307,10 @@ async fn hash_join_with_date64() -> Result<()> {
     let plan = state.optimize(&plan)?;
     let expected = vec![
         "Explain [plan_type:Utf8, plan:Utf8]",
-        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "    Left Join: #t1.c2 = #t2.c2 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "    Left Join: #t1.c2 = #t2.c2 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -1351,10 +1351,10 @@ async fn hash_join_with_decimal() -> Result<()> {
     let plan = state.optimize(&plan)?;
     let expected = vec![
     "Explain [plan_type:Utf8, plan:Utf8]",
-    "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-    "    Right Join: #t1.c3 = #t2.c3 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-    "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
-    "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+    "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+    "    Right Join: #t1.c3 = #t2.c3 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+    "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
+    "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
@@ -1395,10 +1395,10 @@ async fn hash_join_with_dictionary() -> Result<()> {
     let plan = state.optimize(&plan)?;
     let expected = vec![
         "Explain [plan_type:Utf8, plan:Utf8]",
-        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "    Inner Join: #t1.c4 = #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
-        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "  Projection: #t1.c1, #t1.c2, #t1.c3, #t1.c4, #t2.c1, #t2.c2, #t2.c3, #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "    Inner Join: #t1.c4 = #t2.c4 [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N, c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t1 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(5, 2);N, c4:Dictionary(Int32, Utf8);N]",
+        "      TableScan: t2 projection=[c1, c2, c3, c4] [c1:Date32;N, c2:Date64;N, c3:Decimal128(10, 2);N, c4:Dictionary(Int32, Utf8);N]",
     ];
     let formatted = plan.display_indent_schema().to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -279,7 +279,7 @@ fn create_hashjoin_datatype_context() -> Result<SessionContext> {
     let t1_schema = Schema::new(vec![
         Field::new("c1", DataType::Date32, true),
         Field::new("c2", DataType::Date64, true),
-        Field::new("c3", DataType::Decimal(5, 2), true),
+        Field::new("c3", DataType::Decimal128(5, 2), true),
         Field::new(
             "c4",
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
@@ -312,7 +312,7 @@ fn create_hashjoin_datatype_context() -> Result<SessionContext> {
     let t2_schema = Schema::new(vec![
         Field::new("c1", DataType::Date32, true),
         Field::new("c2", DataType::Date64, true),
-        Field::new("c3", DataType::Decimal(10, 2), true),
+        Field::new("c3", DataType::Decimal128(10, 2), true),
         Field::new(
             "c4",
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
-datafusion-common = { path = "../common", features = [], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
+datafusion-common = { path = "../common", version = "10.0.0" }
 sqlparser = "0.20"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { version = "19.0.0", features = ["prettyprint"] }
-datafusion-common = { path = "../common", version = "10.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+datafusion-common = { path = "../common", features = [], optional = false }
 sqlparser = "0.20"

--- a/datafusion/expr/src/type_coercion.rs
+++ b/datafusion/expr/src/type_coercion.rs
@@ -182,7 +182,7 @@ pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
                 | UInt64
                 | Float32
                 | Float64
-                | Decimal(_, _)
+                | Decimal128(_, _)
         ),
         Timestamp(TimeUnit::Nanosecond, None) => {
             matches!(type_from, Null | Timestamp(_, None))

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -689,7 +689,7 @@ pub fn can_hash(data_type: &DataType) -> bool {
         },
         DataType::Utf8 => true,
         DataType::LargeUtf8 => true,
-        DataType::Decimal(_, _) => true,
+        DataType::Decimal128(_, _) => true,
         DataType::Date32 => true,
         DataType::Date64 => true,
         DataType::Dictionary(key_type, value_type)

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,12 +36,12 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow = { version = "20.0.0" }
 cranelift = "0.86.1"
 cranelift-jit = "0.86.1"
 cranelift-module = "0.86.1"
 cranelift-native = "0.86.1"
-datafusion-common = { path = "../common", features = ["jit"], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
+datafusion-common = { path = "../common", version = "10.0.0", features = ["jit"] }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
 
 parking_lot = "0.12"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,12 +36,12 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { version = "19.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 cranelift = "0.86.1"
 cranelift-jit = "0.86.1"
 cranelift-module = "0.86.1"
 cranelift-native = "0.86.1"
-datafusion-common = { path = "../common", version = "10.0.0", features = ["jit"] }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
+datafusion-common = { path = "../common", features = ["jit"], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
 
 parking_lot = "0.12"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -37,12 +37,12 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", features = [], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
-datafusion-physical-expr = { path = "../physical-expr", features = [], optional = false }
+datafusion-common = { path = "../common", version = "10.0.0" }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
+datafusion-physical-expr = { path = "../physical-expr", version = "10.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = "^0.4"
 

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -37,12 +37,12 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { version = "19.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "10.0.0" }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "10.0.0" }
+datafusion-common = { path = "../common", features = [], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
+datafusion-physical-expr = { path = "../physical-expr", features = [], optional = false }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = "^0.4"
 

--- a/datafusion/optimizer/src/decorrelate_scalar_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_scalar_subquery.rs
@@ -69,7 +69,7 @@ impl DecorrelateScalarSubquery {
                                 _ => return Ok(()),
                             };
                             let subquery =
-                                self.optimize(&*subquery.subquery, optimizer_config)?;
+                                self.optimize(&subquery.subquery, optimizer_config)?;
                             let subquery = Arc::new(subquery);
                             let subquery = Subquery { subquery };
                             let res = SubqueryInfo::new(subquery, expr, *op, lhs);
@@ -163,7 +163,7 @@ fn optimize_scalar(
         "optimizing:\n{}",
         query_info.query.subquery.display_indent()
     );
-    let proj = Projection::try_from_plan(&*query_info.query.subquery)
+    let proj = Projection::try_from_plan(&query_info.query.subquery)
         .map_err(|e| context!("scalar subqueries must have a projection", e))?;
     let proj = only_or_err(proj.expr.as_slice())
         .map_err(|e| context!("exactly one expression should be projected", e))?;
@@ -173,7 +173,7 @@ fn optimize_scalar(
         .map_err(|e| context!("Exactly one input is expected. Is this a join?", e))?;
     let aggr = Aggregate::try_from_plan(sub_input)
         .map_err(|e| context!("scalar subqueries must aggregate a value", e))?;
-    let filter = Filter::try_from_plan(&*aggr.input).map_err(|e| {
+    let filter = Filter::try_from_plan(&aggr.input).map_err(|e| {
         context!("scalar subqueries must have a filter to be correlated", e)
     })?;
 

--- a/datafusion/optimizer/src/decorrelate_where_exists.rs
+++ b/datafusion/optimizer/src/decorrelate_where_exists.rs
@@ -56,8 +56,7 @@ impl DecorrelateWhereExists {
         for it in filters.iter() {
             match it {
                 Expr::Exists { subquery, negated } => {
-                    let subquery =
-                        self.optimize(&*subquery.subquery, optimizer_config)?;
+                    let subquery = self.optimize(&subquery.subquery, optimizer_config)?;
                     let subquery = Arc::new(subquery);
                     let subquery = Subquery { subquery };
                     let subquery = SubqueryInfo::new(subquery.clone(), *negated);

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -60,8 +60,7 @@ impl DecorrelateWhereIn {
                     subquery,
                     negated,
                 } => {
-                    let subquery =
-                        self.optimize(&*subquery.subquery, optimizer_config)?;
+                    let subquery = self.optimize(&subquery.subquery, optimizer_config)?;
                     let subquery = Arc::new(subquery);
                     let subquery = Subquery { subquery };
                     let subquery =
@@ -132,7 +131,7 @@ fn optimize_where_in(
     outer_other_exprs: &[Expr],
     optimizer_config: &mut OptimizerConfig,
 ) -> datafusion_common::Result<LogicalPlan> {
-    let proj = Projection::try_from_plan(&*query_info.query.subquery)
+    let proj = Projection::try_from_plan(&query_info.query.subquery)
         .map_err(|e| context!("a projection is required", e))?;
     let mut subqry_input = proj.input.clone();
     let proj = only_or_err(proj.expr.as_slice())

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -159,15 +159,7 @@ fn is_false(expr: &Expr) -> bool {
 
 /// returns true if `haystack` looks like (needle OP X) or (X OP needle)
 fn is_op_with(target_op: Operator, haystack: &Expr, needle: &Expr) -> bool {
-    match haystack {
-        Expr::BinaryExpr { left, op, right }
-            if op == &target_op
-                && (needle == left.as_ref() || needle == right.as_ref()) =>
-        {
-            true
-        }
-        _ => false,
-    }
+    matches!(haystack, Expr::BinaryExpr { left, op, right } if op == &target_op && (needle == left.as_ref() || needle == right.as_ref()))
 }
 
 /// returns the contained boolean value in `expr` as
@@ -1903,7 +1895,7 @@ mod tests {
         let optimized_plan = rule
             .optimize(plan, &mut config)
             .expect("failed to optimize plan");
-        return format!("{:?}", optimized_plan);
+        format!("{:?}", optimized_plan)
     }
 
     #[test]

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -1963,8 +1963,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected =
-            "Cannot cast string '' to value of arrow::datatypes::types::Int32Type type";
+        let expected = "Cannot cast string '' to value of Int32 type";
         let actual = get_optimized_plan_err(&plan, &Utc::now());
         assert_contains!(actual, expected);
     }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,13 +40,13 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { version = "19.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "10.0.0" }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
-datafusion-row = { path = "../row", version = "10.0.0" }
+datafusion-common = { path = "../common", features = [], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
+datafusion-row = { path = "../row", features = [], optional = false }
 hashbrown = { version = "0.12", features = ["raw"] }
 lazy_static = { version = "^1.4.0" }
 md-5 = { version = "^0.10.0", optional = true }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,13 +40,13 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", features = [], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
-datafusion-row = { path = "../row", features = [], optional = false }
+datafusion-common = { path = "../common", version = "10.0.0" }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
+datafusion-row = { path = "../row", version = "10.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }
 lazy_static = { version = "^1.4.0" }
 md-5 = { version = "^0.10.0", optional = true }

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -54,7 +54,7 @@ impl Avg {
         // the result of avg just support FLOAT64 and Decimal data type.
         assert!(matches!(
             data_type,
-            DataType::Float64 | DataType::Decimal(_, _)
+            DataType::Float64 | DataType::Decimal128(_, _)
         ));
         Self {
             name: name.into(),
@@ -301,10 +301,10 @@ mod tests {
 
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Avg,
             ScalarValue::Decimal128(Some(35000), 14, 4),
-            DataType::Decimal(14, 4)
+            DataType::Decimal128(14, 4)
         )
     }
 
@@ -318,10 +318,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Avg,
             ScalarValue::Decimal128(Some(32500), 14, 4),
-            DataType::Decimal(14, 4)
+            DataType::Decimal128(14, 4)
         )
     }
 
@@ -336,10 +336,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Avg,
             ScalarValue::Decimal128(None, 14, 4),
-            DataType::Decimal(14, 4)
+            DataType::Decimal128(14, 4)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -292,7 +292,7 @@ mod tests {
             DataType::Int32,
             DataType::Float32,
             DataType::Float64,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             DataType::Utf8,
         ];
         for fun in funcs {
@@ -453,7 +453,7 @@ mod tests {
             DataType::Int32,
             DataType::Float32,
             DataType::Float64,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             DataType::Utf8,
         ];
         for fun in funcs {
@@ -898,7 +898,7 @@ mod tests {
 
         let observed = return_type(
             &AggregateFunction::ApproxMedian,
-            &[DataType::Decimal(10, 6)],
+            &[DataType::Decimal128(10, 6)],
         );
         assert!(observed.is_err());
 
@@ -914,13 +914,14 @@ mod tests {
         assert_eq!(DataType::Int32, observed);
 
         // test decimal for min
-        let observed = return_type(&AggregateFunction::Min, &[DataType::Decimal(10, 6)])?;
-        assert_eq!(DataType::Decimal(10, 6), observed);
+        let observed =
+            return_type(&AggregateFunction::Min, &[DataType::Decimal128(10, 6)])?;
+        assert_eq!(DataType::Decimal128(10, 6), observed);
 
         // test decimal for max
         let observed =
-            return_type(&AggregateFunction::Max, &[DataType::Decimal(28, 13)])?;
-        assert_eq!(DataType::Decimal(28, 13), observed);
+            return_type(&AggregateFunction::Max, &[DataType::Decimal128(28, 13)])?;
+        assert_eq!(DataType::Decimal128(28, 13), observed);
 
         Ok(())
     }
@@ -939,11 +940,13 @@ mod tests {
         let observed = return_type(&AggregateFunction::Sum, &[DataType::Float64])?;
         assert_eq!(DataType::Float64, observed);
 
-        let observed = return_type(&AggregateFunction::Sum, &[DataType::Decimal(10, 5)])?;
-        assert_eq!(DataType::Decimal(20, 5), observed);
+        let observed =
+            return_type(&AggregateFunction::Sum, &[DataType::Decimal128(10, 5)])?;
+        assert_eq!(DataType::Decimal128(20, 5), observed);
 
-        let observed = return_type(&AggregateFunction::Sum, &[DataType::Decimal(35, 5)])?;
-        assert_eq!(DataType::Decimal(38, 5), observed);
+        let observed =
+            return_type(&AggregateFunction::Sum, &[DataType::Decimal128(35, 5)])?;
+        assert_eq!(DataType::Decimal128(38, 5), observed);
 
         Ok(())
     }
@@ -970,7 +973,7 @@ mod tests {
         assert_eq!(DataType::Int64, observed);
 
         let observed =
-            return_type(&AggregateFunction::Count, &[DataType::Decimal(28, 13)])?;
+            return_type(&AggregateFunction::Count, &[DataType::Decimal128(28, 13)])?;
         assert_eq!(DataType::Int64, observed);
         Ok(())
     }
@@ -986,11 +989,13 @@ mod tests {
         let observed = return_type(&AggregateFunction::Avg, &[DataType::Int32])?;
         assert_eq!(DataType::Float64, observed);
 
-        let observed = return_type(&AggregateFunction::Avg, &[DataType::Decimal(10, 6)])?;
-        assert_eq!(DataType::Decimal(14, 10), observed);
+        let observed =
+            return_type(&AggregateFunction::Avg, &[DataType::Decimal128(10, 6)])?;
+        assert_eq!(DataType::Decimal128(14, 10), observed);
 
-        let observed = return_type(&AggregateFunction::Avg, &[DataType::Decimal(36, 6)])?;
-        assert_eq!(DataType::Decimal(38, 10), observed);
+        let observed =
+            return_type(&AggregateFunction::Avg, &[DataType::Decimal128(36, 6)])?;
+        assert_eq!(DataType::Decimal128(38, 10), observed);
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -207,7 +207,7 @@ macro_rules! typed_min_max_batch_decimal128 {
 macro_rules! min_max_batch {
     ($VALUES:expr, $OP:ident) => {{
         match $VALUES.data_type() {
-            DataType::Decimal(precision, scale) => {
+            DataType::Decimal128(precision, scale) => {
                 typed_min_max_batch_decimal128!($VALUES, precision, scale, $OP)
             }
             // all types that have a natural order
@@ -803,10 +803,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Min,
             ScalarValue::Decimal128(Some(1), 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 
@@ -821,10 +821,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Min,
             ScalarValue::Decimal128(None, 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 
@@ -840,10 +840,10 @@ mod tests {
 
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Min,
             ScalarValue::Decimal128(Some(1), 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 
@@ -892,10 +892,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Max,
             ScalarValue::Decimal128(Some(5), 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 
@@ -909,10 +909,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Max,
             ScalarValue::Decimal128(Some(5), 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 
@@ -926,10 +926,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Min,
             ScalarValue::Decimal128(None, 10, 0),
-            DataType::Decimal(10, 0)
+            DataType::Decimal128(10, 0)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -176,7 +176,7 @@ fn sum_decimal_batch(
 pub(crate) fn sum_batch(values: &ArrayRef, sum_type: &DataType) -> Result<ScalarValue> {
     let values = &cast(values, sum_type)?;
     Ok(match values.data_type() {
-        DataType::Decimal(precision, scale) => {
+        DataType::Decimal128(precision, scale) => {
             sum_decimal_batch(values, precision, scale)?
         }
         DataType::Float64 => typed_sum_delta_batch!(values, Float64Array, Float64),
@@ -544,7 +544,7 @@ mod tests {
                 .collect::<Decimal128Array>()
                 .with_precision_and_scale(10, 0)?,
         );
-        let result = sum_batch(&array, &DataType::Decimal(10, 0))?;
+        let result = sum_batch(&array, &DataType::Decimal128(10, 0))?;
         assert_eq!(ScalarValue::Decimal128(Some(15), 10, 0), result);
 
         // test agg
@@ -557,10 +557,10 @@ mod tests {
 
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Sum,
             ScalarValue::Decimal128(Some(15), 20, 0),
-            DataType::Decimal(20, 0)
+            DataType::Decimal128(20, 0)
         )
     }
 
@@ -579,7 +579,7 @@ mod tests {
                 .collect::<Decimal128Array>()
                 .with_precision_and_scale(10, 0)?,
         );
-        let result = sum_batch(&array, &DataType::Decimal(10, 0))?;
+        let result = sum_batch(&array, &DataType::Decimal128(10, 0))?;
         assert_eq!(ScalarValue::Decimal128(Some(13), 10, 0), result);
 
         // test agg
@@ -591,10 +591,10 @@ mod tests {
         );
         generic_test_op!(
             array,
-            DataType::Decimal(35, 0),
+            DataType::Decimal128(35, 0),
             Sum,
             ScalarValue::Decimal128(Some(13), 38, 0),
-            DataType::Decimal(38, 0)
+            DataType::Decimal128(38, 0)
         )
     }
 
@@ -613,16 +613,16 @@ mod tests {
                 .collect::<Decimal128Array>()
                 .with_precision_and_scale(10, 0)?,
         );
-        let result = sum_batch(&array, &DataType::Decimal(10, 0))?;
+        let result = sum_batch(&array, &DataType::Decimal128(10, 0))?;
         assert_eq!(ScalarValue::Decimal128(None, 10, 0), result);
 
         // test agg
         generic_test_op!(
             array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Sum,
             ScalarValue::Decimal128(None, 20, 0),
-            DataType::Decimal(20, 0)
+            DataType::Decimal128(20, 0)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -289,9 +289,9 @@ mod tests {
         );
         generic_test_sum_distinct!(
             array,
-            DataType::Decimal(35, 0),
+            DataType::Decimal128(35, 0),
             ScalarValue::Decimal128(Some(1), 38, 0),
-            DataType::Decimal(38, 0)
+            DataType::Decimal128(38, 0)
         )
     }
 }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -334,7 +334,7 @@ macro_rules! binary_primitive_array_op {
         match $LEFT.data_type() {
             // TODO support decimal type
             // which is not the primitive type
-            DataType::Decimal(_,_) => compute_decimal_op!($LEFT, $RIGHT, $OP, Decimal128Array),
+            DataType::Decimal128(_,_) => compute_decimal_op!($LEFT, $RIGHT, $OP, Decimal128Array),
             DataType::Int8 => compute_op!($LEFT, $RIGHT, $OP, Int8Array),
             DataType::Int16 => compute_op!($LEFT, $RIGHT, $OP, Int16Array),
             DataType::Int32 => compute_op!($LEFT, $RIGHT, $OP, Int32Array),
@@ -359,7 +359,7 @@ macro_rules! binary_primitive_array_op {
 macro_rules! binary_primitive_array_op_scalar {
     ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
         let result: Result<Arc<dyn Array>> = match $LEFT.data_type() {
-            DataType::Decimal(_,_) => compute_decimal_op_scalar!($LEFT, $RIGHT, $OP, Decimal128Array),
+            DataType::Decimal128(_,_) => compute_decimal_op_scalar!($LEFT, $RIGHT, $OP, Decimal128Array),
             DataType::Int8 => compute_op_scalar!($LEFT, $RIGHT, $OP, Int8Array),
             DataType::Int16 => compute_op_scalar!($LEFT, $RIGHT, $OP, Int16Array),
             DataType::Int32 => compute_op_scalar!($LEFT, $RIGHT, $OP, Int32Array),
@@ -386,7 +386,7 @@ macro_rules! binary_array_op {
     ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
         match $LEFT.data_type() {
             DataType::Null => compute_null_op!($LEFT, $RIGHT, $OP, NullArray),
-            DataType::Decimal(_,_) => compute_decimal_op!($LEFT, $RIGHT, $OP, Decimal128Array),
+            DataType::Decimal128(_,_) => compute_decimal_op!($LEFT, $RIGHT, $OP, Decimal128Array),
             DataType::Int8 => compute_op!($LEFT, $RIGHT, $OP, Int8Array),
             DataType::Int16 => compute_op!($LEFT, $RIGHT, $OP, Int16Array),
             DataType::Int32 => compute_op!($LEFT, $RIGHT, $OP, Int32Array),
@@ -2208,7 +2208,7 @@ mod tests {
         // compare decimal array with other array type
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int64, true),
-            Field::new("b", DataType::Decimal(10, 0), true),
+            Field::new("b", DataType::Decimal128(10, 0), true),
         ]));
 
         let value: i64 = 123;
@@ -2252,7 +2252,7 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Float64, true),
-            Field::new("b", DataType::Decimal(10, 2), true),
+            Field::new("b", DataType::Decimal128(10, 2), true),
         ]));
 
         let value: i128 = 123;
@@ -2353,7 +2353,7 @@ mod tests {
     fn arithmetic_decimal_expr_test() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, true),
-            Field::new("b", DataType::Decimal(10, 2), true),
+            Field::new("b", DataType::Decimal128(10, 2), true),
         ]));
         let value: i128 = 123;
         let decimal_array = Arc::new(create_decimal_array(
@@ -2391,7 +2391,7 @@ mod tests {
         // subtract: decimal array subtract int32 array
         let schema = Arc::new(Schema::new(vec![
             Field::new("b", DataType::Int32, true),
-            Field::new("a", DataType::Decimal(10, 2), true),
+            Field::new("a", DataType::Decimal128(10, 2), true),
         ]));
         let expect = Arc::new(create_decimal_array(
             &[Some(-12177), None, Some(-12178), Some(-12276)],
@@ -2424,7 +2424,7 @@ mod tests {
         // divide: int32 array divide decimal array
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, true),
-            Field::new("b", DataType::Decimal(10, 2), true),
+            Field::new("b", DataType::Decimal128(10, 2), true),
         ]));
         let expect = Arc::new(create_decimal_array(
             &[
@@ -2447,7 +2447,7 @@ mod tests {
         // modulus: int32 array modulus decimal array
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, true),
-            Field::new("b", DataType::Decimal(10, 2), true),
+            Field::new("b", DataType::Decimal128(10, 2), true),
         ]));
         let expect = Arc::new(create_decimal_array(
             &[Some(000), None, Some(100), Some(000)],

--- a/datafusion/physical-expr/src/expressions/binary/adapter.rs
+++ b/datafusion/physical-expr/src/expressions/binary/adapter.rs
@@ -38,7 +38,7 @@ macro_rules! make_dyn_comp_op {
                     // Call `op_decimal` (e.g. `eq_decimal) until
                     // arrow has native support
                     // https://github.com/apache/arrow-rs/issues/1200
-                    (DataType::Decimal(_, _), DataType::Decimal(_, _)) => {
+                    (DataType::Decimal128(_, _), DataType::Decimal128(_, _)) => {
                         [<$OP _decimal>](as_decimal_array(left), as_decimal_array(right))
                     },
                     // By default call the arrow kernel

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -133,7 +133,7 @@ where
 {
     Ok(left
         .iter()
-        .map(|left| left.map(|left| op(left, right)))
+        .map(|left| left.map(|left| op(left.as_i128(), right)))
         .collect())
 }
 
@@ -152,7 +152,7 @@ where
         .zip(right.iter())
         .map(|(left, right)| {
             if let (Some(left), Some(right)) = (left, right) {
-                Some(op(left, right))
+                Some(op(left.as_i128(), right.as_i128()))
             } else {
                 None
             }
@@ -288,7 +288,7 @@ where
         .zip(right.iter())
         .map(|(left, right)| {
             if let (Some(left), Some(right)) = (left, right) {
-                Some(op(left, right)).transpose()
+                Some(op(left.as_i128(), right.as_i128())).transpose()
             } else {
                 Ok(None)
             }
@@ -307,7 +307,7 @@ where
     left.iter()
         .map(|left| {
             if let Some(left) = left {
-                Some(op(left, right)).transpose()
+                Some(op(left.as_i128(), right)).transpose()
             } else {
                 Ok(None)
             }

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -290,9 +290,9 @@ mod tests {
 
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Decimal128Array,
-            DataType::Decimal(20, 6),
+            DataType::Decimal128(20, 6),
             vec![
                 Some(convert(1_234_000)),
                 Some(convert(2_222_000)),
@@ -312,9 +312,9 @@ mod tests {
         let convert = |v: i128| Decimal128::new(10, 2, &v.to_le_bytes());
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Decimal128Array,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             vec![
                 Some(convert(123)),
                 Some(convert(222)),
@@ -339,7 +339,7 @@ mod tests {
             .with_precision_and_scale(10, 0)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int8Array,
             DataType::Int8,
             vec![
@@ -360,7 +360,7 @@ mod tests {
             .with_precision_and_scale(10, 0)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int16Array,
             DataType::Int16,
             vec![
@@ -381,7 +381,7 @@ mod tests {
             .with_precision_and_scale(10, 0)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int32Array,
             DataType::Int32,
             vec![
@@ -402,7 +402,7 @@ mod tests {
             .with_precision_and_scale(10, 0)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int64Array,
             DataType::Int64,
             vec![
@@ -431,7 +431,7 @@ mod tests {
             .with_precision_and_scale(10, 3)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Float32Array,
             DataType::Float32,
             vec![
@@ -452,7 +452,7 @@ mod tests {
             .with_precision_and_scale(20, 6)?;
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(20, 6),
+            DataType::Decimal128(20, 6),
             Float64Array,
             DataType::Float64,
             vec![
@@ -477,7 +477,7 @@ mod tests {
             DataType::Int8,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(3, 0),
+            DataType::Decimal128(3, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -495,7 +495,7 @@ mod tests {
             DataType::Int16,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(5, 0),
+            DataType::Decimal128(5, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -513,7 +513,7 @@ mod tests {
             DataType::Int32,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -531,7 +531,7 @@ mod tests {
             DataType::Int64,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(20, 0),
+            DataType::Decimal128(20, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -549,7 +549,7 @@ mod tests {
             DataType::Int64,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(20, 2),
+            DataType::Decimal128(20, 2),
             vec![
                 Some(convert(100)),
                 Some(convert(200)),
@@ -567,7 +567,7 @@ mod tests {
             DataType::Float32,
             vec![1.5, 2.5, 3.0, 1.123_456_8, 5.50],
             Decimal128Array,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             vec![
                 Some(convert(150)),
                 Some(convert(250)),
@@ -585,7 +585,7 @@ mod tests {
             DataType::Float64,
             vec![1.5, 2.5, 3.0, 1.123_456_8, 5.50],
             Decimal128Array,
-            DataType::Decimal(20, 4),
+            DataType::Decimal128(20, 4),
             vec![
                 Some(convert(15000)),
                 Some(convert(25000)),

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -678,9 +678,9 @@ mod tests {
         match result {
             Ok(_) => panic!("expected error"),
             Err(e) => {
-                assert!(e.to_string().contains(
-                    "Cast error: Cannot cast string '9.1' to value of arrow::datatypes::types::Int32Type type"
-                ))
+                assert!(e
+                    .to_string()
+                    .contains("Cannot cast string '9.1' to value of Int32 type"))
             }
         }
         Ok(())

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -237,9 +237,9 @@ mod tests {
         let convert = |v: i128| Decimal128::new(20, 6, &v.to_le_bytes());
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Decimal128Array,
-            DataType::Decimal(20, 6),
+            DataType::Decimal128(20, 6),
             vec![
                 Some(convert(1_234_000)),
                 Some(convert(2_222_000)),
@@ -254,9 +254,9 @@ mod tests {
         let convert = |v: i128| Decimal128::new(10, 2, &v.to_le_bytes());
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Decimal128Array,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             vec![
                 Some(convert(123)),
                 Some(convert(222)),
@@ -279,7 +279,7 @@ mod tests {
         // decimal to i8
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int8Array,
             DataType::Int8,
             vec![
@@ -296,7 +296,7 @@ mod tests {
         let decimal_array = create_decimal_array(&array, 10, 0);
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int16Array,
             DataType::Int16,
             vec![
@@ -313,7 +313,7 @@ mod tests {
         let decimal_array = create_decimal_array(&array, 10, 0);
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int32Array,
             DataType::Int32,
             vec![
@@ -330,7 +330,7 @@ mod tests {
         let decimal_array = create_decimal_array(&array, 10, 0);
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             Int64Array,
             DataType::Int64,
             vec![
@@ -348,7 +348,7 @@ mod tests {
         let decimal_array = create_decimal_array(&array, 10, 3);
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(10, 3),
+            DataType::Decimal128(10, 3),
             Float32Array,
             DataType::Float32,
             vec![
@@ -364,7 +364,7 @@ mod tests {
         let decimal_array = create_decimal_array(&array, 20, 6);
         generic_decimal_to_other_test_cast!(
             decimal_array,
-            DataType::Decimal(20, 6),
+            DataType::Decimal128(20, 6),
             Float64Array,
             DataType::Float64,
             vec![
@@ -389,7 +389,7 @@ mod tests {
             DataType::Int8,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(3, 0),
+            DataType::Decimal128(3, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -406,7 +406,7 @@ mod tests {
             DataType::Int16,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(5, 0),
+            DataType::Decimal128(5, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -423,7 +423,7 @@ mod tests {
             DataType::Int32,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(10, 0),
+            DataType::Decimal128(10, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -440,7 +440,7 @@ mod tests {
             DataType::Int64,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(20, 0),
+            DataType::Decimal128(20, 0),
             vec![
                 Some(convert(1)),
                 Some(convert(2)),
@@ -457,7 +457,7 @@ mod tests {
             DataType::Int64,
             vec![1, 2, 3, 4, 5],
             Decimal128Array,
-            DataType::Decimal(20, 2),
+            DataType::Decimal128(20, 2),
             vec![
                 Some(convert(100)),
                 Some(convert(200)),
@@ -474,7 +474,7 @@ mod tests {
             DataType::Float32,
             vec![1.5, 2.5, 3.0, 1.123_456_8, 5.50],
             Decimal128Array,
-            DataType::Decimal(10, 2),
+            DataType::Decimal128(10, 2),
             vec![
                 Some(convert(150)),
                 Some(convert(250)),
@@ -491,7 +491,7 @@ mod tests {
             DataType::Float64,
             vec![1.5, 2.5, 3.0, 1.123_456_8, 5.50],
             Decimal128Array,
-            DataType::Decimal(20, 4),
+            DataType::Decimal128(20, 4),
             vec![
                 Some(convert(15000)),
                 Some(convert(25000)),

--- a/datafusion/physical-expr/src/type_coercion.rs
+++ b/datafusion/physical-expr/src/type_coercion.rs
@@ -78,7 +78,7 @@ mod tests {
             Schema::new(
                 t.iter()
                     .enumerate()
-                    .map(|(i, t)| Field::new(&*format!("c{}", i), t.clone(), true))
+                    .map(|(i, t)| Field::new(&format!("c{}", i), t.clone(), true))
                     .collect(),
             )
         };

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -37,13 +37,13 @@ default = []
 json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
-arrow = { version = "19.0.0" }
-datafusion = { path = "../core", version = "10.0.0" }
-datafusion-common = { path = "../common", version = "10.0.0" }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+datafusion = { path = "../core", features = [], optional = false }
+datafusion-common = { path = "../common", features = [], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }
-prost = "0.10"
+prost = "0.11.0"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
@@ -53,4 +53,4 @@ tokio = "1.18"
 
 [build-dependencies]
 pbjson-build = { version = "0.3", optional = true }
-prost-build = { version = "0.10" }
+prost-build = { version = "0.11.1" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -37,10 +37,10 @@ default = []
 json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
-datafusion = { path = "../core", features = [], optional = false }
-datafusion-common = { path = "../common", features = [], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
+arrow = { version = "20.0.0" }
+datafusion = { path = "../core", version = "10.0.0" }
+datafusion-common = { path = "../common", version = "10.0.0" }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }
 prost = "0.11.0"

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -226,7 +226,7 @@ impl From<protobuf::PrimitiveScalarType> for DataType {
                 DataType::Time64(TimeUnit::Nanosecond)
             }
             protobuf::PrimitiveScalarType::Null => DataType::Null,
-            protobuf::PrimitiveScalarType::Decimal128 => DataType::Decimal(0, 0),
+            protobuf::PrimitiveScalarType::Decimal128 => DataType::Decimal128(0, 0),
             protobuf::PrimitiveScalarType::Date64 => DataType::Date64,
             protobuf::PrimitiveScalarType::TimeSecond => {
                 DataType::Timestamp(TimeUnit::Second, None)
@@ -309,7 +309,7 @@ impl TryFrom<&protobuf::arrow_type::ArrowTypeEnum> for DataType {
             arrow_type::ArrowTypeEnum::Decimal(protobuf::Decimal {
                 whole,
                 fractional,
-            }) => DataType::Decimal(*whole as usize, *fractional as usize),
+            }) => DataType::Decimal128(*whole as usize, *fractional as usize),
             arrow_type::ArrowTypeEnum::List(list) => {
                 let list_type =
                     list.as_ref().field_type.as_deref().required("field_type")?;

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -153,7 +153,7 @@ mod roundtrip_tests {
             pub expr: ::core::option::Option<crate::protobuf::LogicalExprNode>,
         }
 
-        #[derive(Clone, PartialEq, ::prost::Message)]
+        #[derive(Clone, PartialEq, Eq, ::prost::Message)]
         pub struct TopKExecProto {
             #[prost(uint64, tag = "1")]
             pub k: u64,
@@ -569,7 +569,7 @@ mod roundtrip_tests {
             DataType::FixedSizeBinary(1234),
             DataType::FixedSizeBinary(-432),
             DataType::LargeBinary,
-            DataType::Decimal(1345, 5431),
+            DataType::Decimal128(1345, 5431),
             // Recursive list tests
             DataType::List(new_box_field("Level1", DataType::Binary, true)),
             DataType::List(new_box_field(
@@ -651,7 +651,7 @@ mod roundtrip_tests {
                 ])),
             ),
             DataType::Dictionary(
-                Box::new(DataType::Decimal(10, 50)),
+                Box::new(DataType::Decimal128(10, 50)),
                 Box::new(DataType::FixedSizeList(
                     new_box_field("Level1", DataType::Binary, true),
                     4,
@@ -724,7 +724,7 @@ mod roundtrip_tests {
             DataType::LargeBinary,
             DataType::Utf8,
             DataType::LargeUtf8,
-            DataType::Decimal(1345, 5431),
+            DataType::Decimal128(1345, 5431),
             // Recursive list tests
             DataType::List(new_box_field("Level1", DataType::Binary, true)),
             DataType::List(new_box_field(
@@ -806,7 +806,7 @@ mod roundtrip_tests {
                 ])),
             ),
             DataType::Dictionary(
-                Box::new(DataType::Decimal(10, 50)),
+                Box::new(DataType::Decimal128(10, 50)),
                 Box::new(DataType::FixedSizeList(
                     new_box_field("Level1", DataType::Binary, true),
                     4,

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -219,7 +219,7 @@ impl From<&DataType> for protobuf::arrow_type::ArrowTypeEnum {
                     value: Some(Box::new(value_type.as_ref().into())),
                 }))
             }
-            DataType::Decimal(whole, fractional) => Self::Decimal(protobuf::Decimal {
+            DataType::Decimal128(whole, fractional) => Self::Decimal(protobuf::Decimal {
                 whole: *whole as u64,
                 fractional: *fractional as u64,
             }),
@@ -1244,7 +1244,7 @@ impl TryFrom<&DataType> for protobuf::scalar_type::Datatype {
             | DataType::Union(_, _, _)
             | DataType::Dictionary(_, _)
             | DataType::Map(_, _)
-            | DataType::Decimal(_, _)
+            | DataType::Decimal128(_, _)
             | DataType::Decimal256(_, _) => {
                 return Err(Error::invalid_scalar_type(val));
             }

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -37,8 +37,8 @@ path = "src/lib.rs"
 jit = ["datafusion-jit"]
 
 [dependencies]
-arrow = { version = "19.0.0" }
-datafusion-common = { path = "../common", version = "10.0.0" }
-datafusion-jit = { path = "../jit", version = "10.0.0", optional = true }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+datafusion-common = { path = "../common", features = [], optional = false }
+datafusion-jit = { path = "../jit", features = [], optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -37,8 +37,8 @@ path = "src/lib.rs"
 jit = ["datafusion-jit"]
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
-datafusion-common = { path = "../common", features = [], optional = false }
-datafusion-jit = { path = "../jit", features = [], optional = true }
+arrow = { version = "20.0.0" }
+datafusion-common = { path = "../common", version = "10.0.0" }
+datafusion-jit = { path = "../jit", version = "10.0.0", optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/row/src/layout.rs
+++ b/datafusion/row/src/layout.rs
@@ -166,7 +166,7 @@ fn word_aligned_offsets(null_width: usize, schema: &Schema) -> (Vec<usize>, usiz
     let mut offset = null_width;
     for f in schema.fields() {
         offsets.push(offset);
-        assert!(!matches!(f.data_type(), DataType::Decimal(_, _)));
+        assert!(!matches!(f.data_type(), DataType::Decimal128(_, _)));
         // All of the current support types can fit into one single 8-bytes word.
         // When we decide to support Decimal type in the future, its width would be
         // of two 8-bytes words and should adapt the width calculation below.

--- a/datafusion/row/src/lib.rs
+++ b/datafusion/row/src/lib.rs
@@ -388,7 +388,7 @@ mod tests {
     fn test_unsupported_type_read() {
         let schema = Arc::new(Schema::new(vec![Field::new(
             "a",
-            DataType::Decimal(5, 2),
+            DataType::Decimal128(5, 2),
             false,
         )]));
         let vector = vec![0; 1024];

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,9 +38,9 @@ unicode_expressions = []
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
-datafusion-common = { path = "../common", features = [], optional = false }
-datafusion-expr = { path = "../expr", features = [], optional = false }
+arrow = { version = "20.0.0", features = ["prettyprint"] }
+datafusion-common = { path = "../common", version = "10.0.0" }
+datafusion-expr = { path = "../expr", version = "10.0.0" }
 hashbrown = "0.12"
 sqlparser = "0.20"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,9 +38,9 @@ unicode_expressions = []
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { version = "19.0.0", features = ["prettyprint"] }
-datafusion-common = { path = "../common", version = "10.0.0" }
-datafusion-expr = { path = "../expr", version = "10.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["prettyprint"], optional = false }
+datafusion-common = { path = "../common", features = [], optional = false }
+datafusion-expr = { path = "../expr", features = [], optional = false }
 hashbrown = "0.12"
 sqlparser = "0.20"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/examples/sql.rs
+++ b/datafusion/sql/examples/sql.rs
@@ -75,7 +75,7 @@ impl MySchemaProvider {
             "state".to_string(),
             create_table_source(vec![
                 Field::new("id", DataType::Int32, false),
-                Field::new("sales_tax", DataType::Decimal(10, 2), false),
+                Field::new("sales_tax", DataType::Decimal128(10, 2), false),
             ]),
         );
         tables.insert(
@@ -85,7 +85,7 @@ impl MySchemaProvider {
                 Field::new("customer_id", DataType::Int32, false),
                 Field::new("item_id", DataType::Int32, false),
                 Field::new("quantity", DataType::Int32, false),
-                Field::new("price", DataType::Decimal(10, 2), false),
+                Field::new("price", DataType::Decimal128(10, 2), false),
             ]),
         );
         Self { tables }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -369,9 +369,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let table_ref: TableReference = table_name.as_str().into();
 
         // check if table_name exists
-        if let Err(e) = self.schema_provider.get_table_provider(table_ref) {
-            return Err(e);
-        }
+        let _ = self.schema_provider.get_table_provider(table_ref)?;
 
         if self.has_table("information_schema", "tables") {
             let sql = format!("SELECT column_name, data_type, is_nullable \
@@ -2287,9 +2285,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let table_name = normalize_sql_object_name(sql_table_name);
         let table_ref: TableReference = table_name.as_str().into();
 
-        if let Err(e) = self.schema_provider.get_table_provider(table_ref) {
-            return Err(e);
-        }
+        let _ = self.schema_provider.get_table_provider(table_ref)?;
 
         // Figure out the where clause
         let columns = vec!["table_name", "table_schema", "table_catalog"].into_iter();
@@ -2334,9 +2330,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let table_name = normalize_sql_object_name(sql_table_name);
         let table_ref: TableReference = table_name.as_str().into();
 
-        if let Err(e) = self.schema_provider.get_table_provider(table_ref) {
-            return Err(e);
-        }
+        let _ = self.schema_provider.get_table_provider(table_ref)?;
 
         // Figure out the where clause
         let columns = vec!["table_name", "table_schema", "table_catalog"].into_iter();
@@ -2626,7 +2620,7 @@ mod tests {
     fn test_int_decimal_default() {
         quick_test(
             "SELECT CAST(10 AS DECIMAL)",
-            "Projection: CAST(Int64(10) AS Decimal(38, 10))\
+            "Projection: CAST(Int64(10) AS Decimal128(38, 10))\
              \n  EmptyRelation",
         );
     }
@@ -2635,7 +2629,7 @@ mod tests {
     fn test_int_decimal_no_scale() {
         quick_test(
             "SELECT CAST(10 AS DECIMAL(5))",
-            "Projection: CAST(Int64(10) AS Decimal(5, 0))\
+            "Projection: CAST(Int64(10) AS Decimal128(5, 0))\
              \n  EmptyRelation",
         );
     }
@@ -4424,7 +4418,7 @@ mod tests {
                 ])),
                 "test_decimal" => Ok(Schema::new(vec![
                     Field::new("id", DataType::Int32, false),
-                    Field::new("price", DataType::Decimal(10, 2), false),
+                    Field::new("price", DataType::Decimal128(10, 2), false),
                 ])),
                 "person" => Ok(Schema::new(vec![
                     Field::new("id", DataType::UInt32, false),

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -17,7 +17,7 @@
 
 //! SQL Utility Functions
 
-use arrow::datatypes::{DataType, DECIMAL_DEFAULT_SCALE, DECIMAL_MAX_PRECISION};
+use arrow::datatypes::{DataType, DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE};
 use sqlparser::ast::Ident;
 
 use datafusion_common::{DataFusionError, Result, ScalarValue};
@@ -454,17 +454,17 @@ pub(crate) fn make_decimal_type(
                 "Cannot specify only scale for decimal data type".to_string(),
             ))
         }
-        (None, None) => (DECIMAL_MAX_PRECISION, DECIMAL_DEFAULT_SCALE),
+        (None, None) => (DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE),
     };
 
     // Arrow decimal is i128 meaning 38 maximum decimal digits
-    if precision > DECIMAL_MAX_PRECISION || scale > precision {
+    if precision > DECIMAL128_MAX_PRECISION || scale > precision {
         Err(DataFusionError::Internal(format!(
             "For decimal(precision, scale) precision must be less than or equal to 38 and scale can't be greater than precision. Got ({}, {})",
             precision, scale
         )))
     } else {
-        Ok(DataType::Decimal(precision, scale))
+        Ok(DataType::Decimal128(precision, scale))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/apache/arrow-datafusion/issues/3006.

Closes https://github.com/apache/arrow-datafusion/pull/3085
Closes https://github.com/apache/arrow-datafusion/pull/3086
Closes https://github.com/apache/arrow-datafusion/pull/3087

This is an alternative to https://github.com/apache/arrow-datafusion/pull/3007 but it retains `object_store = "0.3.0"`.

 # Rationale for this change

We'll have to do it sooner or later, but mostly I want the new authentication capabilities in the FlightSqlServer code.

# What changes are included in this PR?

An attempt at upgrading to the latest arrow.

# Are there any user-facing changes?

Users should be able to use arrow 20
