### PR TITLE
MINOR: Fix broken links in contrib guide

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -16,4 +16,5 @@
 # under the License.
 
 build
+temp
 venv/

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,11 @@
   under the License.
 -->
 
-# DataFusion docs
+# DataFusion Documentation
+
+This folder contains the source content of the [User Guide](./source/user-guide)
+and [Contributor Guide](./source/contributor-guide). These are both published to
+https://arrow.apache.org/datafusion/ as part of the release process.
 
 ## Dependencies
 
@@ -27,19 +31,29 @@ inside a Python virtualenv.
 - Python
 - `pip install -r requirements.txt`
 
-## Build
+## Build & Preview
+
+Run the provided script to build the HTML pages.
 
 ```bash
-make html
+./build.sh
 ```
 
-## Release
+The HTML will be generated into a `build` directory.
+
+Preview the site on Linux by running this command.
+
+```bash
+firefox build/html/index.html
+```
+
+## Release Process
 
 The documentation is served through the
 [arrow-site](https://github.com/apache/arrow-site/) repo. To release a new
 version of the docs, follow these steps:
 
-1. Run `make html` inside `docs` folder to generate the docs website inside the `build/html` folder.
+1. Run `./build.sh` inside `docs` folder to generate the docs website inside the `build/html` folder.
 2. Clone the arrow-site repo
 3. Checkout to the `asf-site` branch (NOT `master`)
 4. Copy build artifacts into `arrow-site` repo's `datafusion` folder with a command such as

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 set -e
 rm -rf build 2> /dev/null
 rm -rf temp 2> /dev/null

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+rm -rf build 2> /dev/null
+rm -rf temp 2> /dev/null
+mkdir temp
+cp -rf source/* temp/
+# replace relative URLs with absolute URLs
+sed -i 's/\.\.\/\.\.\/\.\.\//https:\/\/github.com\/apache\/arrow-datafusion\/blob\/master\//g' temp/contributor-guide/index.md
+make SOURCEDIR=`pwd`/temp html

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -154,7 +154,7 @@ Criterion integrates with Cargo's built-in [benchmark support](https://doc.rust-
 cargo bench --bench BENCHMARK_NAME
 ```
 
-A full list of benchmarks can be found [here](./datafusion/benches).
+A full list of benchmarks can be found [here](../../../datafusion/benches).
 
 _[cargo-criterion](https://github.com/bheisler/cargo-criterion) may also be used for more advanced reporting._
 
@@ -187,7 +187,7 @@ Below is a checklist of what you need to do to add a new scalar function to Data
   - [here](../../../datafusion/physical-expr/src/math_expressions.rs) for math functions
   - [here](../../../datafusion/physical-expr/src/datetime_expressions.rs) for datetime functions
   - create a new module [here](../../../datafusion/physical-expr/src) for other functions
-- In [core/src/physical_plan](datafusion/core/src/physical_plan/functions.rs), add:
+- In [core/src/physical_plan](../../../datafusion/core/src/physical_plan/functions.rs), add:
   - a new variant to `BuiltinScalarFunction`
   - a new entry to `FromStr` with the name of the function as called by SQL
   - a new line in `return_type` with the expected return type of the function, given an incoming type


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix broken links in published docs.

## Before

```
- [dev/rust_lint.sh](../../../dev/rust_lint.sh)
```

## After

```
- [dev/rust_lint.sh](https://github.com/apache/arrow-datafusion/blob/master/dev/rust_lint.sh)
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add a new script to generate HTML which will rewrite the relative URLs in the contributor guide as absolute so that they work when published to the arrow web site.

This script only edits one file because there is only file with such relative links:

```bash
$ find temp -name "*.md" -exec grep -Hi "\.\.\/" {} \;
temp/contributor-guide/index.md:- [ci/scripts/rust_fmt.sh](../../../ci/scripts/rust_fmt.sh)
temp/contributor-guide/index.md:- [ci/scripts/rust_clippy.sh](../../../ci/scripts/rust_clippy.sh)
temp/contributor-guide/index.md:- [ci/scripts/rust_toml_fmt.sh](../../../ci/scripts/rust_toml_fmt.sh)
temp/contributor-guide/index.md:- [dev/rust_lint.sh](../../../dev/rust_lint.sh)
temp/contributor-guide/index.md:These randomly generate a parquet file, and then benchmark queries sourced from [parquet_query_sql.sql](../../../datafusion/core/benches/parquet_query_sql.sql) against it. This can therefore be a quick way to add coverage of particular query and/or data paths.
temp/contributor-guide/index.md:Instructions and tooling for running upstream benchmark suites against DataFusion can be found in [benchmarks](../../../benchmarks).
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/string_expressions.rs) for string functions
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/math_expressions.rs) for math functions
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/datetime_expressions.rs) for datetime functions
temp/contributor-guide/index.md:  - create a new module [here](../../../datafusion/physical-expr/src) for other functions
temp/contributor-guide/index.md:- In [core/tests/sql](../../../datafusion/core/tests/sql), add a new test where the function is called through SQL against well known data and returns the expected result.
temp/contributor-guide/index.md:- In [expr/src/expr_fn.rs](../../../datafusion/expr/src/expr_fn.rs), add:
temp/contributor-guide/index.md:- In [core/src/logical_plan/mod](../../../datafusion/core/src/logical_plan/mod.rs), add:
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/string_expressions.rs) for string functions
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/math_expressions.rs) for math functions
temp/contributor-guide/index.md:  - [here](../../../datafusion/physical-expr/src/datetime_expressions.rs) for datetime functions
temp/contributor-guide/index.md:  - create a new module [here](../../../datafusion/physical-expr/src) for other functions
temp/contributor-guide/index.md:- In [datafusion/expr/src](../../../datafusion/expr/src/aggregate_function.rs), add:
temp/contributor-guide/index.md:- In [tests/sql](../../../datafusion/core/tests/sql), add a new test where the function is called through SQL against well known data and returns the expected result.
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->