### PR TITLE
Fail if field lengths are not same in INTERSECT and EXPECT

### DIFF
--- a/datafusion/core/tests/sql/intersection.rs
+++ b/datafusion/core/tests/sql/intersection.rs
@@ -85,19 +85,3 @@ async fn test_intersect_distinct() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
-
-#[tokio::test]
-#[should_panic(
-    expected = "called `Result::unwrap()` on an `Err` value: \"Plan(\\\"INTERSECT/EXCEPT query \
-    must have the same number of columns. Left columns count = 3 and right columns count = 2 \
-    are not the same.\\\") at Creating logical plan for 'SELECT * FROM (SELECT 1 AS id1, 2 \
-    AS id2, 3 as id3) t1\\n            INTERSECT SELECT * FROM (SELECT 1 AS id1, \
-    2 AS id2) t2'\""
-)]
-async fn intersect_with_different_length() {
-    let sql = "SELECT * FROM (SELECT 1 AS id1, 2 AS id2, 3 as id3) t1
-            INTERSECT SELECT * FROM (SELECT 1 AS id1, 2 AS id2) t2";
-
-    let ctx = create_join_context_qualified("t1", "t2").unwrap();
-    execute_to_batches(&ctx, sql).await;
-}

--- a/datafusion/core/tests/sql/intersection.rs
+++ b/datafusion/core/tests/sql/intersection.rs
@@ -88,11 +88,11 @@ async fn test_intersect_distinct() -> Result<()> {
 
 #[tokio::test]
 #[should_panic(
-    expected = "called `Result::unwrap()` on an `Err` value: \"Plan(\\\"Expected \
-    the no. of fields to be the same. Left fields count = 3 and right fields count = 2 are not \
-    the same.\\\") at Creating logical plan for 'SELECT * FROM (SELECT 1 AS id1, 2 \
-        AS id2, 3 as id3) t1\\n            INTERSECT SELECT * FROM (SELECT 1 AS id1, \
-            2 AS id2) t2'\""
+    expected = "called `Result::unwrap()` on an `Err` value: \"Plan(\\\"INTERSECT/EXCEPT query \
+    must have the same number of columns. Left columns count = 3 and right columns count = 2 \
+    are not the same.\\\") at Creating logical plan for 'SELECT * FROM (SELECT 1 AS id1, 2 \
+    AS id2, 3 as id3) t1\\n            INTERSECT SELECT * FROM (SELECT 1 AS id1, \
+    2 AS id2) t2'\""
 )]
 async fn intersect_with_different_length() {
     let sql = "SELECT * FROM (SELECT 1 AS id1, 2 AS id2, 3 as id3) t1

--- a/datafusion/core/tests/sql/intersection.rs
+++ b/datafusion/core/tests/sql/intersection.rs
@@ -85,3 +85,19 @@ async fn test_intersect_distinct() -> Result<()> {
     assert_batches_eq!(expected, &actual);
     Ok(())
 }
+
+#[tokio::test]
+#[should_panic(
+    expected = "called `Result::unwrap()` on an `Err` value: \"Plan(\\\"Expected \
+    the no. of fields to be the same. Left fields count = 3 and right fields count = 2 are not \
+    the same.\\\") at Creating logical plan for 'SELECT * FROM (SELECT 1 AS id1, 2 \
+        AS id2, 3 as id3) t1\\n            INTERSECT SELECT * FROM (SELECT 1 AS id1, \
+            2 AS id2) t2'\""
+)]
+async fn intersect_with_different_length() {
+    let sql = "SELECT * FROM (SELECT 1 AS id1, 2 AS id2, 3 as id3) t1
+            INTERSECT SELECT * FROM (SELECT 1 AS id1, 2 AS id2) t2";
+
+    let ctx = create_join_context_qualified("t1", "t2").unwrap();
+    execute_to_batches(&ctx, sql).await;
+}

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -786,7 +786,7 @@ impl LogicalPlanBuilder {
 
         if left_len != right_len {
             return Err(DataFusionError::Plan(format!(
-                "Expected the no. of fields to be the same. Left fields count = {} and right fields count = {} are not the same.",
+                "INTERSECT/EXCEPT query must have the same number of columns. Left columns count = {} and right columns count = {} are not the same.",
                 left_len, right_len
             )));
         }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -781,6 +781,16 @@ impl LogicalPlanBuilder {
         join_type: JoinType,
         is_all: bool,
     ) -> Result<LogicalPlan> {
+        let left_len = left_plan.schema().fields().len();
+        let right_len = right_plan.schema().fields().len();
+
+        if left_len != right_len {
+            return Err(DataFusionError::Plan(format!(
+                "Expected the no. of fields to be the same. Left fields count = {} and right fields count = {} are not the same.",
+                left_len, right_len
+            )));
+        }
+
         let join_keys = left_plan
             .schema()
             .fields()

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -786,7 +786,7 @@ impl LogicalPlanBuilder {
 
         if left_len != right_len {
             return Err(DataFusionError::Plan(format!(
-                "INTERSECT/EXCEPT query must have the same number of columns. Left columns count = {} and right columns count = {} are not the same.",
+                "INTERSECT/EXCEPT query must have the same number of columns. Left is {} and right is {}.",
                 left_len, right_len
             )));
         }
@@ -1426,5 +1426,22 @@ mod tests {
             Field::new("c", DataType::UInt32, false),
         ]);
         table_scan(Some(name), &schema, None)?.build()
+    }
+
+    #[test]
+    fn plan_builder_intersect_different_num_columns_error() -> Result<()> {
+        let plan1 = table_scan(None, &employee_schema(), Some(vec![3]))?;
+
+        let plan2 = table_scan(None, &employee_schema(), Some(vec![3, 4]))?;
+
+        let expected = "Error during planning: INTERSECT/EXCEPT query must have the same number of columns. \
+         Left is 1 and right is 2.";
+        let err_msg1 =
+            LogicalPlanBuilder::intersect(plan1.build()?, plan2.build()?, true)
+                .unwrap_err();
+
+        assert_eq!(err_msg1.to_string(), expected);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3632

# Are there any user-facing changes?

Users will see failure if they are using INTERSECT and EXPECT on tables with different field count.
