### PR TITLE
Deprecate legacy datafusion::logical_plan module

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -800,12 +800,12 @@ mod tests {
     use super::*;
     use crate::execution::options::CsvReadOptions;
     use crate::physical_plan::ColumnarValue;
+    use crate::test_util;
     use crate::{assert_batches_sorted_eq, execution::context::SessionContext};
-    use crate::{logical_plan::*, test_util};
     use arrow::datatypes::DataType;
-    use datafusion_expr::{cast, Volatility};
     use datafusion_expr::{
-        BuiltInWindowFunction, ScalarFunctionImplementation, WindowFunction,
+        avg, cast, count, count_distinct, create_udf, lit, max, min, sum,
+        BuiltInWindowFunction, ScalarFunctionImplementation, Volatility, WindowFunction,
     };
 
     #[tokio::test]

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -32,17 +32,17 @@ use futures::{stream::BoxStream, TryStreamExt};
 use log::debug;
 
 use crate::{
-    datasource::MemTable,
-    error::Result,
-    execution::context::SessionContext,
-    logical_plan::{self, Expr, ExprVisitable, ExpressionVisitor, Recursion},
+    datasource::MemTable, error::Result, execution::context::SessionContext,
     scalar::ScalarValue,
 };
 
 use super::PartitionedFile;
 use crate::datasource::listing::ListingTableUrl;
-use datafusion_common::DataFusionError;
-use datafusion_expr::Volatility;
+use datafusion_common::{Column, DataFusionError};
+use datafusion_expr::{
+    expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion},
+    Expr, Volatility,
+};
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
 
@@ -74,7 +74,7 @@ impl ApplicabilityVisitor<'_> {
 impl ExpressionVisitor for ApplicabilityVisitor<'_> {
     fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>> {
         let rec = match expr {
-            Expr::Column(logical_plan::Column { ref name, .. }) => {
+            Expr::Column(Column { ref name, .. }) => {
                 *self.is_applicable &= self.col_names.contains(name);
                 Recursion::Stop(self) // leaf node anyway
             }

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -215,6 +215,9 @@ pub mod dataframe;
 pub mod datasource;
 pub mod error;
 pub mod execution;
+#[deprecated]
+// logical_plan module just contains re-exports and will be removed in a future release
+// https://github.com/apache/arrow-datafusion/issues/2683
 pub mod logical_plan;
 pub mod physical_optimizer;
 pub mod physical_plan;

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -662,12 +662,10 @@ fn build_predicate_expression(
     schema: &Schema,
     required_columns: &mut RequiredStatColumns,
 ) -> Result<Expr> {
-    use crate::logical_plan;
-
     // Returned for unsupported expressions. Such expressions are
     // converted to TRUE. This can still be useful when multiple
     // conditions are joined using AND such as: column > 10 AND TRUE
-    let unhandled = logical_plan::lit(true);
+    let unhandled = lit(true);
 
     // predicate expression can only be a binary expression
     let (left, op, right) = match expr {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/2683

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Part of stabilizing the public API

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Deprecate the legacy `logical_plan` module in `datafusion` "core" crate. This just contains re-exports of other items.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->