### PR TITLE
Add assertion for invariant in `create_physical_expression` and fix ViewTable projection

### DIFF
--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -91,14 +91,17 @@ impl TableProvider for ViewTable {
         state_cloned.execution_props.start_execution();
         if let Some(projection) = projection {
             // avoiding adding a redundant projection (e.g. SELECT * FROM view)
-            let current_projection = (0..self.logical_plan.schema().fields().len()).collect::<Vec<usize>>();
+            let current_projection =
+                (0..self.logical_plan.schema().fields().len()).collect::<Vec<usize>>();
             if projection == &current_projection {
                 state_cloned.create_physical_plan(&self.logical_plan).await
             } else {
                 let fields: Vec<Expr> = projection
                     .iter()
                     .map(|i| {
-                        Expr::Column(self.logical_plan.schema().field(*i).qualified_column())
+                        Expr::Column(
+                            self.logical_plan.schema().field(*i).qualified_column(),
+                        )
                     })
                     .collect();
                 let plan = LogicalPlanBuilder::from(self.logical_plan.clone())

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -90,16 +90,22 @@ impl TableProvider for ViewTable {
         let mut state_cloned = state.clone();
         state_cloned.execution_props.start_execution();
         if let Some(projection) = projection {
-            let fields: Vec<Expr> = projection
-                .iter()
-                .map(|i| {
-                    Expr::Column(self.logical_plan.schema().field(*i).qualified_column())
-                })
-                .collect();
-            let plan = LogicalPlanBuilder::from(self.logical_plan.clone())
-                .project(fields)?
-                .build()?;
-            state_cloned.create_physical_plan(&plan).await
+            // avoiding adding a redundant projection (e.g. SELECT * FROM view)
+            let current_projection = (0..self.logical_plan.schema().fields().len()).collect::<Vec<usize>>();
+            if projection == &current_projection {
+                state_cloned.create_physical_plan(&self.logical_plan).await
+            } else {
+                let fields: Vec<Expr> = projection
+                    .iter()
+                    .map(|i| {
+                        Expr::Column(self.logical_plan.schema().field(*i).qualified_column())
+                    })
+                    .collect();
+                let plan = LogicalPlanBuilder::from(self.logical_plan.clone())
+                    .project(fields)?
+                    .build()?;
+                state_cloned.create_physical_plan(&plan).await
+            }
         } else {
             state_cloned.create_physical_plan(&self.logical_plan).await
         }

--- a/datafusion/optimizer/src/expr_simplifier.rs
+++ b/datafusion/optimizer/src/expr_simplifier.rs
@@ -88,7 +88,7 @@ impl ExprSimplifiable for Expr {
     /// ```
     fn simplify<S: SimplifyInfo>(self, info: &S) -> Result<Self> {
         let mut rewriter = Simplifier::new(info);
-        let mut const_evaluator = ConstEvaluator::new(info.execution_props());
+        let mut const_evaluator = ConstEvaluator::try_new(info.execution_props())?;
 
         // TODO iterate until no changes are made during rewrite
         // (evaluating constants can enable new simplifications and

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -332,7 +332,7 @@ impl SimplifyExpressions {
 /// # use datafusion_expr::expr_rewriter::ExprRewritable;
 ///
 /// let execution_props = ExecutionProps::new();
-/// let mut const_evaluator = ConstEvaluator::new(&execution_props);
+/// let mut const_evaluator = ConstEvaluator::try_new(&execution_props).unwrap();
 ///
 /// // (1 + 2) + a
 /// let expr = (lit(1) + lit(2)) + col("a");
@@ -403,25 +403,23 @@ impl<'a> ConstEvaluator<'a> {
     /// Create a new `ConstantEvaluator`. Session constants (such as
     /// the time for `now()` are taken from the passed
     /// `execution_props`.
-    pub fn new(execution_props: &'a ExecutionProps) -> Self {
-        let input_schema = DFSchema::empty();
-
+    pub fn try_new(execution_props: &'a ExecutionProps) -> Result<Self> {
         // The dummy column name is unused and doesn't matter as only
         // expressions without column references can be evaluated
         static DUMMY_COL_NAME: &str = ".";
         let schema = Schema::new(vec![Field::new(DUMMY_COL_NAME, DataType::Null, true)]);
+        let input_schema = DFSchema::try_from(schema.clone())?;
 
         // Need a single "input" row to produce a single output row
         let col = new_null_array(&DataType::Null, 1);
-        let input_batch =
-            RecordBatch::try_new(std::sync::Arc::new(schema), vec![col]).unwrap();
+        let input_batch = RecordBatch::try_new(std::sync::Arc::new(schema), vec![col])?;
 
-        Self {
+        Ok(Self {
             can_evaluate: vec![],
             execution_props,
             input_schema,
             input_batch,
-        }
+        })
     }
 
     /// Can a function of the specified volatility be evaluated?
@@ -1273,7 +1271,7 @@ mod tests {
             var_providers: None,
         };
 
-        let mut const_evaluator = ConstEvaluator::new(&execution_props);
+        let mut const_evaluator = ConstEvaluator::try_new(&execution_props).unwrap();
         let evaluated_expr = input_expr
             .clone()
             .rewrite(&mut const_evaluator)

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -38,6 +38,7 @@ pub fn create_physical_expr(
     input_schema: &Schema,
     execution_props: &ExecutionProps,
 ) -> Result<Arc<dyn PhysicalExpr>> {
+    assert_eq!(input_schema.fields.len(), input_dfschema.fields().len());
     match e {
         Expr::Alias(expr, ..) => Ok(create_physical_expr(
             expr,

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -31,7 +31,15 @@ use datafusion_expr::binary_rule::comparison_coercion;
 use datafusion_expr::{Expr, Operator};
 use std::sync::Arc;
 
-/// Create a physical expression from a logical expression ([Expr])
+/// Create a physical expression from a logical expression ([Expr]).
+///
+/// # Arguments
+///
+/// * `e` - The logical expression
+/// * `input_dfschema` - The DataFusion schema for the input, used to resolve `Column` references
+///                      to qualified or unqualified fields by name.
+/// * `input_schema` - The Arrow schema for the input, used for determining expression data types
+///                    when performing type coercion.
 pub fn create_physical_expr(
     e: &Expr,
     input_dfschema: &DFSchema,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/3240

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`create_physical_expression` accepts an Arrow schema and a DataFusion schema. They should have the same number of fields but there was no check.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add an assertion that both schemas have the same length
- Fix regressions caused by this change
- ViewTable no longer ignores projections
- Remove some unwraps from simplify_expressions

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Not  sure

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->