### PR TITLE
Fix build

### DIFF
--- a/datafusion/core/src/physical_optimizer/mod.rs
+++ b/datafusion/core/src/physical_optimizer/mod.rs
@@ -23,7 +23,6 @@ pub mod coalesce_batches;
 pub mod hash_build_probe_order;
 pub mod merge_exec;
 pub mod optimizer;
-pub mod parallel_sort;
 pub mod pruning;
 pub mod repartition;
 mod utils;


### PR DESCRIPTION
# Which issue does this PR close?

Fixes a build problem introduce in  ff718d0ca34d702e86943117f7ee77dbf6dcb07c (a module was removed but there was still a reference to it)

 # Rationale for this change
CI is failing on master

# What changes are included in this PR?
Remove `pub mod` declaration for removed module

# Are there any user-facing changes?
No