### PR TITLE
Add `PhysicalPlan` enum to complement `ExecutionPlan` trait

### DIFF
--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -52,6 +52,19 @@ pub enum PhysicalPlan {
     Extension(Arc<dyn ExecutionPlan>),
 }
 
+impl PhysicalPlan {
+    pub fn children(&self) -> Vec<PhysicalPlan> {
+        match self {
+            Self::Projection(exec) => exec
+                .children()
+                .iter()
+                .map(|exec| exec.clone().into())
+                .collect(),
+            _ => todo!(),
+        }
+    }
+}
+
 impl Into<PhysicalPlan> for Arc<dyn ExecutionPlan> {
     fn into(self) -> PhysicalPlan {
         if self.as_any().downcast_ref::<ProjectionExec>().is_some() {
@@ -92,7 +105,9 @@ mod test {
         let plan: Arc<dyn ExecutionPlan> = ctx.create_physical_plan(&plan).await?;
         let plan: PhysicalPlan = plan.into();
         match plan {
-            PhysicalPlan::Projection(_) => {}
+            PhysicalPlan::Projection(_) => {
+                let _children: Vec<PhysicalPlan> = plan.children();
+            }
             PhysicalPlan::Filter(_) => {}
             PhysicalPlan::HashJoin(_) => {}
             PhysicalPlan::Extension(_) => {}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/issues/3651. Not sure if this can close that issue or not.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The proposal in https://github.com/apache/arrow-datafusion/issues/3651 is to change `ExecutionPlan` to be an enum instead of a trait. I am concerned that this may be very disruptive so why don't we add a new `PhysicalPlan` enum that people can optionally use to wrap an `ExecutionPlan`?

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Proof-of-concept of new enum for discussion:

```rust
/// Enum representation of a physical plan
pub enum PhysicalPlan {
    // TODO add all of DataFusion's operators
    Projection(Arc<dyn ExecutionPlan>),
    Filter(Arc<dyn ExecutionPlan>),
    HashJoin(Arc<dyn ExecutionPlan>),
    /// User-provided ExecutionPlan that is not part of the DataFusion crate
    Extension(Arc<dyn ExecutionPlan>),
}
```

There are `Into` implementations so it is easy to convert between `Arc<dyn ExecutionPlan>` and `PhysicalPlan` enum.

I need to spend more time thinking about how we handle the nesting of the enum but wanted to get thoughts on general direction first.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No. This is not a breaking API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->