### PR TITLE
Fix MIRI CI run + and update nightly version used

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -369,8 +369,8 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install nightly-2022-01-17
-          rustup default nightly-2022-01-17
+          rustup toolchain install nightly-2022-08-20
+          rustup default nightly-2022-08-20
           rustup component add rustfmt clippy miri
       - name: Run Miri Checks
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -379,9 +379,7 @@ jobs:
           MIRIFLAGS: "-Zmiri-disable-isolation"
         run: |
           cargo miri setup
-          cargo clean
-          # Ignore MIRI errors until we can get a clean run
-          cargo miri test || true
+          cargo miri test
 
   # Check answers are correct when hash values collide
   hash-collisions:


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

re #3045 

 # Rationale for this change
As suggested by @jackwener 👍
https://github.com/apache/arrow-datafusion/pull/3196#discussion_r950701600


# What changes are included in this PR?
1. Update version of nightly rust used for MIRI run
2. Stop ignoring MIRI results

# Are there any user-facing changes?
