### PR TITLE
add FixedSizeBinary support to create_hashes

### DIFF
--- a/datafusion/core/src/physical_plan/hash_utils.rs
+++ b/datafusion/core/src/physical_plan/hash_utils.rs
@@ -702,10 +702,7 @@ mod tests {
         let hashes_buff = &mut vec![0; fixed_size_binary_array.len()];
         let hashes =
             create_hashes(&[fixed_size_binary_array], &random_state, hashes_buff)?;
-
         assert_eq!(hashes.len(), 3,);
-        assert_ne!(hashes[0], hashes[1]);
-        assert_eq!(hashes[1], hashes[2]);
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1516.

 # Rationale for this change
Allows aggregation queries on FixedSizeBinary columns.

# What changes are included in this PR?
Treats FixedSizeBinary columns the same as Binary columns for creating a hash.

# Are there any user-facing changes?
no