### PR TITLE
[minor] fix bench aggregate_query_sql meta

### DIFF
--- a/datafusion/core/benches/data_utils/mod.rs
+++ b/datafusion/core/benches/data_utils/mod.rs
@@ -58,11 +58,11 @@ pub fn create_schema() -> Schema {
     Schema::new(vec![
         Field::new("utf8", DataType::Utf8, false),
         Field::new("f32", DataType::Float32, false),
-        Field::new("f64", DataType::Float64, false),
+        Field::new("f64", DataType::Float64, true),
         // This field will contain integers randomly selected from a large
         // range of values, i.e. [0, u64::MAX], such that there are none (or
         // very few) repeated values.
-        Field::new("u64_wide", DataType::UInt64, false),
+        Field::new("u64_wide", DataType::UInt64, true),
         // This field will contain integers randomly selected from a narrow
         // range of values such that there are a few distinct values, but they
         // are repeated often.


### PR DESCRIPTION
# Which issue does this PR close?
related #3217 

 # Rationale for this change
when i run `cargo bench --bench aggregate_query_sql`

got 
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: 

InvalidArgumentError("Column 'f64' is declared as non-nullable but contains null values")', datafusion/core/benches/data_utils/mod.rs:140:6

```
https://github.com/apache/arrow-datafusion/blob/fecc5ac4360c05db934cef38e8bde4fb669f01d6/datafusion/core/benches/data_utils/mod.rs#L120

then call 

https://github.com/apache/arrow-datafusion/blob/fecc5ac4360c05db934cef38e8bde4fb669f01d6/datafusion/core/benches/data_utils/mod.rs#L73-L86

but the schema is none-nullable 🤔 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->