### PR TITLE
fix coercion of null for decimal math in binary_rules

### DIFF
--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -311,15 +311,25 @@ fn mathematics_numerical_coercion(
         (Null, dec_type @ Decimal128(_, _)) | (dec_type @ Decimal128(_, _), Null) => {
             Some(dec_type.clone())
         }
-        (dec_type @ Decimal128(_, _), other_type)
-        | (other_type, dec_type @ Decimal128(_, _)) => {
-            let converted_decimal_type = coerce_numeric_type_to_decimal(other_type);
+        (Decimal128(_, _), _) => {
+            let converted_decimal_type = coerce_numeric_type_to_decimal(rhs_type);
             match converted_decimal_type {
                 None => None,
-                Some(other_decimal_type) => coercion_decimal_mathematics_type(
+                Some(right_decimal_type) => coercion_decimal_mathematics_type(
                     mathematics_op,
-                    dec_type,
-                    &other_decimal_type,
+                    lhs_type,
+                    &right_decimal_type,
+                ),
+            }
+        }
+        (_, Decimal128(_, _)) => {
+            let converted_decimal_type = coerce_numeric_type_to_decimal(lhs_type);
+            match converted_decimal_type {
+                None => None,
+                Some(left_decimal_type) => coercion_decimal_mathematics_type(
+                    mathematics_op,
+                    &left_decimal_type,
+                    rhs_type,
                 ),
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3479 . This fix can close that issue -- there's another issue for adding support for casting utf8 to decimal.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Prior to this fix:
```sql
❯ select null + 1::decimal;
Plan("'Null + Decimal128(38, 10)' can't be evaluated because there isn't a common type to coerce the types to")
```

After this fix:
```sql
❯ select null + 1::decimal;
+-----------------+
| NULL + Int64(1) |
+-----------------+
|                 |
+-----------------+
1 row in set. Query took 0.020 seconds.
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->