### PR TITLE
fix divide by zero not throwing proper error for decimal

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -394,11 +394,11 @@ pub(crate) fn divide_decimal_scalar(
     left: &Decimal128Array,
     right: i128,
 ) -> Result<Decimal128Array> {
+    if right == 0 {
+        return Err(DataFusionError::ArrowError(ArrowError::DivideByZero));
+    }
     let mul = 10_f64.powi(left.scale() as i32);
     let array = arith_decimal_scalar(left, right, |left, right| {
-        if right == 0 {
-            return Err(DataFusionError::ArrowError(ArrowError::DivideByZero));
-        }
         let l_value = left as f64;
         let r_value = right as f64;
         let result = ((l_value / r_value) * mul) as i128;
@@ -672,7 +672,7 @@ mod tests {
     #[test]
     fn arithmetic_decimal_divide_by_zero() {
         let left_decimal_array = create_decimal_array(&[Some(101)], 10, 1);
-        let right_decimal_array = create_decimal_array(&[Some(0)], 10, 1);
+        let right_decimal_array = create_decimal_array(&[Some(0)], 1, 1);
 
         let err = divide_decimal(&left_decimal_array, &right_decimal_array).unwrap_err();
         assert_eq!("Arrow error: Divide by zero error", err.to_string());

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -674,13 +674,13 @@ mod tests {
         let left_decimal_array = create_decimal_array(&[Some(101)], 10, 1);
         let right_decimal_array = create_decimal_array(&[Some(0)], 10, 1);
 
-        let _result = divide_decimal(&left_decimal_array, &right_decimal_array)
-            .expect_err("expecting DivideByZero error");
-        let _result = divide_decimal_scalar(&left_decimal_array, 0)
-            .expect_err("expecting DivideByZero error");
-        let _result = modulus_decimal(&left_decimal_array, &right_decimal_array)
-            .expect_err("expecting DivideByZero error");
-        let _result = modulus_decimal_scalar(&left_decimal_array, 0)
-            .expect_err("expecting DivideByZero error");
+        let err = divide_decimal(&left_decimal_array, &right_decimal_array).unwrap_err();
+        assert_eq!("Arrow error: Divide by zero error", err.to_string());
+        let err = divide_decimal_scalar(&left_decimal_array, 0).unwrap_err();
+        assert_eq!("Arrow error: Divide by zero error", err.to_string());
+        let err = modulus_decimal(&left_decimal_array, &right_decimal_array).unwrap_err();
+        assert_eq!("Arrow error: Divide by zero error", err.to_string());
+        let err = modulus_decimal_scalar(&left_decimal_array, 0).unwrap_err();
+        assert_eq!("Arrow error: Divide by zero error", err.to_string());
     }
 }

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -378,6 +378,9 @@ pub(crate) fn divide_decimal(
 ) -> Result<Decimal128Array> {
     let mul = 10_f64.powi(left.scale() as i32);
     let array = arith_decimal(left, right, |left, right| {
+        if right == 0 {
+            return Err(DataFusionError::ArrowError(ArrowError::DivideByZero));
+        }
         let l_value = left as f64;
         let r_value = right as f64;
         let result = ((l_value / r_value) * mul) as i128;
@@ -393,6 +396,9 @@ pub(crate) fn divide_decimal_scalar(
 ) -> Result<Decimal128Array> {
     let mul = 10_f64.powi(left.scale() as i32);
     let array = arith_decimal_scalar(left, right, |left, right| {
+        if right == 0 {
+            return Err(DataFusionError::ArrowError(ArrowError::DivideByZero));
+        }
         let l_value = left as f64;
         let r_value = right as f64;
         let result = ((l_value / r_value) * mul) as i128;
@@ -615,34 +621,66 @@ mod tests {
         assert_eq!(expect, result);
         // divide
         let left_decimal_array = create_decimal_array(
-            &[Some(1234567), None, Some(1234567), Some(1234567)],
+            &[
+                Some(1234567),
+                None,
+                Some(1234567),
+                Some(1234567),
+                Some(1234567),
+            ],
             25,
             3,
         );
-        let right_decimal_array =
-            create_decimal_array(&[Some(10), Some(100), Some(55), Some(-123)], 25, 3);
+        let right_decimal_array = create_decimal_array(
+            &[Some(10), Some(100), Some(55), Some(-123), None],
+            25,
+            3,
+        );
         let result = divide_decimal(&left_decimal_array, &right_decimal_array)?;
         let expect = create_decimal_array(
-            &[Some(123456700), None, Some(22446672), Some(-10037130)],
+            &[Some(123456700), None, Some(22446672), Some(-10037130), None],
             25,
             3,
         );
         assert_eq!(expect, result);
         let result = divide_decimal_scalar(&left_decimal_array, 10)?;
         let expect = create_decimal_array(
-            &[Some(123456700), None, Some(123456700), Some(123456700)],
+            &[
+                Some(123456700),
+                None,
+                Some(123456700),
+                Some(123456700),
+                Some(123456700),
+            ],
             25,
             3,
         );
         assert_eq!(expect, result);
         // modulus
         let result = modulus_decimal(&left_decimal_array, &right_decimal_array)?;
-        let expect = create_decimal_array(&[Some(7), None, Some(37), Some(16)], 25, 3);
+        let expect =
+            create_decimal_array(&[Some(7), None, Some(37), Some(16), None], 25, 3);
         assert_eq!(expect, result);
         let result = modulus_decimal_scalar(&left_decimal_array, 10)?;
-        let expect = create_decimal_array(&[Some(7), None, Some(7), Some(7)], 25, 3);
+        let expect =
+            create_decimal_array(&[Some(7), None, Some(7), Some(7), Some(7)], 25, 3);
         assert_eq!(expect, result);
 
         Ok(())
+    }
+
+    #[test]
+    fn arithmetic_decimal_divide_by_zero() {
+        let left_decimal_array = create_decimal_array(&[Some(101)], 10, 1);
+        let right_decimal_array = create_decimal_array(&[Some(0)], 10, 1);
+
+        let _result = divide_decimal(&left_decimal_array, &right_decimal_array)
+            .expect_err("expecting DivideByZero error");
+        let _result = divide_decimal_scalar(&left_decimal_array, 0)
+            .expect_err("expecting DivideByZero error");
+        let _result = modulus_decimal(&left_decimal_array, &right_decimal_array)
+            .expect_err("expecting DivideByZero error");
+        let _result = modulus_decimal_scalar(&left_decimal_array, 0)
+            .expect_err("expecting DivideByZero error");
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3498 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Fixes the problem detailed in #3498
* Fixes the scalar version of same function
* Adds tests for both of those functions + coverage for modulus as well.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Proper error
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->