### PR TITLE
[MINOR] Change `downcast_value!` macro so it does not need to use `use std::any::type_name;`

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -35,6 +35,7 @@ pub use scalar::{ScalarType, ScalarValue};
 #[macro_export]
 macro_rules! downcast_value {
     ($Value: expr, $Type: ident) => {{
+        use std::any::type_name;
         $Value.as_any().downcast_ref::<$Type>().ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "could not cast value to {}",
@@ -43,6 +44,7 @@ macro_rules! downcast_value {
         })?
     }};
     ($Value: expr, $Type: ident, $T: tt) => {{
+        use std::any::type_name;
         $Value.as_any().downcast_ref::<$Type<T>>().ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "could not cast value to {}",

--- a/datafusion/physical-expr/src/aggregate/approx_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_distinct.rs
@@ -31,7 +31,6 @@ use arrow::datatypes::{
 use datafusion_common::{downcast_value, ScalarValue};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{Accumulator, AggregateState};
-use std::any::type_name;
 use std::any::Any;
 use std::convert::TryFrom;
 use std::convert::TryInto;

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -31,11 +31,7 @@ use datafusion_common::Result;
 use datafusion_common::{downcast_value, ScalarValue};
 use datafusion_expr::{Accumulator, AggregateState};
 use ordered_float::OrderedFloat;
-use std::{
-    any::{type_name, Any},
-    iter,
-    sync::Arc,
-};
+use std::{any::Any, iter, sync::Arc};
 
 /// APPROX_PERCENTILE_CONT aggregate expression
 #[derive(Debug)]

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -17,7 +17,6 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::type_name;
 use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -17,7 +17,6 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::type_name;
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -17,7 +17,6 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::type_name;
 use std::any::Any;
 use std::sync::Arc;
 

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -17,7 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::{type_name, Any};
+use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -17,7 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::{type_name, Any};
+use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -17,7 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use std::any::{type_name, Any};
+use std::any::Any;
 use std::sync::Arc;
 
 use crate::aggregate::stats::StatsType;


### PR DESCRIPTION
# Which issue does this PR close?
N/A


 # Rationale for this change
@iajoiner  added `downcast_value!` in #3347 which is awesome 👏 . @andygrove suggested I use `downcast_value!` in https://github.com/apache/arrow-datafusion/pull/3454#discussion_r970072753 which was also a great idea. 

I noticed I had to add a `use` statement however:

```rust
use std::any::type_name;
```

I figured it would clean up the code and future uses of `downcast_value!` if users didn't have to manually add a `use` as well

# What changes are included in this PR?
1. add `use std::any::type_name;` to the macro definition
2. remove now redundant `use std::any::type_name;` around the codebase 

# Are there any user-facing changes?
No