### PR TITLE
Stop wasting time in CI on MIRI runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -353,36 +353,6 @@ jobs:
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh
 
-  miri-checks:
-    name: cargo miri test (amd64)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
-      - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install nightly-2022-01-17
-          rustup default nightly-2022-01-17
-          rustup component add rustfmt clippy miri
-      - name: Run Miri Checks
-        env:
-          RUST_BACKTRACE: full
-          RUST_LOG: "trace"
-          MIRIFLAGS: "-Zmiri-disable-isolation"
-        run: |
-          cargo miri setup
-          cargo clean
-          # Ignore MIRI errors until we can get a clean run
-          cargo miri test || true
-
   # Check answers are correct when hash values collide
   hash-collisions:
     name: cargo test hash collisions (amd64)


### PR DESCRIPTION
# Which issue does this PR close?
re https://github.com/apache/arrow-datafusion/issues/3045

 # Rationale for this change
DataFusion runs a check called "MIRI" as part of CI. Example: https://github.com/apache/arrow-datafusion/actions/runs/3119021327/jobs/5058711471

This check always completes successfully as the results of running miri are `|| true` d (aka ignored)

This provides a false sense of security (we run MIRI!) as well as wasting CI resources

# What changes are included in this PR?
Stop running MIRI check in CI

# Are there any user-facing changes?
No

Follow on ticket to create a working MIRI CI check: https://github.com/apache/arrow-datafusion/issues/3611