### PR TITLE
Rename `DateIntervalExpr` to `DateTimeIntervalExpr`

### DIFF
--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -36,15 +36,15 @@ use std::fmt::{Display, Formatter};
 use std::ops::{Add, Sub};
 use std::sync::Arc;
 
-/// Perform DATE +/ INTERVAL math
+/// Perform DATE/TIME/TIMESTAMP +/ INTERVAL math
 #[derive(Debug)]
-pub struct DateIntervalExpr {
+pub struct DateTimeIntervalExpr {
     lhs: Arc<dyn PhysicalExpr>,
     op: Operator,
     rhs: Arc<dyn PhysicalExpr>,
 }
 
-impl DateIntervalExpr {
+impl DateTimeIntervalExpr {
     /// Create a new instance of DateIntervalExpr
     pub fn try_new(
         lhs: Arc<dyn PhysicalExpr>,
@@ -76,13 +76,13 @@ impl DateIntervalExpr {
     }
 }
 
-impl Display for DateIntervalExpr {
+impl Display for DateTimeIntervalExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} {} {}", self.lhs, self.op, self.rhs)
     }
 }
 
-impl PhysicalExpr for DateIntervalExpr {
+impl PhysicalExpr for DateTimeIntervalExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -652,7 +652,7 @@ mod tests {
         let lhs = create_physical_expr(&dt, &dfs, &schema, &props)?;
         let rhs = create_physical_expr(&interval, &dfs, &schema, &props)?;
 
-        let cut = DateIntervalExpr::try_new(lhs, op, rhs, &schema)?;
+        let cut = DateTimeIntervalExpr::try_new(lhs, op, rhs, &schema)?;
         let res = cut.evaluate(&batch)?;
 
         let mut builder = Date32Builder::new(8);
@@ -727,7 +727,7 @@ mod tests {
         let lhs = create_physical_expr(dt, &dfs, &schema, &props)?;
         let rhs = create_physical_expr(interval, &dfs, &schema, &props)?;
 
-        let cut = DateIntervalExpr::try_new(lhs, op, rhs, &schema)?;
+        let cut = DateTimeIntervalExpr::try_new(lhs, op, rhs, &schema)?;
         let res = cut.evaluate(&batch)?;
         Ok(res)
     }

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -73,7 +73,7 @@ pub use cast::{
     cast, cast_column, cast_with_options, CastExpr, DEFAULT_DATAFUSION_CAST_OPTIONS,
 };
 pub use column::{col, Column};
-pub use datetime::DateIntervalExpr;
+pub use datetime::DateTimeIntervalExpr;
 pub use get_indexed_field::GetIndexedFieldExpr;
 pub use in_list::{in_list, InListExpr};
 pub use is_not_null::{is_not_null, IsNotNullExpr};

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -18,7 +18,9 @@
 use crate::expressions::try_cast;
 use crate::{
     execution_props::ExecutionProps,
-    expressions::{self, binary, Column, DateIntervalExpr, GetIndexedFieldExpr, Literal},
+    expressions::{
+        self, binary, Column, DateTimeIntervalExpr, GetIndexedFieldExpr, Literal,
+    },
     functions, udf,
     var_provider::VarType,
     PhysicalExpr,
@@ -93,7 +95,7 @@ pub fn create_physical_expr(
                     DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _),
                     Operator::Plus | Operator::Minus,
                     DataType::Interval(_),
-                ) => Ok(Arc::new(DateIntervalExpr::try_new(
+                ) => Ok(Arc::new(DateTimeIntervalExpr::try_new(
                     lhs,
                     *op,
                     rhs,


### PR DESCRIPTION
Draft until https://github.com/apache/arrow-datafusion/pull/3110 is merged

# Which issue does this PR close?


re https://github.com/apache/arrow-datafusion/issues/3103


 # Rationale for this change
As suggested on https://github.com/apache/arrow-datafusion/pull/3110/files#r944322483

Since `DateIntervalExpr` now handles Timestamps in addition to `Date`s calling it  `DateTimeIntervalExpr` makes sense.


# What changes are included in this PR?
Rename `DateIntervalExpr` to `DateTimeIntervalExpr`

# Are there any user-facing changes?
The struct name is changed