### PR TITLE
Actually test that `ScalarValue`s are the same after round trip serialization

### DIFF
--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -465,8 +465,17 @@ mod roundtrip_tests {
             let proto: super::protobuf::ScalarValue = (&test_case)
                 .try_into()
                 .expect("failed conversion to protobuf");
-            let _roundtrip: ScalarValue =
-                (&proto).try_into().expect("failed conversion to protobuf");
+
+            let roundtrip: ScalarValue = (&proto)
+                .try_into()
+                .expect("failed conversion from protobuf");
+
+            assert_eq!(
+                test_case, roundtrip,
+                "ScalarValue was not the same after round trip!\n\n\
+                        Input: {:?}\n\nRoundtrip: {:?}",
+                test_case, roundtrip
+            );
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/3531
Closes #.

 # Rationale for this change
While working on https://github.com/apache/arrow-datafusion/issues/3531  I noticed the round trip scalar serialization test only tests that no errors are thrown while serializing. It doesn't test that the round tripped value is the same



# What changes are included in this PR?
Improve test to validate that the value is the same after roundtrip

# Are there any user-facing changes?
No