### PR TITLE
Add additional DATE_PART units

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1233,6 +1233,11 @@ async fn test_extract_date_part() -> Result<()> {
         "EXTRACT(year FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
         "2020"
     );
+    test_expression!("date_part('QUARTER', CAST('2000-01-01' AS DATE))", "1");
+    test_expression!(
+        "EXTRACT(quarter FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+        "3"
+    );
     test_expression!("date_part('MONTH', CAST('2000-01-01' AS DATE))", "1");
     test_expression!(
         "EXTRACT(month FROM to_timestamp('2020-09-08T12:00:00+00:00'))",

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1248,6 +1248,11 @@ async fn test_extract_date_part() -> Result<()> {
         "EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
         "8"
     );
+    test_expression!("date_part('DOW', CAST('2000-01-01' AS DATE))", "6");
+    test_expression!(
+        "EXTRACT(dow FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+        "2"
+    );
     test_expression!("date_part('HOUR', CAST('2000-01-01' AS DATE))", "0");
     test_expression!(
         "EXTRACT(hour FROM to_timestamp('2020-09-08T12:03:03+00:00'))",

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1248,6 +1248,11 @@ async fn test_extract_date_part() -> Result<()> {
         "EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
         "8"
     );
+    test_expression!("date_part('DOY', CAST('2000-01-01' AS DATE))", "1");
+    test_expression!(
+        "EXTRACT(doy FROM to_timestamp('2020-09-08T12:00:00+00:00'))",
+        "252"
+    );
     test_expression!("date_part('DOW', CAST('2000-01-01' AS DATE))", "6");
     test_expression!(
         "EXTRACT(dow FROM to_timestamp('2020-09-08T12:00:00+00:00'))",

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -452,6 +452,7 @@ pub fn date_part(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         "month" => extract_date_part!(array, temporal::month),
         "week" => extract_date_part!(array, temporal::week),
         "day" => extract_date_part!(array, temporal::day),
+        "dow" => extract_date_part!(array, temporal::num_days_from_sunday),
         "hour" => extract_date_part!(array, temporal::hour),
         "minute" => extract_date_part!(array, temporal::minute),
         "second" => extract_date_part!(array, temporal::second),

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -452,6 +452,7 @@ pub fn date_part(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         "month" => extract_date_part!(array, temporal::month),
         "week" => extract_date_part!(array, temporal::week),
         "day" => extract_date_part!(array, temporal::day),
+        "doy" => extract_date_part!(array, temporal::doy),
         "dow" => extract_date_part!(array, temporal::num_days_from_sunday),
         "hour" => extract_date_part!(array, temporal::hour),
         "minute" => extract_date_part!(array, temporal::minute),

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -449,6 +449,7 @@ pub fn date_part(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 
     let arr = match date_part.to_lowercase().as_str() {
         "year" => extract_date_part!(array, temporal::year),
+        "quarter" => extract_date_part!(array, temporal::quarter),
         "month" => extract_date_part!(array, temporal::month),
         "week" => extract_date_part!(array, temporal::week),
         "day" => extract_date_part!(array, temporal::day),


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3502.

 # Rationale for this change
The `quarter`, `doy` and `dow` `DATE_PART` units are already supported by arrow-rs kernels, so lets add them to DataFusion!

The names and semantics match those in PostgreSQL: https://www.postgresql.org/docs/8.1/functions-datetime.html

# Are there any user-facing changes?
Adds support for `quarter`, `doy` and `dow` `DATE_PART` units.

I'm not sure if there is any documentation that should be updated as well.
