### PR TITLE
Support "IS NOT TRUE/FALSE" syntax

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -382,6 +382,70 @@ async fn query_is_false() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_is_not_true() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+        ]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT c1 IS NOT TRUE as nt FROM test";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-------+",
+        "| nt    |",
+        "+-------+",
+        "| false |",
+        "| true  |",
+        "| true  |",
+        "+-------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_is_not_false() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+        ]))],
+    )?;
+
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test", Arc::new(table))?;
+    let sql = "SELECT c1 IS NOT FALSE as nf FROM test";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-------+",
+        "| nf    |",
+        "+-------+",
+        "| true  |",
+        "| false |",
+        "| true  |",
+        "+-------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn query_is_unknown() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Boolean, true)]));
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1956,6 +1956,18 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 right: Box::new(lit(false)),
             }),
 
+            SQLExpr::IsNotTrue(expr) => Ok(Expr::BinaryExpr {
+                left: Box::new(self.sql_expr_to_logical_expr(*expr, schema, ctes)?),
+                op: Operator::IsDistinctFrom,
+                right: Box::new(lit(true)),
+            }),
+
+            SQLExpr::IsNotFalse(expr) => Ok(Expr::BinaryExpr {
+                left: Box::new(self.sql_expr_to_logical_expr(*expr, schema, ctes)?),
+                op: Operator::IsDistinctFrom,
+                right: Box::new(lit(false)),
+            }),
+
             SQLExpr::IsUnknown(expr) => Ok(Expr::BinaryExpr {
                 left: Box::new(self.sql_expr_to_logical_expr(*expr, schema, ctes)?),
                 op: Operator::IsNotDistinctFrom,


### PR DESCRIPTION
# Which issue does this PR close?
Closes #2265

# What changes are included in this PR?
Similar to #3235 and #3246, this PR adds the "IS NOT TRUE" and "IS NOT FALSE" boolean operations and their SQL-level tests.