### PR TITLE
Simplify the serialization of `ScalarValue::List`

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -714,6 +714,9 @@ message Union{
 }
 
 message ScalarListValue{
+    // encode null explicitly to distinguish a list with a null value
+    // from a list with no values)
+    bool is_null = 3;
     Field field = 1;
     repeated ScalarValue values = 2;
 }
@@ -768,7 +771,7 @@ message ScalarValue{
         //Literal Date32 value always has a unit of day
         int32  date_32_value = 14;
         ScalarListValue list_value = 17;
-        ScalarType null_list_value = 18;
+        //WAS: ScalarType null_list_value = 18;
 
         Decimal128 decimal128_value = 20;
         int64 date_64_value = 21;
@@ -825,17 +828,6 @@ enum PrimitiveScalarType{
     TIME64 = 27;
 }
 
-message ScalarType{
-    oneof datatype{
-        PrimitiveScalarType scalar = 1;
-        ScalarListType list = 2;
-    }
-}
-
-message ScalarListType{
-    repeated string field_names = 3;
-    PrimitiveScalarType deepest_type = 2;
-}
 
 // Broke out into multiple message types so that type
 // metadata did not need to be in separate message

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -95,10 +95,6 @@ impl Error {
         Error::MissingRequiredField(field.into())
     }
 
-    fn at_least_one(field: impl Into<String>) -> Error {
-        Error::AtLeastOneValue(field.into())
-    }
-
     fn unknown(name: impl Into<String>, value: i32) -> Error {
         Error::UnknownEnumVariant {
             name: name.into(),
@@ -559,56 +555,6 @@ impl TryFrom<&i32> for protobuf::AggregateFunction {
     }
 }
 
-impl TryFrom<&protobuf::scalar_type::Datatype> for DataType {
-    type Error = Error;
-
-    fn try_from(
-        scalar_type: &protobuf::scalar_type::Datatype,
-    ) -> Result<Self, Self::Error> {
-        use protobuf::scalar_type::Datatype;
-
-        Ok(match scalar_type {
-            Datatype::Scalar(scalar_type) => {
-                protobuf::PrimitiveScalarType::try_from(scalar_type)?.into()
-            }
-            Datatype::List(protobuf::ScalarListType {
-                deepest_type,
-                field_names,
-            }) => {
-                if field_names.is_empty() {
-                    return Err(Error::at_least_one("field_names"));
-                }
-                let field_type =
-                    protobuf::PrimitiveScalarType::try_from(deepest_type)?.into();
-                // Because length is checked above it is safe to unwrap .last()
-                let mut scalar_type = DataType::List(Box::new(Field::new(
-                    field_names.last().unwrap().as_str(),
-                    field_type,
-                    true,
-                )));
-                // Iterate over field names in reverse order except for the last item in the vector
-                for name in field_names.iter().rev().skip(1) {
-                    let new_datatype = DataType::List(Box::new(Field::new(
-                        name.as_str(),
-                        scalar_type,
-                        true,
-                    )));
-                    scalar_type = new_datatype;
-                }
-                scalar_type
-            }
-        })
-    }
-}
-
-impl TryFrom<&protobuf::ScalarType> for DataType {
-    type Error = Error;
-
-    fn try_from(scalar: &protobuf::ScalarType) -> Result<Self, Self::Error> {
-        scalar.datatype.as_ref().required("datatype")
-    }
-}
-
 impl TryFrom<&protobuf::Schema> for Schema {
     type Error = Error;
 
@@ -676,36 +622,6 @@ impl TryFrom<&protobuf::PrimitiveScalarType> for ScalarValue {
     }
 }
 
-impl TryFrom<&protobuf::ScalarListType> for DataType {
-    type Error = Error;
-    fn try_from(scalar: &protobuf::ScalarListType) -> Result<Self, Self::Error> {
-        use protobuf::PrimitiveScalarType;
-
-        let protobuf::ScalarListType {
-            deepest_type,
-            field_names,
-        } = scalar;
-
-        let depth = field_names.len();
-        if depth == 0 {
-            return Err(Error::at_least_one("field_names"));
-        }
-
-        let mut curr_type = Self::List(Box::new(Field::new(
-            // Since checked vector is not empty above this is safe to unwrap
-            field_names.last().unwrap(),
-            PrimitiveScalarType::try_from(deepest_type)?.into(),
-            true,
-        )));
-        // Iterates over field names in reverse order except for the last item in the vector
-        for name in field_names.iter().rev().skip(1) {
-            let temp_curr_type = Self::List(Box::new(Field::new(name, curr_type, true)));
-            curr_type = temp_curr_type;
-        }
-        Ok(curr_type)
-    }
-}
-
 impl TryFrom<&protobuf::ScalarValue> for ScalarValue {
     type Error = Error;
 
@@ -734,23 +650,23 @@ impl TryFrom<&protobuf::ScalarValue> for ScalarValue {
             Value::Date32Value(v) => Self::Date32(Some(*v)),
             Value::ListValue(scalar_list) => {
                 let protobuf::ScalarListValue {
+                    is_null,
                     values,
-                    field: opt_field,
+                    field,
                 } = &scalar_list;
 
-                let field = opt_field.as_ref().required("field")?;
+                let field: Field = field.as_ref().required("field")?;
                 let field = Box::new(field);
 
-                let typechecked_values: Vec<ScalarValue> = values
-                    .iter()
-                    .map(|val| val.try_into())
-                    .collect::<Result<Vec<_>, _>>()?;
+                let values: Result<Vec<ScalarValue>, Error> =
+                    values.iter().map(|val| val.try_into()).collect();
+                let values = values?;
 
-                Self::List(Some(typechecked_values), field)
-            }
-            Value::NullListValue(v) => {
-                let field = Field::new("item", v.try_into()?, true);
-                Self::List(None, Box::new(field))
+                validate_list_values(field.as_ref(), &values)?;
+
+                let values = if *is_null { None } else { Some(values) };
+
+                Self::List(values, field)
             }
             Value::NullValue(v) => {
                 let null_type_enum = protobuf::PrimitiveScalarType::try_from(v)?;
@@ -838,6 +754,23 @@ impl TryFrom<&protobuf::ScalarValue> for ScalarValue {
             }
         })
     }
+}
+
+/// Ensures that all `values` are of type DataType::List and have the
+/// same type as field
+fn validate_list_values(field: &Field, values: &[ScalarValue]) -> Result<(), Error> {
+    for value in values {
+        let field_type = field.data_type();
+        let value_type = value.get_datatype();
+
+        if field_type != &value_type {
+            return Err(proto_error(format!(
+                "Expected field type {:?}, got scalar of type: {:?}",
+                field_type, value_type
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub fn parse_expr(

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -320,7 +320,7 @@ mod roundtrip_tests {
                 Some(vec![]),
                 Box::new(vec![Field::new("item", DataType::Int16, true)]),
             ),
-            // Should fail due to inconsistent types
+            // Should fail due to inconsistent types in the list
             ScalarValue::new_list(
                 Some(vec![
                     ScalarValue::Int16(None),
@@ -334,6 +334,13 @@ mod roundtrip_tests {
                     ScalarValue::Float32(Some(32.0)),
                 ]),
                 DataType::List(new_box_field("item", DataType::Int16, true)),
+            ),
+            ScalarValue::new_list(
+                Some(vec![
+                    ScalarValue::Float32(None),
+                    ScalarValue::Float32(Some(32.0)),
+                ]),
+                DataType::Int16,
             ),
             ScalarValue::new_list(
                 Some(vec![
@@ -369,15 +376,20 @@ mod roundtrip_tests {
         ];
 
         for test_case in should_fail_on_seralize.into_iter() {
-            let res: std::result::Result<
-                super::protobuf::ScalarValue,
-                super::to_proto::Error,
-            > = (&test_case).try_into();
-            assert!(
-                res.is_err(),
-                "The value {:?} should not have been able to serialize. Serialized to :{:?}",
-                test_case, res
-            );
+            let proto: Result<super::protobuf::ScalarValue, super::to_proto::Error> =
+                (&test_case).try_into();
+
+            // Validation is also done on read, so if serialization passed
+            // also try to convert back to ScalarValue
+            if let Ok(proto) = proto {
+                let res: Result<ScalarValue, _> = (&proto).try_into();
+                assert!(
+                    res.is_err(),
+                    "The value {:?} unexpectedly serialized without error:{:?}",
+                    test_case,
+                    res
+                );
+            }
         }
     }
 
@@ -482,14 +494,11 @@ mod roundtrip_tests {
                     ScalarValue::Float32(Some(2.0)),
                     ScalarValue::Float32(Some(1.0)),
                 ]),
-                DataType::List(new_box_field("level1", DataType::Float32, true)),
+                DataType::Float32,
             ),
             ScalarValue::new_list(
                 Some(vec![
-                    ScalarValue::new_list(
-                        None,
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
-                    ),
+                    ScalarValue::new_list(None, DataType::Float32),
                     ScalarValue::new_list(
                         Some(vec![
                             ScalarValue::Float32(Some(-213.1)),
@@ -498,14 +507,10 @@ mod roundtrip_tests {
                             ScalarValue::Float32(Some(2.0)),
                             ScalarValue::Float32(Some(1.0)),
                         ]),
-                        DataType::List(new_box_field("level2", DataType::Float32, true)),
+                        DataType::Float32,
                     ),
                 ]),
-                DataType::List(new_box_field(
-                    "level1",
-                    DataType::List(new_box_field("level2", DataType::Float32, true)),
-                    true,
-                )),
+                DataType::List(new_box_field("item", DataType::Float32, true)),
             ),
             ScalarValue::Dictionary(
                 Box::new(DataType::Int32),
@@ -576,125 +581,12 @@ mod roundtrip_tests {
             DataType::Utf8,
             DataType::LargeUtf8,
             // Recursive list tests
-            DataType::List(new_box_field("Level1", DataType::Boolean, true)),
+            DataType::List(new_box_field("level1", DataType::Boolean, true)),
             DataType::List(new_box_field(
                 "Level1",
-                DataType::List(new_box_field("Level2", DataType::Date32, true)),
+                DataType::List(new_box_field("level2", DataType::Date32, true)),
                 true,
             )),
-        ];
-
-        let should_fail: Vec<DataType> = vec![
-            DataType::Null,
-            DataType::Float16,
-            // Add more timestamp tests
-            DataType::Timestamp(TimeUnit::Millisecond, None),
-            DataType::Date64,
-            DataType::Time32(TimeUnit::Second),
-            DataType::Time32(TimeUnit::Millisecond),
-            DataType::Time32(TimeUnit::Microsecond),
-            DataType::Time32(TimeUnit::Nanosecond),
-            DataType::Time64(TimeUnit::Second),
-            DataType::Time64(TimeUnit::Millisecond),
-            DataType::Duration(TimeUnit::Second),
-            DataType::Duration(TimeUnit::Millisecond),
-            DataType::Duration(TimeUnit::Microsecond),
-            DataType::Duration(TimeUnit::Nanosecond),
-            DataType::Interval(IntervalUnit::YearMonth),
-            DataType::Interval(IntervalUnit::DayTime),
-            DataType::Binary,
-            DataType::FixedSizeBinary(0),
-            DataType::FixedSizeBinary(1234),
-            DataType::FixedSizeBinary(-432),
-            DataType::LargeBinary,
-            DataType::Decimal128(123, 234),
-            // Recursive list tests
-            DataType::List(new_box_field("Level1", DataType::Binary, true)),
-            DataType::List(new_box_field(
-                "Level1",
-                DataType::List(new_box_field(
-                    "Level2",
-                    DataType::FixedSizeBinary(53),
-                    false,
-                )),
-                true,
-            )),
-            // Fixed size lists
-            DataType::FixedSizeList(new_box_field("Level1", DataType::Binary, true), 4),
-            DataType::FixedSizeList(
-                new_box_field(
-                    "Level1",
-                    DataType::List(new_box_field(
-                        "Level2",
-                        DataType::FixedSizeBinary(53),
-                        false,
-                    )),
-                    true,
-                ),
-                41,
-            ),
-            // Struct Testing
-            DataType::Struct(vec![
-                Field::new("nullable", DataType::Boolean, false),
-                Field::new("name", DataType::Utf8, false),
-                Field::new("datatype", DataType::Binary, false),
-            ]),
-            DataType::Struct(vec![
-                Field::new("nullable", DataType::Boolean, false),
-                Field::new("name", DataType::Utf8, false),
-                Field::new("datatype", DataType::Binary, false),
-                Field::new(
-                    "nested_struct",
-                    DataType::Struct(vec![
-                        Field::new("nullable", DataType::Boolean, false),
-                        Field::new("name", DataType::Utf8, false),
-                        Field::new("datatype", DataType::Binary, false),
-                    ]),
-                    true,
-                ),
-            ]),
-            DataType::Union(
-                vec![
-                    Field::new("nullable", DataType::Boolean, false),
-                    Field::new("name", DataType::Utf8, false),
-                    Field::new("datatype", DataType::Binary, false),
-                ],
-                vec![0, 2, 3],
-                UnionMode::Dense,
-            ),
-            DataType::Union(
-                vec![
-                    Field::new("nullable", DataType::Boolean, false),
-                    Field::new("name", DataType::Utf8, false),
-                    Field::new("datatype", DataType::Binary, false),
-                    Field::new(
-                        "nested_struct",
-                        DataType::Struct(vec![
-                            Field::new("nullable", DataType::Boolean, false),
-                            Field::new("name", DataType::Utf8, false),
-                            Field::new("datatype", DataType::Binary, false),
-                        ]),
-                        true,
-                    ),
-                ],
-                vec![1, 2, 3],
-                UnionMode::Sparse,
-            ),
-            DataType::Dictionary(
-                Box::new(DataType::Utf8),
-                Box::new(DataType::Struct(vec![
-                    Field::new("nullable", DataType::Boolean, false),
-                    Field::new("name", DataType::Utf8, false),
-                    Field::new("datatype", DataType::Binary, false),
-                ])),
-            ),
-            DataType::Dictionary(
-                Box::new(DataType::Decimal128(10, 50)),
-                Box::new(DataType::FixedSizeList(
-                    new_box_field("Level1", DataType::Binary, true),
-                    4,
-                )),
-            ),
         ];
 
         for test_case in should_pass.into_iter() {
@@ -703,22 +595,6 @@ mod roundtrip_tests {
             let roundtrip: Field = (&proto).try_into().unwrap();
             assert_eq!(format!("{:?}", field), format!("{:?}", roundtrip));
         }
-
-        let mut success: Vec<DataType> = Vec::new();
-        for test_case in should_fail.into_iter() {
-            let proto: std::result::Result<
-                super::protobuf::ScalarType,
-                super::to_proto::Error,
-            > = (&Field::new("item", test_case.clone(), true)).try_into();
-            if proto.is_ok() {
-                success.push(test_case)
-            }
-        }
-        assert!(
-            success.is_empty(),
-            "These should have resulted in an error but completed successfully: {:?}",
-            success
-        );
     }
 
     #[test]


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/arrow-datafusion/pull/3536 and doesn't pass all tests~

# Which issue does this PR close?

Re https://github.com/apache/arrow-datafusion/issues/3531


 # Rationale for this change
While working on https://github.com/apache/arrow-datafusion/issues/3531 I found the `ScalarValue::List` serialization code quite challenging to understand as it did not match the structure of `ScalarValue::List`. It can be drastically simplified and maintain the same semantics

I also hope a final PR in this series to remove `PrimitiveScalarType` but I didn't quite make it today and ran out of time

# What changes are included in this PR?
1. Remove special case null handling for ScalarValue::List (it is already covered)

# Are there any user-facing changes?
No