### PR TITLE
Reduce dependencies of `datafusion-sql` crate

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -33,17 +33,17 @@ name = "datafusion_common"
 path = "src/lib.rs"
 
 [features]
+default = []
 avro = ["apache-avro"]
 jit = ["cranelift-module"]
-pyarrow = ["pyo3"]
+pyarrow = ["pyo3", "arrow/pyarrow"]
 
 [dependencies]
-apache-avro = { version = "0.14", features = ["snappy"], optional = true }
-arrow = { version = "23.0.0", features = ["prettyprint"] }
-avro-rs = { version = "0.13", features = ["snappy"], optional = true }
+apache-avro = { version = "0.14", default-features = false, optional = true }
+arrow = { version = "23.0.0", default-features = false }
 cranelift-module = { version = "0.87.0", optional = true }
-object_store = { version = "0.5.0", optional = true }
+object_store = { version = "0.5.0", default-features = false, optional = true }
 ordered-float = "3.0"
-parquet = { version = "23.0.0", features = ["arrow"], optional = true }
+parquet = { version = "23.0.0", default-features = false, optional = true }
 pyo3 = { version = "0.17.1", optional = true }
 sqlparser = "0.23"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -33,8 +33,8 @@ name = "datafusion_common"
 path = "src/lib.rs"
 
 [features]
-default = []
 avro = ["apache-avro"]
+default = []
 jit = ["cranelift-module"]
 pyarrow = ["pyo3", "arrow/pyarrow"]
 

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,7 +39,7 @@ jit = ["cranelift-module"]
 pyarrow = ["pyo3", "arrow/pyarrow"]
 
 [dependencies]
-apache-avro = { version = "0.14", default-features = false, optional = true }
+apache-avro = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 arrow = { version = "23.0.0", default-features = false }
 cranelift-module = { version = "0.87.0", optional = true }
 object_store = { version = "0.5.0", default-features = false, optional = true }

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-arrow = { version = "23.0.0", features = ["prettyprint"] }
+arrow = { version = "23.0.0", default-features = false }
 datafusion-common = { path = "../common", version = "12.0.0" }
 sqlparser = "0.23"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = "23.0.0"
+arrow = { version = "23.0.0", default-features = false }
 cranelift = "0.87.0"
 cranelift-jit = "0.87.0"
 cranelift-module = "0.87.0"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -43,4 +43,3 @@ datafusion-common = { path = "../common", version = "12.0.0" }
 datafusion-expr = { path = "../expr", version = "12.0.0" }
 hashbrown = "0.12"
 sqlparser = "0.23"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -37,7 +37,7 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-arrow = { version = "23.0.0", features = ["prettyprint"] }
+arrow = { version = "23.0.0", default-features = false }
 datafusion-common = { path = "../common", version = "12.0.0" }
 datafusion-expr = { path = "../expr", version = "12.0.0" }
 sqlparser = "0.23"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -41,5 +41,4 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 arrow = { version = "23.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "12.0.0" }
 datafusion-expr = { path = "../expr", version = "12.0.0" }
-hashbrown = "0.12"
 sqlparser = "0.23"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -37,7 +37,6 @@ default = ["unicode_expressions"]
 unicode_expressions = []
 
 [dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 arrow = { version = "23.0.0", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "12.0.0" }
 datafusion-expr = { path = "../expr", version = "12.0.0" }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -4995,8 +4995,8 @@ mod tests {
         quick_test(sql, expected);
     }
 
-    #[tokio::test]
-    async fn subquery_references_cte() {
+    #[test]
+    fn subquery_references_cte() {
         let sql = "WITH \
         cte AS (SELECT * FROM person) \
         SELECT * FROM person WHERE EXISTS (SELECT * FROM cte WHERE id = person.id)";
@@ -5013,8 +5013,8 @@ mod tests {
         quick_test(sql, expected)
     }
 
-    #[tokio::test]
-    async fn aggregate_with_rollup() {
+    #[test]
+    fn aggregate_with_rollup() {
         let sql = "SELECT id, state, age, COUNT(*) FROM person GROUP BY id, ROLLUP (state, age)";
         let expected = "Projection: #person.id, #person.state, #person.age, #COUNT(UInt8(1))\
         \n  Aggregate: groupBy=[[#person.id, ROLLUP (#person.state, #person.age)]], aggr=[[COUNT(UInt8(1))]]\
@@ -5022,8 +5022,8 @@ mod tests {
         quick_test(sql, expected);
     }
 
-    #[tokio::test]
-    async fn aggregate_with_rollup_with_grouping() {
+    #[test]
+    fn aggregate_with_rollup_with_grouping() {
         let sql = "SELECT id, state, age, grouping(state), grouping(age), grouping(state) + grouping(age), COUNT(*) \
         FROM person GROUP BY id, ROLLUP (state, age)";
         let expected = "Projection: #person.id, #person.state, #person.age, #GROUPING(person.state), #GROUPING(person.age), #GROUPING(person.state) + #GROUPING(person.age), #COUNT(UInt8(1))\
@@ -5032,8 +5032,8 @@ mod tests {
         quick_test(sql, expected);
     }
 
-    #[tokio::test]
-    async fn rank_partition_grouping() {
+    #[test]
+    fn rank_partition_grouping() {
         let sql = "select
             sum(age) as total_sum,
             state,
@@ -5054,8 +5054,8 @@ mod tests {
         quick_test(sql, expected);
     }
 
-    #[tokio::test]
-    async fn aggregate_with_cube() {
+    #[test]
+    fn aggregate_with_cube() {
         let sql =
             "SELECT id, state, age, COUNT(*) FROM person GROUP BY id, CUBE (state, age)";
         let expected = "Projection: #person.id, #person.state, #person.age, #COUNT(UInt8(1))\
@@ -5064,8 +5064,8 @@ mod tests {
         quick_test(sql, expected);
     }
 
-    #[tokio::test]
-    async fn round_decimal() {
+    #[test]
+    fn round_decimal() {
         let sql = "SELECT round(price/3, 2) FROM test_decimal";
         let expected = "Projection: round(#test_decimal.price / Int64(3), Int64(2))\
         \n  TableScan: test_decimal";
@@ -5073,8 +5073,8 @@ mod tests {
     }
 
     #[ignore] // see https://github.com/apache/arrow-datafusion/issues/2469
-    #[tokio::test]
-    async fn aggregate_with_grouping_sets() {
+    #[test]
+    fn aggregate_with_grouping_sets() {
         let sql = "SELECT id, state, age, COUNT(*) FROM person GROUP BY id, GROUPING SETS ((state), (state, age), (id, state))";
         let expected = "TBD";
         quick_test(sql, expected);

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -41,8 +41,7 @@ use datafusion_expr::{
 use datafusion_expr::{
     window_function::WindowFunction, BuiltinScalarFunction, TableSource,
 };
-use hashbrown::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{convert::TryInto, vec};


### PR DESCRIPTION
# Which issue does this PR close?

This doesn't close, but contributes to the changes being worked on in #1750.

 # Rationale for this change

By disabling features and removing unused dependencies the build time of those crates is reduced.

# What changes are included in this PR?

This PR removes some unused direct dependencies of the `sql`, `common` and `expr` crates, and disables unused features.

# Are there any user-facing changes?

No