### PR TITLE
Add to_unoptimized_plan

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -520,8 +520,8 @@ impl DataFrame {
         self.plan.schema()
     }
 
-    /// Return the raw (i.e. unoptimized) logical plan represented by this DataFrame.
-    pub fn to_raw_logical_plan(&self) -> LogicalPlan {
+    /// Return the unoptimized logical plan represented by this DataFrame.
+    pub fn to_unoptimized_logical_plan(&self) -> LogicalPlan {
         // Optimize the plan first for better UX
         self.plan.clone()
     }
@@ -1272,7 +1272,7 @@ mod tests {
         \n      Inner Join: #t1.c1 = #t2.c1\
         \n        TableScan: t1\
         \n        TableScan: t2",
-            format!("{:?}", df_renamed.to_raw_logical_plan())
+            format!("{:?}", df_renamed.to_unoptimized_logical_plan())
         );
 
         assert_eq!("\

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -520,7 +520,13 @@ impl DataFrame {
         self.plan.schema()
     }
 
-    /// Return the logical plan represented by this DataFrame.
+    /// Return the raw (i.e. unoptimized) logical plan represented by this DataFrame.
+    pub fn to_raw_logical_plan(&self) -> LogicalPlan {
+        // Optimize the plan first for better UX
+        self.plan.clone()
+    }
+
+    /// Return the optimized logical plan represented by this DataFrame.
     pub fn to_logical_plan(&self) -> Result<LogicalPlan> {
         // Optimize the plan first for better UX
         let state = self.session_state.read().clone();
@@ -1258,6 +1264,17 @@ mod tests {
         );
 
         let df_renamed = df.with_column_renamed("t1.c1", "AAA")?;
+
+        assert_eq!("\
+        Projection: #t1.c1 AS AAA, #t1.c2, #t1.c3, #t2.c1, #t2.c2, #t2.c3\
+        \n  Limit: skip=None, fetch=1\
+        \n    Sort: #t1.c1 ASC NULLS FIRST, #t1.c2 ASC NULLS FIRST, #t1.c3 ASC NULLS FIRST, #t2.c1 ASC NULLS FIRST, #t2.c2 ASC NULLS FIRST, #t2.c3 ASC NULLS FIRST\
+        \n      Inner Join: #t1.c1 = #t2.c1\
+        \n        TableScan: t1\
+        \n        TableScan: t2",
+            format!("{:?}", df_renamed.to_raw_logical_plan())
+        );
+
         assert_eq!("\
         Projection: #t1.c1 AS AAA, #t1.c2, #t1.c3, #t2.c1, #t2.c2, #t2.c3\
         \n  Limit: skip=None, fetch=1\

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -521,7 +521,7 @@ impl DataFrame {
     }
 
     /// Return the unoptimized logical plan represented by this DataFrame.
-    pub fn to_unoptimized_logical_plan(&self) -> LogicalPlan {
+    pub fn to_unoptimized_plan(&self) -> LogicalPlan {
         // Optimize the plan first for better UX
         self.plan.clone()
     }
@@ -1272,7 +1272,7 @@ mod tests {
         \n      Inner Join: #t1.c1 = #t2.c1\
         \n        TableScan: t1\
         \n        TableScan: t2",
-            format!("{:?}", df_renamed.to_unoptimized_logical_plan())
+            format!("{:?}", df_renamed.to_unoptimized_plan())
         );
 
         assert_eq!("\


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3340.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Enable people to fetch the raw `LogicalPlan` in a `DataFrame`.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
`pub fn to_raw_logical_plan(&self) -> LogicalPlan {..} `has been added together with an assertion in a test.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. There are no breaking changes though.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
