### PR TITLE
Make `OptimizerConfig` a builder style API

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1564,14 +1564,16 @@ impl SessionState {
 
     /// Optimizes the logical plan by applying optimizer rules.
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
-        let mut optimizer_config = OptimizerConfig::new().with_skip_failing_rules(
-            self.config
-                .config_options
-                .read()
-                .get_bool(OPT_OPTIMIZER_SKIP_FAILED_RULES),
-        );
-        optimizer_config.query_execution_start_time =
-            self.execution_props.query_execution_start_time;
+        let mut optimizer_config = OptimizerConfig::new()
+            .with_skip_failing_rules(
+                self.config
+                    .config_options
+                    .read()
+                    .get_bool(OPT_OPTIMIZER_SKIP_FAILED_RULES),
+            )
+            .with_query_execution_start_time(
+                self.execution_props.query_execution_start_time,
+            );
 
         if let LogicalPlan::Explain(e) = plan {
             let mut stringified_plans = e.stringified_plans.clone();

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -38,12 +38,15 @@ pub trait OptimizerRule {
     fn name(&self) -> &str;
 }
 
-/// Placeholder for optimizer configuration options
+/// Options to control the DataFusion Optimizer.
 #[derive(Debug)]
 pub struct OptimizerConfig {
-    /// Query execution start time that can be used to rewrite expressions such as `now()`
-    /// to use a literal value instead
-    pub query_execution_start_time: DateTime<Utc>,
+    /// Query execution start time that can be used to rewrite
+    /// expressions such as `now()` to use a literal value instead
+    query_execution_start_time: DateTime<Utc>,
+    /// id generator for optimizer passes
+    // TODO this should not be on the config,
+    // it should be its own 'OptimizerState' or something)
     next_id: usize,
     /// Option to skip rules that produce errors
     skip_failing_rules: bool,
@@ -59,15 +62,33 @@ impl OptimizerConfig {
         }
     }
 
-    /// Specify whether the optimizer should skip rules that produce errors, or fail the query
+    /// Specify whether the optimizer should skip rules that produce
+    /// errors, or fail the query
+    pub fn with_query_execution_start_time(
+        mut self,
+        query_execution_tart_time: DateTime<Utc>,
+    ) -> Self {
+        self.query_execution_start_time = query_execution_tart_time;
+        self
+    }
+
+    /// Specify whether the optimizer should skip rules that produce
+    /// errors, or fail the query
     pub fn with_skip_failing_rules(mut self, b: bool) -> Self {
         self.skip_failing_rules = b;
         self
     }
 
+    /// Generate the next ID needed
     pub fn next_id(&mut self) -> usize {
         self.next_id += 1;
         self.next_id
+    }
+
+    /// Return the time at which the query execution started. This
+    /// time is used as the value for now()
+    pub fn query_execution_start_time(&self) -> DateTime<Utc> {
+        self.query_execution_start_time
     }
 }
 

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -260,7 +260,7 @@ impl OptimizerRule for SimplifyExpressions {
     ) -> Result<LogicalPlan> {
         let mut execution_props = ExecutionProps::new();
         execution_props.query_execution_start_time =
-            optimizer_config.query_execution_start_time;
+            optimizer_config.query_execution_start_time();
         self.optimize_internal(plan, &execution_props)
     }
 }
@@ -1887,8 +1887,8 @@ mod tests {
 
     // expect optimizing will result in an error, returning the error string
     fn get_optimized_plan_err(plan: &LogicalPlan, date_time: &DateTime<Utc>) -> String {
-        let mut config = OptimizerConfig::new();
-        config.query_execution_start_time = *date_time;
+        let mut config =
+            OptimizerConfig::new().with_query_execution_start_time(*date_time);
         let rule = SimplifyExpressions::new();
 
         let err = rule
@@ -1902,8 +1902,8 @@ mod tests {
         plan: &LogicalPlan,
         date_time: &DateTime<Utc>,
     ) -> String {
-        let mut config = OptimizerConfig::new();
-        config.query_execution_start_time = *date_time;
+        let mut config =
+            OptimizerConfig::new().with_query_execution_start_time(*date_time);
         let rule = SimplifyExpressions::new();
 
         let optimized_plan = rule

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -68,7 +68,7 @@ impl OptimizerRule for TypeCoercion {
 
         let mut execution_props = ExecutionProps::new();
         execution_props.query_execution_start_time =
-            optimizer_config.query_execution_start_time;
+            optimizer_config.query_execution_start_time();
         let const_evaluator = ConstEvaluator::try_new(&execution_props)?;
 
         let mut expr_rewrite = TypeCoercionRewriter {


### PR DESCRIPTION
# Which issue does this PR close?

re  https://github.com/apache/arrow-datafusion/issues/3524

 # Rationale for this change
I am preparing to improve the API between the optimizer and the rest of the system and I want to get the basic pattern established before more major changes

# What changes are included in this PR?
This PR moves from modifying public fields to a builder interface for `OptimizerConfig` 

# Are there any user-facing changes?
To set execution start time, must use builder interface now