### PR TITLE
Update cranelift* dependencies `0.87` --> `0.88`

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -41,7 +41,7 @@ pyarrow = ["pyo3", "arrow/pyarrow"]
 [dependencies]
 apache-avro = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 arrow = { version = "23.0.0", default-features = false }
-cranelift-module = { version = "0.87.0", optional = true }
+cranelift-module = { version = "0.88.0", optional = true }
 object_store = { version = "0.5.0", default-features = false, optional = true }
 ordered-float = "3.0"
 parquet = { version = "23.0.0", default-features = false, optional = true }

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -37,10 +37,10 @@ jit = []
 
 [dependencies]
 arrow = { version = "23.0.0", default-features = false }
-cranelift = "0.87.0"
-cranelift-jit = "0.87.0"
-cranelift-module = "0.87.0"
-cranelift-native = "0.87.0"
+cranelift = "0.88.0"
+cranelift-jit = "0.88.0"
+cranelift-module = "0.88.0"
+cranelift-native = "0.88.0"
 datafusion-common = { path = "../common", version = "12.0.0", features = ["jit"] }
 datafusion-expr = { path = "../expr", version = "12.0.0" }
 


### PR DESCRIPTION
# Which issue does this PR close?
N/A

 # Rationale for this change
Dependabot is trying to update all of these dependencies individually but they need to go together (like arrow)

# What changes are included in this PR?
Update cranelift* dependencies `0.87` --> `0.88`

# Are there any user-facing changes?
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->