### PR TITLE
Minor: Improvements to type coercion rule

### DIFF
--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -48,11 +48,12 @@ pub fn create_physical_expr(
     execution_props: &ExecutionProps,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     if input_schema.fields.len() != input_dfschema.fields().len() {
-        return Err(DataFusionError::Internal(
-            "create_physical_expr passed Arrow schema and DataFusion \
-            schema with different number of fields"
-                .to_string(),
-        ));
+        return Err(DataFusionError::Internal(format!(
+            "create_physical_expr expected same number of fields, got \
+                     got Arrow schema with {}  and DataFusion schema with {}",
+            input_schema.fields.len(),
+            input_dfschema.fields().len()
+        )));
     }
     match e {
         Expr::Alias(expr, ..) => Ok(create_physical_expr(


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/arrow-datafusion/pull/3222~

# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/3221

 # Rationale for this change


I saw a few minor improvements while reviewing https://github.com/apache/arrow-datafusion/pull/3222



# What changes are included in this PR?

1. Improve error message
2. Avoid a `clone`
3. Remove special case interval handling


# Are there any user-facing changes?
No
