### PR TITLE
Implement Eq trait for Expr and nested types

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -81,7 +81,7 @@ use std::sync::Arc;
 ///   assert_eq!(op, Operator::Eq);
 /// }
 /// ```
-#[derive(Clone, PartialEq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Expr {
     /// An expression with a specific name.
     Alias(Box<Expr>, String),
@@ -293,7 +293,7 @@ pub enum Expr {
 /// for Postgres definition.
 /// See https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-groupby.html
 /// for Apache Spark definition.
-#[derive(Clone, PartialEq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum GroupingSet {
     /// Rollup grouping sets
     Rollup(Vec<Expr>),

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1430,6 +1430,8 @@ impl PartialEq for Subquery {
     }
 }
 
+impl Eq for Subquery {}
+
 /// Logical partitioning schemes supported by the repartition operator.
 #[derive(Debug, Clone)]
 pub enum Partitioning {

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -56,6 +56,8 @@ impl PartialEq for AggregateUDF {
     }
 }
 
+impl Eq for AggregateUDF {}
+
 impl std::hash::Hash for AggregateUDF {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -59,6 +59,8 @@ impl PartialEq for ScalarUDF {
     }
 }
 
+impl Eq for ScalarUDF {}
+
 impl std::hash::Hash for ScalarUDF {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);


### PR DESCRIPTION
 # Rationale for this change
Expr is currently not compatible with the `HashSet` container because it does not implement to `std::cmp::Eq` trait. This PR implements that trait for `Expr` and any nested components