### PR TITLE
Add support for inline column alias in CREATE VIEW

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -354,15 +354,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.set_expr_to_plan(*set_expr, alias, ctes, outer_query_schema)?;
 
         let plan = self.order_by(plan, query.order_by)?;
-        let plan = self.limit(plan, query.offset, query.limit);
+        let plan = self.limit(plan, query.offset, query.limit)?;
         match columns {
             Some(_) => {
                 let mut new_builder =
-                    LogicalPlanBuilder::from(plan.as_ref().unwrap().clone());
+                    LogicalPlanBuilder::from(plan.clone());
                 new_builder = new_builder
                     .project(
-                        plan.as_ref()
-                            .unwrap()
+                        plan
                             .schema()
                             .fields()
                             .iter()
@@ -376,9 +375,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     })?;
                 new_builder.build()
             }
-            None => {
-                plan
-            }
+            None => Ok(plan),
         }
     }
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -356,17 +356,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.order_by(plan, query.order_by)?;
         let plan = self.limit(plan, query.offset, query.limit)?;
         match columns {
-            Some(c) => {
-                let mut new_builder = LogicalPlanBuilder::from(plan.clone());
-                new_builder = new_builder
-                    .project(plan.schema().fields().iter().zip(c.into_iter()).map(
-                        |(field, ident)| col(field.name()).alias(&normalize_ident(ident)),
-                    ))
-                    .map_err(|e| {
-                        context!("Failed to apply alias to inline projection.\n", e)
-                    })?;
-                new_builder.build()
-            }
+            Some(c) => LogicalPlanBuilder::from(plan.clone())
+                .project(plan.schema().fields().iter().zip(c.into_iter()).map(
+                    |(field, ident)| col(field.name()).alias(&normalize_ident(ident)),
+                ))
+                .map_err(|e| {
+                    context!("Failed to apply alias to inline projection.\n", e)
+                })?
+                .build(),
             None => Ok(plan),
         }
     }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -356,20 +356,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.order_by(plan, query.order_by)?;
         let plan = self.limit(plan, query.offset, query.limit)?;
         match columns {
-            Some(_) => {
-                let mut new_builder =
-                    LogicalPlanBuilder::from(plan.clone());
+            Some(c) => {
+                let mut new_builder = LogicalPlanBuilder::from(plan.clone());
                 new_builder = new_builder
-                    .project(
-                        plan
-                            .schema()
-                            .fields()
-                            .iter()
-                            .zip(columns.unwrap().into_iter())
-                            .map(|(field, ident)| {
-                                col(field.name()).alias(&normalize_ident(ident))
-                            }),
-                    )
+                    .project(plan.schema().fields().iter().zip(c.into_iter()).map(
+                        |(field, ident)| col(field.name()).alias(&normalize_ident(ident)),
+                    ))
                     .map_err(|e| {
                         context!("Failed to apply alias to inline projection.\n", e)
                     })?;


### PR DESCRIPTION
- Add columns argument to planner::query_to_plan
- Add columns argument to planner::query_to_plan_with_alias
- Add test query_view_with_alias to view.rs
- Add test query_view_with_inline_alias to view.rs

Resolves #3108

fix(planner): Updated Statement::CreateView logic

- Added match for empty columns vector to determine optional value

Closes #3108

 # Rationale for this change
Enables part of TPCH Query 15.

# What changes are included in this PR?
Added capability for inline column aliases in sql queries.

# Are there any user-facing changes?
Added capability for inline column aliases in sql queries.