### PR TITLE
add timestamptz

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2703,6 +2703,10 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> Result<DataType> {
         | SQLDataType::Text
         | SQLDataType::String => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        SQLDataType::TimestampTz => Ok(DataType::Timestamp(
+            TimeUnit::Nanosecond,
+            Some("UTC".into()),
+        )),
         SQLDataType::Date => Ok(DataType::Date32),
         SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Nanosecond)),
         SQLDataType::Decimal(precision, scale) => make_decimal_type(*precision, *scale),
@@ -2716,7 +2720,6 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> Result<DataType> {
         | SQLDataType::Varbinary(_)
         | SQLDataType::Blob(_)
         | SQLDataType::Datetime
-        | SQLDataType::TimestampTz
         | SQLDataType::Interval
         | SQLDataType::Regclass
         | SQLDataType::Custom(_)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3659 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix the timezone as `UTC` for now before we figure out how to deal with non-utc timezone

casting between timestamp and timestamptz has no ambiguity under this situation
```bash
❯ select from_unixtime(0)::timestamptz, arrow_typeof(from_unixtime(0)::timestamptz);
+------------------------+-------------------------------------+
| fromunixtime(Int64(0)) | arrowtypeof(fromunixtime(Int64(0))) |
+------------------------+-------------------------------------+
| 1970-01-01 00:00:00    | Timestamp(Nanosecond, Some("UTC"))  |
+------------------------+-------------------------------------+
1 row in set. Query took 0.002 seconds.
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->