### PR TITLE
Expose RowAccumulator in physical_plan

### DIFF
--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -31,6 +31,7 @@ use arrow::record_batch::RecordBatch;
 
 pub use datafusion_expr::Accumulator;
 pub use datafusion_expr::ColumnarValue;
+pub use datafusion_physical_expr::aggregate::row_accumulator::RowAccumulator;
 pub use display::DisplayFormatType;
 use futures::stream::Stream;
 use std::fmt;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3138.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Expose RowAccumulator to the public in physical_plan so that other crates can implement `AggregateExpr` with that feature.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Expose RowAccumulator to the public in physical_plan.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->