### PR TITLE
Implement `IS UNKNOWN`/`IS NOT UNKNOWN` operators

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -382,6 +382,70 @@ async fn query_is_false() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_is_unknown() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+        ]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT c1 IS UNKNOWN as t FROM test";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-------+",
+        "| t     |",
+        "+-------+",
+        "| false |",
+        "| false |",
+        "| true  |",
+        "+-------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_is_not_unknown() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+        ]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT c1 IS NOT UNKNOWN as t FROM test";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-------+",
+        "| t     |",
+        "+-------+",
+        "| true  |",
+        "| true  |",
+        "| false |",
+        "+-------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_without_from() -> Result<()> {
     // Test for SELECT <expression> without FROM.
     // Should evaluate expressions in project position.

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1956,6 +1956,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 right: Box::new(lit(false)),
             }),
 
+            SQLExpr::IsUnknown(expr) => Ok(Expr::BinaryExpr {
+                left: Box::new(self.sql_expr_to_logical_expr(*expr, schema, ctes)?),
+                op: Operator::IsNotDistinctFrom,
+                right: Box::new(lit(ScalarValue::Boolean(None))),
+            }),
+
+            SQLExpr::IsNotUnknown(expr) => Ok(Expr::BinaryExpr {
+                left: Box::new(self.sql_expr_to_logical_expr(*expr, schema, ctes)?),
+                op: Operator::IsDistinctFrom,
+                right: Box::new(lit(ScalarValue::Boolean(None))),
+            }),
 
             SQLExpr::UnaryOp { op, expr } => self.parse_sql_unary_op(op, *expr, schema, ctes),
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3195.

 # Rationale for this change
This PR implements `IS UNKNOWN` and `IS NOT UNKNOWN` SQL operations (similar to #3235).

# What changes are included in this PR?
The transformation of SQL-level `IS UNKNOWN` / `IS NOT UNKNOWN` operations to `IS DISTINCT FROM` queries in the logical level.

# Are there any user-facing changes?
2 new operators.

@andygrove [I assume that just like #3225](https://github.com/apache/arrow-datafusion/pull/3189#discussion_r951814941), this would also require some type-checking. Should we implement it afterwards, or should we wait your PR and I can make the required changes in this PR.