### PR TITLE
changed TPC-H benchmark to use Decimal types

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,8 @@ implementations as well as other query engines.
 
 ## Benchmark derived from TPC-H
 
-These benchmarks are derived from the [TPC-H][1] benchmark.
+These benchmarks are derived from the [TPC-H][1] benchmark. And we use this repo as the source of tpch-gen and answers: 
+https://github.com/databricks/tpch-dbgen.git, based on [2.17.1](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf) version of TPC-H.
 
 ## Generating Test Data
 


### PR DESCRIPTION


# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3392 and closes #166.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* changed datatypes to match TPC-H definition -- where Float64 was used, using Decimal128 now
* added special handling of q15 results, where we want to capture the results of the second of 3 statements
* fixed up the comparison of query results against known-good answers
* stop ignoring q15 and q21
* update README with link to benchmark PDF for reference

Assuming you set the TPCH_DATA env, all the tests now complete successfully except:
* q6 returns wrong results according to this test
* q9 has at least one row that's off by .01
* q11 "attempt to multiply with overflow" panic
* q14 "attempt to multiply with overflow" panic
* q17 "attempt to multiply with overflow" panic

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->