### PR TITLE
Add test for casting time before 1970 to timestamp

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1147,6 +1147,26 @@ async fn to_timestamp_seconds_i32() -> Result<()> {
 }
 
 #[tokio::test]
+async fn cast_timestamp_negative() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select cast('1969-01-01T00:00:00.1' as timestamp);";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+--------------------------------------------------------------------+",
+        "| CAST(Utf8(\"1969-01-01T00:00:00.1\") AS Timestamp(Nanosecond, None)) |",
+        "+--------------------------------------------------------------------+",
+        "| 1969-01-01 08:00:00.100                                            |",
+        "+--------------------------------------------------------------------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn date_bin() {
     let ctx = SessionContext::new();
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3082.

 # Rationale for this change
There was a bug in arrow.rs that wasn't handling negative timestamps properly. This was fixed in #2325. This issue adds a test for a downstream problem faced in #3082.
