### PR TITLE
Clean up CI workflows by removing "matrix" strategy, simplifying names

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,14 +25,11 @@ on:
 jobs:
   # Check crate compiles
   linux-build-lib:
-    name: Build Libraries on AMD64 Rust ${{ matrix.rust }}
+    name: cargo check
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -49,7 +46,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Check workspace in debug mode
         run: |
           cargo check
@@ -65,15 +62,11 @@ jobs:
 
   # test the crate
   linux-test:
-    name: Test Workspace on AMD64 Rust ${{ matrix.rust }}
+    name: cargo test (amd64)
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -101,7 +94,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Run tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -115,7 +108,7 @@ jobs:
           cargo run --example avro_sql --features=datafusion/avro
 
   integration-test:
-    name: "Integration Test"
+    name: "Compare to postgres"
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
     services:
@@ -171,12 +164,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
   windows:
-    name: Test on Windows Rust ${{ matrix.rust }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest]
-        rust: [stable]
+    name: cargo test (win64)
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -195,8 +184,8 @@ jobs:
       # with a OS-dependent path.
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+          rustup toolchain install stable
+          rustup default stable
           rustup component add rustfmt
       - name: Run tests
         shell: bash
@@ -208,12 +197,8 @@ jobs:
           RUSTFLAGS: "-C debuginfo=0"
 
   macos:
-    name: Test on MacOS Rust ${{ matrix.rust }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest]
-        rust: [stable]
+    name: cargo test (mac)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -233,8 +218,8 @@ jobs:
       # with a OS-dependent path.
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+          rustup toolchain install stable
+          rustup default stable
           rustup component add rustfmt
       - name: Run tests
         shell: bash
@@ -245,14 +230,11 @@ jobs:
           RUSTFLAGS: "-C debuginfo=0"
 
   test-datafusion-pyarrow:
+    name: cargo test pyarrow (amd64)
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -277,7 +259,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Run tests
         run: |
           cd datafusion
@@ -299,12 +281,8 @@ jobs:
         run: ci/scripts/rust_fmt.sh
 
   coverage:
-    name: Coverage
+    name: coverage
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -321,8 +299,8 @@ jobs:
           protoc --version
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+          rustup toolchain install stable
+          rustup default stable
           rustup component add rustfmt clippy
       - name: Cache Cargo
         uses: actions/cache@v3
@@ -342,15 +320,11 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
 
   clippy:
-    name: Clippy
+    name: clippy
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -368,7 +342,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Install Clippy
         run: |
           rustup component add clippy
@@ -376,12 +350,8 @@ jobs:
         run: ci/scripts/rust_clippy.sh
 
   miri-checks:
-    name: MIRI
+    name: cargo miri test (amd64)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [nightly-2022-01-17]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -395,8 +365,8 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+          rustup toolchain install nightly-2022-01-17
+          rustup default nightly-2022-01-17
           rustup component add rustfmt clippy miri
       - name: Run Miri Checks
         env:
@@ -411,15 +381,11 @@ jobs:
 
   # Check answers are correct when hash values collide
   hash-collisions:
-    name: Test Hash Collisions on AMD64 Rust ${{ matrix.rust }}
+    name: cargo test hash collisions (amd64)
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -437,7 +403,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Run tests
         run: |
           cd datafusion
@@ -445,15 +411,11 @@ jobs:
           cargo test --all --features=force_hash_collisions
 
   cargo-toml-formatting-checks:
-    name: Check Cargo.toml formatting
+    name: check Cargo.toml formatting
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
     container:
-      image: ${{ matrix.arch }}/rust
+      image: amd64/rust
       env:
         # Disable full debug symbol generation to speed up CI build and keep memory down
         # "1" means line tables only, which is useful for panic tracebacks.
@@ -471,7 +433,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - name: Install cargo-tomlfmt
         run: |
           which cargo-tomlfmt || cargo install cargo-tomlfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,6 @@ jobs:
   linux-build-lib:
     name: cargo check
     runs-on: ubuntu-latest
-    strategy:
     container:
       image: amd64/rust
       env:


### PR DESCRIPTION
# Which issue does this PR close?

Next installment of https://github.com/apache/arrow-datafusion/issues/3045

 # Rationale for this change
The CI checks make use of the 'matrix' strategy (see [docs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs))  but have only one matrix combination. This makes them overly confusing.

As part of cleaning up the DataFusion CI I am first pruning out unnecessary complexity first


# What changes are included in this PR?
1. Remove matrix strategy config for jobs that have a single combination
2. Rename the jobs to be consistent

# Are there any user-facing changes?
No