### PR TITLE
Implement bitwise XOR operator (`#`)

### DIFF
--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -57,6 +57,7 @@ pub fn binary_operator_data_type(
         // bitwise operations return the common coerced type
         Operator::BitwiseAnd
         | Operator::BitwiseOr
+        | Operator::BitwiseXor
         | Operator::BitwiseShiftLeft
         | Operator::BitwiseShiftRight => Ok(result_type),
         // math operations return the same value as the common coerced type
@@ -81,6 +82,7 @@ pub fn coerce_types(
     let result = match op {
         Operator::BitwiseAnd
         | Operator::BitwiseOr
+        | Operator::BitwiseXor
         | Operator::BitwiseShiftRight
         | Operator::BitwiseShiftLeft => bitwise_coercion(lhs_type, rhs_type),
         Operator::And | Operator::Or => match (lhs_type, rhs_type) {

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -71,6 +71,8 @@ pub enum Operator {
     BitwiseAnd,
     /// Bitwise or, like `|`
     BitwiseOr,
+    /// Bitwise xor, like `#`
+    BitwiseXor,
     /// Bitwise right, like `>>`
     BitwiseShiftRight,
     /// Bitwise left, like `<<`
@@ -107,6 +109,7 @@ impl Operator {
             | Operator::RegexNotIMatch
             | Operator::BitwiseAnd
             | Operator::BitwiseOr
+            | Operator::BitwiseXor
             | Operator::BitwiseShiftRight
             | Operator::BitwiseShiftLeft
             | Operator::StringConcat => None,
@@ -140,6 +143,7 @@ impl fmt::Display for Operator {
             Operator::IsNotDistinctFrom => "IS NOT DISTINCT FROM",
             Operator::BitwiseAnd => "&",
             Operator::BitwiseOr => "|",
+            Operator::BitwiseXor => "#",
             Operator::BitwiseShiftRight => ">>",
             Operator::BitwiseShiftLeft => "<<",
             Operator::StringConcat => "||",

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -57,6 +57,7 @@ use arrow::compute::kernels::concat_elements::concat_elements_utf8;
 use kernels::{
     bitwise_and, bitwise_and_scalar, bitwise_or, bitwise_or_scalar, bitwise_shift_left,
     bitwise_shift_left_scalar, bitwise_shift_right, bitwise_shift_right_scalar,
+    bitwise_xor, bitwise_xor_scalar,
 };
 use kernels_arrow::{
     add_decimal, add_decimal_scalar, divide_decimal, divide_decimal_scalar,
@@ -764,6 +765,7 @@ impl BinaryExpr {
             ),
             Operator::BitwiseAnd => bitwise_and_scalar(array, scalar.clone()),
             Operator::BitwiseOr => bitwise_or_scalar(array, scalar.clone()),
+            Operator::BitwiseXor => bitwise_xor_scalar(array, scalar.clone()),
             Operator::BitwiseShiftRight => {
                 bitwise_shift_right_scalar(array, scalar.clone())
             }
@@ -880,6 +882,7 @@ impl BinaryExpr {
             }
             Operator::BitwiseAnd => bitwise_and(left, right),
             Operator::BitwiseOr => bitwise_or(left, right),
+            Operator::BitwiseXor => bitwise_xor(left, right),
             Operator::BitwiseShiftRight => bitwise_shift_right(left, right),
             Operator::BitwiseShiftLeft => bitwise_shift_left(left, right),
             Operator::StringConcat => {
@@ -1294,6 +1297,18 @@ mod tests {
             Int64Array,
             DataType::Int64,
             vec![11i64, 6i64, 7i64]
+        );
+        test_coercion!(
+            Int16Array,
+            DataType::Int16,
+            vec![3i16, 2i16, 3i16],
+            Int64Array,
+            DataType::Int64,
+            vec![10i64, 6i64, 5i64],
+            Operator::BitwiseXor,
+            Int64Array,
+            DataType::Int64,
+            vec![9i64, 4i64, 6i64]
         );
         Ok(())
     }
@@ -2511,6 +2526,11 @@ mod tests {
         result = bitwise_or(left.clone(), right.clone())?;
         let expected = Int32Array::from(vec![Some(13), None, Some(15)]);
         assert_eq!(result.as_ref(), &expected);
+
+        result = bitwise_xor(left.clone(), right.clone())?;
+        let expected = Int32Array::from(vec![Some(13), None, Some(12)]);
+        assert_eq!(result.as_ref(), &expected);
+
         Ok(())
     }
 
@@ -2550,8 +2570,12 @@ mod tests {
         let expected = Int32Array::from(vec![Some(0), None, Some(3)]);
         assert_eq!(result.as_ref(), &expected);
 
-        result = bitwise_or_scalar(&left, right).unwrap()?;
+        result = bitwise_or_scalar(&left, right.clone()).unwrap()?;
         let expected = Int32Array::from(vec![Some(15), None, Some(11)]);
+        assert_eq!(result.as_ref(), &expected);
+
+        result = bitwise_xor_scalar(&left, right.clone()).unwrap()?;
+        let expected = Int32Array::from(vec![Some(15), None, Some(8)]);
         assert_eq!(result.as_ref(), &expected);
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -2574,7 +2574,7 @@ mod tests {
         let expected = Int32Array::from(vec![Some(15), None, Some(11)]);
         assert_eq!(result.as_ref(), &expected);
 
-        result = bitwise_xor_scalar(&left, right.clone()).unwrap()?;
+        result = bitwise_xor_scalar(&left, right).unwrap()?;
         let expected = Int32Array::from(vec![Some(15), None, Some(8)]);
         assert_eq!(result.as_ref(), &expected);
         Ok(())

--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -201,6 +201,28 @@ pub(crate) fn bitwise_or(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
     }
 }
 
+pub(crate) fn bitwise_xor(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
+    match &left.data_type() {
+        DataType::Int8 => {
+            binary_bitwise_array_op!(left, right, |a, b| a ^ b, Int8Array)
+        }
+        DataType::Int16 => {
+            binary_bitwise_array_op!(left, right, |a, b| a ^ b, Int16Array)
+        }
+        DataType::Int32 => {
+            binary_bitwise_array_op!(left, right, |a, b| a ^ b, Int32Array)
+        }
+        DataType::Int64 => {
+            binary_bitwise_array_op!(left, right, |a, b| a ^ b, Int64Array)
+        }
+        other => Err(DataFusionError::Internal(format!(
+            "Data type {:?} not supported for binary operation '{}' on dyn arrays",
+            other,
+            Operator::BitwiseXor
+        ))),
+    }
+}
+
 pub(crate) fn bitwise_and_scalar(
     array: &dyn Array,
     scalar: ScalarValue,
@@ -248,6 +270,32 @@ pub(crate) fn bitwise_or_scalar(
             "Data type {:?} not supported for binary operation '{}' on dyn arrays",
             other,
             Operator::BitwiseOr
+        ))),
+    };
+    Some(result)
+}
+
+pub(crate) fn bitwise_xor_scalar(
+    array: &dyn Array,
+    scalar: ScalarValue,
+) -> Option<Result<ArrayRef>> {
+    let result = match array.data_type() {
+        DataType::Int8 => {
+            binary_bitwise_array_scalar!(array, scalar, |a, b| a ^ b, Int8Array, i8)
+        }
+        DataType::Int16 => {
+            binary_bitwise_array_scalar!(array, scalar, |a, b| a ^ b, Int16Array, i16)
+        }
+        DataType::Int32 => {
+            binary_bitwise_array_scalar!(array, scalar, |a, b| a ^ b, Int32Array, i32)
+        }
+        DataType::Int64 => {
+            binary_bitwise_array_scalar!(array, scalar, |a, b| a ^ b, Int64Array, i64)
+        }
+        other => Err(DataFusionError::Internal(format!(
+            "Data type {:?} not supported for binary operation '{}' on dyn arrays",
+            other,
+            Operator::BitwiseXor
         ))),
     };
     Some(result)

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1589,6 +1589,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             BinaryOperator::PGRegexNotIMatch => Ok(Operator::RegexNotIMatch),
             BinaryOperator::BitwiseAnd => Ok(Operator::BitwiseAnd),
             BinaryOperator::BitwiseOr => Ok(Operator::BitwiseOr),
+            BinaryOperator::BitwiseXor => Ok(Operator::BitwiseXor),
             BinaryOperator::PGBitwiseShiftRight => Ok(Operator::BitwiseShiftRight),
             BinaryOperator::PGBitwiseShiftLeft => Ok(Operator::BitwiseShiftLeft),
             BinaryOperator::StringConcat => Ok(Operator::StringConcat),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3420 

# Are there any user-facing changes?
I think inclusion of bitwise XOR is a user-facing change.

Not sure if any documentation change is required. I mimicked a similar PR #1876. If any documentation update is required, then reviewers can point me to the documentation changes required.