### PR TITLE
MINOR: stop ignoring TPCH tests that now work

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,14 +18,14 @@
 [package]
 name = "datafusion-benchmarks"
 description = "DataFusion Benchmarks"
-version = "5.0.0"
+version = "11.0.0"
 edition = "2021"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 license = "Apache-2.0"
 publish = false
-rust-version = "1.59"
+rust-version = "1.62"
 
 [features]
 simd = ["datafusion/simd"]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -61,6 +61,8 @@ The benchmark program also supports CSV and Parquet input file formats and a uti
 cargo run --release --bin tpch -- convert --input ./data --output /mnt/tpch-parquet --format parquet
 ```
 
+Or if you want to verify and run all the queries in the benchmark, you can just run `cargo test`.
+
 ## Expected output
 
 The result of query 1 should produce the following output when executed against the SF=1 dataset.

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -333,7 +333,6 @@ async fn convert_tbl(opt: ConvertOpt) -> Result<()> {
 
         // create the physical plan
         let csv = csv.to_logical_plan()?;
-        let csv = ctx.optimize(&csv)?;
         let csv = ctx.create_physical_plan(&csv).await?;
 
         let output_path = output_root_path.join(table);
@@ -702,9 +701,8 @@ mod tests {
         run_query(1).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/159
     #[tokio::test]
-    async fn run_2() -> Result<()> {
+    async fn run_q2() -> Result<()> {
         run_query(2).await
     }
 
@@ -713,7 +711,6 @@ mod tests {
         run_query(3).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/160
     #[tokio::test]
     async fn run_q4() -> Result<()> {
         run_query(4).await
@@ -749,7 +746,6 @@ mod tests {
         run_query(10).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/163
     #[tokio::test]
     async fn run_q11() -> Result<()> {
         run_query(11).await
@@ -781,7 +777,6 @@ mod tests {
         run_query(16).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/168
     #[tokio::test]
     async fn run_q17() -> Result<()> {
         run_query(17).await
@@ -792,12 +787,12 @@ mod tests {
         run_query(18).await
     }
 
+    #[ignore] // maybe it works, but if it never finishes, how can you tell?
     #[tokio::test]
     async fn run_q19() -> Result<()> {
         run_query(19).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/171
     #[tokio::test]
     async fn run_q20() -> Result<()> {
         run_query(20).await
@@ -809,7 +804,6 @@ mod tests {
         run_query(21).await
     }
 
-    #[ignore] // https://github.com/apache/arrow-datafusion/issues/175
     #[tokio::test]
     async fn run_q22() -> Result<()> {
         run_query(22).await
@@ -819,21 +813,6 @@ mod tests {
     fn col_str(column: &ArrayRef, row_index: usize) -> String {
         if column.is_null(row_index) {
             return "NULL".to_string();
-        }
-
-        // Special case ListArray as there is no pretty print support for it yet
-        if let DataType::FixedSizeList(_, n) = column.data_type() {
-            let array = column
-                .as_any()
-                .downcast_ref::<FixedSizeListArray>()
-                .unwrap()
-                .value(row_index);
-
-            let mut r = Vec::with_capacity(*n as usize);
-            for i in 0..*n {
-                r.push(col_str(&array, i as usize));
-            }
-            return format!("[{}]", r.join(","));
         }
 
         array_value_to_string(column, row_index).unwrap()

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-examples"
 description = "DataFusion usage examples"
-version = "5.0.0"
+version = "11.0.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 keywords = [ "arrow", "query", "sql" ]
 edition = "2021"
 publish = false
-rust-version = "1.59"
+rust-version = "1.62"
 
 [[example]]
 name = "avro_sql"

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -17,13 +17,12 @@
 # limitations under the License.
 #
 
-# Script that updates verions for datafusion crates, locally
+# Script that updates versions for datafusion crates, locally
 #
 # dependencies:
 # pip install tomlkit
 
 import re
-import os
 import argparse
 from pathlib import Path
 import tomlkit
@@ -39,6 +38,8 @@ crates = {
     'datafusion-proto': 'datafusion/proto/Cargo.toml',
     'datafusion-row': 'datafusion/row/Cargo.toml',
     'datafusion-sql': 'datafusion/sql/Cargo.toml',
+    'datafusion-benchmarks': 'benchmarks/Cargo.toml',
+    'datafusion-examples': 'datafusion-examples/Cargo.toml',
 }
 
 def update_datafusion_version(cargo_toml: str, new_version: str):


### PR DESCRIPTION
minor updates to remove code that's now in arrow-rs and update rust version, etc.
removed an optimize call that isn't needed, as optimize gets called in the next function

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* remove [#ignore] from some tests that now work
* add an ignore to q19 which is so slow that it doesn't actually work
* minor updates to version, rust-version, remove some code that's in arrow-rs now
* remove a call to optimize that isn't needed, as it's optimized in the next function call

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->