### PR TITLE
[Improve] Use arrow::compute::sort in approx_percentile_cont

### DIFF
--- a/datafusion/core/benches/aggregate_query_sql.rs
+++ b/datafusion/core/benches/aggregate_query_sql.rs
@@ -143,6 +143,26 @@ fn criterion_benchmark(c: &mut Criterion) {
             )
         })
     });
+
+    c.bench_function("aggregate_query_approx_percentile_cont_on_u64", |b| {
+        b.iter(|| {
+            query(
+                ctx.clone(),
+                "SELECT utf8, approx_percentile_cont(u64_wide, 0.5, 2500)  \
+                 FROM t GROUP BY utf8",
+            )
+        })
+    });
+
+    c.bench_function("aggregate_query_approx_percentile_cont_on_f32", |b| {
+        b.iter(|| {
+            query(
+                ctx.clone(),
+                "SELECT utf8, approx_percentile_cont(f32, 0.5, 2500)  \
+                 FROM t GROUP BY utf8",
+            )
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -370,9 +370,10 @@ impl Accumulator for ApproxPercentileAccumulator {
 
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
-        let unsorted_values =
-            ApproxPercentileAccumulator::convert_to_ordered_float(values)?;
-        self.digest = self.digest.merge_unsorted_f64(unsorted_values);
+        let sorted_values = &arrow::compute::sort(values, None)?;
+        let sorted_values =
+            ApproxPercentileAccumulator::convert_to_ordered_float(sorted_values)?;
+        self.digest = self.digest.merge_sorted_f64(&sorted_values);
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -260,6 +260,7 @@ impl TDigest {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn merge_unsorted_f64(
         &self,
         unsorted_values: Vec<OrderedFloat<f64>>,
@@ -269,7 +270,10 @@ impl TDigest {
         self.merge_sorted_f64(&values)
     }
 
-    fn merge_sorted_f64(&self, sorted_values: &[OrderedFloat<f64>]) -> TDigest {
+    pub(crate) fn merge_sorted_f64(
+        &self,
+        sorted_values: &[OrderedFloat<f64>],
+    ) -> TDigest {
         #[cfg(debug_assertions)]
         debug_assert!(is_sorted(sorted_values), "unsorted input to TDigest");
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #3217 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Before we use std::sort in update_batch of aggregate `approx_percentile_cont`
We can use `arrow::compute::sort` and `merge_sorted_f64 ` replace   `merge_unsorted_f64 `

run bench get 
```
aggregate_query_approx_percentile_cont_on_u64                                                                            
                        time:   [6.1686 ms 6.1978 ms 6.2367 ms]
                        change: [-8.4056% -7.5404% -6.5993%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

aggregate_query_approx_percentile_cont_on_f32                                                                              
                        time:   [7.0710 ms 7.1209 ms 7.1847 ms]
                        change: [-7.5669% -6.6221% -5.5469%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->