### PR TITLE
Move optimizer init to optimizer crate

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1446,7 +1446,7 @@ impl SessionState {
                 .register_catalog(config.default_catalog.clone(), default_catalog);
         }
 
-        let x = OptimizerConfig::new().filter_null_keys(
+        let optimizer_config = OptimizerConfig::new().filter_null_keys(
             config
                 .config_options
                 .read()
@@ -1479,7 +1479,7 @@ impl SessionState {
 
         SessionState {
             session_id,
-            optimizer: Optimizer::new(&x),
+            optimizer: Optimizer::new(&optimizer_config),
             physical_optimizers,
             query_planner: Arc::new(DefaultQueryPlanner {}),
             catalog_list,

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -17,6 +17,24 @@
 
 //! Query optimizer traits
 
+use crate::common_subexpr_eliminate::CommonSubexprEliminate;
+use crate::decorrelate_where_exists::DecorrelateWhereExists;
+use crate::decorrelate_where_in::DecorrelateWhereIn;
+use crate::eliminate_filter::EliminateFilter;
+use crate::eliminate_limit::EliminateLimit;
+use crate::filter_null_join_keys::FilterNullJoinKeys;
+use crate::filter_push_down::FilterPushDown;
+use crate::limit_push_down::LimitPushDown;
+use crate::projection_push_down::ProjectionPushDown;
+use crate::reduce_cross_join::ReduceCrossJoin;
+use crate::reduce_outer_join::ReduceOuterJoin;
+use crate::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
+use crate::scalar_subquery_to_join::ScalarSubqueryToJoin;
+use crate::simplify_expressions::SimplifyExpressions;
+use crate::single_distinct_to_groupby::SingleDistinctToGroupBy;
+use crate::subquery_filter_to_join::SubqueryFilterToJoin;
+use crate::type_coercion::TypeCoercion;
+use crate::unwrap_cast_in_comparison::UnwrapCastInComparison;
 use chrono::{DateTime, Utc};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::logical_plan::LogicalPlan;
@@ -50,6 +68,8 @@ pub struct OptimizerConfig {
     next_id: usize,
     /// Option to skip rules that produce errors
     skip_failing_rules: bool,
+    /// Specify whether to enable the filter_null_keys rule
+    filter_null_keys: bool,
 }
 
 impl OptimizerConfig {
@@ -59,7 +79,14 @@ impl OptimizerConfig {
             query_execution_start_time: chrono::Utc::now(),
             next_id: 0, // useful for generating things like unique subquery aliases
             skip_failing_rules: true,
+            filter_null_keys: true,
         }
+    }
+
+    /// Specify whether to enable the filter_null_keys rule
+    pub fn filter_null_keys(mut self, filter_null_keys: bool) -> Self {
+        self.filter_null_keys = filter_null_keys;
+        self
     }
 
     /// Specify whether the optimizer should skip rules that produce
@@ -107,8 +134,35 @@ pub struct Optimizer {
 }
 
 impl Optimizer {
+    /// Create a new optimizer using the recommended list of rules
+    pub fn new(config: &OptimizerConfig) -> Self {
+        let mut rules: Vec<Arc<dyn OptimizerRule + Sync + Send>> = vec![
+            Arc::new(TypeCoercion::new()),
+            Arc::new(SimplifyExpressions::new()),
+            Arc::new(UnwrapCastInComparison::new()),
+            Arc::new(DecorrelateWhereExists::new()),
+            Arc::new(DecorrelateWhereIn::new()),
+            Arc::new(ScalarSubqueryToJoin::new()),
+            Arc::new(SubqueryFilterToJoin::new()),
+            Arc::new(EliminateFilter::new()),
+            Arc::new(ReduceCrossJoin::new()),
+            Arc::new(CommonSubexprEliminate::new()),
+            Arc::new(EliminateLimit::new()),
+            Arc::new(ProjectionPushDown::new()),
+            Arc::new(RewriteDisjunctivePredicate::new()),
+        ];
+        if config.filter_null_keys {
+            rules.push(Arc::new(FilterNullJoinKeys::default()));
+        }
+        rules.push(Arc::new(ReduceOuterJoin::new()));
+        rules.push(Arc::new(FilterPushDown::new()));
+        rules.push(Arc::new(LimitPushDown::new()));
+        rules.push(Arc::new(SingleDistinctToGroupBy::new()));
+        Self::with_rules(rules)
+    }
+
     /// Create a new optimizer with the given rules
-    pub fn new(rules: Vec<Arc<dyn OptimizerRule + Send + Sync>>) -> Self {
+    pub fn with_rules(rules: Vec<Arc<dyn OptimizerRule + Send + Sync>>) -> Self {
         Self { rules }
     }
 
@@ -172,7 +226,7 @@ mod tests {
 
     #[test]
     fn skip_failing_rule() -> Result<(), DataFusionError> {
-        let opt = Optimizer::new(vec![Arc::new(BadRule {})]);
+        let opt = Optimizer::with_rules(vec![Arc::new(BadRule {})]);
         let mut config = OptimizerConfig::new().with_skip_failing_rules(true);
         let plan = LogicalPlan::EmptyRelation(EmptyRelation {
             produce_one_row: false,
@@ -184,7 +238,7 @@ mod tests {
 
     #[test]
     fn no_skip_failing_rule() -> Result<(), DataFusionError> {
-        let opt = Optimizer::new(vec![Arc::new(BadRule {})]);
+        let opt = Optimizer::with_rules(vec![Arc::new(BadRule {})]);
         let mut config = OptimizerConfig::new().with_skip_failing_rules(false);
         let plan = LogicalPlan::EmptyRelation(EmptyRelation {
             produce_one_row: false,

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -18,25 +18,7 @@
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource};
-use datafusion_optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
-use datafusion_optimizer::decorrelate_where_exists::DecorrelateWhereExists;
-use datafusion_optimizer::decorrelate_where_in::DecorrelateWhereIn;
-use datafusion_optimizer::eliminate_filter::EliminateFilter;
-use datafusion_optimizer::eliminate_limit::EliminateLimit;
-use datafusion_optimizer::filter_null_join_keys::FilterNullJoinKeys;
-use datafusion_optimizer::filter_push_down::FilterPushDown;
-use datafusion_optimizer::limit_push_down::LimitPushDown;
 use datafusion_optimizer::optimizer::Optimizer;
-use datafusion_optimizer::projection_push_down::ProjectionPushDown;
-use datafusion_optimizer::reduce_cross_join::ReduceCrossJoin;
-use datafusion_optimizer::reduce_outer_join::ReduceOuterJoin;
-use datafusion_optimizer::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
-use datafusion_optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
-use datafusion_optimizer::simplify_expressions::SimplifyExpressions;
-use datafusion_optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
-use datafusion_optimizer::subquery_filter_to_join::SubqueryFilterToJoin;
-use datafusion_optimizer::type_coercion::TypeCoercion;
-use datafusion_optimizer::unwrap_cast_in_comparison::UnwrapCastInComparison;
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
 use datafusion_sql::planner::{ContextProvider, SqlToRel};
 use datafusion_sql::sqlparser::ast::Statement;
@@ -104,31 +86,6 @@ fn between_date64_plus_interval() -> Result<()> {
 }
 
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
-    // TODO should make align with rules in the context
-    // https://github.com/apache/arrow-datafusion/issues/3524
-    let rules: Vec<Arc<dyn OptimizerRule + Sync + Send>> = vec![
-        Arc::new(TypeCoercion::new()),
-        Arc::new(SimplifyExpressions::new()),
-        Arc::new(UnwrapCastInComparison::new()),
-        Arc::new(DecorrelateWhereExists::new()),
-        Arc::new(DecorrelateWhereIn::new()),
-        Arc::new(ScalarSubqueryToJoin::new()),
-        Arc::new(SubqueryFilterToJoin::new()),
-        Arc::new(EliminateFilter::new()),
-        Arc::new(CommonSubexprEliminate::new()),
-        Arc::new(EliminateLimit::new()),
-        Arc::new(ReduceCrossJoin::new()),
-        Arc::new(ProjectionPushDown::new()),
-        Arc::new(RewriteDisjunctivePredicate::new()),
-        Arc::new(FilterNullJoinKeys::default()),
-        Arc::new(ReduceOuterJoin::new()),
-        Arc::new(FilterPushDown::new()),
-        Arc::new(LimitPushDown::new()),
-        Arc::new(SingleDistinctToGroupBy::new()),
-    ];
-
-    let optimizer = Optimizer::new(rules);
-
     // parse the SQL
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
     let ast: Vec<Statement> = Parser::parse_sql(&dialect, sql).unwrap();
@@ -141,6 +98,7 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
 
     // optimize the logical plan
     let mut config = OptimizerConfig::new().with_skip_failing_rules(false);
+    let optimizer = Optimizer::new(&config);
     optimizer.optimize(&plan, &mut config, &observe)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/3524

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We need the optimizer tests in the optimizer crate to run against the same set of rules that DataFusion actually uses.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Move the list of rules to the optimizer crate.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->