### PR TITLE
[sqlparser-0.21] Update trimExpr members during planning

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -47,4 +47,4 @@ ordered-float = "3.0"
 parquet = { version = "20.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 serde_json = "1.0"
-sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "31ba0012f747c9e2fc551b95fd2ee3bfa46b12e6" }
+sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "42c5d43b45d3e7a573ac24dd5c927c43bbd3768c" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -85,7 +85,7 @@ pyo3 = { version = "0.16", optional = true }
 rand = "0.8"
 rayon = { version = "1.5", optional = true }
 smallvec = { version = "1.6", features = ["union"] }
-sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "31ba0012f747c9e2fc551b95fd2ee3bfa46b12e6" }
+sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "42c5d43b45d3e7a573ac24dd5c927c43bbd3768c" }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -38,4 +38,4 @@ path = "src/lib.rs"
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 arrow = { version = "20.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "11.0.0" }
-sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "31ba0012f747c9e2fc551b95fd2ee3bfa46b12e6" }
+sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "42c5d43b45d3e7a573ac24dd5c927c43bbd3768c" }

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -42,5 +42,5 @@ arrow = { version = "20.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 hashbrown = "0.12"
-sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "31ba0012f747c9e2fc551b95fd2ee3bfa46b12e6" }
+sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs", rev = "42c5d43b45d3e7a573ac24dd5c927c43bbd3768c" }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2026,21 +2026,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 ))
             }
 
-            SQLExpr::Trim { expr, trim_where } => {
-                let (fun, where_expr) = match trim_where {
-                    Some((TrimWhereField::Leading, expr)) => {
-                        (BuiltinScalarFunction::Ltrim, Some(expr))
+            SQLExpr::Trim { expr, trim_where, trim_what } => {
+                let fun = match trim_where {
+                    Some(TrimWhereField::Leading) => {
+                        BuiltinScalarFunction::Ltrim
                     }
-                    Some((TrimWhereField::Trailing, expr)) => {
-                        (BuiltinScalarFunction::Rtrim, Some(expr))
+                    Some(TrimWhereField::Trailing) => {
+                        BuiltinScalarFunction::Rtrim
                     }
-                    Some((TrimWhereField::Both, expr)) => {
-                        (BuiltinScalarFunction::Btrim, Some(expr))
+                    Some(TrimWhereField::Both) => {
+                        BuiltinScalarFunction::Btrim
                     }
-                    None => (BuiltinScalarFunction::Trim, None),
+                    None => BuiltinScalarFunction::Trim
                 };
                 let arg = self.sql_expr_to_logical_expr(*expr, schema, ctes)?;
-                let args = match where_expr {
+                let args = match trim_what {
                     Some(to_trim) => {
                         let to_trim = self.sql_expr_to_logical_expr(*to_trim, schema, ctes)?;
                         vec![arg, to_trim]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Extension of https://github.com/sqlparser-rs/sqlparser-rs/issues/568 into datafusion

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Updates were made to sqlparser parsing logic https://github.com/sqlparser-rs/sqlparser-rs/pull/573 to handle optional trim flag and trim what Expr's better matching postgresql syntax. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This pr updates the planner logic to handle the changes made to the struct members of Expr::Trim from sqlparser.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->


---

Note: Errors are related to other changes made in sqlparser around the handling of `like/ilike` being addressed in #3101. Might need to consolidate both the changes in a single pr for tests to pass.