### PR TITLE
Upgrade to arrow 22

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -31,7 +31,7 @@ readme = "README.md"
 [dependencies]
 arrow = "22.0.0"
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { version = "11.0.0", path = "../datafusion/core" }
+datafusion = { path = "../datafusion/core", version = "11.0.0" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.62"
 readme = "README.md"
 
 [dependencies]
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+arrow = "22.0.0"
 clap = { version = "3", features = ["derive", "cargo"] }
 datafusion = { version = "11.0.0", path = "../datafusion/core" }
 dirs = "4.0.0"

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -29,9 +29,9 @@ rust-version = "1.62"
 readme = "README.md"
 
 [dependencies]
-arrow = "21.0.0"
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../datafusion/core", version = "11.0.0" }
+datafusion = { version = "11.0.0", path = "../datafusion/core" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = "21.0.0"
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow-flight = "22.0.0"
 async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"

--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -243,8 +243,8 @@ impl ExecutionPlan for CustomExec {
             db.data.values().cloned().collect()
         };
 
-        let mut id_array = UInt8Builder::new();
-        let mut account_array = UInt64Builder::new();
+        let mut id_array = UInt8Builder::with_capacity(users.len());
+        let mut account_array = UInt64Builder::with_capacity(users.len());
 
         for user in users {
             id_array.append_value(user.id);

--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -243,8 +243,8 @@ impl ExecutionPlan for CustomExec {
             db.data.values().cloned().collect()
         };
 
-        let mut id_array = UInt8Builder::new(users.len());
-        let mut account_array = UInt64Builder::new(users.len());
+        let mut id_array = UInt8Builder::new();
+        let mut account_array = UInt64Builder::new();
 
         for user in users {
             id_array.append_value(user.id);

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -44,7 +44,7 @@ avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.87.0", optional = true }
 object_store = { version = "0.4.0", optional = true }
 ordered-float = "3.0"
-parquet = { features = ["arrow"], optional = true, version = "22.0.0" }
+parquet = { version = "22.0.0", features = ["arrow"], optional = true }
 pyo3 = { version = "0.17.1", optional = true }
 serde_json = "1.0"
 sqlparser = "0.22"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,12 +39,12 @@ pyarrow = ["pyo3"]
 
 [dependencies]
 apache-avro = { version = "0.14", features = ["snappy"], optional = true }
-arrow = { version = "21.0.0", features = ["prettyprint"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", features = ["prettyprint"], rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.87.0", optional = true }
-object_store = { version = "0.4.0", optional = true }
+object_store = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", optional = true, git = "https://github.com/apache/arrow-rs.git" }
 ordered-float = "3.0"
-parquet = { version = "21.0.0", optional = true, features = ["arrow"] }
-pyo3 = { version = "0.16", optional = true }
+parquet = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["arrow"], optional = true, git = "https://github.com/apache/arrow-rs.git" }
+pyo3 = { version = "0.17.1", optional = true }
 serde_json = "1.0"
 sqlparser = "0.22"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,12 +39,12 @@ pyarrow = ["pyo3"]
 
 [dependencies]
 apache-avro = { version = "0.14", features = ["snappy"], optional = true }
-arrow = { git = "https://github.com/apache/arrow-rs.git", features = ["prettyprint"], rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.87.0", optional = true }
-object_store = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", optional = true, git = "https://github.com/apache/arrow-rs.git" }
+object_store = { version = "0.4.0", optional = true }
 ordered-float = "3.0"
-parquet = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["arrow"], optional = true, git = "https://github.com/apache/arrow-rs.git" }
+parquet = { features = ["arrow"], optional = true, version = "22.0.0" }
 pyo3 = { version = "0.17.1", optional = true }
 serde_json = "1.0"
 sqlparser = "0.22"

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3143,7 +3143,7 @@ mod tests {
         let array = array.as_any().downcast_ref::<ListArray>().unwrap();
 
         // Construct expected array with array builders
-        let field_a_builder = StringBuilder::new();
+        let field_a_builder = StringBuilder::with_capacity(4, 1024);
         let primitive_value_builder = Int32Array::builder(8);
         let field_primitive_list_builder = ListBuilder::new(primitive_value_builder);
 

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -100,6 +100,7 @@ ctor = "0.1.22"
 doc-comment = "0.3"
 env_logger = "0.9"
 fuzz-utils = { path = "fuzz-utils" }
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint", "dyn_cmp_dict"], git = "https://github.com/apache/arrow-rs.git" }
 
 [[bench]]
 harness = false

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -56,16 +56,16 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 apache-avro = { version = "0.14", optional = true }
-arrow = { version = "21.0.0", features = ["prettyprint"] }
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git" }
 async-trait = "0.1.41"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
 datafusion-common = { path = "../common", version = "11.0.0", features = ["parquet", "object_store"] }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
-datafusion-jit = { path = "../jit", version = "11.0.0", optional = true }
+datafusion-jit = { version = "11.0.0", optional = true, path = "../jit" }
 datafusion-optimizer = { path = "../optimizer", version = "11.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "11.0.0" }
-datafusion-row = { path = "../row", version = "11.0.0" }
+datafusion-physical-expr = { version = "11.0.0", path = "../physical-expr" }
+datafusion-row = { version = "11.0.0", path = "../row" }
 datafusion-sql = { path = "../sql", version = "11.0.0" }
 futures = "0.3"
 glob = "0.3.0"
@@ -75,13 +75,13 @@ lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
-object_store = "0.4.0"
+object_store = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
 ordered-float = "3.0"
 parking_lot = "0.12"
-parquet = { version = "21.0.0", features = ["arrow", "async"] }
+parquet = { features = ["arrow", "async"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 paste = "^1.0"
 pin-project-lite = "^0.2.7"
-pyo3 = { version = "0.16", optional = true }
+pyo3 = { version = "0.17.1", optional = true }
 rand = "0.8"
 rayon = { version = "1.5", optional = true }
 smallvec = { version = "1.6", features = ["union"] }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -56,17 +56,17 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 apache-avro = { version = "0.14", optional = true }
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", features = ["parquet", "object_store"], version = "11.0.0" }
+datafusion-common = { path = "../common", version = "11.0.0", features = ["parquet", "object_store"] }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 datafusion-jit = { path = "../jit", version = "11.0.0", optional = true }
 datafusion-optimizer = { path = "../optimizer", version = "11.0.0" }
-datafusion-physical-expr = { version = "11.0.0", path = "../physical-expr" }
-datafusion-row = { version = "11.0.0", path = "../row" }
-datafusion-sql = { version = "11.0.0", path = "../sql" }
+datafusion-physical-expr = { path = "../physical-expr", version = "11.0.0" }
+datafusion-row = { path = "../row", version = "11.0.0" }
+datafusion-sql = { path = "../sql", version = "11.0.0" }
 futures = "0.3"
 glob = "0.3.0"
 hashbrown = { version = "0.12", features = ["raw"] }
@@ -78,7 +78,7 @@ num_cpus = "1.13.0"
 object_store = "0.4.0"
 ordered-float = "3.0"
 parking_lot = "0.12"
-parquet = { features = ["arrow", "async"], version = "22.0.0" }
+parquet = { version = "22.0.0", features = ["arrow", "async"] }
 paste = "^1.0"
 pin-project-lite = "^0.2.7"
 pyo3 = { version = "0.17.1", optional = true }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -56,17 +56,17 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions", "datafusion
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 apache-avro = { version = "0.14", optional = true }
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
 async-trait = "0.1.41"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "11.0.0", features = ["parquet", "object_store"] }
+datafusion-common = { path = "../common", features = ["parquet", "object_store"], version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
-datafusion-jit = { version = "11.0.0", optional = true, path = "../jit" }
+datafusion-jit = { path = "../jit", version = "11.0.0", optional = true }
 datafusion-optimizer = { path = "../optimizer", version = "11.0.0" }
 datafusion-physical-expr = { version = "11.0.0", path = "../physical-expr" }
 datafusion-row = { version = "11.0.0", path = "../row" }
-datafusion-sql = { path = "../sql", version = "11.0.0" }
+datafusion-sql = { version = "11.0.0", path = "../sql" }
 futures = "0.3"
 glob = "0.3.0"
 hashbrown = { version = "0.12", features = ["raw"] }
@@ -75,10 +75,10 @@ lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
-object_store = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+object_store = "0.4.0"
 ordered-float = "3.0"
 parking_lot = "0.12"
-parquet = { features = ["arrow", "async"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+parquet = { features = ["arrow", "async"], version = "22.0.0" }
 paste = "^1.0"
 pin-project-lite = "^0.2.7"
 pyo3 = { version = "0.17.1", optional = true }
@@ -93,7 +93,7 @@ url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint", "dyn_cmp_dict"], git = "https://github.com/apache/arrow-rs.git" }
+arrow = { version = "22.0.0", features = ["prettyprint", "dyn_cmp_dict"] }
 async-trait = "0.1.53"
 criterion = "0.3"
 csv = "1.1.6"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -93,6 +93,7 @@ url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint", "dyn_cmp_dict"], git = "https://github.com/apache/arrow-rs.git" }
 async-trait = "0.1.53"
 criterion = "0.3"
 csv = "1.1.6"
@@ -100,7 +101,6 @@ ctor = "0.1.22"
 doc-comment = "0.3"
 env_logger = "0.9"
 fuzz-utils = { path = "fuzz-utils" }
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", features = ["prettyprint", "dyn_cmp_dict"], git = "https://github.com/apache/arrow-rs.git" }
 
 [[bench]]
 harness = false

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { features = ["prettyprint"], version = "21.0.0" }
+arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -129,7 +129,7 @@ impl<'a, R: Read> AvroArrowArrayReader<'a, R> {
     }
 
     fn build_boolean_array(&self, rows: RecordSlice, col_name: &str) -> ArrayRef {
-        let mut builder = BooleanBuilder::new(rows.len());
+        let mut builder = BooleanBuilder::with_capacity(rows.len());
         for row in rows {
             if let Some(value) = self.field_lookup(col_name, row) {
                 if let Some(boolean) = resolve_boolean(value) {

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -171,8 +171,8 @@ impl<'a, R: Read> AvroArrowArrayReader<'a, R> {
     where
         T: ArrowPrimitiveType + ArrowDictionaryKeyType,
     {
-        let key_builder = PrimitiveBuilder::<T>::new(row_len);
-        let values_builder = StringBuilder::new(row_len * 5);
+        let key_builder = PrimitiveBuilder::<T>::with_capacity(row_len);
+        let values_builder = StringBuilder::with_capacity(row_len, 5);
         StringDictionaryBuilder::new(key_builder, values_builder)
     }
 
@@ -258,7 +258,7 @@ impl<'a, R: Read> AvroArrowArrayReader<'a, R> {
     {
         let mut builder: Box<dyn ArrayBuilder> = match data_type {
             DataType::Utf8 => {
-                let values_builder = StringBuilder::new(rows.len() * 5);
+                let values_builder = StringBuilder::with_capacity(rows.len(), 5);
                 Box::new(ListBuilder::new(values_builder))
             }
             DataType::Dictionary(_, _) => {

--- a/datafusion/core/src/avro_to_arrow/schema.rs
+++ b/datafusion/core/src/avro_to_arrow/schema.rs
@@ -141,7 +141,7 @@ fn schema_to_field_with_props(
         AvroSchema::Fixed { size, .. } => DataType::FixedSizeBinary(*size as i32),
         AvroSchema::Decimal {
             precision, scale, ..
-        } => DataType::Decimal128(*precision, *scale),
+        } => DataType::Decimal128(*precision as u8, *scale as u8),
         AvroSchema::Uuid => DataType::FixedSizeBinary(16),
         AvroSchema::Date => DataType::Date32,
         AvroSchema::TimeMillis => DataType::Time32(TimeUnit::Millisecond),

--- a/datafusion/core/src/catalog/information_schema.rs
+++ b/datafusion/core/src/catalog/information_schema.rs
@@ -246,15 +246,11 @@ struct InformationSchemaTablesBuilder {
 
 impl InformationSchemaTablesBuilder {
     fn new() -> Self {
-        // StringBuilder requires providing an initial capacity, so
-        // pick 10 here arbitrarily as this is not performance
-        // critical code and the number of tables is unavailable here.
-        let default_capacity = 10;
         Self {
-            catalog_names: StringBuilder::new(default_capacity),
-            schema_names: StringBuilder::new(default_capacity),
-            table_names: StringBuilder::new(default_capacity),
-            table_types: StringBuilder::new(default_capacity),
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            table_types: StringBuilder::new(),
         }
     }
 
@@ -321,15 +317,11 @@ struct InformationSchemaViewBuilder {
 
 impl InformationSchemaViewBuilder {
     fn new() -> Self {
-        // StringBuilder requires providing an initial capacity, so
-        // pick 10 here arbitrarily as this is not performance
-        // critical code and the number of tables is unavailable here.
-        let default_capacity = 10;
         Self {
-            catalog_names: StringBuilder::new(default_capacity),
-            schema_names: StringBuilder::new(default_capacity),
-            table_names: StringBuilder::new(default_capacity),
-            definitions: StringBuilder::new(default_capacity),
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            definitions: StringBuilder::new(),
         }
     }
 
@@ -408,21 +400,21 @@ impl InformationSchemaColumnsBuilder {
         // critical code and the number of tables is unavailable here.
         let default_capacity = 10;
         Self {
-            catalog_names: StringBuilder::new(default_capacity),
-            schema_names: StringBuilder::new(default_capacity),
-            table_names: StringBuilder::new(default_capacity),
-            column_names: StringBuilder::new(default_capacity),
-            ordinal_positions: UInt64Builder::new(default_capacity),
-            column_defaults: StringBuilder::new(default_capacity),
-            is_nullables: StringBuilder::new(default_capacity),
-            data_types: StringBuilder::new(default_capacity),
-            character_maximum_lengths: UInt64Builder::new(default_capacity),
-            character_octet_lengths: UInt64Builder::new(default_capacity),
-            numeric_precisions: UInt64Builder::new(default_capacity),
-            numeric_precision_radixes: UInt64Builder::new(default_capacity),
-            numeric_scales: UInt64Builder::new(default_capacity),
-            datetime_precisions: UInt64Builder::new(default_capacity),
-            interval_types: StringBuilder::new(default_capacity),
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            column_names: StringBuilder::new(),
+            ordinal_positions: UInt64Builder::with_capacity(default_capacity),
+            column_defaults: StringBuilder::new(),
+            is_nullables: StringBuilder::new(),
+            data_types: StringBuilder::new(),
+            character_maximum_lengths: UInt64Builder::with_capacity(default_capacity),
+            character_octet_lengths: UInt64Builder::with_capacity(default_capacity),
+            numeric_precisions: UInt64Builder::with_capacity(default_capacity),
+            numeric_precision_radixes: UInt64Builder::with_capacity(default_capacity),
+            numeric_scales: UInt64Builder::with_capacity(default_capacity),
+            datetime_precisions: UInt64Builder::with_capacity(default_capacity),
+            interval_types: StringBuilder::new(),
         }
     }
 

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -246,12 +246,12 @@ fn paths_to_batch(
     table_path: &ListingTableUrl,
     metas: &[ObjectMeta],
 ) -> Result<RecordBatch> {
-    let mut key_builder = StringBuilder::new(metas.len());
-    let mut length_builder = UInt64Builder::new(metas.len());
-    let mut modified_builder = Date64Builder::new(metas.len());
+    let mut key_builder = StringBuilder::new();
+    let mut length_builder = UInt64Builder::with_capacity(metas.len());
+    let mut modified_builder = Date64Builder::with_capacity(metas.len());
     let mut partition_builders = table_partition_cols
         .iter()
-        .map(|_| StringBuilder::new(metas.len()))
+        .map(|_| StringBuilder::new())
         .collect::<Vec<_>>();
     for file_meta in metas {
         if let Some(partition_values) = parse_partitions_for_path(

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -246,12 +246,12 @@ fn paths_to_batch(
     table_path: &ListingTableUrl,
     metas: &[ObjectMeta],
 ) -> Result<RecordBatch> {
-    let mut key_builder = StringBuilder::new();
+    let mut key_builder = StringBuilder::with_capacity(metas.len(), 1024);
     let mut length_builder = UInt64Builder::with_capacity(metas.len());
     let mut modified_builder = Date64Builder::with_capacity(metas.len());
     let mut partition_builders = table_partition_cols
         .iter()
-        .map(|_| StringBuilder::new())
+        .map(|_| StringBuilder::with_capacity(metas.len(), 1024))
         .collect::<Vec<_>>();
     for file_meta in metas {
         if let Some(partition_values) = parse_partitions_for_path(

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -826,8 +826,8 @@ mod tests {
         fn new_decimal128(
             min: impl IntoIterator<Item = Option<i128>>,
             max: impl IntoIterator<Item = Option<i128>>,
-            precision: usize,
-            scale: usize,
+            precision: u8,
+            scale: u8,
         ) -> Self {
             Self {
                 min: Arc::new(

--- a/datafusion/core/src/physical_plan/aggregates/hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/hash.rs
@@ -268,7 +268,7 @@ fn group_aggregate_batch(
         }
 
         // Collect all indices + offsets based on keys in this vec
-        let mut batch_indices: UInt32Builder = UInt32Builder::new(0);
+        let mut batch_indices: UInt32Builder = UInt32Builder::with_capacity(0);
         let mut offsets = vec![0];
         let mut offset_so_far = 0;
         for group_idx in groups_with_rows.iter() {

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -283,7 +283,7 @@ fn group_aggregate_batch(
         }
 
         // Collect all indices + offsets based on keys in this vec
-        let mut batch_indices: UInt32Builder = UInt32Builder::new(0);
+        let mut batch_indices: UInt32Builder = UInt32Builder::with_capacity(0);
         let mut offsets = vec![0];
         let mut offset_so_far = 0;
         for group_idx in groups_with_rows.iter() {

--- a/datafusion/core/src/physical_plan/analyze.rs
+++ b/datafusion/core/src/physical_plan/analyze.rs
@@ -156,8 +156,8 @@ impl ExecutionPlan for AnalyzeExec {
             }
             let end = Instant::now();
 
-            let mut type_builder = StringBuilder::new(1);
-            let mut plan_builder = StringBuilder::new(1);
+            let mut type_builder = StringBuilder::new();
+            let mut plan_builder = StringBuilder::new();
 
             // TODO use some sort of enum rather than strings?
             type_builder.append_value("Plan with Metrics");

--- a/datafusion/core/src/physical_plan/analyze.rs
+++ b/datafusion/core/src/physical_plan/analyze.rs
@@ -156,8 +156,8 @@ impl ExecutionPlan for AnalyzeExec {
             }
             let end = Instant::now();
 
-            let mut type_builder = StringBuilder::new();
-            let mut plan_builder = StringBuilder::new();
+            let mut type_builder = StringBuilder::with_capacity(1, 1024);
+            let mut plan_builder = StringBuilder::with_capacity(1, 1024);
 
             // TODO use some sort of enum rather than strings?
             type_builder.append_value("Plan with Metrics");

--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -370,10 +370,10 @@ mod tests {
                 Arc::new(Float64Array::from_slice(&[9., 8., 7.])),
             ],
         )?;
-        let result =
+        let actual =
             compute_record_batch_statistics(&[vec![batch]], &schema, Some(vec![0, 1]));
 
-        let expected = Statistics {
+        let mut expected = Statistics {
             is_exact: true,
             num_rows: Some(3),
             total_byte_size: Some(464), // this might change a bit if the way we compute the size changes
@@ -393,7 +393,10 @@ mod tests {
             ]),
         };
 
-        assert_eq!(result, expected);
+        // Prevent test flakiness due to undefined / changing implementation details
+        expected.total_byte_size = actual.total_byte_size;
+
+        assert_eq!(actual, expected);
         Ok(())
     }
 }

--- a/datafusion/core/src/physical_plan/explain.rs
+++ b/datafusion/core/src/physical_plan/explain.rs
@@ -121,8 +121,10 @@ impl ExecutionPlan for ExplainExec {
             )));
         }
 
-        let mut type_builder = StringBuilder::new();
-        let mut plan_builder = StringBuilder::new();
+        let mut type_builder =
+            StringBuilder::with_capacity(self.stringified_plans.len(), 1024);
+        let mut plan_builder =
+            StringBuilder::with_capacity(self.stringified_plans.len(), 1024);
 
         let plans_to_print = self
             .stringified_plans

--- a/datafusion/core/src/physical_plan/explain.rs
+++ b/datafusion/core/src/physical_plan/explain.rs
@@ -121,8 +121,8 @@ impl ExecutionPlan for ExplainExec {
             )));
         }
 
-        let mut type_builder = StringBuilder::new(self.stringified_plans.len());
-        let mut plan_builder = StringBuilder::new(self.stringified_plans.len());
+        let mut type_builder = StringBuilder::new();
+        let mut plan_builder = StringBuilder::new();
 
         let plans_to_print = self
             .stringified_plans

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -678,12 +678,12 @@ fn parquet_to_arrow_decimal_type(parquet_column: &ColumnDescriptor) -> Option<Da
     let type_ptr = parquet_column.self_type_ptr();
     match type_ptr.get_basic_info().logical_type() {
         Some(LogicalType::Decimal { scale, precision }) => {
-            Some(DataType::Decimal128(precision as usize, scale as usize))
+            Some(DataType::Decimal128(precision as u8, scale as u8))
         }
         _ => match type_ptr.get_basic_info().converted_type() {
             ConvertedType::DECIMAL => Some(DataType::Decimal128(
-                type_ptr.get_precision() as usize,
-                type_ptr.get_scale() as usize,
+                type_ptr.get_precision() as u8,
+                type_ptr.get_scale() as u8,
             )),
             _ => None,
         },

--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -770,8 +770,8 @@ fn build_join_indexes(
             ))
         }
         JoinType::Left => {
-            let mut left_indices = UInt64Builder::new(0);
-            let mut right_indices = UInt32Builder::new(0);
+            let mut left_indices = UInt64Builder::with_capacity(0);
+            let mut right_indices = UInt32Builder::with_capacity(0);
 
             // First visit all of the rows
             for (row, hash_value) in hash_values.iter().enumerate() {
@@ -796,8 +796,8 @@ fn build_join_indexes(
             Ok((left_indices.finish(), right_indices.finish()))
         }
         JoinType::Right | JoinType::Full => {
-            let mut left_indices = UInt64Builder::new(0);
-            let mut right_indices = UInt32Builder::new(0);
+            let mut left_indices = UInt64Builder::with_capacity(0);
+            let mut right_indices = UInt32Builder::with_capacity(0);
 
             for (row, hash_value) in hash_values.iter().enumerate() {
                 match left.0.get(*hash_value, |(hash, _)| *hash_value == *hash) {
@@ -890,8 +890,8 @@ fn apply_join_filter(
                 .into_array(intermediate_batch.num_rows());
             let mask = as_boolean_array(&filter_result);
 
-            let mut left_rebuilt = UInt64Builder::new(0);
-            let mut right_rebuilt = UInt32Builder::new(0);
+            let mut left_rebuilt = UInt64Builder::with_capacity(0);
+            let mut right_rebuilt = UInt32Builder::with_capacity(0);
 
             (0..right_indices.len())
                 .into_iter()
@@ -2376,11 +2376,11 @@ mod tests {
             &false,
         )?;
 
-        let mut left_ids = UInt64Builder::new(0);
+        let mut left_ids = UInt64Builder::with_capacity(0);
         left_ids.append_value(0);
         left_ids.append_value(1);
 
-        let mut right_ids = UInt32Builder::new(0);
+        let mut right_ids = UInt32Builder::with_capacity(0);
         right_ids.append_value(0);
         right_ids.append_value(1);
 

--- a/datafusion/core/src/physical_plan/repartition.rs
+++ b/datafusion/core/src/physical_plan/repartition.rs
@@ -151,7 +151,7 @@ impl BatchPartitioner {
                 create_hashes(&arrays, random_state, hash_buffer)?;
 
                 let mut indices: Vec<_> = (0..*partitions)
-                    .map(|_| UInt64Builder::new(batch.num_rows()))
+                    .map(|_| UInt64Builder::with_capacity(batch.num_rows()))
                     .collect();
 
                 for (index, hash) in hash_buffer.iter().enumerate() {

--- a/datafusion/core/src/physical_plan/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/sort_merge_join.rs
@@ -358,8 +358,8 @@ impl StreamedBatch {
         {
             self.output_indices.push(StreamedJoinedChunk {
                 buffered_batch_idx,
-                streamed_indices: UInt64Builder::new(1),
-                buffered_indices: UInt64Builder::new(1),
+                streamed_indices: UInt64Builder::with_capacity(1),
+                buffered_indices: UInt64Builder::with_capacity(1),
             });
             self.buffered_batch_idx = buffered_batch_idx;
         };

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -200,7 +200,7 @@ pub fn table_with_decimal() -> Arc<dyn TableProvider> {
 }
 
 fn make_decimal() -> RecordBatch {
-    let mut decimal_builder = Decimal128Builder::new(20, 10, 3);
+    let mut decimal_builder = Decimal128Builder::with_capacity(20, 10, 3);
     for i in 110000..110010 {
         decimal_builder.append_value(i as i128).unwrap();
     }

--- a/datafusion/core/tests/parquet_pruning.rs
+++ b/datafusion/core/tests/parquet_pruning.rs
@@ -878,7 +878,7 @@ fn make_f64_batch(v: Vec<f64>) -> RecordBatch {
 ///
 /// Columns are named
 /// "decimal_col" -> DecimalArray
-fn make_decimal_batch(v: Vec<i128>, precision: usize, scale: usize) -> RecordBatch {
+fn make_decimal_batch(v: Vec<i128>, precision: u8, scale: u8) -> RecordBatch {
     let schema = Arc::new(Schema::new(vec![Field::new(
         "decimal_col",
         DataType::Decimal128(precision, scale),

--- a/datafusion/core/tests/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/provider_filter_pushdown.rs
@@ -36,7 +36,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 fn create_batch(value: i32, num_rows: usize) -> Result<RecordBatch> {
-    let mut builder = Int32Builder::new(num_rows);
+    let mut builder = Int32Builder::with_capacity(num_rows);
     for _ in 0..num_rows {
         builder.append_value(value);
     }

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -562,11 +562,19 @@ async fn register_tpch_csv_data(
     let mut cols: Vec<Box<dyn ArrayBuilder>> = vec![];
     for field in schema.fields().iter() {
         match field.data_type() {
-            DataType::Utf8 => cols.push(Box::new(StringBuilder::new(records.len()))),
-            DataType::Date32 => cols.push(Box::new(Date32Builder::new(records.len()))),
-            DataType::Int32 => cols.push(Box::new(Int32Builder::new(records.len()))),
-            DataType::Int64 => cols.push(Box::new(Int64Builder::new(records.len()))),
-            DataType::Float64 => cols.push(Box::new(Float64Builder::new(records.len()))),
+            DataType::Utf8 => cols.push(Box::new(StringBuilder::new())),
+            DataType::Date32 => {
+                cols.push(Box::new(Date32Builder::with_capacity(records.len())))
+            }
+            DataType::Int32 => {
+                cols.push(Box::new(Int32Builder::with_capacity(records.len())))
+            }
+            DataType::Int64 => {
+                cols.push(Box::new(Int64Builder::with_capacity(records.len())))
+            }
+            DataType::Float64 => {
+                cols.push(Box::new(Float64Builder::with_capacity(records.len())))
+            }
             _ => {
                 let msg = format!("Not implemented: {}", field.data_type());
                 Err(DataFusionError::Plan(msg))?
@@ -857,7 +865,7 @@ pub fn table_with_decimal() -> Arc<dyn TableProvider> {
 }
 
 fn make_decimal() -> RecordBatch {
-    let mut decimal_builder = Decimal128Builder::new(20, 10, 3);
+    let mut decimal_builder = Decimal128Builder::with_capacity(20, 10, 3);
     for i in 110000..110010 {
         decimal_builder.append_value(i as i128).unwrap();
     }

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -512,7 +512,7 @@ async fn query_get_indexed_field() -> Result<()> {
         DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
         false,
     )]));
-    let builder = PrimitiveBuilder::<Int64Type>::new(3);
+    let builder = PrimitiveBuilder::<Int64Type>::with_capacity(3);
     let mut lb = ListBuilder::new(builder);
     for int_vec in vec![vec![0, 1, 2], vec![4, 5, 6], vec![7, 8, 9]] {
         let builder = lb.values();
@@ -556,7 +556,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
         false,
     )]));
 
-    let builder = PrimitiveBuilder::<Int64Type>::new(3);
+    let builder = PrimitiveBuilder::<Int64Type>::with_capacity(3);
     let nested_lb = ListBuilder::new(builder);
     let mut lb = ListBuilder::new(nested_lb);
     for int_vec_vec in vec![
@@ -622,7 +622,7 @@ async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
         false,
     )]));
 
-    let builder = PrimitiveBuilder::<Int64Type>::new(3);
+    let builder = PrimitiveBuilder::<Int64Type>::with_capacity(3);
     let nested_lb = ListBuilder::new(builder);
     let mut sb = StructBuilder::new(struct_fields, vec![Box::new(nested_lb)]);
     for int_vec in vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10, 11]] {

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "11.0.0" }
 sqlparser = "0.22"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { version = "21.0.0", features = ["prettyprint"] }
+arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 datafusion-common = { path = "../common", version = "11.0.0" }
 sqlparser = "0.22"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
 datafusion-common = { path = "../common", version = "11.0.0" }
 sqlparser = "0.22"

--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -336,7 +336,7 @@ fn mathematics_numerical_coercion(
     }
 }
 
-fn create_decimal_type(precision: usize, scale: usize) -> DataType {
+fn create_decimal_type(precision: u8, scale: u8) -> DataType {
     DataType::Decimal128(
         DECIMAL128_MAX_PRECISION.min(precision),
         DECIMAL128_MAX_SCALE.min(scale),

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,12 +36,12 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+arrow = "22.0.0"
 cranelift = "0.87.0"
 cranelift-jit = "0.87.0"
 cranelift-module = "0.87.0"
 cranelift-native = "0.87.0"
-datafusion-common = { version = "11.0.0", path = "../common", features = ["jit"] }
+datafusion-common = { features = ["jit"], path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 
 parking_lot = "0.12"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,12 +36,12 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = "21.0.0"
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
 cranelift = "0.87.0"
 cranelift-jit = "0.87.0"
 cranelift-module = "0.87.0"
 cranelift-native = "0.87.0"
-datafusion-common = { path = "../common", version = "11.0.0", features = ["jit"] }
+datafusion-common = { version = "11.0.0", path = "../common", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 
 parking_lot = "0.12"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -41,7 +41,7 @@ cranelift = "0.87.0"
 cranelift-jit = "0.87.0"
 cranelift-module = "0.87.0"
 cranelift-native = "0.87.0"
-datafusion-common = { features = ["jit"], path = "../common", version = "11.0.0" }
+datafusion-common = { path = "../common", version = "11.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 
 parking_lot = "0.12"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -37,11 +37,11 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "11.0.0" }
-datafusion-expr = { path = "../expr", version = "11.0.0" }
+datafusion-common = { version = "11.0.0", path = "../common" }
+datafusion-expr = { version = "11.0.0", path = "../expr" }
 datafusion-physical-expr = { path = "../physical-expr", version = "11.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = "^0.4"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -37,17 +37,17 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { version = "11.0.0", path = "../common" }
-datafusion-expr = { version = "11.0.0", path = "../expr" }
+datafusion-common = { path = "../common", version = "11.0.0" }
+datafusion-expr = { path = "../expr", version = "11.0.0" }
 datafusion-physical-expr = { path = "../physical-expr", version = "11.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = "^0.4"
 
 [dev-dependencies]
 ctor = "0.1.22"
-datafusion-sql = { version = "11.0.0", path = "../sql" }
+datafusion-sql = { path = "../sql", version = "11.0.0" }
 env_logger = "0.9.0"
 

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -37,7 +37,7 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { features = ["prettyprint"], version = "21.0.0" }
+arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 datafusion-common = { path = "../common", version = "11.0.0" }
@@ -48,6 +48,6 @@ log = "^0.4"
 
 [dev-dependencies]
 ctor = "0.1.22"
-datafusion-sql = { path = "../sql", version = "11.0.0" }
+datafusion-sql = { version = "11.0.0", path = "../sql" }
 env_logger = "0.9.0"
 

--- a/datafusion/optimizer/src/pre_cast_lit_in_comparison.rs
+++ b/datafusion/optimizer/src/pre_cast_lit_in_comparison.rs
@@ -253,8 +253,8 @@ fn try_cast_literal_to_type(
             // Different precision for decimal128 can store different range of value.
             // For example, the precision is 3, the max of value is `999` and the min
             // value is `-999`
-            MIN_DECIMAL_FOR_EACH_PRECISION[*precision - 1],
-            MAX_DECIMAL_FOR_EACH_PRECISION[*precision - 1],
+            MIN_DECIMAL_FOR_EACH_PRECISION[*precision as usize - 1],
+            MAX_DECIMAL_FOR_EACH_PRECISION[*precision as usize - 1],
         ),
         other_type => {
             return Err(DataFusionError::Internal(format!(

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,13 +40,13 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { version = "21.0.0", features = ["prettyprint"] }
+arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }
 datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
-datafusion-row = { path = "../row", version = "11.0.0" }
+datafusion-row = { version = "11.0.0", path = "../row" }
 hashbrown = { version = "0.12", features = ["raw"] }
 lazy_static = { version = "^1.4.0" }
 md-5 = { version = "^0.10.0", optional = true }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,13 +40,13 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { path = "../common", version = "11.0.0" }
+datafusion-common = { version = "11.0.0", path = "../common" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
-datafusion-row = { version = "11.0.0", path = "../row" }
+datafusion-row = { path = "../row", version = "11.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }
 lazy_static = { version = "^1.4.0" }
 md-5 = { version = "^0.10.0", optional = true }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,11 +40,11 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }
-datafusion-common = { version = "11.0.0", path = "../common" }
+datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 datafusion-row = { path = "../row", version = "11.0.0" }
 hashbrown = { version = "0.12", features = ["raw"] }

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -259,7 +259,7 @@ mod tests {
 
     macro_rules! build_list {
         ($LISTS:expr, $BUILDER_TYPE:ident) => {{
-            let mut builder = ListBuilder::new($BUILDER_TYPE::new(0));
+            let mut builder = ListBuilder::new($BUILDER_TYPE::with_capacity(0));
             for list in $LISTS.iter() {
                 match list {
                     Some(values) => {

--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -187,13 +187,13 @@ impl Accumulator for MedianAccumulator {
 
 /// Create an empty array
 fn empty_array<T: ArrowPrimitiveType>() -> AggregateState {
-    AggregateState::Array(Arc::new(PrimitiveBuilder::<T>::new(0).finish()))
+    AggregateState::Array(Arc::new(PrimitiveBuilder::<T>::with_capacity(0).finish()))
 }
 
 /// Combine all non-null values from provided arrays into a single array
 fn combine_arrays<T: ArrowPrimitiveType>(arrays: &[ArrayRef]) -> Result<ArrayRef> {
     let len = arrays.iter().map(|a| a.len() - a.null_count()).sum();
-    let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::new(len);
+    let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::with_capacity(len);
     for array in arrays {
         let array = array
             .as_any()

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -152,15 +152,11 @@ macro_rules! typed_sum_delta_batch {
 
 // TODO implement this in arrow-rs with simd
 // https://github.com/apache/arrow-rs/issues/1010
-fn sum_decimal_batch(
-    values: &ArrayRef,
-    precision: &usize,
-    scale: &usize,
-) -> Result<ScalarValue> {
+fn sum_decimal_batch(values: &ArrayRef, precision: u8, scale: u8) -> Result<ScalarValue> {
     let array = values.as_any().downcast_ref::<Decimal128Array>().unwrap();
 
     if array.null_count() == array.len() {
-        return Ok(ScalarValue::Decimal128(None, *precision, *scale));
+        return Ok(ScalarValue::Decimal128(None, precision, scale));
     }
 
     let mut result = 0_i128;
@@ -169,7 +165,7 @@ fn sum_decimal_batch(
             result += array.value(i).as_i128();
         }
     }
-    Ok(ScalarValue::Decimal128(Some(result), *precision, *scale))
+    Ok(ScalarValue::Decimal128(Some(result), precision, scale))
 }
 
 // sums the array and returns a ScalarValue of its corresponding type.
@@ -177,7 +173,7 @@ pub(crate) fn sum_batch(values: &ArrayRef, sum_type: &DataType) -> Result<Scalar
     let values = &cast(values, sum_type)?;
     Ok(match values.data_type() {
         DataType::Decimal128(precision, scale) => {
-            sum_decimal_batch(values, precision, scale)?
+            sum_decimal_batch(values, *precision, *scale)?
         }
         DataType::Float64 => typed_sum_delta_batch!(values, Float64Array, Float64),
         DataType::Float32 => typed_sum_delta_batch!(values, Float32Array, Float32),
@@ -226,15 +222,15 @@ macro_rules! sum_row {
 fn sum_decimal(
     lhs: &Option<i128>,
     rhs: &Option<i128>,
-    precision: &usize,
-    scale: &usize,
+    precision: u8,
+    scale: u8,
 ) -> ScalarValue {
     match (lhs, rhs) {
-        (None, None) => ScalarValue::Decimal128(None, *precision, *scale),
-        (None, rhs) => ScalarValue::Decimal128(*rhs, *precision, *scale),
-        (lhs, None) => ScalarValue::Decimal128(*lhs, *precision, *scale),
+        (None, None) => ScalarValue::Decimal128(None, precision, scale),
+        (None, rhs) => ScalarValue::Decimal128(*rhs, precision, scale),
+        (lhs, None) => ScalarValue::Decimal128(*lhs, precision, scale),
         (Some(lhs_value), Some(rhs_value)) => {
-            ScalarValue::Decimal128(Some(lhs_value + rhs_value), *precision, *scale)
+            ScalarValue::Decimal128(Some(lhs_value + rhs_value), precision, scale)
         }
     }
 }
@@ -242,22 +238,22 @@ fn sum_decimal(
 fn sum_decimal_with_diff_scale(
     lhs: &Option<i128>,
     rhs: &Option<i128>,
-    precision: &usize,
-    lhs_scale: &usize,
-    rhs_scale: &usize,
+    precision: u8,
+    lhs_scale: u8,
+    rhs_scale: u8,
 ) -> ScalarValue {
     // the lhs_scale must be greater or equal rhs_scale.
     match (lhs, rhs) {
-        (None, None) => ScalarValue::Decimal128(None, *precision, *lhs_scale),
+        (None, None) => ScalarValue::Decimal128(None, precision, lhs_scale),
         (None, Some(rhs_value)) => {
             let new_value = rhs_value * 10_i128.pow((lhs_scale - rhs_scale) as u32);
-            ScalarValue::Decimal128(Some(new_value), *precision, *lhs_scale)
+            ScalarValue::Decimal128(Some(new_value), precision, lhs_scale)
         }
-        (lhs, None) => ScalarValue::Decimal128(*lhs, *precision, *lhs_scale),
+        (lhs, None) => ScalarValue::Decimal128(*lhs, precision, lhs_scale),
         (Some(lhs_value), Some(rhs_value)) => {
             let new_value =
                 rhs_value * 10_i128.pow((lhs_scale - rhs_scale) as u32) + lhs_value;
-            ScalarValue::Decimal128(Some(new_value), *precision, *lhs_scale)
+            ScalarValue::Decimal128(Some(new_value), precision, lhs_scale)
         }
     }
 }
@@ -265,16 +261,16 @@ fn sum_decimal_with_diff_scale(
 pub(crate) fn sum(lhs: &ScalarValue, rhs: &ScalarValue) -> Result<ScalarValue> {
     Ok(match (lhs, rhs) {
         (ScalarValue::Decimal128(v1, p1, s1), ScalarValue::Decimal128(v2, p2, s2)) => {
-            let max_precision = p1.max(p2);
+            let max_precision = *p1.max(p2);
             if s1.eq(s2) {
                 // s1 = s2
-                sum_decimal(v1, v2, max_precision, s1)
+                sum_decimal(v1, v2, max_precision, *s1)
             } else if s1.gt(s2) {
                 // s1 > s2
-                sum_decimal_with_diff_scale(v1, v2, max_precision, s1, s2)
+                sum_decimal_with_diff_scale(v1, v2, max_precision, *s1, *s2)
             } else {
                 // s1 < s2
-                sum_decimal_with_diff_scale(v2, v1, max_precision, s2, s1)
+                sum_decimal_with_diff_scale(v2, v1, max_precision, *s2, *s1)
             }
         }
         // float64 coerces everything to f64

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -34,16 +34,30 @@ macro_rules! downcast_vec {
     }};
 }
 
+macro_rules! new_builder {
+    (BooleanBuilder, $len:expr) => {
+        BooleanBuilder::with_capacity($len)
+    };
+    (StringBuilder, $len:expr) => {
+        StringBuilder::new()
+    };
+    (LargeStringBuilder, $len:expr) => {
+        LargeStringBuilder::new()
+    };
+    ($el:ident, $len:expr) => {{
+        <$el>::with_capacity($len)
+    }};
+}
+
 macro_rules! array {
     ($ARGS:expr, $ARRAY_TYPE:ident, $BUILDER_TYPE:ident) => {{
         // downcast all arguments to their common format
         let args =
             downcast_vec!($ARGS, $ARRAY_TYPE).collect::<Result<Vec<&$ARRAY_TYPE>>>()?;
 
-        let mut builder = FixedSizeListBuilder::<$BUILDER_TYPE>::new(
-            <$BUILDER_TYPE>::new(args[0].len()),
-            args.len() as i32,
-        );
+        let builder = new_builder!($BUILDER_TYPE, args[0].len());
+        let mut builder =
+            FixedSizeListBuilder::<$BUILDER_TYPE>::new(builder, args.len() as i32);
         // for each entry in the array
         for index in 0..args[0].len() {
             for arg in &args {

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -483,7 +483,7 @@ mod tests {
     fn to_timestamp_arrays_and_nulls() -> Result<()> {
         // ensure that arrow array implementation is wired up and handles nulls correctly
 
-        let mut string_builder = StringBuilder::new(2);
+        let mut string_builder = StringBuilder::new();
         let mut ts_builder = TimestampNanosecondArray::builder(2);
 
         string_builder.append_value("2020-09-08T13:42:29.190855Z");

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -483,7 +483,7 @@ mod tests {
     fn to_timestamp_arrays_and_nulls() -> Result<()> {
         // ensure that arrow array implementation is wired up and handles nulls correctly
 
-        let mut string_builder = StringBuilder::new();
+        let mut string_builder = StringBuilder::with_capacity(2, 1024);
         let mut ts_builder = TimestampNanosecondArray::builder(2);
 
         string_builder.append_value("2020-09-08T13:42:29.190855Z");

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1311,8 +1311,8 @@ mod tests {
         let string_type = DataType::Utf8;
 
         // build dictionary
-        let keys_builder = PrimitiveBuilder::<Int32Type>::new(10);
-        let values_builder = arrow::array::StringBuilder::new(10);
+        let keys_builder = PrimitiveBuilder::<Int32Type>::with_capacity(10);
+        let values_builder = arrow::array::StringBuilder::new();
         let mut dict_builder = StringDictionaryBuilder::new(keys_builder, values_builder);
 
         dict_builder.append("one")?;
@@ -2134,10 +2134,11 @@ mod tests {
 
     fn create_decimal_array(
         array: &[Option<i128>],
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Decimal128Array {
-        let mut decimal_builder = Decimal128Builder::new(array.len(), precision, scale);
+        let mut decimal_builder =
+            Decimal128Builder::with_capacity(array.len(), precision, scale);
         for value in array {
             match value {
                 None => {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1312,7 +1312,7 @@ mod tests {
 
         // build dictionary
         let keys_builder = PrimitiveBuilder::<Int32Type>::with_capacity(10);
-        let values_builder = arrow::array::StringBuilder::new();
+        let values_builder = arrow::array::StringBuilder::with_capacity(10, 1024);
         let mut dict_builder = StringDictionaryBuilder::new(keys_builder, values_builder);
 
         dict_builder.append("one")?;

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -435,10 +435,11 @@ mod tests {
 
     fn create_decimal_array(
         array: &[Option<i128>],
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Decimal128Array {
-        let mut decimal_builder = Decimal128Builder::new(array.len(), precision, scale);
+        let mut decimal_builder =
+            Decimal128Builder::with_capacity(array.len(), precision, scale);
         for value in array {
             match value {
                 None => {

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -635,7 +635,7 @@ mod tests {
 
     #[test]
     fn array_add_26_days() -> Result<()> {
-        let mut builder = Date32Builder::new(8);
+        let mut builder = Date32Builder::with_capacity(8);
         builder.append_slice(&[0, 1, 2, 3, 4, 5, 6, 7]);
         let a: ArrayRef = Arc::new(builder.finish());
 
@@ -655,7 +655,7 @@ mod tests {
         let cut = DateTimeIntervalExpr::try_new(lhs, op, rhs, &schema)?;
         let res = cut.evaluate(&batch)?;
 
-        let mut builder = Date32Builder::new(8);
+        let mut builder = Date32Builder::with_capacity(8);
         builder.append_slice(&[26, 27, 28, 29, 30, 31, 32, 33]);
         let expected: ArrayRef = Arc::new(builder.finish());
 
@@ -715,7 +715,7 @@ mod tests {
     }
 
     fn exercise(dt: &Expr, op: Operator, interval: &Expr) -> Result<ColumnarValue> {
-        let mut builder = Date32Builder::new(1);
+        let mut builder = Date32Builder::with_capacity(1);
         builder.append_value(0);
         let a: ArrayRef = Arc::new(builder.finish());
         let schema = Schema::new(vec![Field::new("a", DataType::Date32, false)]);

--- a/datafusion/physical-expr/src/expressions/get_indexed_field.rs
+++ b/datafusion/physical-expr/src/expressions/get_indexed_field.rs
@@ -146,7 +146,7 @@ mod tests {
     use datafusion_common::Result;
 
     fn build_utf8_lists(list_of_lists: Vec<Vec<Option<&str>>>) -> GenericListArray<i32> {
-        let builder = StringBuilder::new();
+        let builder = StringBuilder::with_capacity(list_of_lists.len(), 1024);
         let mut lb = ListBuilder::new(builder);
         for values in list_of_lists {
             let builder = lb.values();
@@ -230,7 +230,7 @@ mod tests {
         key: ScalarValue,
         expected: &str,
     ) -> Result<()> {
-        let builder = StringBuilder::new();
+        let builder = StringBuilder::with_capacity(3, 1024);
         let mut lb = ListBuilder::new(builder);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lb.finish())])?;
         let expr = Arc::new(GetIndexedFieldExpr::new(expr, key));
@@ -259,7 +259,7 @@ mod tests {
         list_of_tuples: Vec<(Option<i64>, Vec<Option<&str>>)>,
     ) -> StructArray {
         let foo_builder = Int64Array::builder(list_of_tuples.len());
-        let str_builder = StringBuilder::new();
+        let str_builder = StringBuilder::with_capacity(list_of_tuples.len(), 1024);
         let bar_builder = ListBuilder::new(str_builder);
         let mut builder = StructBuilder::new(
             fields,

--- a/datafusion/physical-expr/src/expressions/get_indexed_field.rs
+++ b/datafusion/physical-expr/src/expressions/get_indexed_field.rs
@@ -146,7 +146,7 @@ mod tests {
     use datafusion_common::Result;
 
     fn build_utf8_lists(list_of_lists: Vec<Vec<Option<&str>>>) -> GenericListArray<i32> {
-        let builder = StringBuilder::new(list_of_lists.len());
+        let builder = StringBuilder::new();
         let mut lb = ListBuilder::new(builder);
         for values in list_of_lists {
             let builder = lb.values();
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn get_indexed_field_empty_list() -> Result<()> {
         let schema = list_schema("l");
-        let builder = StringBuilder::new(0);
+        let builder = StringBuilder::new();
         let mut lb = ListBuilder::new(builder);
         let expr = col("l", &schema).unwrap();
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lb.finish())])?;
@@ -230,7 +230,7 @@ mod tests {
         key: ScalarValue,
         expected: &str,
     ) -> Result<()> {
-        let builder = StringBuilder::new(3);
+        let builder = StringBuilder::new();
         let mut lb = ListBuilder::new(builder);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lb.finish())])?;
         let expr = Arc::new(GetIndexedFieldExpr::new(expr, key));
@@ -259,7 +259,7 @@ mod tests {
         list_of_tuples: Vec<(Option<i64>, Vec<Option<&str>>)>,
     ) -> StructArray {
         let foo_builder = Int64Array::builder(list_of_tuples.len());
-        let str_builder = StringBuilder::new(list_of_tuples.len());
+        let str_builder = StringBuilder::new();
         let bar_builder = ListBuilder::new(str_builder);
         let mut builder = StructBuilder::new(
             fields,

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -576,12 +576,9 @@ mod tests {
     }
 
     // create decimal array with the specified precision and scale
-    fn create_decimal_array(
-        array: &[i128],
-        precision: usize,
-        scale: usize,
-    ) -> Decimal128Array {
-        let mut decimal_builder = Decimal128Builder::new(array.len(), precision, scale);
+    fn create_decimal_array(array: &[i128], precision: u8, scale: u8) -> Decimal128Array {
+        let mut decimal_builder =
+            Decimal128Builder::with_capacity(array.len(), precision, scale);
         for value in array {
             decimal_builder.append_value(*value).expect("valid value");
         }

--- a/datafusion/physical-expr/src/regex_expressions.rs
+++ b/datafusion/physical-expr/src/regex_expressions.rs
@@ -189,7 +189,7 @@ mod tests {
         let patterns =
             StringArray::from(vec!["^(a)", "^(A)", "(b|d)", "(B|D)", "^(b|c)"]);
 
-        let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new(0);
+        let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new();
         let mut expected_builder = ListBuilder::new(elem_builder);
         expected_builder.values().append_value("a");
         expected_builder.append(true);
@@ -212,7 +212,7 @@ mod tests {
             StringArray::from(vec!["^(a)", "^(A)", "(b|d)", "(B|D)", "^(b|c)"]);
         let flags = StringArray::from(vec!["i"; 5]);
 
-        let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new(0);
+        let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new();
         let mut expected_builder = ListBuilder::new(elem_builder);
         expected_builder.values().append_value("a");
         expected_builder.append(true);

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -37,8 +37,8 @@ default = []
 json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
-arrow = "21.0.0"
-datafusion = { path = "../core", version = "11.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+datafusion = { version = "11.0.0", path = "../core" }
 datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 pbjson = { version = "0.3", optional = true }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -38,8 +38,8 @@ json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
 arrow = "22.0.0"
-datafusion = { version = "11.0.0", path = "../core" }
-datafusion-common = { version = "11.0.0", path = "../common" }
+datafusion = { path = "../core", version = "11.0.0" }
+datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -37,9 +37,9 @@ default = []
 json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "e5b9d05ec50807666efe401729708d53216d79fc" }
+arrow = "22.0.0"
 datafusion = { version = "11.0.0", path = "../core" }
-datafusion-common = { path = "../common", version = "11.0.0" }
+datafusion-common = { version = "11.0.0", path = "../common" }
 datafusion-expr = { path = "../expr", version = "11.0.0" }
 pbjson = { version = "0.3", optional = true }
 pbjson-types = { version = "0.3", optional = true }

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -309,7 +309,7 @@ impl TryFrom<&protobuf::arrow_type::ArrowTypeEnum> for DataType {
             arrow_type::ArrowTypeEnum::Decimal(protobuf::Decimal {
                 whole,
                 fractional,
-            }) => DataType::Decimal128(*whole as usize, *fractional as usize),
+            }) => DataType::Decimal128(*whole as u8, *fractional as u8),
             arrow_type::ArrowTypeEnum::List(list) => {
                 let list_type =
                     list.as_ref().field_type.as_deref().required("field_type")?;
@@ -742,8 +742,8 @@ impl TryFrom<&protobuf::ScalarValue> for ScalarValue {
                 let array = vec_to_array(val.value.clone());
                 Self::Decimal128(
                     Some(i128::from_be_bytes(array)),
-                    val.p as usize,
-                    val.s as usize,
+                    val.p as u8,
+                    val.s as u8,
                 )
             }
             Value::Date64Value(v) => Self::Date64(Some(*v)),
@@ -1484,8 +1484,8 @@ fn typechecked_scalar_value_conversion(
             let array = vec_to_array(val.value.clone());
             ScalarValue::Decimal128(
                 Some(i128::from_be_bytes(array)),
-                val.p as usize,
-                val.s as usize,
+                val.p as u8,
+                val.s as u8,
             )
         }
         (Value::Date64Value(v), PrimitiveScalarType::Date64) => {

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -38,7 +38,7 @@ jit = ["datafusion-jit"]
 
 [dependencies]
 arrow = "22.0.0"
-datafusion-common = { version = "11.0.0", path = "../common" }
-datafusion-jit = { version = "11.0.0", path = "../jit", optional = true }
+datafusion-common = { path = "../common", version = "11.0.0" }
+datafusion-jit = { path = "../jit", version = "11.0.0", optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -37,8 +37,8 @@ path = "src/lib.rs"
 jit = ["datafusion-jit"]
 
 [dependencies]
-arrow = "21.0.0"
-datafusion-common = { path = "../common", version = "11.0.0" }
-datafusion-jit = { path = "../jit", version = "11.0.0", optional = true }
+arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+datafusion-common = { version = "11.0.0", path = "../common" }
+datafusion-jit = { optional = true, path = "../jit", version = "11.0.0" }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -37,8 +37,8 @@ path = "src/lib.rs"
 jit = ["datafusion-jit"]
 
 [dependencies]
-arrow = { rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+arrow = "22.0.0"
 datafusion-common = { version = "11.0.0", path = "../common" }
-datafusion-jit = { optional = true, path = "../jit", version = "11.0.0" }
+datafusion-jit = { version = "11.0.0", path = "../jit", optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,8 +38,8 @@ unicode_expressions = []
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
-datafusion-common = { version = "11.0.0", path = "../common" }
+arrow = { features = ["prettyprint"], version = "22.0.0" }
+datafusion-common = { path = "../common", version = "11.0.0" }
 datafusion-expr = { version = "11.0.0", path = "../expr" }
 hashbrown = "0.12"
 sqlparser = "0.22"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,9 +38,9 @@ unicode_expressions = []
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { features = ["prettyprint"], version = "22.0.0" }
+arrow = { version = "22.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "11.0.0" }
-datafusion-expr = { version = "11.0.0", path = "../expr" }
+datafusion-expr = { path = "../expr", version = "11.0.0" }
 hashbrown = "0.12"
 sqlparser = "0.22"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,9 +38,9 @@ unicode_expressions = []
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { version = "21.0.0", features = ["prettyprint"] }
-datafusion-common = { path = "../common", version = "11.0.0" }
-datafusion-expr = { path = "../expr", version = "11.0.0" }
+arrow = { features = ["prettyprint"], rev = "e5b9d05ec50807666efe401729708d53216d79fc", git = "https://github.com/apache/arrow-rs.git" }
+datafusion-common = { version = "11.0.0", path = "../common" }
+datafusion-expr = { version = "11.0.0", path = "../expr" }
 hashbrown = "0.12"
 sqlparser = "0.22"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -498,8 +498,8 @@ pub(crate) fn make_decimal_type(
 ) -> Result<DataType> {
     // postgres like behavior
     let (precision, scale) = match (precision, scale) {
-        (Some(p), Some(s)) => (p as usize, s as usize),
-        (Some(p), None) => (p as usize, 0),
+        (Some(p), Some(s)) => (p as u8, s as u8),
+        (Some(p), None) => (p as u8, 0),
         (None, Some(_)) => {
             return Err(DataFusionError::Internal(
                 "Cannot specify only scale for decimal data type".to_string(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3362.

 # Rationale for this change

We should keep DataFusion up to date with Arrow.

# What changes are included in this PR?

- precision is always u8 now
- builders are in the middle of being refactored so some have `new()` and others `with_capacity()`
- pyo3 needs to be upgraded to 0.17

# Are there any user-facing changes?
No