### PR TITLE
MINOR: Remove `unwrap` calls from `single_distinct_to_groupby optimizer` rule

### DIFF
--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -69,39 +69,37 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                 let mut all_group_args: Vec<Expr> = group_expr.clone();
 
                 // remove distinct and collection args
-                let new_aggr_expr = aggr_expr
-                    .iter()
-                    .map(|agg_expr| match agg_expr {
+                let mut new_aggr_expr = Vec::with_capacity(aggr_expr.len());
+                for agg_expr in aggr_expr {
+                    let x = match agg_expr {
                         Expr::AggregateFunction { fun, args, .. } => {
                             // is_single_distinct_agg ensure args.len=1
-                            if group_fields_set
-                                .insert(args[0].name(input.schema()).unwrap())
-                            {
+                            if group_fields_set.insert(args[0].name(input.schema())?) {
                                 all_group_args
                                     .push(args[0].clone().alias(SINGLE_DISTINCT_ALIAS));
                             }
                             Expr::AggregateFunction {
                                 fun: fun.clone(),
                                 args: vec![col(SINGLE_DISTINCT_ALIAS)],
-                                distinct: false, // intentional to remove distict here
+                                distinct: false, // intentional to remove distinct here
                             }
                         }
                         _ => agg_expr.clone(),
-                    })
-                    .collect::<Vec<_>>();
+                    };
+                    new_aggr_expr.push(x);
+                }
 
                 let all_group_expr = grouping_set_to_exprlist(&all_group_args)?;
 
                 let all_field = all_group_expr
                     .iter()
-                    .map(|expr| expr.to_field(input.schema()).unwrap())
-                    .collect::<Vec<_>>();
+                    .map(|expr| expr.to_field(input.schema()))
+                    .collect::<Result<Vec<_>>>()?;
 
                 let grouped_schema = DFSchema::new_with_metadata(
                     all_field,
                     input.schema().metadata().clone(),
-                )
-                .unwrap();
+                )?;
                 let grouped_agg = LogicalPlan::Aggregate(Aggregate {
                     input: input.clone(),
                     group_expr: all_group_args,
@@ -109,17 +107,14 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                     schema: Arc::new(grouped_schema.clone()),
                 });
                 let grouped_agg = optimize_children(&grouped_agg);
-                let final_agg_schema = Arc::new(
-                    DFSchema::new_with_metadata(
-                        base_group_expr
-                            .iter()
-                            .chain(new_aggr_expr.iter())
-                            .map(|expr| expr.to_field(&grouped_schema).unwrap())
-                            .collect::<Vec<_>>(),
-                        input.schema().metadata().clone(),
-                    )
-                    .unwrap(),
-                );
+                let final_agg_schema = Arc::new(DFSchema::new_with_metadata(
+                    base_group_expr
+                        .iter()
+                        .chain(new_aggr_expr.iter())
+                        .map(|expr| expr.to_field(&grouped_schema))
+                        .collect::<Result<Vec<_>>>()?,
+                    input.schema().metadata().clone(),
+                )?);
 
                 // so the aggregates are displayed in the same way even after the rewrite
                 let mut alias_expr: Vec<Expr> = Vec::new();
@@ -135,7 +130,7 @@ fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
                     });
 
                 let final_agg = LogicalPlan::Aggregate(Aggregate {
-                    input: Arc::new(grouped_agg.unwrap()),
+                    input: Arc::new(grouped_agg?),
                     group_expr: group_expr.clone(),
                     aggr_expr: new_aggr_expr,
                     schema: final_agg_schema,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The optimizer can skip rules that return an `Err` but cannot recover from a panic. so it is better for rules to return `Err`.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Replace `unwrap` with `?`. This required changing one `map` with side-effects into a `for` loop. IMO we should avoid mutating external state in `map` operations.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->