### PR TITLE
Return proper error message for ill formed variable reference

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1561,7 +1561,8 @@ impl ContextProvider for SessionState {
             return None;
         }
 
-        let provider_type = if &variable_names[0][0..2] == "@@" {
+        let first_variable = &variable_names[0];
+        let provider_type = if first_variable.len() > 1 && &first_variable[0..2] == "@@" {
             VarType::System
         } else {
             VarType::UserDefined
@@ -1854,6 +1855,21 @@ mod tests {
         ];
         assert_batches_eq!(expected, &results);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_variable_err() -> Result<()> {
+        let ctx = SessionContext::new();
+
+        let err = plan_and_collect(&ctx, "SElECT @=   X#=?!~ 5")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Execution error: variable [\"@\"] has no type information"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3137 . Kudos to @syheliel for the detailed error report and reproducer 👍 

 # Rationale for this change
Errors are better than `panics`

# What changes are included in this PR?
Check length before slicing `2`

# Are there any user-facing changes?
Better error message