### PR TITLE
MINOR: add github action trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,9 +18,11 @@
 name: Rust
 
 on:
-  # always trigger
+  # always trigger on PR
   push:
   pull_request:
+  # manual trigger
+  workflow_dispatch:
 
 jobs:
   # Check crate compiles

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ on:
   push:
   pull_request:
   # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ref #3321.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

GitHub Action will only run on PR updating, we cannot trigger one on demand manually. This is inconvenient if we want to run one on master or without submitting a PR.

I've tried this patch in my fork repo, now I can see this button:
![image](https://user-images.githubusercontent.com/15380403/187865413-7b5f10c2-7b1f-4583-ae83-a00dde792fe5.png)


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add an [action trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch] that allows us to trigger an action manually.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->