### PR TITLE
Fix bug in dictionary coercion and allow better coercion

### DIFF
--- a/datafusion/expr/src/binary_rule.rs
+++ b/datafusion/expr/src/binary_rule.rs
@@ -435,14 +435,6 @@ fn both_numeric_or_null_and_numeric(lhs_type: &DataType, rhs_type: &DataType) ->
     }
 }
 
-/// Coercion rules for dictionary values (aka the type of the  dictionary itself)
-fn dictionary_value_coercion(
-    lhs_type: &DataType,
-    rhs_type: &DataType,
-) -> Option<DataType> {
-    numerical_coercion(lhs_type, rhs_type).or_else(|| string_coercion(lhs_type, rhs_type))
-}
-
 /// Coercion rules for Dictionaries: the type that both lhs and rhs
 /// can be casted to for the purpose of a computation.
 ///
@@ -457,7 +449,7 @@ fn dictionary_coercion(
         (
             DataType::Dictionary(_lhs_index_type, lhs_value_type),
             DataType::Dictionary(_rhs_index_type, rhs_value_type),
-        ) => dictionary_value_coercion(lhs_value_type, rhs_value_type),
+        ) => comparison_coercion(lhs_value_type, rhs_value_type),
         (d @ DataType::Dictionary(_, value_type), other_type)
         | (other_type, d @ DataType::Dictionary(_, value_type))
             if preserve_dictionaries && value_type.as_ref() == other_type =>
@@ -465,10 +457,10 @@ fn dictionary_coercion(
             Some(d.clone())
         }
         (DataType::Dictionary(_index_type, value_type), _) => {
-            dictionary_value_coercion(value_type, rhs_type)
+            comparison_coercion(value_type, rhs_type)
         }
         (_, DataType::Dictionary(_index_type, value_type)) => {
-            dictionary_value_coercion(lhs_type, value_type)
+            comparison_coercion(lhs_type, value_type)
         }
         _ => None,
     }
@@ -782,8 +774,14 @@ mod tests {
             Some(Int32)
         );
 
+        // Since we can coerce values of Int16 to Utf8 can support this
         let lhs_type = Dictionary(Box::new(Int8), Box::new(Utf8));
         let rhs_type = Dictionary(Box::new(Int8), Box::new(Int16));
+        assert_eq!(dictionary_coercion(&lhs_type, &rhs_type, true), Some(Utf8));
+
+        // Can not coerce values of Binary to int,  cannot support this
+        let lhs_type = Dictionary(Box::new(Int8), Box::new(Utf8));
+        let rhs_type = Dictionary(Box::new(Int8), Box::new(Binary));
         assert_eq!(dictionary_coercion(&lhs_type, &rhs_type, true), None);
 
         let lhs_type = Dictionary(Box::new(Int8), Box::new(Utf8));


### PR DESCRIPTION
# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/3685



 # Rationale for this change
see https://github.com/apache/arrow-datafusion/issues/3685


# What changes are included in this PR?
1. Improve dictionary array coercion to allow the value coercion for all the same
2. tests for same


# Are there any user-facing changes?
Less error