### PR TITLE
MINOR: rename optimizer rule to ScalarSubqueryToJoin

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -103,7 +103,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use datafusion_common::ScalarValue;
 use datafusion_expr::TableSource;
-use datafusion_optimizer::decorrelate_scalar_subquery::DecorrelateScalarSubquery;
+use datafusion_optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion_optimizer::decorrelate_where_exists::DecorrelateWhereExists;
 use datafusion_optimizer::decorrelate_where_in::DecorrelateWhereIn;
 use datafusion_optimizer::filter_null_join_keys::FilterNullJoinKeys;
@@ -1365,7 +1365,7 @@ impl SessionState {
             Arc::new(PreCastLitInComparisonExpressions::new()),
             Arc::new(DecorrelateWhereExists::new()),
             Arc::new(DecorrelateWhereIn::new()),
-            Arc::new(DecorrelateScalarSubquery::new()),
+            Arc::new(ScalarSubqueryToJoin::new()),
             Arc::new(SubqueryFilterToJoin::new()),
             Arc::new(EliminateFilter::new()),
             Arc::new(CommonSubexprEliminate::new()),

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -103,12 +103,12 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use datafusion_common::ScalarValue;
 use datafusion_expr::TableSource;
-use datafusion_optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion_optimizer::decorrelate_where_exists::DecorrelateWhereExists;
 use datafusion_optimizer::decorrelate_where_in::DecorrelateWhereIn;
 use datafusion_optimizer::filter_null_join_keys::FilterNullJoinKeys;
 use datafusion_optimizer::pre_cast_lit_in_comparison::PreCastLitInComparisonExpressions;
 use datafusion_optimizer::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
+use datafusion_optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion_sql::{
     parser::DFParser,
     planner::{ContextProvider, SqlToRel},

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 pub mod common_subexpr_eliminate;
-pub mod decorrelate_scalar_subquery;
+pub mod scalar_subquery_to_join;
 pub mod decorrelate_where_exists;
 pub mod decorrelate_where_in;
 pub mod eliminate_filter;

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 pub mod common_subexpr_eliminate;
-pub mod scalar_subquery_to_join;
 pub mod decorrelate_where_exists;
 pub mod decorrelate_where_in;
 pub mod eliminate_filter;
@@ -28,6 +27,7 @@ pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
 pub mod reduce_outer_join;
+pub mod scalar_subquery_to_join;
 pub mod simplify_expressions;
 pub mod single_distinct_to_groupby;
 pub mod subquery_filter_to_join;

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -131,7 +131,7 @@ impl OptimizerRule for ScalarSubqueryToJoin {
     }
 
     fn name(&self) -> &str {
-        "decorrelate_scalar_subquery"
+        "scalar_subquery_to_join"
     }
 }
 

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -28,9 +28,9 @@ use std::sync::Arc;
 
 /// Optimizer rule for rewriting subquery filters to joins
 #[derive(Default)]
-pub struct DecorrelateScalarSubquery {}
+pub struct ScalarSubqueryToJoin {}
 
-impl DecorrelateScalarSubquery {
+impl ScalarSubqueryToJoin {
     #[allow(missing_docs)]
     pub fn new() -> Self {
         Self {}
@@ -88,7 +88,7 @@ impl DecorrelateScalarSubquery {
     }
 }
 
-impl OptimizerRule for DecorrelateScalarSubquery {
+impl OptimizerRule for ScalarSubqueryToJoin {
     fn optimize(
         &self,
         plan: &LogicalPlan,
@@ -355,7 +355,7 @@ mod tests {
       Projection: #orders.o_custkey, #MAX(orders.o_custkey) AS __value, alias=__sq_2 [o_custkey:Int64, __value:Int64;N]
         Aggregate: groupBy=[[#orders.o_custkey]], aggr=[[MAX(#orders.o_custkey)]] [o_custkey:Int64, MAX(orders.o_custkey):Int64;N]
           TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -402,7 +402,7 @@ mod tests {
               Projection: #lineitem.l_orderkey, #SUM(lineitem.l_extendedprice) AS __value, alias=__sq_1 [l_orderkey:Int64, __value:Float64;N]
                 Aggregate: groupBy=[[#lineitem.l_orderkey]], aggr=[[SUM(#lineitem.l_extendedprice)]] [l_orderkey:Int64, SUM(lineitem.l_extendedprice):Float64;N]
                   TableScan: lineitem [l_orderkey:Int64, l_partkey:Int64, l_suppkey:Int64, l_linenumber:Int32, l_quantity:Float64, l_extendedprice:Float64]"#;
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -435,7 +435,7 @@ mod tests {
           Filter: #orders.o_orderkey = Int32(1) [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]
             TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -464,7 +464,7 @@ mod tests {
         Aggregate: groupBy=[[]], aggr=[[MAX(#orders.o_custkey)]] [MAX(orders.o_custkey):Int64;N]
           Filter: #customer.c_custkey = #customer.c_custkey [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]
             TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -493,7 +493,7 @@ mod tests {
           Filter: #orders.o_custkey = #orders.o_custkey [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]
             TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -515,7 +515,7 @@ mod tests {
 
         let expected = r#"only joins on column equality are presently supported"#;
 
-        assert_optimizer_err(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimizer_err(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -536,7 +536,7 @@ mod tests {
             .build()?;
 
         let expected = r#"can't optimize < column comparison"#;
-        assert_optimizer_err(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimizer_err(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -561,7 +561,7 @@ mod tests {
             .build()?;
 
         let expected = r#"Optimizing disjunctions not supported!"#;
-        assert_optimizer_err(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimizer_err(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -580,7 +580,7 @@ mod tests {
             .build()?;
 
         let expected = r#"scalar subqueries must have a projection"#;
-        assert_optimizer_err(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimizer_err(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         let expected = r#""#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -630,7 +630,7 @@ mod tests {
             .build()?;
 
         let expected = r#"exactly one expression should be projected"#;
-        assert_optimizer_err(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimizer_err(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -663,7 +663,7 @@ mod tests {
           Aggregate: groupBy=[[#orders.o_custkey]], aggr=[[MAX(#orders.o_custkey)]] [o_custkey:Int64, MAX(orders.o_custkey):Int64;N]
             TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -696,7 +696,7 @@ mod tests {
           Filter: #customer.c_custkey = #orders.o_custkey [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]
             TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]
     TableScan: customer [c_custkey:Int64, c_name:Utf8]"#;
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -724,7 +724,7 @@ mod tests {
         Aggregate: groupBy=[[#sq.a]], aggr=[[MIN(#sq.c)]] [a:UInt32, MIN(sq.c):UInt32;N]
           TableScan: sq [a:UInt32, b:UInt32, c:UInt32]"#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 
@@ -751,7 +751,7 @@ mod tests {
         Aggregate: groupBy=[[]], aggr=[[MAX(#orders.o_custkey)]] [MAX(orders.o_custkey):Int64;N]
           TableScan: orders [o_orderkey:Int64, o_custkey:Int64, o_orderstatus:Utf8, o_totalprice:Float64;N]"#;
 
-        assert_optimized_plan_eq(&DecorrelateScalarSubquery::new(), &plan, expected);
+        assert_optimized_plan_eq(&ScalarSubqueryToJoin::new(), &plan, expected);
         Ok(())
     }
 }

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -19,7 +19,6 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource};
 use datafusion_optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
-use datafusion_optimizer::decorrelate_scalar_subquery::DecorrelateScalarSubquery;
 use datafusion_optimizer::decorrelate_where_exists::DecorrelateWhereExists;
 use datafusion_optimizer::decorrelate_where_in::DecorrelateWhereIn;
 use datafusion_optimizer::eliminate_filter::EliminateFilter;
@@ -31,6 +30,7 @@ use datafusion_optimizer::optimizer::Optimizer;
 use datafusion_optimizer::projection_push_down::ProjectionPushDown;
 use datafusion_optimizer::reduce_outer_join::ReduceOuterJoin;
 use datafusion_optimizer::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
+use datafusion_optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion_optimizer::simplify_expressions::SimplifyExpressions;
 use datafusion_optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
 use datafusion_optimizer::subquery_filter_to_join::SubqueryFilterToJoin;
@@ -63,7 +63,7 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
         Arc::new(SimplifyExpressions::new()),
         Arc::new(DecorrelateWhereExists::new()),
         Arc::new(DecorrelateWhereIn::new()),
-        Arc::new(DecorrelateScalarSubquery::new()),
+        Arc::new(ScalarSubqueryToJoin::new()),
         Arc::new(SubqueryFilterToJoin::new()),
         Arc::new(EliminateFilter::new()),
         Arc::new(CommonSubexprEliminate::new()),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Just renames optimizer rule DecorrelateScalarSubquery to ScalarSubqueryToJoin to more accurately reflect what it's doing. Per request of @avantgardnerio during discussion of #3287.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->