### PR TITLE
Simplify `concat_ws(null, ..)` to `null`

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -1164,6 +1164,13 @@ mod tests {
             assert_eq!(simplify(expr), null);
         }
 
+        // NULLs in other positions are not simplified.
+        {
+            let expr = build_concat_ws_expr(&[lit("|"), null.clone(),  col("c2")]);
+            assert_eq!(simplify(expr.clone()), expr);
+        }
+
+
         // nested test
         {
             let sub_expr = build_concat_ws_expr(&[null.clone(), col("c1"), col("c2")]);

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -1178,7 +1178,7 @@ mod tests {
         {
             let sub_expr = build_concat_ws_expr(&[null.clone(), col("c1"), col("c2")]);
             let expr = build_concat_ws_expr(&[sub_expr, col("c3"), col("c4")]);
-            assert_eq!(simplify(expr), null.clone());
+            assert_eq!(simplify(expr), null);
         }
     }
 

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -26,12 +26,11 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
     expr_fn::{and, or},
-    expr_rewriter::RewriteRecursion,
-    expr_rewriter::{ExprRewritable, ExprRewriter},
+    expr_rewriter::{ExprRewritable, ExprRewriter, RewriteRecursion},
     lit,
     logical_plan::LogicalPlan,
     utils::from_plan,
-    ColumnarValue, Expr, ExprSchemable, Operator, Volatility,
+    BuiltinScalarFunction, ColumnarValue, Expr, ExprSchemable, Operator, Volatility,
 };
 use datafusion_physical_expr::{create_physical_expr, execution_props::ExecutionProps};
 use std::sync::Arc;
@@ -816,6 +815,23 @@ impl<'a, S: SimplifyInfo> ExprRewriter for Simplifier<'a, S> {
                 out_expr.rewrite(self)?
             }
 
+            // concat_ws
+            ScalarFunction {
+                fun: BuiltinScalarFunction::ConcatWithSeparator,
+                args,
+            } => {
+                match &args[..] {
+                    [Expr::Literal(sp), ..] if sp.is_null() => {
+                        Expr::Literal(ScalarValue::Utf8(None))
+                    }
+                    // TODO https://github.com/apache/arrow-datafusion/issues/3599
+                    _ => ScalarFunction {
+                        fun: BuiltinScalarFunction::ConcatWithSeparator,
+                        args,
+                    },
+                }
+            }
+
             //
             // Rules for Between
             //
@@ -1130,6 +1146,40 @@ mod tests {
     fn test_simplify_with_type_coercion() {
         let expr_plus = binary_expr(lit(1_i32), Operator::Plus, lit(1_i64));
         assert_eq!(simplify(expr_plus), lit(2_i64));
+    }
+
+    #[test]
+    fn test_simplify_concat_ws_null_separator() {
+        fn build_concat_ws_expr(args: &[Expr]) -> Expr {
+            Expr::ScalarFunction {
+                fun: BuiltinScalarFunction::ConcatWithSeparator,
+                args: args.to_vec(),
+            }
+        }
+
+        let null = Expr::Literal(ScalarValue::Utf8(None));
+        // simple test
+        {
+            let expr = build_concat_ws_expr(&[null.clone(), col("c1"), col("c2")]);
+            assert_eq!(simplify(expr), null);
+        }
+
+        // nested test
+        {
+            let sub_expr = build_concat_ws_expr(&[null.clone(), col("c1"), col("c2")]);
+            let expr = build_concat_ws_expr(&[lit("|"), sub_expr, col("c3")]);
+            assert_eq!(
+                simplify(expr),
+                build_concat_ws_expr(&[lit("|"), null.clone(), col("c3")])
+            );
+        }
+
+        // nested test -- separator
+        {
+            let sub_expr = build_concat_ws_expr(&[null.clone(), col("c1"), col("c2")]);
+            let expr = build_concat_ws_expr(&[sub_expr, col("c3"), col("c4")]);
+            assert_eq!(simplify(expr), null.clone());
+        }
     }
 
     // ------------------------------

--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -1166,10 +1166,9 @@ mod tests {
 
         // NULLs in other positions are not simplified.
         {
-            let expr = build_concat_ws_expr(&[lit("|"), null.clone(),  col("c2")]);
+            let expr = build_concat_ws_expr(&[lit("|"), null.clone(), col("c2")]);
             assert_eq!(simplify(expr.clone()), expr);
         }
-
 
         // nested test
         {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3607.

 # Rationale for this change

## Before the optimization
```sql
❯ create table t as select 'aa' as a, 'bb' as b, 'cc' as c;
0 rows in set. Query took 0.008 seconds.
❯ explain select concat_ws(null, a, b, c) from t;
+---------------+------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                   |
+---------------+------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: concatwithseparator(NULL, #t.a, #t.b, #t.c)                                                                |
|               |   TableScan: t projection=[a, b, c]                                                                                    |
| physical_plan | ProjectionExec: expr=[concatwithseparator(CAST(NULL AS Utf8), a@0, b@1, c@2) as concatwithseparator(NULL,t.a,t.b,t.c)] |
|               |   MemoryExec: partitions=1, partition_sizes=[1]                                                                        |
|               |                                                                                                                        |
+---------------+------------------------------------------------------------------------------------------------------------------------+
```

## After the optimization
```sql
❯ create table t as select 'aa' as a, 'bb' as b, 'cc' as c;
0 rows in set. Query took 0.009 seconds.
❯ explain select concat_ws(null, a, b, c) from t;
+---------------+----------------------------------------------------------------------+
| plan_type     | plan                                                                 |
+---------------+----------------------------------------------------------------------+
| logical_plan  | Projection: Utf8(NULL) AS concatwithseparator(NULL,t.a,t.b,t.c)      |
|               |   TableScan: t projection=[a]                                        |
| physical_plan | ProjectionExec: expr=[NULL as concatwithseparator(NULL,t.a,t.b,t.c)] |
|               |   MemoryExec: partitions=1, partition_sizes=[1]                      |
|               |                                                                      |
+---------------+----------------------------------------------------------------------+
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->