### PR TITLE
MINOR: Note that most communication happens on github

### DIFF
--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -26,6 +26,9 @@ All participation in the Apache Arrow DataFusion project is governed by the
 Apache Software Foundation's [code of
 conduct](https://www.apache.org/foundation/policies/conduct.html).
 
+The vast majority of communication occurs in the open on our
+[github repository](https://github.com/apache/arrow-datafusion).
+
 ## Questions?
 
 ### Mailing list


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change

Someone asked me for an invite to the community, and when reviewing the communication page on the docs I didn't see any explicit mention about the github site

# What changes are included in this PR?
Explicitly state that most communication happens via github tickets / issues

# Are there any user-facing changes?
Docs