### PR TITLE
Replace panic with Result in reader.rs

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -440,8 +440,7 @@ fn create_batch_from_map(
         .unzip();
 
     let mut columns: Vec<ArrayRef> =
-        read_as_batch(&group_buffers, group_schema, RowType::Compact)
-            .map_err(|e| ArrowError::ParseError(e.to_string()))?;
+        read_as_batch(&group_buffers, group_schema, RowType::Compact)?;
 
     match mode {
         AggregateMode::Partial => columns.extend(read_as_batch(

--- a/datafusion/row/src/reader.rs
+++ b/datafusion/row/src/reader.rs
@@ -305,7 +305,7 @@ macro_rules! fn_read_field {
                 let to = to
                     .as_any_mut()
                     .downcast_mut::<$ARRAY>()
-                    .ok_or(
+                    .ok_or_else(||
                         DataFusionError::Internal(
                             format!("Error downcasting ArrayBuilder to {:?}", stringify!($ARRAY)),
                         ),
@@ -318,7 +318,7 @@ macro_rules! fn_read_field {
                 let to = to
                     .as_any_mut()
                     .downcast_mut::<$ARRAY>()
-                    .ok_or(
+                    .ok_or_else(||
                         DataFusionError::Internal(
                             format!("Error downcasting ArrayBuilder to {:?}", stringify!($ARRAY)),
                         ),
@@ -350,11 +350,14 @@ pub(crate) fn read_field_binary(
     col_idx: usize,
     row: &RowReader,
 ) -> Result<()> {
-    let to = to.as_any_mut().downcast_mut::<BinaryBuilder>().ok_or(
-        DataFusionError::Internal(
-            "Error downcasting ArrayBuilder to BinaryBuilder".into(),
-        ),
-    )?;
+    let to = to
+        .as_any_mut()
+        .downcast_mut::<BinaryBuilder>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "Error downcasting ArrayBuilder to BinaryBuilder".into(),
+            )
+        })?;
     if row.is_valid_at(col_idx) {
         to.append_value(row.get_binary(col_idx));
     } else {
@@ -368,11 +371,14 @@ pub(crate) fn read_field_binary_null_free(
     col_idx: usize,
     row: &RowReader,
 ) -> Result<()> {
-    let to = to.as_any_mut().downcast_mut::<BinaryBuilder>().ok_or(
-        DataFusionError::Internal(
-            "Error downcasting ArrayBuilder to BinaryBuilder".into(),
-        ),
-    )?;
+    let to = to
+        .as_any_mut()
+        .downcast_mut::<BinaryBuilder>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "Error downcasting ArrayBuilder to BinaryBuilder".into(),
+            )
+        })?;
     to.append_value(row.get_binary(col_idx));
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?
Partial fix for #3317

 # Rationale for this change
Replace panic with Result.

# What changes are included in this PR?
Replace panic with replace in below places


"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":302                     .unwrap();
"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":310                     .unwrap();
"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":337     let to = to.as_any_mut().downcast_mut::<BinaryBuilder>().unwrap();
"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":350     let to = to.as_any_mut().downcast_mut::<BinaryBuilder>().unwrap();
"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":377         _ => unimplemented!(),
"/home/andy/git/apache/arrow-datafusion/datafusion/row/src/reader.rs":404         _ => unimplemented!(),


# Are there any user-facing changes?
Not sure. Few functions are modified to return `Result`. Not sure if they are part of public API.
