### PR TITLE
CREATE VIEW should return empty dataframe

### DIFF
--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -100,6 +100,21 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn create_view_return_empty_dataframe() -> Result<()> {
+        let session_ctx = SessionContext::new();
+
+        let df = session_ctx
+            .sql("CREATE VIEW xyz AS SELECT 1")
+            .await?
+            .collect()
+            .await?;
+
+        assert!(df.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn query_view() -> Result<()> {
         let session_ctx = SessionContext::with_config(
             SessionConfig::new().with_information_schema(true),

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -370,14 +370,16 @@ impl SessionContext {
                             Arc::new(ViewTable::try_new((*input).clone(), definition)?);
 
                         self.register_table(name.as_str(), table)?;
-                        Ok(Arc::new(DataFrame::new(self.state.clone(), &input)))
+                        let plan = LogicalPlanBuilder::empty(false).build()?;
+                        Ok(Arc::new(DataFrame::new(self.state.clone(), &plan)))
                     }
                     (_, Err(_)) => {
                         let table =
                             Arc::new(ViewTable::try_new((*input).clone(), definition)?);
 
                         self.register_table(name.as_str(), table)?;
-                        Ok(Arc::new(DataFrame::new(self.state.clone(), &input)))
+                        let plan = LogicalPlanBuilder::empty(false).build()?;
+                        Ok(Arc::new(DataFrame::new(self.state.clone(), &plan)))
                     }
                     (false, Ok(_)) => Err(DataFusionError::Execution(format!(
                         "Table '{:?}' already exists",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3236 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Per issue -- create view should just create the view.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

yes, CREATE VIEW will no longer return the results of the given SQL. It will return an empty dataframe upon success.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->