### PR TITLE
fix: clippy

### DIFF
--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -193,7 +193,7 @@ pub(crate) fn spawn_execution(
         while let Some(item) = stream.next().await {
             // If send fails, plan being torn down,
             // there is no place to send the error.
-            if let Err(_) = output.send(item).await {
+            if output.send(item).await.is_err() {
                 return;
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

NA 

 # Rationale for this change
Get CI on master back to green

Clippy is failing on master: https://github.com/apache/arrow-datafusion/runs/8168861104?check_suite_focus=true

```
   Checking datafusion v11.0.0 (/__w/arrow-datafusion/arrow-datafusion/datafusion/core)
error: redundant pattern matching, consider using `is_err()`
   --> datafusion/core/src/physical_plan/common.rs:196:20
    |
196 |             if let Err(_) = output.send(item).await {
    |             -------^^^^^^-------------------------- help: try this: `if (output.send(item).await).is_err()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching

error: could not compile `datafusion` due to previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

This error was introduced in https://github.com/apache/arrow-datafusion/pull/3276 which I merged 🤦 ; It isn't clear to me why CI wasn't run on that PR


# What changes are included in this PR?
Do what clippy says

# Are there any user-facing changes?
No