### PR TITLE
remove the type coercion in the simplify_expressions rule

### DIFF
--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -117,14 +117,8 @@ fn optimize_internal(
     from_plan(plan, &new_expr, &new_inputs)
 }
 
-pub(crate) struct TypeCoercionRewriter {
+struct TypeCoercionRewriter {
     pub(crate) schema: DFSchemaRef,
-}
-
-impl TypeCoercionRewriter {
-    pub(crate) fn new(schema: DFSchemaRef) -> TypeCoercionRewriter {
-        TypeCoercionRewriter { schema }
-    }
 }
 
 impl ExprRewriter for TypeCoercionRewriter {
@@ -796,7 +790,7 @@ mod test {
             )
             .unwrap(),
         );
-        let mut rewriter = TypeCoercionRewriter::new(schema);
+        let mut rewriter = TypeCoercionRewriter { schema };
         let expr = is_true(lit(12i32).eq(lit(13i64)));
         let expected = is_true(
             cast(lit(ScalarValue::Int32(Some(12))), DataType::Int64)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
After this https://github.com/apache/arrow-datafusion/pull/3636 merged, we don't need to do the type coercion in the  `simplify_expressions`.
Like the comments in https://github.com/apache/arrow-datafusion/issues/3556#issuecomment-1256165309

Closes #3556

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->