### PR TITLE
Add type coercion for UDFs in logical plan

### DIFF
--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -265,10 +265,9 @@ mod test {
     }
 
     fn empty() -> Arc<LogicalPlan> {
-        let empty = Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
+        Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
-        }));
-        empty
+        }))
     }
 }

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -117,7 +117,7 @@ impl ExprRewriter for TypeCoercionRewriter {
 /// `signature`, if possible.
 ///
 /// See the module level documentation for more detail on coercion.
-pub fn coerce_arguments_for_signature(
+fn coerce_arguments_for_signature(
     expressions: &[Expr],
     schema: &DFSchema,
     signature: &Signature,

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -104,7 +104,7 @@ impl ExprRewriter for TypeCoercionRewriter {
                     &fun.signature,
                 )?;
                 Ok(Expr::ScalarUDF {
-                    fun: fun.clone(),
+                    fun,
                     args: new_expr,
                 })
             }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/issues/2355
Follows on from https://github.com/apache/arrow-datafusion/pull/3222 and https://github.com/apache/arrow-datafusion/pull/3250

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We currently perform type coercion for UDFs in the physical planner/optimizer. I would like to have this logic in the logical plan so that other projects (such as Dask SQL) can benefit from this.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Update the `TypeCoercion` rule to support Scalar UDFs

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, logical plans will be different in some cases.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->