### PR TITLE
Generate hash aggregation output in smaller record batches

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -298,6 +298,7 @@ impl ExecutionPlan for AggregateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        let batch_size = context.session_config().batch_size();
         let input = self.input.execute(partition, context)?;
 
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
@@ -318,6 +319,7 @@ impl ExecutionPlan for AggregateExec {
                 self.aggr_expr.clone(),
                 input,
                 baseline_metrics,
+                batch_size,
             )?))
         } else {
             Ok(Box::pin(GroupedHashAggregateStream::new(

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -428,6 +428,7 @@ fn create_group_rows(arrays: Vec<ArrayRef>, schema: &Schema) -> Vec<Vec<u8>> {
 }
 
 /// Create a RecordBatch with all group keys and accumulator' states or values.
+#[allow(clippy::too_many_arguments)]
 fn create_batch_from_map(
     mode: &AggregateMode,
     group_schema: &Schema,
@@ -490,8 +491,7 @@ fn create_batch_from_map(
         .map(|(col, desired_field)| cast(col, desired_field.data_type()))
         .collect::<ArrowResult<Vec<_>>>()?;
 
-    RecordBatch::try_new(Arc::new(output_schema.to_owned()), columns)
-        .map(|result| Some(result))
+    RecordBatch::try_new(Arc::new(output_schema.to_owned()), columns).map(Some)
 }
 
 fn read_as_batch(rows: &[Vec<u8>], schema: &Schema, row_type: RowType) -> Vec<ArrayRef> {

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -85,8 +85,10 @@ pub(crate) struct GroupedHashAggregateStreamV2 {
 
     baseline_metrics: BaselineMetrics,
     random_state: RandomState,
-
+    /// size to be used for resulting RecordBatches
     batch_size: usize,
+    /// if the result is chunked into batches,
+    /// last offset is preserved for continuation.
     row_group_skip_position: usize,
 }
 
@@ -107,6 +109,7 @@ impl GroupedHashAggregateStreamV2 {
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
         input: SendableRecordBatchStream,
         baseline_metrics: BaselineMetrics,
+        batch_size: usize,
     ) -> Result<Self> {
         let timer = baseline_metrics.elapsed_compute().timer();
 
@@ -137,7 +140,7 @@ impl GroupedHashAggregateStreamV2 {
             aggregate_expressions,
             aggr_state: Default::default(),
             random_state: Default::default(),
-            batch_size: 8192,
+            batch_size,
             row_group_skip_position: 0,
         })
     }


### PR DESCRIPTION
this change would prevent of cloning of whole state, doubling memory needed for aggregation.

relates to apache/arrow-datafusion#1570

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
--> 
Closes #3460.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

update `poll_next` method to return multiple aggregation state batches rather than a single one.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->