### PR TITLE
MINOR: Stop ignoring `AggregateFunction::distinct` in protobuf serde code

### DIFF
--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -72,7 +72,11 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                 let new_aggr_expr = aggr_expr
                     .iter()
                     .map(|agg_expr| match agg_expr {
-                        Expr::AggregateFunction { fun, args, .. } => {
+                        Expr::AggregateFunction {
+                            fun,
+                            args,
+                            distinct,
+                        } => {
                             // is_single_distinct_agg ensure args.len=1
                             if group_fields_set
                                 .insert(args[0].name(input.schema()).unwrap())
@@ -83,7 +87,7 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                             Expr::AggregateFunction {
                                 fun: fun.clone(),
                                 args: vec![col(SINGLE_DISTINCT_ALIAS)],
-                                distinct: false,
+                                distinct: *distinct,
                             }
                         }
                         _ => agg_expr.clone(),

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -72,11 +72,7 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                 let new_aggr_expr = aggr_expr
                     .iter()
                     .map(|agg_expr| match agg_expr {
-                        Expr::AggregateFunction {
-                            fun,
-                            args,
-                            distinct,
-                        } => {
+                        Expr::AggregateFunction { fun, args, .. } => {
                             // is_single_distinct_agg ensure args.len=1
                             if group_fields_set
                                 .insert(args[0].name(input.schema()).unwrap())
@@ -87,7 +83,7 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                             Expr::AggregateFunction {
                                 fun: fun.clone(),
                                 args: vec![col(SINGLE_DISTINCT_ALIAS)],
-                                distinct: *distinct,
+                                distinct: false, // intentional to remove distict here
                             }
                         }
                         _ => agg_expr.clone(),

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -17,11 +17,7 @@
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::{DataFusionError, Result};
-use datafusion_expr::logical_plan::builder::LogicalTableSource;
-use datafusion_expr::{
-    col, count, count_distinct, AggregateUDF, LogicalPlan, LogicalPlanBuilder, ScalarUDF,
-    TableSource,
-};
+use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource};
 use datafusion_optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
 use datafusion_optimizer::decorrelate_scalar_subquery::DecorrelateScalarSubquery;
 use datafusion_optimizer::decorrelate_where_exists::DecorrelateWhereExists;
@@ -60,71 +56,7 @@ fn distribute_by() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn count_distinct_multi_sql() -> Result<()> {
-    let sql = "SELECT COUNT(col_int32) AS num, COUNT(DISTINCT col_int32) AS num_distinct FROM test";
-    let plan = test_sql(sql)?;
-    let expected = "Projection: #COUNT(test.col_int32) AS num, #COUNT(DISTINCT test.col_int32) AS num_distinct\
-    \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#test.col_int32), COUNT(DISTINCT #test.col_int32)]]\
-    \n    TableScan: test projection=[col_int32]";
-    assert_eq!(expected, format!("{:?}", plan));
-    Ok(())
-}
-
-#[test]
-fn count_distinct_multi_plan_builder() -> Result<()> {
-    let schema_provider = MySchemaProvider {};
-    let table_name: TableReference = "test".into();
-    let table = schema_provider.get_table_provider(table_name)?;
-    let table_source = LogicalTableSource::new(table.schema());
-
-    let plan = LogicalPlanBuilder::scan("test", Arc::new(table_source), None)?
-        .aggregate(
-            vec![col("test.col_int32")],
-            vec![
-                count(col("test.col_int32")),
-                count_distinct(col("test.col_int32")),
-            ],
-        )?
-        .project(vec![col("test.col_int32")])?
-        .build()?;
-
-    println!("{}", plan.display_indent());
-
-    let plan = optimize_plan(&plan)?;
-
-    let expected = "Projection: #COUNT(test.col_int32) AS num, #COUNT(DISTINCT test.col_int32) AS num_distinct\
-    \n  Aggregate: groupBy=[[]], aggr=[[COUNT(#test.col_int32), COUNT(DISTINCT #test.col_int32)]]\
-    \n    TableScan: test projection=[col_int32]";
-    assert_eq!(expected, format!("{:?}", plan));
-    Ok(())
-}
-
-fn optimize_plan(plan: &LogicalPlan) -> Result<LogicalPlan> {
-    let mut config = OptimizerConfig::new().with_skip_failing_rules(false);
-    let optimizer = create_optimizer();
-    optimizer.optimize(&plan, &mut config, &observe)
-}
-
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
-    let optimizer = create_optimizer();
-
-    // parse the SQL
-    let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
-    let ast: Vec<Statement> = Parser::parse_sql(&dialect, sql).unwrap();
-    let statement = &ast[0];
-
-    // create a logical query plan
-    let schema_provider = MySchemaProvider {};
-    let sql_to_rel = SqlToRel::new(&schema_provider);
-    let plan = sql_to_rel.sql_statement_to_plan(statement.clone()).unwrap();
-
-    // optimize the logical plan
-    let mut config = OptimizerConfig::new().with_skip_failing_rules(false);
-    optimizer.optimize(&plan, &mut config, &observe)
-}
-
-fn create_optimizer() -> Optimizer {
     let rules: Vec<Arc<dyn OptimizerRule + Sync + Send>> = vec![
         // Simplify expressions first to maximize the chance
         // of applying other optimizations
@@ -146,13 +78,29 @@ fn create_optimizer() -> Optimizer {
     ];
 
     let optimizer = Optimizer::new(rules);
-    optimizer
+
+    // parse the SQL
+    let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
+    let ast: Vec<Statement> = Parser::parse_sql(&dialect, sql).unwrap();
+    let statement = &ast[0];
+
+    // create a logical query plan
+    let schema_provider = MySchemaProvider {};
+    let sql_to_rel = SqlToRel::new(&schema_provider);
+    let plan = sql_to_rel.sql_statement_to_plan(statement.clone()).unwrap();
+
+    // optimize the logical plan
+    let mut config = OptimizerConfig::new().with_skip_failing_rules(false);
+    optimizer.optimize(&plan, &mut config, &observe)
 }
 
 struct MySchemaProvider {}
 
 impl ContextProvider for MySchemaProvider {
-    fn get_table_provider(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
+    fn get_table_provider(
+        &self,
+        name: TableReference,
+    ) -> datafusion_common::Result<Arc<dyn TableSource>> {
         let table_name = name.table();
         if table_name.starts_with("test") {
             let schema = Schema::new_with_metadata(

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -474,6 +474,7 @@ enum AggregateFunction {
 message AggregateExprNode {
   AggregateFunction aggr_function = 1;
   repeated LogicalExprNode expr = 2;
+  bool distinct = 3;
 }
 
 message AggregateUDFExprNode {

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -890,7 +890,7 @@ pub fn parse_expr(
                     .iter()
                     .map(|e| parse_expr(e, registry))
                     .collect::<Result<Vec<_>, _>>()?,
-                distinct: false, // TODO
+                distinct: expr.distinct,
             })
         }
         ExprType::Alias(alias) => Ok(Expr::Alias(

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -913,6 +913,28 @@ mod roundtrip_tests {
     }
 
     #[test]
+    fn roundtrip_count() {
+        let test_expr = Expr::AggregateFunction {
+            fun: AggregateFunction::Count,
+            args: vec![col("bananas")],
+            distinct: false,
+        };
+        let ctx = SessionContext::new();
+        roundtrip_expr_test(test_expr, ctx);
+    }
+
+    #[test]
+    fn roundtrip_count_distinct() {
+        let test_expr = Expr::AggregateFunction {
+            fun: AggregateFunction::Count,
+            args: vec![col("bananas")],
+            distinct: true,
+        };
+        let ctx = SessionContext::new();
+        roundtrip_expr_test(test_expr, ctx);
+    }
+
+    #[test]
     fn roundtrip_approx_percentile_cont() {
         let test_expr = Expr::AggregateFunction {
             fun: AggregateFunction::ApproxPercentileCont,

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -502,7 +502,9 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
                 }
             }
             Expr::AggregateFunction {
-                ref fun, ref args, ..
+                ref fun,
+                ref args,
+                ref distinct,
             } => {
                 let aggr_function = match fun {
                     AggregateFunction::ApproxDistinct => {
@@ -550,6 +552,7 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
                         .iter()
                         .map(|v| v.try_into())
                         .collect::<Result<Vec<_>, _>>()?,
+                    distinct: *distinct,
                 };
                 Self {
                     expr_type: Some(ExprType::AggregateExpr(aggregate_expr)),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We should not have hard-coded values for `distinct`. We should use the intended values, otherwise queries could return the wrong results.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove hard-coded distinct values and add tests.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, fixes some incorrect query results.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->