### PR TITLE
minor: fix bug in `downcast_value!` macro

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -43,10 +43,10 @@ macro_rules! downcast_value {
         })?
     }};
     ($Value: expr, $Type: ident, $T: tt) => {{
-        $Value.as_any().downcast_ref::<$Type<T>>().ok_or_else(|| {
+        $Value.as_any().downcast_ref::<$Type<$T>>().ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "could not cast value to {}",
-                type_name::<$Type<T>>()
+                type_name::<$Type<$T>>()
             ))
         })?
     }};


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change
There is a bug pointed out by @iajoiner  https://github.com/apache/arrow-datafusion/pull/3484#issuecomment-1247192612

We don't see the problem because the only uses of the variant of the macro are all in generics that use `T` 

When I remove that variant, you can see the locations

```
error: no rules expected the token `,`
   --> datafusion/physical-expr/src/aggregate/approx_distinct.rs:252:58
    |
252 |             downcast_value!(values[0], GenericBinaryArray, T);
    |                                                          ^ no rules expected this token in macro call

error: no rules expected the token `,`
   --> datafusion/physical-expr/src/aggregate/approx_distinct.rs:268:58
    |
268 |             downcast_value!(values[0], GenericStringArray, T);
    |                                                          ^ no rules expected this token in macro call

error: no rules expected the token `,`
   --> datafusion/physical-expr/src/aggregate/approx_distinct.rs:284:82
    |
284 |         let array: &PrimitiveArray<T> = downcast_value!(values[0], PrimitiveArray, T);
    |                                                                                  ^ no rules expected this token in macro call
```

# What changes are included in this PR?
1. Change `T` to `$T` 

# Are there any user-facing changes?
No