### PR TITLE
add time_zone into ConfigOptions

### DIFF
--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -47,6 +47,9 @@ pub const OPT_COALESCE_TARGET_BATCH_SIZE: &str =
 pub const OPT_OPTIMIZER_SKIP_FAILED_RULES: &str =
     "datafusion.optimizer.skip_failed_rules";
 
+/// Configuration option "datafusion.execution.time_zone"
+pub const OPT_TIME_ZONE: &str = "datafusion.execution.time_zone";
+
 /// Definition of a configuration option
 pub struct ConfigDefinition {
     /// key used to identifier this configuration option
@@ -100,6 +103,20 @@ impl ConfigDefinition {
             description,
             DataType::UInt64,
             ScalarValue::UInt64(Some(default_value)),
+        )
+    }
+
+    /// Create a configuration option definition with a string value
+    pub fn new_string(
+        key: impl Into<String>,
+        description: impl Into<String>,
+        default_value: String,
+    ) -> Self {
+        Self::new(
+            key,
+            description,
+            DataType::UInt64,
+            ScalarValue::Utf8(Some(default_value)),
         )
     }
 }
@@ -167,7 +184,14 @@ impl BuiltInConfigs {
                 messages if any optimization rules produce errors and then proceed to the next \
                 rule. When set to false, any rules that produce errors will cause the query to fail.",
                 true
-            )],
+            ),
+            ConfigDefinition::new_string(
+                OPT_TIME_ZONE,
+                "The session time zone which some function require \
+                e.g. EXTRACT(HOUR from SOME_TIME) shift the underline datetime according to the time zone,
+                then extract the hour",
+                "UTC".into()
+            )]
         }
     }
 
@@ -276,6 +300,14 @@ impl ConfigOptions {
         match self.get(key) {
             Some(ScalarValue::UInt64(Some(n))) => n,
             _ => 0,
+        }
+    }
+
+    /// get a string configuration option
+    pub fn get_string(&self, key: &str) -> String {
+        match self.get(key) {
+            Some(ScalarValue::Utf8(Some(s))) => s,
+            _ => "".into(),
         }
     }
 

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -115,7 +115,7 @@ impl ConfigDefinition {
         Self::new(
             key,
             description,
-            DataType::UInt64,
+            DataType::Utf8,
             ScalarValue::Utf8(Some(default_value)),
         )
     }

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -703,3 +703,41 @@ async fn show_all() {
         .len();
     assert_eq!(expected_length, results[0].num_rows());
 }
+
+#[tokio::test]
+async fn show_time_zone_default_utc() {
+    // https://github.com/apache/arrow-datafusion/issues/3255
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+    let sql = "SHOW TIME ZONE";
+    let results = plan_and_collect(&ctx, sql).await.unwrap();
+
+    let expected = vec![
+        "+--------------------------------+---------+",
+        "| name                           | setting |",
+        "+--------------------------------+---------+",
+        "| datafusion.execution.time_zone | UTC     |",
+        "+--------------------------------+---------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+}
+
+#[tokio::test]
+async fn show_timezone_default_utc() {
+    // https://github.com/apache/arrow-datafusion/issues/3255
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+    let sql = "SHOW TIMEZONE";
+    let results = plan_and_collect(&ctx, sql).await.unwrap();
+
+    let expected = vec![
+        "+--------------------------------+---------+",
+        "| name                           | setting |",
+        "+--------------------------------+---------+",
+        "| datafusion.execution.time_zone | UTC     |",
+        "+--------------------------------+---------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+}

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2387,7 +2387,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
 
         let variable_lower = variable.to_lowercase();
-        println!("{}", variable_lower);
 
         let query = if variable_lower == "all" {
             String::from("SELECT name, setting FROM information_schema.df_settings")

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2386,8 +2386,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             ));
         }
 
-        let query = if variable.to_lowercase() == "all" {
+        let variable_lower = variable.to_lowercase();
+        println!("{}", variable_lower);
+
+        let query = if variable_lower == "all" {
             String::from("SELECT name, setting FROM information_schema.df_settings")
+        } else if variable_lower == "timezone" || variable_lower == "time.zone" {
+            // we could introduce alias in OptionDefinition if this string matching thing grows
+            String::from("SELECT name, setting FROM information_schema.df_settings WHERE name = 'datafusion.execution.time_zone'")
         } else {
             format!(
                 "SELECT name, setting FROM information_schema.df_settings WHERE name = '{}'",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3255 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

some of the function requires session timezone to work
e.g. `EXTRACT(HOUR FROM SOME_TIME)` need this 

as `SHOW` statement is done in #3455 
we could do this now

```bash
❯ show datafusion.execution.time_zone;
datafusion.execution.time_zone
+--------------------------------+---------+
| name                           | setting |
+--------------------------------+---------+
| datafusion.execution.time_zone | UTC     |
+--------------------------------+---------+
1 row in set. Query took 0.004 seconds.
```
I also added the shortcut to align with postgrseql

```bash
❯ show timezone;
timezone
+--------------------------------+---------+
| name                           | setting |
+--------------------------------+---------+
| datafusion.execution.time_zone | UTC     |
+--------------------------------+---------+
1 row in set. Query took 0.004 seconds.

❯ show time zone;
time.zone
+--------------------------------+---------+
| name                           | setting |
+--------------------------------+---------+
| datafusion.execution.time_zone | UTC     |
+--------------------------------+---------+
1 row in set. Query took 0.004 seconds.
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->