### PR TITLE
Pushdown `RowFilter` in `ParquetExec`

### DIFF
--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -44,6 +44,8 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter};
+
+use datafusion_expr::binary_expr;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{binary_expr, cast, try_cast, ExprSchemable};
 use datafusion_physical_expr::create_physical_expr;

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -45,7 +45,6 @@ use arrow::{
 };
 use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter};
 
-use datafusion_expr::binary_expr;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{binary_expr, cast, try_cast, ExprSchemable};
 use datafusion_physical_expr::create_physical_expr;

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -25,6 +25,7 @@ mod delimited_stream;
 mod file_stream;
 mod json;
 mod parquet;
+mod row_filter;
 
 pub(crate) use self::csv::plan_to_csv;
 pub use self::csv::CsvExec;

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -68,6 +68,30 @@ use parquet::file::{
 };
 use parquet::schema::types::ColumnDescriptor;
 
+#[derive(Debug, Clone, Default)]
+/// Specify options for the parquet scan
+pub struct ParquetScanOptions {
+    /// If true, any available `pruning_predicate` will be converted to a `RowFilter`
+    /// and pushed down to the `ParquetRecordBatchStream`. This will enable row level
+    /// filter at the decoder level
+    pushdown_filters: bool,
+    /// If true, the generated `RowFilter` may reorder the predicate `Expr`s to try and optimize
+    /// the cost of filter evaluation.
+    reorder_predicates: bool,
+}
+
+impl ParquetScanOptions {
+    pub fn with_pushdown_filters(mut self, pushdown_filters: bool) -> Self {
+        self.pushdown_filters = pushdown_filters;
+        self
+    }
+
+    pub fn with_reorder_predicates(mut self, reorder_predicates: bool) -> Self {
+        self.reorder_predicates = reorder_predicates;
+        self
+    }
+}
+
 /// Execution plan for scanning one or more Parquet partitions
 #[derive(Debug, Clone)]
 pub struct ParquetExec {
@@ -82,9 +106,8 @@ pub struct ParquetExec {
     metadata_size_hint: Option<usize>,
     /// Optional user defined parquet file reader factory
     parquet_file_reader_factory: Option<Arc<dyn ParquetFileReaderFactory>>,
-    /// If true, the predicates pushed down to the parquet scan may be reordered.
-    /// Defaults to true
-    reorder_predicates: bool,
+    /// Options to specify behavior of parquet scan
+    scan_options: ParquetScanOptions,
 }
 
 impl ParquetExec {
@@ -125,7 +148,7 @@ impl ParquetExec {
             pruning_predicate,
             metadata_size_hint,
             parquet_file_reader_factory: None,
-            reorder_predicates: true,
+            scan_options: ParquetScanOptions::default(),
         }
     }
 
@@ -154,11 +177,9 @@ impl ParquetExec {
         self
     }
 
-    /// Configure whether the given pruning predicate may be reordered when building a `RowFilter`.
-    /// If allowed, the `RowFilter` will attempt to order the predicates so that the least expensive
-    /// predicates are executed first.
-    pub fn with_reorder_predicates(mut self, reorder: bool) -> Self {
-        self.reorder_predicates = reorder;
+    /// Configure `ParquetScanOptions`
+    pub fn with_scan_options(mut self, scan_options: ParquetScanOptions) -> Self {
+        self.scan_options = scan_options;
         self
     }
 }
@@ -271,7 +292,7 @@ impl ExecutionPlan for ParquetExec {
             metadata_size_hint: self.metadata_size_hint,
             metrics: self.metrics.clone(),
             parquet_file_reader_factory,
-            reorder_predicates: self.reorder_predicates,
+            scan_options: self.scan_options.clone(),
         };
 
         let stream = FileStream::new(
@@ -333,7 +354,7 @@ struct ParquetOpener {
     metadata_size_hint: Option<usize>,
     metrics: ExecutionPlanMetricsSet,
     parquet_file_reader_factory: Arc<dyn ParquetFileReaderFactory>,
-    reorder_predicates: bool,
+    scan_options: ParquetScanOptions,
 }
 
 impl FileOpener for ParquetOpener {
@@ -363,7 +384,8 @@ impl FileOpener for ParquetOpener {
         let projection = self.projection.clone();
         let pruning_predicate = self.pruning_predicate.clone();
         let table_schema = self.table_schema.clone();
-        let reorder_predicates = self.reorder_predicates;
+        let reorder_predicates = self.scan_options.reorder_predicates;
+        let pushdown_filters = self.scan_options.pushdown_filters;
 
         Ok(Box::pin(async move {
             let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
@@ -375,7 +397,9 @@ impl FileOpener for ParquetOpener {
                 adapted_projections.iter().cloned(),
             );
 
-            if let Some(predicate) = pruning_predicate.as_ref().map(|p| p.logical_expr())
+            if let Some(predicate) = pushdown_filters
+                .then(|| pruning_predicate.as_ref().map(|p| p.logical_expr()))
+                .flatten()
             {
                 if let Ok(Some(filter)) = build_row_filter(
                     predicate.clone(),
@@ -869,6 +893,7 @@ mod tests {
         projection: Option<Vec<usize>>,
         schema: Option<SchemaRef>,
         predicate: Option<Expr>,
+        pushdown_predicate: bool,
     ) -> Result<Vec<RecordBatch>> {
         let file_schema = match schema {
             Some(schema) => schema,
@@ -881,7 +906,7 @@ mod tests {
         let file_groups = meta.into_iter().map(Into::into).collect();
 
         // prepare the scan
-        let parquet_exec = ParquetExec::new(
+        let mut parquet_exec = ParquetExec::new(
             FileScanConfig {
                 object_store_url: ObjectStoreUrl::local_filesystem(),
                 file_groups: vec![file_groups],
@@ -894,6 +919,14 @@ mod tests {
             predicate,
             None,
         );
+
+        if pushdown_predicate {
+            parquet_exec = parquet_exec.with_scan_options(
+                ParquetScanOptions::default()
+                    .with_pushdown_filters(true)
+                    .with_reorder_predicates(true),
+            );
+        }
 
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
@@ -942,9 +975,10 @@ mod tests {
         let batch3 = add_to_batch(&batch1, "c3", c3);
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2, batch3], None, None, None)
-            .await
-            .unwrap();
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2, batch3], None, None, None, false)
+                .await
+                .unwrap();
         let expected = vec![
             "+-----+----+----+",
             "| c1  | c2 | c3 |",
@@ -983,7 +1017,7 @@ mod tests {
         let batch2 = create_batch(vec![("c3", c3), ("c2", c2), ("c1", c1)]);
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, None)
+        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, None, false)
             .await
             .unwrap();
         let expected = vec![
@@ -1017,7 +1051,7 @@ mod tests {
         let batch2 = create_batch(vec![("c3", c3), ("c2", c2)]);
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, None)
+        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, None, false)
             .await
             .unwrap();
         let expected = vec![
@@ -1053,9 +1087,47 @@ mod tests {
         let filter = col("c2").eq(lit(2_i64));
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter))
-            .await
-            .unwrap();
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter), false)
+                .await
+                .unwrap();
+        let expected = vec![
+            "+-----+----+----+",
+            "| c1  | c3 | c2 |",
+            "+-----+----+----+",
+            "|     |    |    |",
+            "|     | 10 | 1  |",
+            "|     | 20 |    |",
+            "|     | 20 | 2  |",
+            "| Foo | 10 |    |",
+            "| bar |    |    |",
+            "+-----+----+----+",
+        ];
+        assert_batches_sorted_eq!(expected, &read);
+    }
+
+    #[tokio::test]
+    async fn evolved_schema_intersection_filter_with_filter_pushdown() {
+        let c1: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("Foo"), None, Some("bar")]));
+
+        let c2: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(2), None]));
+
+        let c3: ArrayRef = Arc::new(Int8Array::from(vec![Some(10), Some(20), None]));
+
+        // batch1: c1(string), c3(int8)
+        let batch1 = create_batch(vec![("c1", c1), ("c3", c3.clone())]);
+
+        // batch2: c3(int8), c2(int64)
+        let batch2 = create_batch(vec![("c3", c3), ("c2", c2)]);
+
+        let filter = col("c2").eq(lit(2_i64));
+
+        // read/write them files:
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter), true)
+                .await
+                .unwrap();
         let expected = vec![
             "+----+----+----+",
             "| c1 | c3 | c2 |",
@@ -1089,10 +1161,15 @@ mod tests {
         let batch2 = create_batch(vec![("c3", c3), ("c2", c2), ("c1", c1), ("c4", c4)]);
 
         // read/write them files:
-        let read =
-            round_trip_to_parquet(vec![batch1, batch2], Some(vec![0, 3]), None, None)
-                .await
-                .unwrap();
+        let read = round_trip_to_parquet(
+            vec![batch1, batch2],
+            Some(vec![0, 3]),
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
         let expected = vec![
             "+-----+-----+",
             "| c1  | c4  |",
@@ -1130,9 +1207,10 @@ mod tests {
         let filter = col("c3").eq(lit(0_i8));
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter))
-            .await
-            .unwrap();
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter), false)
+                .await
+                .unwrap();
 
         // Predicate should prune all row groups
         assert_eq!(read.len(), 0);
@@ -1154,9 +1232,51 @@ mod tests {
         let filter = col("c2").eq(lit(1_i64));
 
         // read/write them files:
-        let read = round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter))
-            .await
-            .unwrap();
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter), false)
+                .await
+                .unwrap();
+
+        // This does not look correct since the "c2" values in the result do not in fact match the predicate `c2 == 0`
+        // but parquet pruning is not exact. If the min/max values are not defined (which they are not in this case since the it is
+        // a null array, then the pruning predicate (currently) can not be applied.
+        // In a real query where this predicate was pushed down from a filter stage instead of created directly in the `ParquetExec`,
+        // the filter stage would be preserved as a separate execution plan stage so the actual query results would be as expected.
+        let expected = vec![
+            "+-----+----+",
+            "| c1  | c2 |",
+            "+-----+----+",
+            "|     |    |",
+            "|     |    |",
+            "|     | 1  |",
+            "|     | 2  |",
+            "| Foo |    |",
+            "| bar |    |",
+            "+-----+----+",
+        ];
+        assert_batches_sorted_eq!(expected, &read);
+    }
+
+    #[tokio::test]
+    async fn evolved_schema_disjoint_schema_filter_with_pushdown() {
+        let c1: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("Foo"), None, Some("bar")]));
+
+        let c2: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(2), None]));
+
+        // batch1: c1(string)
+        let batch1 = create_batch(vec![("c1", c1.clone())]);
+
+        // batch2: c2(int64)
+        let batch2 = create_batch(vec![("c2", c2)]);
+
+        let filter = col("c2").eq(lit(1_i64));
+
+        // read/write them files:
+        let read =
+            round_trip_to_parquet(vec![batch1, batch2], None, None, Some(filter), true)
+                .await
+                .unwrap();
 
         // This does not look correct since the "c2" values in the result do not in fact match the predicate `c2 == 0`
         // but parquet pruning is not exact. If the min/max values are not defined (which they are not in this case since the it is
@@ -1207,6 +1327,7 @@ mod tests {
             None,
             Some(Arc::new(schema)),
             None,
+            false,
         )
         .await;
         assert_contains!(read.unwrap_err().to_string(),

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -73,7 +73,7 @@ use parquet::schema::types::ColumnDescriptor;
 pub struct ParquetScanOptions {
     /// If true, any available `pruning_predicate` will be converted to a `RowFilter`
     /// and pushed down to the `ParquetRecordBatchStream`. This will enable row level
-    /// filter at the decoder level
+    /// filter at the decoder level. Defaults to false
     pushdown_filters: bool,
     /// If true, the generated `RowFilter` may reorder the predicate `Expr`s to try and optimize
     /// the cost of filter evaluation.

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1278,11 +1278,6 @@ mod tests {
                 .await
                 .unwrap();
 
-        // This does not look correct since the "c2" values in the result do not in fact match the predicate `c2 == 0`
-        // but parquet pruning is not exact. If the min/max values are not defined (which they are not in this case since the it is
-        // a null array, then the pruning predicate (currently) can not be applied.
-        // In a real query where this predicate was pushed down from a filter stage instead of created directly in the `ParquetExec`,
-        // the filter stage would be preserved as a separate execution plan stage so the actual query results would be as expected.
         let expected = vec![
             "+----+----+",
             "| c1 | c2 |",

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -215,9 +215,6 @@ pub fn build_row_filter(
     table_schema: &Schema,
     metadata: &ParquetMetaData,
 ) -> Result<Option<RowFilter>> {
-    println!("File schema: {:#?}", file_schema);
-    println!("Table schema: {:#?}", table_schema);
-
     let predicates = disjoin_filters(expr);
 
     let candidates: Vec<FilterCandidate> = predicates
@@ -227,10 +224,8 @@ pub fn build_row_filter(
                 FilterCandidateBuilder::new(expr.clone(), file_schema, table_schema)
                     .build(metadata)
             {
-                println!("{:?} valid row filter", expr);
                 candidate
             } else {
-                println!("{:?} not valid row filter", expr);
                 None
             }
         })

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use arrow::array::{Array, BooleanArray};
 use arrow::compute::prep_null_mask_filter;
 use arrow::datatypes::{DataType, Field, Schema};

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -295,6 +295,8 @@ pub fn build_row_filter(
     }
 }
 
+/// return true if this is a non nested type.
+// TODO remove after https://github.com/apache/arrow-rs/issues/2704 is done
 fn is_primitive_field(field: &Field) -> bool {
     !matches!(
         field.data_type(),

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -47,7 +47,6 @@ use std::sync::Arc;
 /// focus on the evaluation cost.
 ///
 /// The basic algorithm for constructing the `RowFilter` is as follows
-///
 ///     1. Recursively break conjunctions into separate predicates. An expression like `a = 1 AND (b = 2 AND c = 3)` would be
 ///        separated into the expressions `a = 1`, `b = 2`, and `c = 3`.
 ///     2. Determine whether each predicate is suitable as an `ArrowPredicate`. As long as the predicate does not reference any projected columns

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -1,0 +1,355 @@
+use arrow::array::{Array, BooleanArray};
+use arrow::compute::prep_null_mask_filter;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::error::{ArrowError, Result as ArrowResult};
+use arrow::record_batch::RecordBatch;
+use datafusion_common::{Column, Result, ScalarValue, ToDFSchema};
+use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter, RewriteRecursion};
+
+use datafusion_expr::{Expr, Operator};
+use datafusion_physical_expr::execution_props::ExecutionProps;
+use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
+use parquet::arrow::arrow_reader::{ArrowPredicate, RowFilter};
+use parquet::arrow::ProjectionMask;
+use parquet::file::metadata::ParquetMetaData;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// A predicate which can be passed to `ParquetRecordBatchStream` to perform row-level
+/// filtering during parquet decoding.
+#[derive(Debug)]
+pub(crate) struct DatafusionArrowPredicate {
+    physical_expr: Arc<dyn PhysicalExpr>,
+    projection: ProjectionMask,
+}
+
+impl DatafusionArrowPredicate {
+    pub fn try_new(
+        candidate: FilterCandidate,
+        schema: &Schema,
+        metadata: &ParquetMetaData,
+    ) -> Result<Self> {
+        let props = ExecutionProps::default();
+
+        let schema = schema.project(&candidate.projection)?;
+        let df_schema = schema.clone().to_dfschema()?;
+
+        let physical_expr =
+            create_physical_expr(&candidate.expr, &df_schema, &schema, &props)?;
+
+        Ok(Self {
+            physical_expr,
+            projection: ProjectionMask::roots(
+                metadata.file_metadata().schema_descr(),
+                candidate.projection,
+            ),
+        })
+    }
+}
+
+impl ArrowPredicate for DatafusionArrowPredicate {
+    fn projection(&self) -> &ProjectionMask {
+        &self.projection
+    }
+
+    fn evaluate(&mut self, batch: RecordBatch) -> ArrowResult<BooleanArray> {
+        match self
+            .physical_expr
+            .evaluate(&batch)
+            .map(|v| v.into_array(batch.num_rows()))
+        {
+            Ok(array) => {
+                if let Some(mask) = array.as_any().downcast_ref::<BooleanArray>() {
+                    let mask = match mask.null_count() {
+                        0 => BooleanArray::from(mask.data().clone()),
+                        _ => prep_null_mask_filter(mask),
+                    };
+
+                    Ok(mask)
+                } else {
+                    Err(ArrowError::ComputeError(
+                        "Unexpected result of predicate evaluation, expected BooleanArray".to_owned(),
+                    ))
+                }
+            }
+            Err(e) => Err(ArrowError::ComputeError(format!(
+                "Error evaluating filter predicate: {:?}",
+                e
+            ))),
+        }
+    }
+}
+
+/// A candidate expression for creating a `RowFilter` contains the
+/// expression as well as data to estimate the cost of evaluating
+/// the resulting expression.
+pub(crate) struct FilterCandidate {
+    expr: Expr,
+    required_bytes: usize,
+    can_use_index: bool,
+    projection: Vec<usize>,
+}
+
+/// Helper to build a `FilterCandidate`. This will do several things
+/// 1. Determine the columns required to evaluate the expression
+/// 2. Calculate data required to estimate the cost of evaluating the filter
+/// 3. Rewrite column expressions in the predicate which reference columns not in the particular file schema.
+///    This is relevant in the case where we have determined the table schema by merging all individual file schemas
+///    and any given file may or may not contain all columns in the merged schema. If a particular column is not present
+///    we replace the column expression with a literal expression that produces a null value.
+struct FilterCandidateBuilder<'a> {
+    expr: Expr,
+    file_schema: &'a Schema,
+    table_schema: &'a Schema,
+    required_columns: HashSet<Column>,
+    required_column_indices: Vec<usize>,
+    non_primitive_columns: bool,
+    projected_columns: bool,
+}
+
+impl<'a> FilterCandidateBuilder<'a> {
+    pub fn new(expr: Expr, file_schema: &'a Schema, table_schema: &'a Schema) -> Self {
+        Self {
+            expr,
+            file_schema,
+            table_schema,
+            required_columns: HashSet::new(),
+            required_column_indices: vec![],
+            non_primitive_columns: false,
+            projected_columns: false,
+        }
+    }
+
+    pub fn build(
+        mut self,
+        metadata: &ParquetMetaData,
+    ) -> Result<Option<FilterCandidate>> {
+        let expr = self.expr.clone();
+        let expr = expr.rewrite(&mut self)?;
+
+        if self.non_primitive_columns || self.projected_columns {
+            Ok(None)
+        } else {
+            let required_bytes =
+                size_of_columns(&self.required_columns, self.file_schema, metadata)?;
+            let can_use_index =
+                columns_sorted(&self.required_columns, self.file_schema, metadata)?;
+
+            Ok(Some(FilterCandidate {
+                expr,
+                required_bytes,
+                can_use_index,
+                projection: self.required_column_indices,
+            }))
+        }
+    }
+}
+
+impl<'a> ExprRewriter for FilterCandidateBuilder<'a> {
+    fn pre_visit(&mut self, expr: &Expr) -> Result<RewriteRecursion> {
+        if let Expr::Column(column) = expr {
+            if let Ok(idx) = self.file_schema.index_of(&column.name) {
+                self.required_columns.insert(column.clone());
+                self.required_column_indices.push(idx);
+
+                if !is_primitive_field(self.file_schema.field(idx)) {
+                    self.non_primitive_columns = true;
+                }
+            } else if self.table_schema.index_of(&column.name).is_err() {
+                // If the column does not exist in the (un-projected) table schema then
+                // it must be a projected column.
+                self.projected_columns = true;
+            }
+        }
+        Ok(RewriteRecursion::Continue)
+    }
+
+    fn mutate(&mut self, expr: Expr) -> Result<Expr> {
+        if let Expr::Column(Column { name, .. }) = &expr {
+            if self.file_schema.field_with_name(name).is_err() {
+                return Ok(Expr::Literal(ScalarValue::Null));
+            }
+        }
+
+        Ok(expr)
+    }
+}
+
+/// Calculate the total compressed size of all `Column's required for
+/// predicate `Expr`. This should represent the total amount of file IO
+/// required to evaluate the predicate.
+fn size_of_columns(
+    columns: &HashSet<Column>,
+    schema: &Schema,
+    metadata: &ParquetMetaData,
+) -> Result<usize> {
+    let mut total_size = 0;
+    let row_groups = metadata.row_groups();
+    for Column { name, .. } in columns.iter() {
+        let idx = schema.index_of(name)?;
+
+        for rg in row_groups.iter() {
+            total_size += rg.column(idx).compressed_size() as usize;
+        }
+    }
+
+    Ok(total_size)
+}
+
+/// For a given set of `Column`s required for predicate `Expr` determine whether all
+/// columns are sorted. Sorted columns may be queried more efficiently in the presence of
+/// a PageIndex.
+fn columns_sorted(
+    _columns: &HashSet<Column>,
+    _schema: &Schema,
+    _metadata: &ParquetMetaData,
+) -> Result<bool> {
+    // TODO How do we know this?
+    Ok(false)
+}
+
+/// Build a [`RowFilter`] from the given predicate `Expr`
+pub fn build_row_filter(
+    expr: Expr,
+    file_schema: &Schema,
+    table_schema: &Schema,
+    metadata: &ParquetMetaData,
+) -> Result<Option<RowFilter>> {
+    println!("File schema: {:#?}", file_schema);
+    println!("Table schema: {:#?}", table_schema);
+
+    let predicates = disjoin_filters(expr);
+
+    let candidates: Vec<FilterCandidate> = predicates
+        .into_iter()
+        .flat_map(|expr| {
+            if let Ok(candidate) =
+                FilterCandidateBuilder::new(expr.clone(), file_schema, table_schema)
+                    .build(metadata)
+            {
+                println!("{:?} valid row filter", expr);
+                candidate
+            } else {
+                println!("{:?} not valid row filter", expr);
+                None
+            }
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let (indexed_candidates, mut other_candidates): (Vec<_>, Vec<_>) =
+        candidates.into_iter().partition(|c| c.can_use_index);
+
+    let mut filters: Vec<Box<dyn ArrowPredicate>> = vec![];
+
+    for candidate in indexed_candidates {
+        let filter = DatafusionArrowPredicate::try_new(candidate, file_schema, metadata)?;
+
+        filters.push(Box::new(filter));
+    }
+
+    other_candidates.sort_by_key(|c| c.required_bytes);
+    for candidate in other_candidates {
+        let filter = DatafusionArrowPredicate::try_new(candidate, file_schema, metadata)?;
+
+        filters.push(Box::new(filter));
+    }
+
+    Ok(Some(RowFilter::new(filters)))
+}
+
+fn is_primitive_field(field: &Field) -> bool {
+    !matches!(
+        field.data_type(),
+        DataType::List(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::LargeList(_)
+            | DataType::Struct(_)
+            | DataType::Union(_, _, _)
+            | DataType::Dictionary(_, _)
+            | DataType::Map(_, _)
+    )
+}
+
+/// Take combined filter (multiple boolean expressions ANDed together)
+/// and break down into distinct filters. This should be the inverse of
+/// `datafusion_expr::expr_fn::combine_filters`
+fn disjoin_filters(combined_expr: Expr) -> Vec<Expr> {
+    match combined_expr {
+        Expr::BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        } => {
+            let mut exprs = disjoin_filters(*left);
+            exprs.extend(disjoin_filters(*right));
+            exprs
+        }
+        expr => {
+            vec![expr]
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::physical_plan::file_format::row_filter::disjoin_filters;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    use datafusion_expr::{and, col, lit, Expr};
+
+    fn assert_predicates(actual: Vec<Expr>, expected: Vec<Expr>) {
+        assert_eq!(
+            actual.len(),
+            expected.len(),
+            "Predicates are not equal, found {} predicates but expected {}",
+            actual.len(),
+            expected.len()
+        );
+
+        for expr in expected.into_iter() {
+            assert!(
+                actual.contains(&expr),
+                "Predicates are not equal, predicate {:?} not found in {:?}",
+                expr,
+                actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_disjoin() {
+        let _schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Utf8, true),
+        ]);
+
+        let expr = col("a").eq(lit("s"));
+        let actual = disjoin_filters(expr);
+
+        assert_predicates(actual, vec![col("a").eq(lit("s"))]);
+    }
+
+    #[test]
+    fn test_disjoin_complex() {
+        let _schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Utf8, true),
+        ]);
+
+        let expr = and(col("a"), col("b"));
+        let actual = disjoin_filters(expr);
+
+        assert_predicates(actual, vec![col("a"), col("b")]);
+
+        let expr = col("a").and(col("b")).or(col("c"));
+        let actual = disjoin_filters(expr.clone());
+
+        assert_predicates(actual, vec![expr]);
+    }
+}

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use arrow::array::{Array, BooleanArray};
-use arrow::compute::prep_null_mask_filter;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
@@ -76,12 +75,7 @@ impl ArrowPredicate for DatafusionArrowPredicate {
         {
             Ok(array) => {
                 if let Some(mask) = array.as_any().downcast_ref::<BooleanArray>() {
-                    let mask = match mask.null_count() {
-                        0 => BooleanArray::from(mask.data().clone()),
-                        _ => prep_null_mask_filter(mask),
-                    };
-
-                    Ok(mask)
+                    Ok(BooleanArray::from(mask.data().clone()))
                 } else {
                     Err(ArrowError::ComputeError(
                         "Unexpected result of predicate evaluation, expected BooleanArray".to_owned(),

--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -341,7 +341,7 @@ mod test {
         assert!(candidate.is_none());
     }
 
-    // If a column exists in the table schema but not the file schema it should be rewritten to a null expression
+    // We should ignore predicate that read non-primitive columns
     #[test]
     fn test_filter_candidate_builder_ignore_complex_types() {
         let testdata = crate::test_util::parquet_test_data();

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -479,10 +479,8 @@ pub fn combine_filters_disjunctive(filters: &[Expr]) -> Option<Expr> {
     if filters.is_empty() {
         return None;
     }
-    let combined_filter = filters
-        .iter()
-        .reduce(|acc, filter| or(acc, filter.clone()));
-    Some(combined_filter)
+
+    filters.iter().cloned().reduce(or)
 }
 
 /// Recursively un-alias an expressions

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -481,8 +481,7 @@ pub fn combine_filters_disjunctive(filters: &[Expr]) -> Option<Expr> {
     }
     let combined_filter = filters
         .iter()
-        .skip(1)
-        .fold(filters[0].clone(), |acc, filter| or(acc, filter.clone()));
+        .reduce(|acc, filter| or(acc, filter.clone()));
     Some(combined_filter)
 }
 

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -452,6 +452,20 @@ pub fn combine_filters(filters: &[Expr]) -> Option<Expr> {
     Some(combined_filter)
 }
 
+/// Combines an array of filter expressions into a single filter expression
+/// consisting of the input filter expressions joined with logical OR.
+/// Returns None if the filters array is empty.
+pub fn combine_filters_disjunctive(filters: &[Expr]) -> Option<Expr> {
+    if filters.is_empty() {
+        return None;
+    }
+    let combined_filter = filters
+        .iter()
+        .skip(1)
+        .fold(filters[0].clone(), |acc, filter| or(acc, filter.clone()));
+    Some(combined_filter)
+}
+
 /// Recursively un-alias an expressions
 #[inline]
 pub fn unalias(expr: Expr) -> Expr {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3360 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Putting this out there for comment since it's at a point where I am more or less happy with the design and all the existing tests pass. 

The key points for this PR:

1. Introduce a helper to build a `RowFilter` from a filter `Expr` pushed down to the `ParquetExec`. 
2. If a pruning predicate is available on the `ParquetExec`, build a `RowFilter` (if we ca) and construct our `ParquetRecordBatchStream` with it. 

To build a `RowFilter` we need to go through a few steps:
1. Take the pruning `Expr` (which has been combined into a single predicate) and tear it back apart into separate predicates which are ANDed together. 
2. For each predicate, first determine whether we can use it as a row filter. We consider it valid for that purpose if it does not reference any non-primitive columns (per @tustvold suggestion) and if it does not reference any projected columns (which are not yet available). 
3. Rewrite the `Expr` to replace any columns not present in the file schema to be null literal (to handle merged schemas without involving the `SchemaAdapter`), 
4. Gather some stats to estimate the cost of evaluating the expression (currently just total size of all columns and whether all columns are sorted). 
5. Now each predicate is a `FilterCandidate` and we can sort the candidates by evaluation cost so we can apply the "cheap" filters first. 
6. Convert each candidate to an `DatafusionArrowPredicate` and build a `RowFilter` from the whole lot of them. 

TODOs:
1. Need some more specific unit tests
2. Benchmarks!
3. I can't actually figure out how to tell whether columns are sorted from the `ParquetMetadata` :)
4. Current cost estimation (purely based on compressed size of columns) is the simplest thing that could possibly work but not sure if there is a better way to do it... 

A separate conceptual question is around optimizing the number of distinct filters. In this design we simply assume that we want to break the filter into as many distinct predicates as we can but I'm not sure that is always the case given that this forces serial evaluation of the filters. I can imagine many cases where it would be better to group predicates together for evaluation. I didn't want to make the initial implementation too complicated so I punted on that for now, but eventually may want to do cost estimation at a higher level to determine the optimal grouping. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->