### PR TITLE
Add serialization of `ScalarValue::Binary` and `ScalarValue::LargeBinary`, `ScalarValue::Time64`

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -759,6 +759,9 @@ message ScalarValue{
         int64 interval_daytime_value = 25;
         ScalarTimestampValue timestamp_value = 26;
         ScalarDictionaryValue dictionary_value = 27;
+        bytes binary_value = 28;
+        bytes large_binary_value = 29;
+        int64 time64_value = 30;
     }
 }
 
@@ -786,16 +789,21 @@ enum PrimitiveScalarType{
     UTF8 = 11;
     LARGE_UTF8 = 12;
     DATE32 = 13;
-    TIME_MICROSECOND = 14;
-    TIME_NANOSECOND = 15;
+    TIMESTAMP_MICROSECOND = 14;
+    TIMESTAMP_NANOSECOND = 15;
     NULL = 16;
 
     DECIMAL128 = 17;
     DATE64 = 20;
-    TIME_SECOND = 21;
-    TIME_MILLISECOND = 22;
+    TIMESTAMP_SECOND = 21;
+    TIMESTAMP_MILLISECOND = 22;
     INTERVAL_YEARMONTH = 23;
     INTERVAL_DAYTIME = 24;
+
+    BINARY = 25;
+    LARGE_BINARY = 26;
+
+    TIME64 = 27;
 }
 
 message ScalarType{

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -402,6 +402,10 @@ mod roundtrip_tests {
             ScalarValue::LargeUtf8(Some(String::from("Test Large utf8"))),
             ScalarValue::Date32(Some(0)),
             ScalarValue::Date32(Some(i32::MAX)),
+            ScalarValue::Date32(None),
+            ScalarValue::Time64(Some(0)),
+            ScalarValue::Time64(Some(i64::MAX)),
+            ScalarValue::Time64(None),
             ScalarValue::TimestampNanosecond(Some(0), None),
             ScalarValue::TimestampNanosecond(Some(i64::MAX), None),
             ScalarValue::TimestampNanosecond(Some(0), Some("UTC".to_string())),
@@ -459,6 +463,10 @@ mod roundtrip_tests {
                 Box::new(DataType::Int32),
                 Box::new(ScalarValue::Utf8(None)),
             ),
+            ScalarValue::Binary(Some(b"bar".to_vec())),
+            ScalarValue::Binary(None),
+            ScalarValue::LargeBinary(Some(b"bar".to_vec())),
+            ScalarValue::LargeBinary(None),
         ];
 
         for test_case in should_pass.into_iter() {

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1098,7 +1098,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                 })
             }
             datafusion::scalar::ScalarValue::TimestampMicrosecond(val, tz) => {
-                create_proto_scalar(val, PrimitiveScalarType::TimeMicrosecond, |s| {
+                create_proto_scalar(val, PrimitiveScalarType::TimestampMicrosecond, |s| {
                     Value::TimestampValue(protobuf::ScalarTimestampValue {
                         timezone: tz.as_ref().unwrap_or(&"".to_string()).clone(),
                         value: Some(
@@ -1110,7 +1110,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                 })
             }
             datafusion::scalar::ScalarValue::TimestampNanosecond(val, tz) => {
-                create_proto_scalar(val, PrimitiveScalarType::TimeNanosecond, |s| {
+                create_proto_scalar(val, PrimitiveScalarType::TimestampNanosecond, |s| {
                     Value::TimestampValue(protobuf::ScalarTimestampValue {
                         timezone: tz.as_ref().unwrap_or(&"".to_string()).clone(),
                         value: Some(
@@ -1145,7 +1145,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                 })
             }
             datafusion::scalar::ScalarValue::TimestampSecond(val, tz) => {
-                create_proto_scalar(val, PrimitiveScalarType::TimeSecond, |s| {
+                create_proto_scalar(val, PrimitiveScalarType::TimestampSecond, |s| {
                     Value::TimestampValue(protobuf::ScalarTimestampValue {
                         timezone: tz.as_ref().unwrap_or(&"".to_string()).clone(),
                         value: Some(
@@ -1155,7 +1155,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                 })
             }
             datafusion::scalar::ScalarValue::TimestampMillisecond(val, tz) => {
-                create_proto_scalar(val, PrimitiveScalarType::TimeMillisecond, |s| {
+                create_proto_scalar(val, PrimitiveScalarType::TimestampMillisecond, |s| {
                     Value::TimestampValue(protobuf::ScalarTimestampValue {
                         timezone: tz.as_ref().unwrap_or(&"".to_string()).clone(),
                         value: Some(
@@ -1180,19 +1180,21 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                 value: Some(Value::NullValue(PrimitiveScalarType::Null as i32)),
             },
 
-            datafusion::scalar::ScalarValue::Binary(_) => {
-                // not yet implemented (TODO file ticket)
-                return Err(Error::invalid_scalar_value(val));
+            scalar::ScalarValue::Binary(val) => {
+                create_proto_scalar(val, PrimitiveScalarType::Binary, |s| {
+                    Value::BinaryValue(s.to_owned())
+                })
+            }
+            scalar::ScalarValue::LargeBinary(val) => {
+                create_proto_scalar(val, PrimitiveScalarType::LargeBinary, |s| {
+                    Value::LargeBinaryValue(s.to_owned())
+                })
             }
 
-            datafusion::scalar::ScalarValue::LargeBinary(_) => {
-                // not yet implemented (TODO file ticket)
-                return Err(Error::invalid_scalar_value(val));
-            }
-
-            datafusion::scalar::ScalarValue::Time64(_) => {
-                // not yet implemented (TODO file ticket)
-                return Err(Error::invalid_scalar_value(val));
+            datafusion::scalar::ScalarValue::Time64(v) => {
+                create_proto_scalar(v, PrimitiveScalarType::Time64, |v| {
+                    Value::Time64Value(*v)
+                })
             }
 
             datafusion::scalar::ScalarValue::IntervalMonthDayNano(_) => {
@@ -1335,10 +1337,10 @@ impl TryFrom<&DataType> for protobuf::scalar_type::Datatype {
             DataType::Date32 => Self::Scalar(PrimitiveScalarType::Date32 as i32),
             DataType::Time64(time_unit) => match time_unit {
                 TimeUnit::Microsecond => {
-                    Self::Scalar(PrimitiveScalarType::TimeMicrosecond as i32)
+                    Self::Scalar(PrimitiveScalarType::TimestampMicrosecond as i32)
                 }
                 TimeUnit::Nanosecond => {
-                    Self::Scalar(PrimitiveScalarType::TimeNanosecond as i32)
+                    Self::Scalar(PrimitiveScalarType::TimestampNanosecond as i32)
                 }
                 _ => {
                     return Err(Error::invalid_time_unit(time_unit));
@@ -1379,8 +1381,10 @@ impl TryFrom<&DataType> for protobuf::scalar_type::Datatype {
                     DataType::Float64 => PrimitiveScalarType::Float64,
                     DataType::Date32 => PrimitiveScalarType::Date32,
                     DataType::Time64(time_unit) => match time_unit {
-                        TimeUnit::Microsecond => PrimitiveScalarType::TimeMicrosecond,
-                        TimeUnit::Nanosecond => PrimitiveScalarType::TimeNanosecond,
+                        TimeUnit::Microsecond => {
+                            PrimitiveScalarType::TimestampMicrosecond
+                        }
+                        TimeUnit::Nanosecond => PrimitiveScalarType::TimestampNanosecond,
                         _ => {
                             return Err(Error::invalid_time_unit(time_unit));
                         }


### PR DESCRIPTION
# Which issue does this PR close?

~Draft as it builds on~
- [x] https://github.com/apache/arrow-datafusion/pull/3532
- [x] https://github.com/apache/arrow-datafusion/pull/3537

Part of https://github.com/apache/arrow-datafusion/issues/3531



 # Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/3531


# What changes are included in this PR?

1. Implement serialization code for: `ScalarValue::{,Large}Binary`
2. Implement serialization code for `ScalarValue::Time64`
3. Fix code for `ScalarValue::Timestamp*`
2. Add tests


# Are there any user-facing changes?
Better serialization support