### PR TITLE
return empty dataframe on create table, remove a duplicate optimize call

### DIFF
--- a/datafusion/core/tests/sql/create_drop.rs
+++ b/datafusion/core/tests/sql/create_drop.rs
@@ -57,12 +57,14 @@ async fn create_or_replace_table_as() -> Result<()> {
         SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 
     // Create table
-    ctx.sql("CREATE TABLE y AS VALUES (1,2),(3,4)")
+    let result = ctx
+        .sql("CREATE TABLE y AS VALUES (1,2),(3,4)")
         .await
         .unwrap()
         .collect()
         .await
         .unwrap();
+    assert!(result.is_empty());
 
     // Replace table
     ctx.sql("CREATE OR REPLACE TABLE y AS VALUES (5,6)")

--- a/docs/source/user-guide/sql/ddl.md
+++ b/docs/source/user-guide/sql/ddl.md
@@ -78,16 +78,16 @@ PARTITIONED BY (year, month)
 LOCATION '/mnt/nyctaxi';
 ```
 
-## CREATE MEMORY TABLE
+## CREATE TABLE
 
-Memory table can be created with query.
+An in-memory table can be created with a query or values list.
 
-```
-CREATE TABLE TABLE_NAME AS [SELECT | VALUES LIST]
-```
+<pre>
+CREATE [OR REPLACE] TABLE [IF NOT EXISTS] <b><i>table_name</i></b> AS [SELECT | VALUES LIST];
+</pre>
 
 ```sql
-CREATE TABLE valuetable AS VALUES(1,'HELLO'),(12,'DATAFUSION');
+CREATE TABLE valuetable IF NOT EXISTS AS VALUES(1,'HELLO'),(12,'DATAFUSION');
 
 CREATE TABLE memtable as select * from valuetable;
 ```


### PR DESCRIPTION
update docs

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3265 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* per issue, successful `create table` returns an empty dataframe instead of a full select of what's in the table
* removed an extra optimize() call during creation
* updated docs

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Slight. When creating a table in datafusion-cli, it will no longer return the contents of the table created.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->