### PR TITLE
Use consistent name for  `TimeUnit::Millisecond`

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -668,7 +668,7 @@ enum DateUnit{
 
 enum TimeUnit{
     Second = 0;
-    TimeMillisecond = 1;
+    Millisecond = 1;
     Microsecond = 2;
     Nanosecond = 3;
 }

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -1349,7 +1349,7 @@ impl From<protobuf::TimeUnit> for TimeUnit {
     fn from(time_unit: protobuf::TimeUnit) -> Self {
         match time_unit {
             protobuf::TimeUnit::Second => TimeUnit::Second,
-            protobuf::TimeUnit::TimeMillisecond => TimeUnit::Millisecond,
+            protobuf::TimeUnit::Millisecond => TimeUnit::Millisecond,
             protobuf::TimeUnit::Microsecond => TimeUnit::Microsecond,
             protobuf::TimeUnit::Nanosecond => TimeUnit::Nanosecond,
         }

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1431,7 +1431,7 @@ impl From<&TimeUnit> for protobuf::TimeUnit {
     fn from(val: &TimeUnit) -> Self {
         match val {
             TimeUnit::Second => protobuf::TimeUnit::Second,
-            TimeUnit::Millisecond => protobuf::TimeUnit::TimeMillisecond,
+            TimeUnit::Millisecond => protobuf::TimeUnit::Millisecond,
             TimeUnit::Microsecond => protobuf::TimeUnit::Microsecond,
             TimeUnit::Nanosecond => protobuf::TimeUnit::Nanosecond,
         }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #3531


 # Rationale for this change

As pointed out by @waitingkuo on https://github.com/apache/arrow-datafusion/pull/3534/files#r975610617 the naming of the TimeUnit enum in protobuf was not consistent with the arrow [Schema](https://docs.rs/arrow/23.0.0/arrow/datatypes/enum.TimeUnit.html) leading to confusing


# What changes are included in this PR?
1. Rename `TimeUnit::TimeMillisecond` to `TimeUnit::Millisecond` to be consistent with arrow

# Are there any user-facing changes?
No