### PR TITLE
Stop skipping failing optimizer rules in tests

### DIFF
--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -21,7 +21,7 @@ use datafusion::test_util::scan_empty;
 
 #[tokio::test]
 async fn csv_query_avg_multi_batch() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT avg(c12) FROM aggregate_test_100";
     let plan = ctx.create_logical_plan(sql).unwrap();
@@ -42,7 +42,7 @@ async fn csv_query_avg_multi_batch() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT avg(c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -54,7 +54,7 @@ async fn csv_query_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_covariance_1() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT covar_pop(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -66,7 +66,7 @@ async fn csv_query_covariance_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_covariance_2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT covar(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -78,7 +78,7 @@ async fn csv_query_covariance_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_correlation() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT corr(c2, c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -90,7 +90,7 @@ async fn csv_query_correlation() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_1() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT var_pop(c2) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -102,7 +102,7 @@ async fn csv_query_variance_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT var_pop(c6) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -114,7 +114,7 @@ async fn csv_query_variance_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_3() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT var_pop(c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -126,7 +126,7 @@ async fn csv_query_variance_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_4() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT var(c2) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -138,7 +138,7 @@ async fn csv_query_variance_4() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_variance_5() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT var_samp(c2) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -150,7 +150,7 @@ async fn csv_query_variance_5() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_1() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT stddev_pop(c2) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -162,7 +162,7 @@ async fn csv_query_stddev_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT stddev_pop(c6) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -174,7 +174,7 @@ async fn csv_query_stddev_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_3() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT stddev_pop(c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -186,7 +186,7 @@ async fn csv_query_stddev_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_4() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT stddev(c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -198,7 +198,7 @@ async fn csv_query_stddev_4() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_5() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT stddev_samp(c12) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -210,7 +210,7 @@ async fn csv_query_stddev_5() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_stddev_6() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "select stddev(sq.column1) from (values (1.1), (2.0), (3.0)) as sq";
     let mut actual = execute(&ctx, sql).await;
@@ -222,7 +222,7 @@ async fn csv_query_stddev_6() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_median_1() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT approx_median(c2) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -233,7 +233,7 @@ async fn csv_query_approx_median_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_median_2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT approx_median(c6) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -244,7 +244,7 @@ async fn csv_query_approx_median_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_median_3() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT approx_median(c12) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -255,7 +255,7 @@ async fn csv_query_approx_median_3() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_1() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT median(c2) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -266,7 +266,7 @@ async fn csv_query_median_1() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT median(c6) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -277,7 +277,7 @@ async fn csv_query_median_2() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_median_3() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT median(c12) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -424,7 +424,7 @@ async fn median_test(
     values: ArrayRef,
     expected: &str,
 ) -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Arc::new(Schema::new(vec![Field::new("a", data_type, false)]));
     let batch = RecordBatch::try_new(schema.clone(), vec![values])?;
     ctx.register_batch("t", batch)?;
@@ -437,7 +437,7 @@ async fn median_test(
 
 #[tokio::test]
 async fn csv_query_external_table_count() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT COUNT(c12) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -454,7 +454,7 @@ async fn csv_query_external_table_count() {
 
 #[tokio::test]
 async fn csv_query_external_table_sum() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // cast smallint and int to bigint to avoid overflow during calculation
     register_aggregate_csv_by_sql(&ctx).await;
     let sql =
@@ -472,7 +472,7 @@ async fn csv_query_external_table_sum() {
 
 #[tokio::test]
 async fn csv_query_count() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT count(c12) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -489,7 +489,7 @@ async fn csv_query_count() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT count(distinct c2) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -506,7 +506,7 @@ async fn csv_query_count_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_distinct_expr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT count(distinct c2 % 2) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -523,7 +523,7 @@ async fn csv_query_count_distinct_expr() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_count_star() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT COUNT(*) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -539,7 +539,7 @@ async fn csv_query_count_star() {
 
 #[tokio::test]
 async fn csv_query_count_one() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT COUNT(1) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -556,7 +556,7 @@ async fn csv_query_count_one() {
 #[tokio::test]
 #[ignore] // https://github.com/apache/arrow-datafusion/issues/3353
 async fn csv_query_approx_count() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT approx_distinct(c9) count_c9, approx_distinct(cast(c9 as varchar)) count_c9_str FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -573,7 +573,7 @@ async fn csv_query_approx_count() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_count_dupe_expr_aliased() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "SELECT approx_distinct(c9) a, approx_distinct(c9) b FROM aggregate_test_100";
@@ -614,7 +614,7 @@ async fn csv_query_approx_count_dupe_expr_aliased() -> Result<()> {
 // float values.
 #[tokio::test]
 async fn csv_query_approx_percentile_cont() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
 
     // Generate an assertion that the estimated $percentile value for $column is
@@ -679,7 +679,7 @@ async fn csv_query_approx_percentile_cont() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_cube_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
 
     let sql = "SELECT c1, c2, AVG(c3) FROM aggregate_test_100 GROUP BY CUBE (c1, c2) ORDER BY c1, c2";
@@ -732,7 +732,7 @@ async fn csv_query_cube_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_rollup_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
 
     let sql = "SELECT c1, c2, c3, AVG(c4) FROM aggregate_test_100 GROUP BY ROLLUP (c1, c2, c3) ORDER BY c1, c2, c3";
@@ -878,7 +878,7 @@ async fn csv_query_rollup_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_percentile_cont_with_weight() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
 
     // compare approx_percentile_cont and approx_percentile_cont_with_weight
@@ -945,7 +945,7 @@ async fn csv_query_approx_percentile_cont_with_weight() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_approx_percentile_cont_with_histogram_bins() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
 
     // compare approx_percentile_cont and approx_percentile_cont_with_weight
@@ -993,7 +993,7 @@ async fn csv_query_approx_percentile_cont_with_histogram_bins() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_sum_crossjoin() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT a.c1, b.c1, SUM(a.c2) FROM aggregate_test_100 as a CROSS JOIN aggregate_test_100 as b GROUP BY a.c1, b.c1 ORDER BY a.c1, b.c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1033,7 +1033,7 @@ async fn csv_query_sum_crossjoin() {
 
 #[tokio::test]
 async fn csv_query_cube_sum_crossjoin() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT a.c1, b.c1, SUM(a.c2) FROM aggregate_test_100 as a CROSS JOIN aggregate_test_100 as b GROUP BY CUBE (a.c1, b.c1) ORDER BY a.c1, b.c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1084,7 +1084,7 @@ async fn csv_query_cube_sum_crossjoin() {
 
 #[tokio::test]
 async fn csv_query_cube_distinct_count() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT c1, c2, COUNT(DISTINCT c3) FROM aggregate_test_100 GROUP BY CUBE (c1,c2) ORDER BY c1,c2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1135,7 +1135,7 @@ async fn csv_query_cube_distinct_count() {
 
 #[tokio::test]
 async fn csv_query_rollup_distinct_count() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT c1, c2, COUNT(DISTINCT c3) FROM aggregate_test_100 GROUP BY ROLLUP (c1,c2) ORDER BY c1,c2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1181,7 +1181,7 @@ async fn csv_query_rollup_distinct_count() {
 
 #[tokio::test]
 async fn csv_query_rollup_sum_crossjoin() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT a.c1, b.c1, SUM(a.c2) FROM aggregate_test_100 as a CROSS JOIN aggregate_test_100 as b GROUP BY ROLLUP (a.c1, b.c1) ORDER BY a.c1, b.c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1227,7 +1227,7 @@ async fn csv_query_rollup_sum_crossjoin() {
 
 #[tokio::test]
 async fn query_count_without_from() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT count(1 + 1)";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -1243,7 +1243,7 @@ async fn query_count_without_from() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 ORDER BY c13 LIMIT 2) test";
@@ -1261,7 +1261,7 @@ async fn csv_query_array_agg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_empty() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 LIMIT 0) test";
@@ -1279,7 +1279,7 @@ async fn csv_query_array_agg_empty() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_one() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "SELECT array_agg(c13) FROM (SELECT * FROM aggregate_test_100 ORDER BY c13 LIMIT 1) test";
@@ -1297,7 +1297,7 @@ async fn csv_query_array_agg_one() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_with_overflow() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "select c2, sum(c3) sum_c3, avg(c3) avg_c3, max(c3) max_c3, min(c3) min_c3, count(c3) count_c3 from aggregate_test_100 group by c2 order by c2";
@@ -1319,7 +1319,7 @@ async fn csv_query_array_agg_with_overflow() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_cube_agg_with_overflow() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "select c1, c2, sum(c3) sum_c3, avg(c3) avg_c3, max(c3) max_c3, min(c3) min_c3, count(c3) count_c3 from aggregate_test_100 group by CUBE (c1,c2) order by c1, c2";
@@ -1372,7 +1372,7 @@ async fn csv_query_array_cube_agg_with_overflow() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_array_agg_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT array_agg(distinct c2) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1422,7 +1422,7 @@ async fn csv_query_array_agg_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_sum() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = plan_and_collect(
@@ -1439,7 +1439,7 @@ async fn aggregate_timestamps_sum() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_count() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
@@ -1462,7 +1462,7 @@ async fn aggregate_timestamps_count() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_min() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
@@ -1485,7 +1485,7 @@ async fn aggregate_timestamps_min() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_max() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = execute_to_batches(
@@ -1508,7 +1508,7 @@ async fn aggregate_timestamps_max() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_timestamps_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let results = plan_and_collect(
@@ -1524,7 +1524,7 @@ async fn aggregate_timestamps_avg() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_time_min_and_max() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select min(t), max(t) from  (select '00:00:00' as t union select '00:00:01' union select '00:00:02');";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1543,7 +1543,7 @@ async fn aggregate_time_min_and_max() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_decimal_min() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // the data type of c1 is decimal(10,3)
     ctx.register_table("d_table", table_with_decimal()).unwrap();
     let result = plan_and_collect(&ctx, "select min(c1) from d_table")
@@ -1566,7 +1566,7 @@ async fn aggregate_decimal_min() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_decimal_max() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // the data type of c1 is decimal(10,3)
     ctx.register_table("d_table", table_with_decimal()).unwrap();
 
@@ -1590,7 +1590,7 @@ async fn aggregate_decimal_max() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_decimal_sum() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // the data type of c1 is decimal(10,3)
     ctx.register_table("d_table", table_with_decimal()).unwrap();
     let result = plan_and_collect(&ctx, "select sum(c1) from d_table")
@@ -1613,7 +1613,7 @@ async fn aggregate_decimal_sum() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_decimal_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // the data type of c1 is decimal(10,3)
     ctx.register_table("d_table", table_with_decimal()).unwrap();
     let result = plan_and_collect(&ctx, "select avg(c1) from d_table")
@@ -1846,7 +1846,7 @@ async fn aggregate_avg_add() -> Result<()> {
 
 #[tokio::test]
 async fn case_sensitive_identifiers_aggregates() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_sequence(1, 1).unwrap())
         .unwrap();
 
@@ -2023,7 +2023,7 @@ async fn simple_avg() -> Result<()> {
         vec![Arc::new(Int32Array::from_slice(&[4, 5]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
     ctx.register_table("t", Arc::new(provider))?;
@@ -2058,7 +2058,7 @@ async fn simple_mean() -> Result<()> {
         vec![Arc::new(Int32Array::from_slice(&[4, 5]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
     ctx.register_table("t", Arc::new(provider))?;
@@ -2107,7 +2107,7 @@ async fn query_sum_distinct() -> Result<()> {
         ],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
 
     // 2 different aggregate functions: avg and sum(distinct)
@@ -2151,7 +2151,7 @@ async fn query_count_distinct() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT COUNT(DISTINCT c1) FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -2170,7 +2170,7 @@ async fn run_count_distinct_integers_aggregated_scenario(
     partitions: Vec<Vec<(&str, u64)>>,
 ) -> Result<Vec<RecordBatch>> {
     let tmp_dir = TempDir::new()?;
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Arc::new(Schema::new(vec![
         Field::new("c_group", DataType::Utf8, false),
         Field::new("c_int8", DataType::Int8, false),
@@ -2292,7 +2292,7 @@ async fn count_distinct_integers_aggregated_multiple_partitions() -> Result<()> 
 
 #[tokio::test]
 async fn aggregate_with_alias() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),

--- a/datafusion/core/tests/sql/arrow_typeof.rs
+++ b/datafusion/core/tests/sql/arrow_typeof.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn arrow_typeof_null() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(null)";
     let actual = execute(&ctx, sql).await;
     let expected = "Null";
@@ -30,7 +30,7 @@ async fn arrow_typeof_null() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_boolean() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(true)";
     let actual = execute(&ctx, sql).await;
     let expected = "Boolean";
@@ -41,7 +41,7 @@ async fn arrow_typeof_boolean() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_i64() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(1)";
     let actual = execute(&ctx, sql).await;
     let expected = "Int64";
@@ -52,7 +52,7 @@ async fn arrow_typeof_i64() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_i32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(1::int)";
     let actual = execute(&ctx, sql).await;
     let expected = "Int32";
@@ -63,7 +63,7 @@ async fn arrow_typeof_i32() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_f64() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(1.0)";
     let actual = execute(&ctx, sql).await;
     let expected = "Float64";
@@ -74,7 +74,7 @@ async fn arrow_typeof_f64() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_f32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(1.0::float)";
     let actual = execute(&ctx, sql).await;
     let expected = "Float32";
@@ -85,7 +85,7 @@ async fn arrow_typeof_f32() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_decimal() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(1::Decimal)";
     let actual = execute(&ctx, sql).await;
     let expected = "Decimal128(38, 10)";
@@ -96,7 +96,7 @@ async fn arrow_typeof_decimal() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_timestamp() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(now()::timestamp)";
     let actual = execute(&ctx, sql).await;
     let expected = "Timestamp(Nanosecond, None)";
@@ -107,7 +107,7 @@ async fn arrow_typeof_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_timestamp_utc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(now())";
     let actual = execute(&ctx, sql).await;
     let expected = "Timestamp(Nanosecond, Some(\"UTC\"))";
@@ -118,7 +118,7 @@ async fn arrow_typeof_timestamp_utc() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_timestamp_date32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof(now()::date)";
     let actual = execute(&ctx, sql).await;
     let expected = "Date32";
@@ -129,7 +129,7 @@ async fn arrow_typeof_timestamp_date32() -> Result<()> {
 
 #[tokio::test]
 async fn arrow_typeof_utf8() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT arrow_typeof('1')";
     let actual = execute(&ctx, sql).await;
     let expected = "Utf8";

--- a/datafusion/core/tests/sql/avro.rs
+++ b/datafusion/core/tests/sql/avro.rs
@@ -30,7 +30,7 @@ async fn register_alltypes_avro(ctx: &SessionContext) {
 
 #[tokio::test]
 async fn avro_query() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_avro(&ctx).await;
     // NOTE that string_col is actually a binary column and does not have the UTF8 logical type
     // so we need an explicit cast
@@ -71,7 +71,7 @@ async fn avro_query_multiple_files() {
     )
     .unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_avro(
         "alltypes_plain",
         table_path.display().to_string().as_str(),
@@ -111,7 +111,7 @@ async fn avro_query_multiple_files() {
 
 #[tokio::test]
 async fn avro_single_nan_schema() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let testdata = datafusion::test_util::arrow_test_data();
     ctx.register_avro(
         "single_nan",
@@ -134,7 +134,7 @@ async fn avro_single_nan_schema() {
 
 #[tokio::test]
 async fn avro_explain() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_avro(&ctx).await;
 
     let sql = "EXPLAIN SELECT count(*) from alltypes_plain";

--- a/datafusion/core/tests/sql/cast.rs
+++ b/datafusion/core/tests/sql/cast.rs
@@ -15,14 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::sql::execute_to_batches;
+use super::*;
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use datafusion::error::Result;
-use datafusion::prelude::SessionContext;
 
 async fn execute_sql(sql: &str) -> Vec<RecordBatch> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     execute_to_batches(&ctx, sql).await
 }
 

--- a/datafusion/core/tests/sql/create_drop.rs
+++ b/datafusion/core/tests/sql/create_drop.rs
@@ -28,7 +28,7 @@ use super::*;
 
 #[tokio::test]
 async fn create_table_as() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "CREATE TABLE my_table AS SELECT * FROM aggregate_simple";
@@ -101,7 +101,7 @@ async fn create_or_replace_table_as() -> Result<()> {
 
 #[tokio::test]
 async fn drop_table() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "CREATE TABLE my_table AS SELECT * FROM aggregate_simple";
@@ -144,7 +144,7 @@ async fn drop_view() -> Result<()> {
 #[tokio::test]
 #[should_panic(expected = "doesn't exist")]
 async fn drop_view_nonexistent() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.sql("DROP VIEW non_existent_view")
         .await
         .unwrap()
@@ -156,7 +156,7 @@ async fn drop_view_nonexistent() {
 #[tokio::test]
 #[should_panic(expected = "doesn't exist")]
 async fn drop_view_cant_drop_table() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.sql("CREATE TABLE t AS SELECT 1")
         .await
         .unwrap()
@@ -174,7 +174,7 @@ async fn drop_view_cant_drop_table() {
 #[tokio::test]
 #[should_panic(expected = "doesn't exist")]
 async fn drop_table_cant_drop_view() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.sql("CREATE VIEW v AS SELECT 1")
         .await
         .unwrap()
@@ -219,7 +219,7 @@ async fn drop_view_if_exists() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_create_external_table() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT c1, c2, c3, c4, c5, c6, c7, c8, c9, 10, c11, c12, c13 FROM aggregate_test_100 LIMIT 1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -235,7 +235,7 @@ async fn csv_query_create_external_table() {
 
 #[tokio::test]
 async fn create_external_table_with_timestamps() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let data = "Jorge,2018-12-13T12:12:10.011Z\n\
                 Andrew,2018-11-13T17:11:10.011Z";
@@ -346,7 +346,7 @@ async fn sql_create_table_if_not_exists() -> Result<()> {
 
 #[tokio::test]
 async fn create_pipe_delimited_csv_table() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "CREATE EXTERNAL TABLE aggregate_simple STORED AS CSV WITH HEADER ROW DELIMITER '|' LOCATION 'tests/aggregate_simple_pipe.csv'";
     ctx.sql(sql).await.unwrap();
@@ -422,7 +422,7 @@ async fn create_custom_table() -> Result<()> {
 
 #[tokio::test]
 async fn create_bad_custom_table() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "CREATE EXTERNAL TABLE dt STORED AS DELTATABLE LOCATION 's3://bucket/schema/table';";
     let res = ctx.sql(sql).await;

--- a/datafusion/core/tests/sql/decimal.rs
+++ b/datafusion/core/tests/sql/decimal.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn decimal_cast() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select cast(1.23 as decimal(10,4))";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(
@@ -70,7 +70,7 @@ async fn decimal_cast() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_by_sql() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     let sql = "SELECT c1 from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -105,7 +105,7 @@ async fn decimal_by_sql() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_by_filter() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     let sql = "select c1 from decimal_simple where c1 > 0.000030";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -155,7 +155,7 @@ async fn decimal_by_filter() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_agg_function() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     // min
     let sql = "select min(c1) from decimal_simple where c4=false";
@@ -228,7 +228,7 @@ async fn decimal_agg_function() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_logic_op() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     // logic operation: eq
     let sql = "select * from decimal_simple where c1=CAST(0.00002 as Decimal(10,8))";
@@ -365,7 +365,7 @@ async fn decimal_logic_op() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_arithmetic_op() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     // add
     let sql = "select c1+1 from decimal_simple"; // add scalar
@@ -665,7 +665,7 @@ async fn decimal_arithmetic_op() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_sort() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     let sql = "select * from decimal_simple where c1 >= 0.00004 order by c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -735,7 +735,7 @@ async fn decimal_sort() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_group_function() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     let sql = "select count(*),c1 from decimal_simple group by c1 order by c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -783,7 +783,7 @@ async fn decimal_group_function() -> Result<()> {
 
 #[tokio::test]
 async fn sql_abs_decimal() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_decimal_csv_table_by_sql(&ctx).await;
     let sql = "SELECT abs(c1) from decimal_simple";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -814,7 +814,7 @@ async fn sql_abs_decimal() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_null_scalar_array_comparison() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select a < null from (values (1.1::decimal)) as t(a)";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(1, actual.len());
@@ -827,7 +827,7 @@ async fn decimal_null_scalar_array_comparison() -> Result<()> {
 
 #[tokio::test]
 async fn decimal_null_array_scalar_comparison() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select null <= a from (values (1.1::decimal)) as t(a);";
     let actual = execute_to_batches(&ctx, sql).await;
     assert_eq!(1, actual.len());

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -20,7 +20,7 @@ use super::*;
 #[tokio::test]
 async fn csv_query_error() -> Result<()> {
     // sin(utf8) should error
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT sin(c1) FROM aggregate_test_100";
     let plan = ctx.create_logical_plan(sql);
@@ -31,7 +31,7 @@ async fn csv_query_error() -> Result<()> {
 #[tokio::test]
 async fn test_cast_expressions_error() -> Result<()> {
     // sin(utf8) should error
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT CAST(c1 AS INT) FROM aggregate_test_100";
     let plan = ctx.create_logical_plan(sql).unwrap();
@@ -55,7 +55,7 @@ async fn test_cast_expressions_error() -> Result<()> {
 
 #[tokio::test]
 async fn test_aggregation_with_bad_arguments() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT COUNT(DISTINCT) FROM aggregate_test_100";
     let logical_plan = ctx.create_logical_plan(sql);
@@ -72,7 +72,7 @@ async fn test_aggregation_with_bad_arguments() -> Result<()> {
 
 #[tokio::test]
 async fn query_cte_incorrect() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // self reference
     let sql = "WITH t AS (SELECT * FROM t) SELECT * from u";
@@ -106,7 +106,7 @@ async fn query_cte_incorrect() -> Result<()> {
 
 #[tokio::test]
 async fn test_select_wildcard_without_table() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT * ";
     let actual = ctx.sql(sql).await;
     match actual {
@@ -123,7 +123,7 @@ async fn test_select_wildcard_without_table() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_qualified_table_references() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
 
     for table_ref in &[

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -180,7 +180,7 @@ async fn explain_analyze_baseline_metrics() {
 async fn csv_explain_plans() {
     // This test verify the look of each plan in its full cycle plan creation
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN SELECT c1 FROM aggregate_test_100 where c2 > 10";
 
@@ -354,7 +354,7 @@ async fn csv_explain_plans() {
 
 #[tokio::test]
 async fn csv_explain_verbose() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN VERBOSE SELECT c1 FROM aggregate_test_100 where c2 > 10";
     let actual = execute(&ctx, sql).await;
@@ -375,7 +375,7 @@ async fn csv_explain_verbose() {
 
 #[tokio::test]
 async fn csv_explain_inlist_verbose() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN VERBOSE SELECT c1 FROM aggregate_test_100 where c2 in (1,2,4)";
     let actual = execute(&ctx, sql).await;
@@ -403,7 +403,7 @@ async fn csv_explain_inlist_verbose() {
 async fn csv_explain_verbose_plans() {
     // This test verify the look of each plan in its full cycle plan creation
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN VERBOSE SELECT c1 FROM aggregate_test_100 where c2 > 10";
 
@@ -583,7 +583,7 @@ async fn csv_explain_verbose_plans() {
 async fn explain_analyze_runs_optimizers() {
     // repro for https://github.com/apache/arrow-datafusion/issues/917
     // where EXPLAIN ANALYZE was not correctly running optiimizer
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
 
     // This happens as an optimization pass where count(*) can be
@@ -608,7 +608,7 @@ async fn explain_analyze_runs_optimizers() {
 
 #[tokio::test]
 async fn tpch_explain_q10() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     register_tpch_csv(&ctx, "customer").await?;
     register_tpch_csv(&ctx, "orders").await?;
@@ -769,7 +769,7 @@ async fn test_physical_plan_display_indent_multi_children() {
 async fn csv_explain() {
     // This test uses the execute function that create full plan cycle: logical, optimized logical, and physical,
     // then execute the physical plan and return the final explain results
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN SELECT c1 FROM aggregate_test_100 where c2 > cast(10 as int)";
     let actual = execute(&ctx, sql).await;
@@ -804,7 +804,7 @@ async fn csv_explain() {
 #[cfg_attr(tarpaulin, ignore)]
 async fn csv_explain_analyze() {
     // This test uses the execute function to run an actual plan under EXPLAIN ANALYZE
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "EXPLAIN ANALYZE SELECT count(*), c1 FROM aggregate_test_100 group by c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -826,7 +826,7 @@ async fn csv_explain_analyze() {
 #[cfg_attr(tarpaulin, ignore)]
 async fn csv_explain_analyze_verbose() {
     // This test uses the execute function to run an actual plan under EXPLAIN VERBOSE ANALYZE
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql =
         "EXPLAIN ANALYZE VERBOSE SELECT count(*), c1 FROM aggregate_test_100 group by c1";

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -147,7 +147,7 @@ async fn case_when_else_with_null_contant() -> Result<()> {
 
 #[tokio::test]
 async fn case_expr_with_null() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select case when b is null then null else b end from (select a,b from (values (1,null),(2,3)) as t (a,b)) a;";
     let actual = execute_to_batches(&ctx, sql).await;
 
@@ -179,7 +179,7 @@ async fn case_expr_with_null() -> Result<()> {
 
 #[tokio::test]
 async fn case_expr_with_nulls() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select case when b is null then null when b < 3 then null when b >=3 then b + 1 else b end from (select a,b from (values (1,null),(1,2),(2,3)) as t (a,b)) a";
     let actual = execute_to_batches(&ctx, sql).await;
 
@@ -224,7 +224,7 @@ async fn query_not() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT NOT c1 FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -243,7 +243,7 @@ async fn query_not() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_sum_cast() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     // c8 = i32; c6 = i64
     let sql = "SELECT c8 + c6 FROM aggregate_test_100";
@@ -264,7 +264,7 @@ async fn query_is_null() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS NULL FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -294,7 +294,7 @@ async fn query_is_not_null() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS NOT NULL FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -324,7 +324,7 @@ async fn query_is_true() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS TRUE as t FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -354,7 +354,7 @@ async fn query_is_false() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS FALSE as f FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -384,7 +384,7 @@ async fn query_is_not_true() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS NOT TRUE as nt FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -414,7 +414,7 @@ async fn query_is_not_false() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS NOT FALSE as nf FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -444,7 +444,7 @@ async fn query_is_unknown() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS UNKNOWN as t FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -474,7 +474,7 @@ async fn query_is_not_unknown() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT c1 IS NOT UNKNOWN as t FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -495,7 +495,7 @@ async fn query_is_not_unknown() -> Result<()> {
 async fn query_without_from() -> Result<()> {
     // Test for SELECT <expression> without FROM.
     // Should evaluate expressions in project position.
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT 1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -536,7 +536,7 @@ async fn query_scalar_minus_array() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT 4 - c1 FROM test";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -556,7 +556,7 @@ async fn query_scalar_minus_array() -> Result<()> {
 
 #[tokio::test]
 async fn test_string_concat_operator() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     // concat 2 strings
     let sql = "SELECT 'aa' || 'b'";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -609,7 +609,7 @@ async fn test_string_concat_operator() -> Result<()> {
 
 #[tokio::test]
 async fn test_not_expressions() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT not(true), not(false)";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1152,7 +1152,7 @@ async fn test_cast_expressions() -> Result<()> {
 
 #[tokio::test]
 async fn test_random_expression() -> Result<()> {
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     let sql = "SELECT random() r1";
     let actual = execute(&ctx, sql).await;
     let r1 = actual[0][0].parse::<f64>().unwrap();
@@ -1163,7 +1163,7 @@ async fn test_random_expression() -> Result<()> {
 
 #[tokio::test]
 async fn case_with_bool_type_result() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select case when 'cpu' != 'cpu' then true else false end";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -1179,7 +1179,7 @@ async fn case_with_bool_type_result() -> Result<()> {
 
 #[tokio::test]
 async fn in_list_array() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT
             c1 IN ('a', 'c') AS utf8_in_true
@@ -1314,7 +1314,7 @@ async fn test_in_list_scalar() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_boolean_eq_neq() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_boolean(&ctx).await.unwrap();
     // verify the plumbing is all hooked up for eq and neq
     let sql = "SELECT a, b, a = b as eq, b = true as eq_scalar, a != b as neq, a != true as neq_scalar FROM t1";
@@ -1340,7 +1340,7 @@ async fn csv_query_boolean_eq_neq() {
 
 #[tokio::test]
 async fn csv_query_boolean_lt_lt_eq() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_boolean(&ctx).await.unwrap();
     // verify the plumbing is all hooked up for < and <=
     let sql = "SELECT a, b, a < b as lt, b = true as lt_scalar, a <= b as lt_eq, a <= true as lt_eq_scalar FROM t1";
@@ -1366,7 +1366,7 @@ async fn csv_query_boolean_lt_lt_eq() {
 
 #[tokio::test]
 async fn csv_query_boolean_gt_gt_eq() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_boolean(&ctx).await.unwrap();
     // verify the plumbing is all hooked up for > and >=
     let sql = "SELECT a, b, a > b as gt, b = true as gt_scalar, a >= b as gt_eq, a >= true as gt_eq_scalar FROM t1";
@@ -1392,7 +1392,7 @@ async fn csv_query_boolean_gt_gt_eq() {
 
 #[tokio::test]
 async fn csv_query_boolean_distinct_from() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_boolean(&ctx).await.unwrap();
     // verify the plumbing is all hooked up for is distinct from and is not distinct from
     let sql = "SELECT a, b, \
@@ -1423,7 +1423,7 @@ async fn csv_query_boolean_distinct_from() {
 
 #[tokio::test]
 async fn csv_query_nullif_divide_by_0() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c8/nullif(c7, 0) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;
@@ -1445,7 +1445,7 @@ async fn csv_query_nullif_divide_by_0() -> Result<()> {
 }
 #[tokio::test]
 async fn csv_count_star() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT COUNT(*), COUNT(1) AS c, COUNT(c1) FROM aggregate_test_100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1462,7 +1462,7 @@ async fn csv_count_star() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_avg_sqrt() -> Result<()> {
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT avg(custom_sqrt(c12)) FROM aggregate_test_100";
     let mut actual = execute(&ctx, sql).await;
@@ -1475,7 +1475,7 @@ async fn csv_query_avg_sqrt() -> Result<()> {
 // this query used to deadlock due to the call udf(udf())
 #[tokio::test]
 async fn csv_query_sqrt_sqrt() -> Result<()> {
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT sqrt(sqrt(c12)) FROM aggregate_test_100 LIMIT 1";
     let actual = execute(&ctx, sql).await;
@@ -1487,7 +1487,7 @@ async fn csv_query_sqrt_sqrt() -> Result<()> {
 
 #[tokio::test]
 async fn nested_subquery() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Schema::new(vec![
         Field::new("id", DataType::Int16, false),
         Field::new("a", DataType::Int16, false),
@@ -1516,7 +1516,7 @@ async fn nested_subquery() -> Result<()> {
 
 #[tokio::test]
 async fn like_nlike_with_null_lt() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT column1 like NULL as col_null, NULL like column1 as null_col from (values('a'), ('b'), (NULL)) as t";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -1546,7 +1546,7 @@ async fn like_nlike_with_null_lt() {
 
 #[tokio::test]
 async fn comparisons_with_null_lt() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // we expect all the following queries to yield a two null values
     let cases = vec![
@@ -1599,7 +1599,7 @@ async fn comparisons_with_null_lt() {
 
 #[tokio::test]
 async fn binary_mathematical_operator_with_null_lt() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let cases = vec![
         // 1. Integer and NULL
@@ -1688,7 +1688,7 @@ async fn query_binary_eq() -> Result<()> {
         vec![Arc::new(c1), Arc::new(c2), Arc::new(c3), Arc::new(c4)],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     ctx.register_batch("test", data)?;
 

--- a/datafusion/core/tests/sql/group_by.rs
+++ b/datafusion/core/tests/sql/group_by.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn csv_query_group_by_int_min_max() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c2, MIN(c12), MAX(c12) FROM aggregate_test_100 GROUP BY c2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -40,7 +40,7 @@ async fn csv_query_group_by_int_min_max() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_float32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql =
@@ -65,7 +65,7 @@ async fn csv_query_group_by_float32() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_float64() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql =
@@ -90,7 +90,7 @@ async fn csv_query_group_by_float64() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_boolean() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql =
@@ -112,7 +112,7 @@ async fn csv_query_group_by_boolean() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_two_columns() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, c2, MIN(c3) FROM aggregate_test_100 GROUP BY c1, c2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -153,7 +153,7 @@ async fn csv_query_group_by_two_columns() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_and_having() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, MIN(c3) AS m FROM aggregate_test_100 GROUP BY c1 HAVING m < -100 AND MAX(c3) > 70";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -171,7 +171,7 @@ async fn csv_query_group_by_and_having() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_and_having_and_where() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, MIN(c3) AS m
                FROM aggregate_test_100
@@ -192,7 +192,9 @@ async fn csv_query_group_by_and_having_and_where() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_having_without_group_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    let ctx = create_test_ctx_skip_failing_optimizer_rules();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 HAVING c2 >= 4 AND c3 > 90";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -213,7 +215,7 @@ async fn csv_query_having_without_group_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_substr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     // there is an input column "c1" as well a projection expression aliased as "c1"
     let sql = "SELECT substr(c1, 1, 1) c1 \
@@ -239,7 +241,7 @@ async fn csv_query_group_by_substr() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_avg() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, avg(c12) FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -260,7 +262,7 @@ async fn csv_query_group_by_avg() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_with_aliases() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 AS c12, avg(c12) AS c1 FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -281,7 +283,7 @@ async fn csv_query_group_by_with_aliases() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_int_count() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, count(c12) FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -302,7 +304,7 @@ async fn csv_query_group_by_int_count() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_with_aliased_aggregate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, count(c12) AS count FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -323,7 +325,7 @@ async fn csv_query_group_with_aliased_aggregate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_string_min_max() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, MIN(c12), MAX(c12) FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -357,7 +359,7 @@ async fn query_group_on_null() -> Result<()> {
         ]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT COUNT(*), c1 FROM test GROUP BY c1";
 
@@ -414,7 +416,7 @@ async fn query_group_on_null_multi_col() -> Result<()> {
         ],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT COUNT(*), c1, c2 FROM test GROUP BY c1, c2";
 
@@ -443,7 +445,7 @@ async fn query_group_on_null_multi_col() -> Result<()> {
 
 #[tokio::test]
 async fn csv_group_by_date() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Arc::new(Schema::new(vec![
         Field::new("date", DataType::Date32, false),
         Field::new("cnt", DataType::Int32, false),
@@ -488,7 +490,7 @@ async fn csv_group_by_date() -> Result<()> {
 #[tokio::test]
 async fn group_by_date_trunc() -> Result<()> {
     let tmp_dir = TempDir::new()?;
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Arc::new(Schema::new(vec![
         Field::new("c2", DataType::UInt64, false),
         Field::new(
@@ -538,7 +540,7 @@ async fn group_by_date_trunc() -> Result<()> {
 
 #[tokio::test]
 async fn group_by_largeutf8() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // input data looks like:
     // A, 1
@@ -585,7 +587,7 @@ async fn group_by_largeutf8() {
 #[tokio::test]
 async fn group_by_dictionary() {
     async fn run_test_case<K: ArrowDictionaryKeyType>() {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
 
         // input data looks like:
         // A, 1
@@ -677,7 +679,7 @@ async fn group_by_dictionary() {
 
 #[tokio::test]
 async fn csv_query_group_by_order_by_substr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT substr(c1, 1, 1), avg(c12) \
         FROM aggregate_test_100 \
@@ -701,7 +703,7 @@ async fn csv_query_group_by_order_by_substr() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_order_by_substr_aliased_projection() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT substr(c1, 1, 1) as name, avg(c12) as average \
         FROM aggregate_test_100 \
@@ -725,7 +727,7 @@ async fn csv_query_group_by_order_by_substr_aliased_projection() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_order_by_avg_group_by_substr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT substr(c1, 1, 1) as name, avg(c12) as average \
         FROM aggregate_test_100 \

--- a/datafusion/core/tests/sql/idenfifers.rs
+++ b/datafusion/core/tests/sql/idenfifers.rs
@@ -20,12 +20,12 @@ use std::sync::Arc;
 use arrow::{array::StringArray, record_batch::RecordBatch};
 use datafusion::{assert_batches_sorted_eq, assert_contains, prelude::*};
 
-use crate::sql::plan_and_collect;
+use crate::sql::{create_test_ctx, plan_and_collect};
 
 #[tokio::test]
 async fn normalized_column_identifiers() {
     // create local execution context
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // register csv file with the execution context
     ctx.register_csv(
@@ -201,7 +201,7 @@ async fn case_insensitive_in_sql_errors() {
     ])
     .unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", record_batch).unwrap();
 
     // None of these tests shoud pass

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -30,7 +30,7 @@ use super::*;
 
 #[tokio::test]
 async fn information_schema_tables_not_exist_by_default() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let err = plan_and_collect(&ctx, "SELECT * from information_schema.tables")
         .await
@@ -483,7 +483,7 @@ async fn show_unsupported_when_information_schema_off() {
 
 #[tokio::test]
 async fn information_schema_columns_not_exist_by_default() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let err = plan_and_collect(&ctx, "SELECT * from information_schema.columns")
         .await

--- a/datafusion/core/tests/sql/intersection.rs
+++ b/datafusion/core/tests/sql/intersection.rs
@@ -49,7 +49,7 @@ async fn intersect_with_null_equal() {
 
 #[tokio::test]
 async fn test_intersect_all() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 INTERSECT ALL SELECT int_col, double_col FROM alltypes_plain LIMIT 4";
@@ -70,7 +70,7 @@ async fn test_intersect_all() -> Result<()> {
 
 #[tokio::test]
 async fn test_intersect_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 INTERSECT SELECT int_col, double_col FROM alltypes_plain";

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -289,7 +289,7 @@ async fn left_join_null_filter() -> Result<()> {
     // Since t2 is the non-preserved side of the join, we cannot push down a NULL filter.
     // Note that this is only true because IS NULL does not remove nulls. For filters that
     // remove nulls, we can rewrite the join as an inner join and then push down the filter.
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_name IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -310,7 +310,7 @@ async fn left_join_null_filter() -> Result<()> {
 #[tokio::test]
 async fn left_join_null_filter_on_join_column() -> Result<()> {
     // Again, since t2 is the non-preserved side of the join, we cannot push down a NULL filter.
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_id IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -329,7 +329,7 @@ async fn left_join_null_filter_on_join_column() -> Result<()> {
 
 #[tokio::test]
 async fn left_join_not_null_filter() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_name IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -348,7 +348,7 @@ async fn left_join_not_null_filter() -> Result<()> {
 
 #[tokio::test]
 async fn left_join_not_null_filter_on_join_column() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t2_id, t2_name FROM t1 LEFT JOIN t2 ON t1_id = t2_id WHERE t2_id IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+-------+---------+",
@@ -368,7 +368,11 @@ async fn left_join_not_null_filter_on_join_column() -> Result<()> {
 
 #[tokio::test]
 async fn self_join_non_equijoin() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal(\"Optimizer rule 'unwrap_cast_in_comparison' failed due to unexpected error:
+    //   Internal error: Error target data type UInt32
+    let ctx = create_join_context_with_nulls(true)?;
     let sql =
         "SELECT x.t1_id, y.t1_id FROM t1 x JOIN t1 y ON x.t1_id = 11 AND y.t1_id = 44";
     let expected = vec![
@@ -386,7 +390,7 @@ async fn self_join_non_equijoin() -> Result<()> {
 
 #[tokio::test]
 async fn right_join_null_filter() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -404,7 +408,7 @@ async fn right_join_null_filter() -> Result<()> {
 
 #[tokio::test]
 async fn right_join_null_filter_on_join_column() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_id IS NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -421,7 +425,7 @@ async fn right_join_null_filter_on_join_column() -> Result<()> {
 
 #[tokio::test]
 async fn right_join_not_null_filter() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NOT NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -440,7 +444,7 @@ async fn right_join_not_null_filter() -> Result<()> {
 
 #[tokio::test]
 async fn right_join_not_null_filter_on_join_column() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_id IS NOT NULL ORDER BY t2_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -460,7 +464,7 @@ async fn right_join_not_null_filter_on_join_column() -> Result<()> {
 
 #[tokio::test]
 async fn full_join_null_filter() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -479,7 +483,7 @@ async fn full_join_null_filter() -> Result<()> {
 
 #[tokio::test]
 async fn full_join_not_null_filter() -> Result<()> {
-    let ctx = create_join_context_with_nulls()?;
+    let ctx = create_join_context_with_nulls(false)?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 FULL OUTER JOIN t2 ON t1_id = t2_id WHERE t1_name IS NOT NULL ORDER BY t1_id";
     let expected = vec![
         "+-------+---------+-------+",
@@ -739,7 +743,7 @@ async fn cross_join_unbalanced() {
 
 #[tokio::test]
 async fn test_join_timestamp() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // register time table
     let timestamp_schema = Arc::new(Schema::new(vec![Field::new(
@@ -780,7 +784,7 @@ async fn test_join_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn test_join_float32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // register population table
     let population_schema = Arc::new(Schema::new(vec![
@@ -819,7 +823,7 @@ async fn test_join_float32() -> Result<()> {
 
 #[tokio::test]
 async fn test_join_float64() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // register population table
     let population_schema = Arc::new(Schema::new(vec![
@@ -902,7 +906,7 @@ async fn nestedjoin_with_alias() -> Result<()> {
         "| 1 | 2 | 1 | 3 |",
         "+---+---+---+---+",
     ];
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
 
@@ -919,7 +923,7 @@ async fn nestedjoin_without_alias() -> Result<()> {
         "| 1 | 2 | 1 | 3 |",
         "+---+---+---+---+",
     ];
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let actual = execute_to_batches(&ctx, sql).await;
     assert_batches_eq!(expected, &actual);
 
@@ -957,7 +961,7 @@ async fn inner_join_nulls() {
 
 #[tokio::test]
 async fn join_tables_with_duplicated_column_name_not_in_on_constraint() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let batch = RecordBatch::try_from_iter(vec![
         ("id", Arc::new(Int32Array::from_slice(&[1, 2, 3])) as _),
         (
@@ -1018,7 +1022,7 @@ async fn join_tables_with_duplicated_column_name_not_in_on_constraint() -> Resul
 
 #[tokio::test]
 async fn join_timestamp() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("t", table_with_timestamps()).unwrap();
 
     let expected = vec![
@@ -1066,7 +1070,7 @@ async fn join_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn left_join_should_not_panic_with_empty_side() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Schema::new(vec![
         Field::new("t1_id", DataType::Int64, true),

--- a/datafusion/core/tests/sql/json.rs
+++ b/datafusion/core/tests/sql/json.rs
@@ -21,7 +21,7 @@ const TEST_DATA_BASE: &str = "tests/jsons";
 
 #[tokio::test]
 async fn json_query() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let path = format!("{}/2.json", TEST_DATA_BASE);
     ctx.register_json("t1", &path, NdJsonReadOptions::default())
         .await
@@ -54,7 +54,7 @@ async fn json_query() {
 #[tokio::test]
 #[should_panic]
 async fn json_single_nan_schema() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let path = format!("{}/3.json", TEST_DATA_BASE);
     ctx.register_json("single_nan", &path, NdJsonReadOptions::default())
         .await
@@ -74,7 +74,7 @@ async fn json_single_nan_schema() {
 #[tokio::test]
 #[cfg_attr(tarpaulin, ignore)]
 async fn json_explain() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let path = format!("{}/2.json", TEST_DATA_BASE);
     ctx.register_json("t1", &path, NdJsonReadOptions::default())
         .await

--- a/datafusion/core/tests/sql/limit.rs
+++ b/datafusion/core/tests/sql/limit.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn csv_query_limit() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -38,7 +38,7 @@ async fn csv_query_limit() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_bigger_than_nbr_of_rows() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c2 FROM aggregate_test_100 LIMIT 200";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -64,7 +64,7 @@ async fn csv_query_limit_bigger_than_nbr_of_rows() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_with_same_nbr_of_rows() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c2 FROM aggregate_test_100 LIMIT 100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -89,7 +89,7 @@ async fn csv_query_limit_with_same_nbr_of_rows() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_limit_zero() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 0";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -187,7 +187,7 @@ async fn limit_multi_partitions() -> Result<()> {
 
 #[tokio::test]
 async fn csv_offset_without_limit_99() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 99";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -205,7 +205,7 @@ async fn csv_offset_without_limit_99() -> Result<()> {
 
 #[tokio::test]
 async fn csv_offset_without_limit_100() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -216,7 +216,7 @@ async fn csv_offset_without_limit_100() -> Result<()> {
 
 #[tokio::test]
 async fn csv_offset_without_limit_101() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 101";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -227,7 +227,7 @@ async fn csv_offset_without_limit_101() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_offset() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 OFFSET 2 LIMIT 2";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -246,7 +246,7 @@ async fn csv_query_offset() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_offset_the_same_as_nbr_of_rows() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 1 OFFSET 100";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -257,7 +257,7 @@ async fn csv_query_offset_the_same_as_nbr_of_rows() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_offset_bigger_than_nbr_of_rows() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1 FROM aggregate_test_100 LIMIT 1 OFFSET 101";
     let actual = execute_to_batches(&ctx, sql).await;

--- a/datafusion/core/tests/sql/math.rs
+++ b/datafusion/core/tests/sql/math.rs
@@ -20,7 +20,7 @@ use arrow::array::Float64Array;
 
 #[tokio::test]
 async fn test_atan2() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Arc::new(Schema::new(vec![
         Field::new("x", DataType::Float64, true),

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -202,6 +202,8 @@ fn create_case_context() -> Result<SessionContext> {
 fn create_join_context(column_left: &str, column_right: &str) -> Result<SessionContext> {
     // TODO we should not be ignoring optimizer errors here
     // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal(\"Optimizer rule 'unwrap_cast_in_comparison' failed due to unexpected error:
+    //  Internal error: Error target data type UInt32
     let ctx = create_test_ctx_skip_failing_optimizer_rules();
 
     let t1_schema = Arc::new(Schema::new(vec![

--- a/datafusion/core/tests/sql/order.rs
+++ b/datafusion/core/tests/sql/order.rs
@@ -20,7 +20,7 @@ use fuzz_utils::{batches_to_vec, partitions_to_sorted_vec};
 
 #[tokio::test]
 async fn test_sort_unprojected_col() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // execute the query
     let sql = "SELECT id FROM alltypes_plain ORDER BY int_col, double_col";
@@ -46,7 +46,7 @@ async fn test_sort_unprojected_col() -> Result<()> {
 
 #[tokio::test]
 async fn test_order_by_agg_expr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT MIN(c12) FROM aggregate_test_100 ORDER BY MIN(c12)";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -67,7 +67,7 @@ async fn test_order_by_agg_expr() -> Result<()> {
 
 #[tokio::test]
 async fn test_nulls_first_asc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -85,7 +85,7 @@ async fn test_nulls_first_asc() -> Result<()> {
 
 #[tokio::test]
 async fn test_nulls_first_desc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num DESC";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -103,7 +103,7 @@ async fn test_nulls_first_desc() -> Result<()> {
 
 #[tokio::test]
 async fn test_specific_nulls_last_desc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num DESC NULLS LAST";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -121,7 +121,7 @@ async fn test_specific_nulls_last_desc() -> Result<()> {
 
 #[tokio::test]
 async fn test_specific_nulls_first_asc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (null, 'three')) AS t (num,letter) ORDER BY num ASC NULLS FIRST";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -213,7 +213,7 @@ async fn sort_empty() -> Result<()> {
 
 #[tokio::test]
 async fn sort_with_lots_of_repetition_values() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let filename = "tests/parquet/repeat_much.snappy.parquet";
 
     ctx.register_parquet("rep", filename, ParquetReadOptions::default())

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -24,7 +24,7 @@ use super::*;
 
 #[tokio::test]
 async fn parquet_query() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // NOTE that string_col is actually a binary column and does not have the UTF8 logical type
     // so we need an explicit cast
@@ -50,7 +50,7 @@ async fn parquet_query() {
 
 #[tokio::test]
 async fn parquet_single_nan_schema() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let testdata = datafusion::test_util::parquet_test_data();
     ctx.register_parquet(
         "single_nan",
@@ -74,7 +74,7 @@ async fn parquet_single_nan_schema() {
 #[tokio::test]
 #[ignore = "Test ignored, will be enabled as part of the nested Parquet reader"]
 async fn parquet_list_columns() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let testdata = datafusion::test_util::parquet_test_data();
     ctx.register_parquet(
         "list_columns",
@@ -209,7 +209,7 @@ async fn parquet_query_with_max_min() {
     }
 
     // query parquet
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     ctx.register_parquet(
         "foo",

--- a/datafusion/core/tests/sql/parquet_schema.rs
+++ b/datafusion/core/tests/sql/parquet_schema.rs
@@ -79,7 +79,7 @@ async fn schema_merge_ignores_metadata_by_default() {
     // (no errors)
     let table_path = table_dir.to_str().unwrap().to_string();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let df = ctx
         .read_parquet(&table_path, options.clone())
         .await
@@ -140,7 +140,7 @@ async fn schema_merge_can_preserve_metadata() {
     // (no errors)
     let table_path = table_dir.to_str().unwrap().to_string();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let df = ctx
         .read_parquet(&table_path, options.clone())
         .await

--- a/datafusion/core/tests/sql/predicates.rs
+++ b/datafusion/core/tests/sql/predicates.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn csv_query_with_predicate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, c12 FROM aggregate_test_100 WHERE c12 > 0.376 AND c12 < 0.4";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -37,7 +37,7 @@ async fn csv_query_with_predicate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_with_negative_predicate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c1, c4 FROM aggregate_test_100 WHERE c3 < -55 AND -c4 > 30000";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -55,7 +55,7 @@ async fn csv_query_with_negative_predicate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_with_negated_predicate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT COUNT(1) FROM aggregate_test_100 WHERE NOT(c1 != 'a')";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -72,7 +72,7 @@ async fn csv_query_with_negated_predicate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_with_is_not_null_predicate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT COUNT(1) FROM aggregate_test_100 WHERE c1 IS NOT NULL";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -89,7 +89,7 @@ async fn csv_query_with_is_not_null_predicate() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_with_is_null_predicate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT COUNT(1) FROM aggregate_test_100 WHERE c1 IS NULL";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -106,7 +106,7 @@ async fn csv_query_with_is_null_predicate() -> Result<()> {
 
 #[tokio::test]
 async fn query_where_neg_num() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
 
     // Negative numbers do not parse correctly as of Arrow 2.0.0
@@ -134,7 +134,7 @@ async fn query_where_neg_num() -> Result<()> {
 
 #[tokio::test]
 async fn like() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv_by_sql(&ctx).await;
     let sql = "SELECT COUNT(c1) FROM aggregate_test_100 WHERE c13 LIKE '%FB%'";
     // check that the physical and logical schemas are equal
@@ -152,7 +152,7 @@ async fn like() -> Result<()> {
 
 #[tokio::test]
 async fn csv_between_expr() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c4 FROM aggregate_test_100 WHERE c12 BETWEEN 0.995 AND 1.0";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -169,7 +169,7 @@ async fn csv_between_expr() -> Result<()> {
 
 #[tokio::test]
 async fn csv_between_expr_negated() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT c4 FROM aggregate_test_100 WHERE c12 NOT BETWEEN 0 AND 0.995";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -192,7 +192,7 @@ async fn like_on_strings() -> Result<()> {
 
     let batch = RecordBatch::try_from_iter(vec![("c1", Arc::new(input) as _)]).unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", batch)?;
 
     let sql = "SELECT * FROM test WHERE c1 LIKE '%a%'";
@@ -218,7 +218,7 @@ async fn like_on_string_dictionaries() -> Result<()> {
 
     let batch = RecordBatch::try_from_iter(vec![("c1", Arc::new(input) as _)]).unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", batch)?;
 
     let sql = "SELECT * FROM test WHERE c1 LIKE '%a%'";
@@ -244,7 +244,7 @@ async fn test_regexp_is_match() -> Result<()> {
 
     let batch = RecordBatch::try_from_iter(vec![("c1", Arc::new(input) as _)]).unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", batch)?;
 
     let sql = "SELECT * FROM test WHERE c1 ~ 'z'";
@@ -330,7 +330,7 @@ async fn except_with_null_equal() {
 
 #[tokio::test]
 async fn test_expect_all() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 EXCEPT ALL SELECT int_col, double_col FROM alltypes_plain where int_col < 1";
@@ -351,7 +351,7 @@ async fn test_expect_all() -> Result<()> {
 
 #[tokio::test]
 async fn test_expect_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_alltypes_parquet(&ctx).await;
     // execute the query
     let sql = "SELECT int_col, double_col FROM alltypes_plain where int_col > 0 EXCEPT SELECT int_col, double_col FROM alltypes_plain where int_col < 1";
@@ -369,7 +369,7 @@ async fn test_expect_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn csv_in_set_test() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT count(*) FROM aggregate_test_100 WHERE c7 in ('25','155','204','77','208','67','139','191','26','7','202','113','129','197','249','146','129','220','154','163','220','19','71','243','150','231','196','170','99','255');";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -388,7 +388,7 @@ async fn csv_in_set_test() -> Result<()> {
 #[ignore]
 // https://github.com/apache/arrow-datafusion/issues/3635
 async fn multiple_or_predicates() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "lineitem").await?;
     register_tpch_csv(&ctx, "part").await?;
     let sql = "explain select
@@ -444,7 +444,7 @@ async fn multiple_or_predicates() -> Result<()> {
 // Fix for issue#78 join predicates from inside of OR expr also pulled up properly.
 #[tokio::test]
 async fn tpch_q19_pull_predicates_to_innerjoin_simplified() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     register_tpch_csv(&ctx, "part").await?;
     register_tpch_csv(&ctx, "lineitem").await?;

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -24,7 +24,7 @@ use super::*;
 
 #[tokio::test]
 async fn projection_same_fields() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select (1+1) as a from (select 1 as a) as b;";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -44,7 +44,7 @@ async fn projection_same_fields() -> Result<()> {
 
 #[tokio::test]
 async fn projection_type_alias() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     // Query that aliases one column to the name of a different column
@@ -67,7 +67,7 @@ async fn projection_type_alias() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_group_by_avg_with_projection() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT avg(c12), c1 FROM aggregate_test_100 GROUP BY c1";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -223,7 +223,7 @@ async fn preserve_nullability_on_projection() -> Result<()> {
 
 #[tokio::test]
 async fn project_cast_dictionary() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let host: DictionaryArray<Int32Type> = vec![Some("host1"), None, Some("host2")]
         .into_iter()
@@ -288,7 +288,7 @@ async fn projection_on_memory_scan() -> Result<()> {
             .build()?;
     assert_fields_eq(&plan, vec!["b"]);
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let optimized_plan = ctx.optimize(&plan)?;
     match &optimized_plan {
         LogicalPlan::Projection(Projection { input, .. }) => match &**input {
@@ -338,7 +338,7 @@ fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {
 
 #[tokio::test]
 async fn project_column_with_same_name_as_relation() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select a.a from (select 1 as a) as a;";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -351,7 +351,7 @@ async fn project_column_with_same_name_as_relation() -> Result<()> {
 
 #[tokio::test]
 async fn project_column_with_filters_that_cant_pushed_down_always_false() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select * from (select 1 as a) f where f.a=2;";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -364,7 +364,7 @@ async fn project_column_with_filters_that_cant_pushed_down_always_false() -> Res
 
 #[tokio::test]
 async fn project_column_with_filters_that_cant_pushed_down_always_true() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select * from (select 1 as a) f where f.a=1;";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -377,7 +377,7 @@ async fn project_column_with_filters_that_cant_pushed_down_always_true() -> Resu
 
 #[tokio::test]
 async fn project_columns_in_memory_without_propagation() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select column1 as a from (values (1), (2)) f where f.column1 = 2;";
     let actual = execute_to_batches(&ctx, sql).await;

--- a/datafusion/core/tests/sql/references.rs
+++ b/datafusion/core/tests/sql/references.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn qualified_table_references() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
 
     for table_ref in &[
@@ -43,7 +43,7 @@ async fn qualified_table_references() -> Result<()> {
 
 #[tokio::test]
 async fn qualified_table_references_and_fields() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let c1: StringArray = vec!["foofoo", "foobar", "foobaz"]
         .into_iter()

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -24,7 +24,7 @@ use tempfile::TempDir;
 
 #[tokio::test]
 async fn all_where_empty() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT *
                FROM aggregate_test_100
@@ -37,7 +37,7 @@ async fn all_where_empty() -> Result<()> {
 
 #[tokio::test]
 async fn select_values_list() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     {
         let sql = "VALUES (1)";
         let actual = execute_to_batches(&ctx, sql).await;
@@ -277,7 +277,7 @@ async fn select_values_list() -> Result<()> {
 
 #[tokio::test]
 async fn select_all() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "SELECT c1 FROM aggregate_simple order by c1";
@@ -316,7 +316,7 @@ async fn select_all() -> Result<()> {
 
 #[tokio::test]
 async fn select_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "SELECT DISTINCT * FROM aggregate_simple";
@@ -333,7 +333,7 @@ async fn select_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn select_distinct_simple_1() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await.unwrap();
 
     let sql = "SELECT DISTINCT c1 FROM aggregate_simple order by c1";
@@ -355,7 +355,7 @@ async fn select_distinct_simple_1() {
 
 #[tokio::test]
 async fn select_distinct_simple_2() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await.unwrap();
 
     let sql = "SELECT DISTINCT c1, c2 FROM aggregate_simple order by c1";
@@ -377,7 +377,7 @@ async fn select_distinct_simple_2() {
 
 #[tokio::test]
 async fn select_distinct_simple_3() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await.unwrap();
 
     let sql = "SELECT distinct c3 FROM aggregate_simple order by c3";
@@ -396,7 +396,7 @@ async fn select_distinct_simple_3() {
 
 #[tokio::test]
 async fn select_distinct_simple_4() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await.unwrap();
 
     let sql = "SELECT distinct c1+c2 as a FROM aggregate_simple";
@@ -418,7 +418,7 @@ async fn select_distinct_simple_4() {
 
 #[tokio::test]
 async fn select_distinct_from() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select
         1 IS DISTINCT FROM CAST(NULL as INT) as a,
@@ -463,7 +463,7 @@ async fn select_distinct_from() {
 
 #[tokio::test]
 async fn select_distinct_from_utf8() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select
         'x' IS DISTINCT FROM NULL as a,
@@ -484,7 +484,7 @@ async fn select_distinct_from_utf8() {
 
 #[tokio::test]
 async fn use_between_expression_in_select_query() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT 1 NOT BETWEEN 3 AND 5";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -532,7 +532,7 @@ async fn use_between_expression_in_select_query() -> Result<()> {
 
 #[tokio::test]
 async fn query_get_indexed_field() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Arc::new(Schema::new(vec![Field::new(
         "some_list",
         DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
@@ -571,7 +571,7 @@ async fn query_get_indexed_field() -> Result<()> {
 
 #[tokio::test]
 async fn query_nested_get_indexed_field() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let nested_dt = DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
     // Nested schema of { "some_list": [[i64]] }
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -634,7 +634,7 @@ async fn query_nested_get_indexed_field() -> Result<()> {
 
 #[tokio::test]
 async fn query_nested_get_indexed_field_on_struct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let nested_dt = DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
     // Nested schema of { "some_struct": { "bar": [i64] } }
     let struct_fields = vec![Field::new("bar", nested_dt.clone(), true)];
@@ -724,7 +724,7 @@ async fn query_on_string_dictionary() -> Result<()> {
     ])
     .unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", batch)?;
 
     // Basic SELECT
@@ -911,7 +911,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
 #[tokio::test]
 async fn query_cte_with_alias() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let schema = Schema::new(vec![
         Field::new("id", DataType::Int16, false),
         Field::new("a", DataType::Int16, false),
@@ -936,7 +936,7 @@ async fn query_cte_with_alias() -> Result<()> {
 async fn query_cte() -> Result<()> {
     // Test for SELECT <expression> without FROM.
     // Should evaluate expressions in project position.
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // simple with
     let sql = "WITH t AS (SELECT 1) SELECT * FROM t";
@@ -996,7 +996,9 @@ async fn query_cte() -> Result<()> {
 
 #[tokio::test]
 async fn csv_select_nested() -> Result<()> {
-    let ctx = SessionContext::new();
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    let ctx = create_test_ctx_skip_failing_optimizer_rules();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT o1, o2, c3
                FROM (
@@ -1028,7 +1030,9 @@ async fn csv_select_nested() -> Result<()> {
 
 #[tokio::test]
 async fn csv_select_nested_without_aliases() -> Result<()> {
-    let ctx = SessionContext::new();
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    let ctx = create_test_ctx_skip_failing_optimizer_rules();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT o1, o2, c3
                FROM (
@@ -1060,7 +1064,7 @@ async fn csv_select_nested_without_aliases() -> Result<()> {
 
 #[tokio::test]
 async fn csv_join_unaliased_subqueries() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT o1, o2, c3, p1, p2, p3 FROM \
         (SELECT c1 AS o1, c2 + 1 AS o2, c3 FROM aggregate_test_100), \
@@ -1146,7 +1150,7 @@ async fn query_with_filter_string_type_coercion() {
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(large_string_array)])
             .unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("t", batch).unwrap();
     let sql = "select * from t where large_string = '1'";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1176,7 +1180,7 @@ async fn query_with_filter_string_type_coercion() {
 
 #[tokio::test]
 async fn query_empty_table() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let empty_table = Arc::new(EmptyTable::new(Arc::new(Schema::empty())));
     ctx.register_table("test_tbl", empty_table).unwrap();
     let sql = "SELECT * FROM test_tbl";
@@ -1211,7 +1215,9 @@ async fn boolean_literal() -> Result<()> {
 
 #[tokio::test]
 async fn unprojected_filter() {
-    let ctx = SessionContext::new();
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    let ctx = create_test_ctx_skip_failing_optimizer_rules();
     let df = ctx.read_table(table_with_sequence(1, 3).unwrap()).unwrap();
 
     let df = df
@@ -1238,7 +1244,7 @@ async fn case_sensitive_in_default_dialect() {
     let batch =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(int32_array)]).unwrap();
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("t", batch).unwrap();
 
     {

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -998,6 +998,8 @@ async fn query_cte() -> Result<()> {
 async fn csv_select_nested() -> Result<()> {
     // TODO we should not be ignoring optimizer errors here
     // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal(\"Optimizer rule 'unwrap_cast_in_comparison' failed due to unexpected error:
+    //   Internal error: Error target data type UInt32
     let ctx = create_test_ctx_skip_failing_optimizer_rules();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT o1, o2, c3
@@ -1032,6 +1034,8 @@ async fn csv_select_nested() -> Result<()> {
 async fn csv_select_nested_without_aliases() -> Result<()> {
     // TODO we should not be ignoring optimizer errors here
     // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal(\"Optimizer rule 'unwrap_cast_in_comparison' failed due to unexpected error:
+    //   Internal error: Error target data type UInt32
     let ctx = create_test_ctx_skip_failing_optimizer_rules();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT o1, o2, c3
@@ -1217,6 +1221,8 @@ async fn boolean_literal() -> Result<()> {
 async fn unprojected_filter() {
     // TODO we should not be ignoring optimizer errors here
     // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal("Optimizer rule 'type_coercion' failed due to unexpected error: Schema error:
+    // No field named '?table?.i'. Valid fields are '?table?.i + ?table?.i'."
     let ctx = create_test_ctx_skip_failing_optimizer_rules();
     let df = ctx.read_table(table_with_sequence(1, 3).unwrap()).unwrap();
 

--- a/datafusion/core/tests/sql/subqueries.rs
+++ b/datafusion/core/tests/sql/subqueries.rs
@@ -18,7 +18,6 @@
 use super::*;
 use crate::sql::execute_to_batches;
 use datafusion::assert_batches_eq;
-use datafusion::prelude::SessionContext;
 use log::debug;
 
 #[cfg(test)]
@@ -29,7 +28,7 @@ fn init() {
 
 #[tokio::test]
 async fn correlated_recursive_scalar_subquery() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "customer").await?;
     register_tpch_csv(&ctx, "orders").await?;
     register_tpch_csv(&ctx, "lineitem").await?;
@@ -80,7 +79,7 @@ async fn correlated_where_in() -> Result<()> {
 65,7382,897,2,22,28366.36,0,0.05,N,O,1995-07-17,1995-06-04,1995-07-19,COLLECT COD,FOB,
 "#;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv_data(&ctx, "orders", orders).await?;
     register_tpch_csv_data(&ctx, "lineitem", lineitems).await?;
 
@@ -117,7 +116,7 @@ where o_orderstatus in (
 
 #[tokio::test]
 async fn tpch_q2_correlated() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "part").await?;
     register_tpch_csv(&ctx, "supplier").await?;
     register_tpch_csv(&ctx, "partsupp").await?;
@@ -186,7 +185,7 @@ async fn tpch_q4_correlated() -> Result<()> {
 65,5970,481,1,26,48775.22,0.03,0.03,A,F,1995-04-20,1995-04-25,1995-05-13,NONE,TRUCK,
 "#;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv_data(&ctx, "orders", orders).await?;
     register_tpch_csv_data(&ctx, "lineitem", lineitems).await?;
 
@@ -238,7 +237,7 @@ async fn tpch_q17_correlated() -> Result<()> {
 1,63700,3701,3,1.0,13309.6,0.1,0.02,N,O,1996-01-29,1996-03-05,1996-01-31,TAKE BACK RETURN,REG AIR,"riously. regular, express dep"
 "#;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv_data(&ctx, "part", parts).await?;
     register_tpch_csv_data(&ctx, "lineitem", lineitems).await?;
 
@@ -291,7 +290,7 @@ async fn tpch_q17_correlated() -> Result<()> {
 
 #[tokio::test]
 async fn tpch_q20_correlated() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "supplier").await?;
     register_tpch_csv(&ctx, "nation").await?;
     register_tpch_csv(&ctx, "partsupp").await?;
@@ -353,7 +352,7 @@ order by s_name;
 
 #[tokio::test]
 async fn tpch_q22_correlated() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "customer").await?;
     register_tpch_csv(&ctx, "orders").await?;
 
@@ -415,7 +414,7 @@ order by cntrycode;"#;
 
 #[tokio::test]
 async fn tpch_q11_correlated() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_tpch_csv(&ctx, "partsupp").await?;
     register_tpch_csv(&ctx, "supplier").await?;
     register_tpch_csv(&ctx, "nation").await?;

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1048,6 +1048,8 @@ async fn sub_interval_day() -> Result<()> {
 async fn cast_string_to_time() {
     // TODO we should not be ignoring optimizer errors here
     // https://github.com/apache/arrow-datafusion/issues/3695
+    // Internal error: Optimizer rule 'simplify_expressions' failed due to unexpected error:
+    //   Arrow error: Cast error: Cannot cast string 'not a time' to value of Time64(Nanosecond) type
     let ctx = create_test_ctx_skip_failing_optimizer_rules();
 
     let sql = "select \

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -21,7 +21,7 @@ use std::ops::Add;
 
 #[tokio::test]
 async fn query_cast_timestamp_millis() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -52,7 +52,7 @@ async fn query_cast_timestamp_millis() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_micros() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -84,7 +84,7 @@ async fn query_cast_timestamp_micros() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_seconds() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -114,7 +114,7 @@ async fn query_cast_timestamp_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     // Original column is nanos, convert to millis and check timestamp
@@ -164,7 +164,7 @@ async fn query_cast_timestamp_nanos_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_secs", make_timestamp_table::<TimestampSecondType>()?)?;
 
     // Original column is seconds, convert to millis and check timestamp
@@ -214,7 +214,7 @@ async fn query_cast_timestamp_seconds_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_micros_to_others() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table(
         "ts_micros",
         make_timestamp_table::<TimestampMicrosecondType>()?,
@@ -266,7 +266,7 @@ async fn query_cast_timestamp_micros_to_others() -> Result<()> {
 
 #[tokio::test]
 async fn query_cast_timestamp_from_unixtime() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let t1_schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
     let t1_data = RecordBatch::try_new(
@@ -296,7 +296,7 @@ async fn query_cast_timestamp_from_unixtime() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp('2020-09-08T12:00:00+00:00')";
@@ -315,7 +315,7 @@ async fn to_timestamp() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_millis() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table(
         "ts_data",
         make_timestamp_table::<TimestampMillisecondType>()?,
@@ -336,7 +336,7 @@ async fn to_timestamp_millis() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_micros() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table(
         "ts_data",
         make_timestamp_table::<TimestampMicrosecondType>()?,
@@ -358,7 +358,7 @@ async fn to_timestamp_micros() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_seconds() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_data", make_timestamp_table::<TimestampSecondType>()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp_seconds('2020-09-08T12:00:00+00:00')";
@@ -377,7 +377,7 @@ async fn to_timestamp_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn from_unixtime() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_data", make_timestamp_table::<TimestampSecondType>()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > from_unixtime(1599566400)"; // '2020-09-08T12:00:00+00:00'
@@ -396,7 +396,7 @@ async fn from_unixtime() -> Result<()> {
 
 #[tokio::test]
 async fn count_distinct_timestamps() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     let sql = "SELECT COUNT(DISTINCT(ts)) FROM ts_data";
@@ -416,7 +416,7 @@ async fn count_distinct_timestamps() -> Result<()> {
 #[tokio::test]
 async fn test_current_timestamp_expressions() -> Result<()> {
     let t1 = chrono::Utc::now().timestamp();
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let actual = execute(&ctx, "SELECT NOW(), NOW() as t2").await;
     let res1 = actual[0][0].as_str();
     let res2 = actual[0][1].as_str();
@@ -433,7 +433,7 @@ async fn test_current_timestamp_expressions() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_in_same_stmt_using_sql_function() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let df1 = ctx.sql("select now(), now() as now2").await?;
     let result = result_vec(&df1.collect().await?);
@@ -444,7 +444,7 @@ async fn test_now_in_same_stmt_using_sql_function() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_across_statements() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let actual1 = execute(&ctx, "SELECT NOW()").await;
     let res1 = actual1[0][0].as_str();
@@ -459,7 +459,7 @@ async fn test_now_across_statements() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_across_statements_using_sql_function() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let df1 = ctx.sql("select now()").await?;
     let rb1 = df1.collect().await?;
@@ -478,7 +478,7 @@ async fn test_now_across_statements_using_sql_function() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_dataframe_api() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let df = ctx.sql("select 1").await?; // use this to get a DataFrame
     let df = df.select(vec![now(), now().alias("now2")])?;
     let result = result_vec(&df.collect().await?);
@@ -489,7 +489,7 @@ async fn test_now_dataframe_api() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_dataframe_api_across_statements() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let df = ctx.sql("select 1").await?; // use this to get a DataFrame
     let df = df.select(vec![now()])?;
     let result = result_vec(&df.collect().await?);
@@ -505,7 +505,7 @@ async fn test_now_dataframe_api_across_statements() -> Result<()> {
 
 #[tokio::test]
 async fn test_now_in_view() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let _df = ctx
         .sql("create or replace view test_now as select now()")
         .await?
@@ -525,7 +525,7 @@ async fn test_now_in_view() -> Result<()> {
 
 #[tokio::test]
 async fn timestamp_minmax() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let table_a = make_timestamp_tz_table::<TimestampMillisecondType>(None)?;
     let table_b =
         make_timestamp_tz_table::<TimestampNanosecondType>(Some("UTC".to_owned()))?;
@@ -549,7 +549,7 @@ async fn timestamp_minmax() -> Result<()> {
 #[tokio::test]
 async fn timestamp_coercion() -> Result<()> {
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a =
             make_timestamp_tz_table::<TimestampSecondType>(Some("UTC".to_owned()))?;
         let table_b =
@@ -578,7 +578,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampSecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -606,7 +606,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampSecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -633,7 +633,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -660,7 +660,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -687,7 +687,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMillisecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -714,7 +714,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -741,7 +741,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMillisecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -768,7 +768,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampMicrosecondType>()?;
         let table_b = make_timestamp_table::<TimestampNanosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -795,7 +795,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampSecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -822,7 +822,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMillisecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -849,7 +849,7 @@ async fn timestamp_coercion() -> Result<()> {
     }
 
     {
-        let ctx = SessionContext::new();
+        let ctx = create_test_ctx();
         let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
         let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
         ctx.register_table("table_a", table_a)?;
@@ -880,7 +880,7 @@ async fn timestamp_coercion() -> Result<()> {
 
 #[tokio::test]
 async fn group_by_timestamp_millis() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new(
@@ -926,7 +926,7 @@ async fn group_by_timestamp_millis() -> Result<()> {
 
 #[tokio::test]
 async fn interval_year() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-01-01' + interval '1' year as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -946,7 +946,7 @@ async fn interval_year() -> Result<()> {
 
 #[tokio::test]
 async fn add_interval_month() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-01-31' + interval '1' month as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -966,7 +966,7 @@ async fn add_interval_month() -> Result<()> {
 
 #[tokio::test]
 async fn sub_interval_month() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-03-31' - interval '1' month as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -986,7 +986,7 @@ async fn sub_interval_month() -> Result<()> {
 
 #[tokio::test]
 async fn sub_month_wrap() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-01-15' - interval '1' month as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1006,7 +1006,7 @@ async fn sub_month_wrap() -> Result<()> {
 
 #[tokio::test]
 async fn add_interval_day() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-01-15' + interval '1' day as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1026,7 +1026,7 @@ async fn add_interval_day() -> Result<()> {
 
 #[tokio::test]
 async fn sub_interval_day() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select date '1994-01-01' - interval '1' day as date;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1046,7 +1046,9 @@ async fn sub_interval_day() -> Result<()> {
 
 #[tokio::test]
 async fn cast_string_to_time() {
-    let ctx = SessionContext::new();
+    // TODO we should not be ignoring optimizer errors here
+    // https://github.com/apache/arrow-datafusion/issues/3695
+    let ctx = create_test_ctx_skip_failing_optimizer_rules();
 
     let sql = "select \
         time '08:09:10.123456789' as time_nano, \
@@ -1084,7 +1086,7 @@ async fn cast_string_to_time() {
 
 #[tokio::test]
 async fn cast_to_timestamp_twice() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp(a) from (select to_timestamp(1) as a)A;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1104,7 +1106,7 @@ async fn cast_to_timestamp_twice() -> Result<()> {
 
 #[tokio::test]
 async fn cast_to_timestamp_seconds_twice() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql =
         "select to_timestamp_seconds(a) from (select to_timestamp_seconds(1) as a)A;";
@@ -1125,7 +1127,7 @@ async fn cast_to_timestamp_seconds_twice() -> Result<()> {
 
 #[tokio::test]
 async fn cast_to_timestamp_millis_twice() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp_millis(a) from (select to_timestamp_millis(1) as a)A;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1145,7 +1147,7 @@ async fn cast_to_timestamp_millis_twice() -> Result<()> {
 
 #[tokio::test]
 async fn cast_to_timestamp_micros_twice() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp_micros(a) from (select to_timestamp_micros(1) as a)A;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1165,7 +1167,7 @@ async fn cast_to_timestamp_micros_twice() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_i32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp(cast (1 as int));";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1185,7 +1187,7 @@ async fn to_timestamp_i32() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_micros_i32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp_micros(cast (1 as int));";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1205,7 +1207,7 @@ async fn to_timestamp_micros_i32() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_millis_i32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp_millis(cast (1 as int));";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1225,7 +1227,7 @@ async fn to_timestamp_millis_i32() -> Result<()> {
 
 #[tokio::test]
 async fn to_timestamp_seconds_i32() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select to_timestamp_seconds(cast (1 as int));";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1245,7 +1247,7 @@ async fn to_timestamp_seconds_i32() -> Result<()> {
 
 #[tokio::test]
 async fn date_bin() {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT DATE_BIN(INTERVAL '15 minutes', TIMESTAMP '2022-08-03 14:38:50Z', TIMESTAMP '1970-01-01T00:00:00Z') AS res";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1356,7 +1358,7 @@ async fn date_bin() {
 
 #[tokio::test]
 async fn timestamp_add_interval_second() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT NOW(), NOW() + INTERVAL '1' SECOND;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1375,7 +1377,7 @@ async fn timestamp_add_interval_second() -> Result<()> {
 
 #[tokio::test]
 async fn timestamp_sub_interval_days() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT NOW(), NOW() - INTERVAL '8' DAY;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1395,7 +1397,7 @@ async fn timestamp_sub_interval_days() -> Result<()> {
 #[tokio::test]
 #[ignore] // https://github.com/apache/arrow-datafusion/issues/3327
 async fn timestamp_add_interval_months() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT NOW(), NOW() + INTERVAL '17' MONTH;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1420,7 +1422,7 @@ async fn timestamp_add_interval_months() -> Result<()> {
 
 #[tokio::test]
 async fn timestamp_sub_interval_years() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "SELECT NOW(), NOW() - INTERVAL '16' YEAR;";
     let results = execute_to_batches(&ctx, sql).await;
@@ -1439,7 +1441,7 @@ async fn timestamp_sub_interval_years() -> Result<()> {
 
 #[tokio::test]
 async fn timestamp_array_add_interval() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
     let table_b = make_timestamp_table::<TimestampMicrosecondType>()?;
     ctx.register_table("table_a", table_a)?;
@@ -1502,7 +1504,7 @@ async fn timestamp_array_add_interval() -> Result<()> {
 #[tokio::test]
 async fn cast_timestamp_before_1970() -> Result<()> {
     // this is a repro for issue #3082
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     let sql = "select cast('1969-01-01T00:00:00Z' as timestamp);";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1533,7 +1535,7 @@ async fn cast_timestamp_before_1970() -> Result<()> {
 
 #[tokio::test]
 async fn cast_timestamp_to_timestamptz() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let table_a = make_timestamp_table::<TimestampNanosecondType>()?;
 
     ctx.register_table("table_a", table_a)?;

--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -27,7 +27,7 @@ use datafusion::{
 /// physical plan have the same schema.
 #[tokio::test]
 async fn csv_query_custom_udf_with_cast() -> Result<()> {
-    let ctx = create_ctx()?;
+    let ctx = create_ctx_with_custom_udf()?;
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT avg(custom_sqrt(c11)) FROM aggregate_test_100";
     let actual = execute(&ctx, sql).await;

--- a/datafusion/core/tests/sql/unicode.rs
+++ b/datafusion/core/tests/sql/unicode.rs
@@ -114,7 +114,7 @@ async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
         vec![Arc::new(T::from(vec!["", "a", "aa", "aaa"]))],
     )?;
 
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     ctx.register_batch("test", data)?;
     let sql = "SELECT length(c1) FROM test";
     let actual = execute(&ctx, sql).await;

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn union_all() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT 1 as x UNION ALL SELECT 2 as x";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]
@@ -37,7 +37,7 @@ async fn union_all() -> Result<()> {
 
 #[tokio::test]
 async fn csv_union_all() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql =
         "SELECT c1 FROM aggregate_test_100 UNION ALL SELECT c1 FROM aggregate_test_100";
@@ -48,7 +48,7 @@ async fn csv_union_all() -> Result<()> {
 
 #[tokio::test]
 async fn union_distinct() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "SELECT 1 as x UNION SELECT 1 as x";
     let actual = execute_to_batches(&ctx, sql).await;
     #[rustfmt::skip]
@@ -65,7 +65,7 @@ async fn union_distinct() -> Result<()> {
 
 #[tokio::test]
 async fn union_all_with_aggregate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql =
         "SELECT SUM(d) FROM (SELECT 1 as c, 2 as d UNION ALL SELECT 1 as c, 3 AS d) as a";
     let actual = execute_to_batches(&ctx, sql).await;

--- a/datafusion/core/tests/sql/wildcard.rs
+++ b/datafusion/core/tests/sql/wildcard.rs
@@ -19,7 +19,7 @@ use super::*;
 
 #[tokio::test]
 async fn select_qualified_wildcard() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "SELECT agg.* FROM aggregate_simple as agg order by c1";
@@ -54,7 +54,7 @@ async fn select_qualified_wildcard() -> Result<()> {
 
 #[tokio::test]
 async fn select_non_alias_qualified_wildcard() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "SELECT aggregate_simple.* FROM aggregate_simple order by c1";
@@ -132,7 +132,7 @@ async fn select_non_alias_qualified_wildcard_join() -> Result<()> {
 
 #[tokio::test]
 async fn select_wrong_qualified_wildcard() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_simple_csv(&ctx).await?;
 
     let sql = "SELECT agg.* FROM aggregate_simple order by c1";

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -20,7 +20,7 @@ use super::*;
 /// for window functions without order by the first, last, and nth function call does not make sense
 #[tokio::test]
 async fn csv_query_window_with_empty_over() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "select \
                c9, \
@@ -49,7 +49,7 @@ async fn csv_query_window_with_empty_over() -> Result<()> {
 /// for window functions without order by the first, last, and nth function call does not make sense
 #[tokio::test]
 async fn csv_query_window_with_partition_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "select \
                c9, \
@@ -79,7 +79,7 @@ async fn csv_query_window_with_partition_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_window_with_order_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "select \
                c9, \
@@ -112,7 +112,7 @@ async fn csv_query_window_with_order_by() -> Result<()> {
 
 #[tokio::test]
 async fn csv_query_window_with_partition_by_order_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "select \
                c9, \
@@ -301,7 +301,7 @@ async fn window_partition_by_order_by() -> Result<()> {
 
 #[tokio::test]
 async fn window_expr_eliminate() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
 
     // window expr is not referenced anywhere, eliminate it.
     let sql = "WITH _sample_data AS (
@@ -436,7 +436,7 @@ async fn window_expr_eliminate() -> Result<()> {
 
 #[tokio::test]
 async fn window_in_expression() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select 1 - lag(amount, 1) over (order by idx) from (values ('a', 1, 100), ('a', 2, 150)) as t (col1, idx, amount)";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
@@ -453,7 +453,7 @@ async fn window_in_expression() -> Result<()> {
 
 #[tokio::test]
 async fn window_with_agg_in_expression() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     let sql = "select col1, idx, count(*), sum(amount), lag(sum(amount), 1) over (order by idx) as prev_amount,
         sum(amount) - lag(sum(amount), 1) over (order by idx) as difference from (
         select * from (values ('a', 1, 100), ('a', 2, 150)) as t (col1, idx, amount)
@@ -474,7 +474,7 @@ async fn window_with_agg_in_expression() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_empty() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c3) OVER(),\
@@ -500,7 +500,7 @@ async fn window_frame_empty() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_rows_preceding() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c4) OVER(ORDER BY c4 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -525,7 +525,7 @@ async fn window_frame_rows_preceding() -> Result<()> {
 }
 #[tokio::test]
 async fn window_frame_rows_preceding_with_partition_unique_order_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c4) OVER(PARTITION BY c1 ORDER BY c9 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -554,7 +554,7 @@ async fn window_frame_rows_preceding_with_partition_unique_order_by() -> Result<
 
 // #[tokio::test]
 // async fn window_frame_rows_preceding_with_non_unique_partition() -> Result<()> {
-//     let ctx = SessionContext::new();
+//     let ctx = create_test_ctx();
 //     register_aggregate_csv(&ctx).await?;
 //     let sql = "SELECT \
 //                SUM(c4) OVER(PARTITION BY c1 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -580,7 +580,7 @@ async fn window_frame_rows_preceding_with_partition_unique_order_by() -> Result<
 
 #[tokio::test]
 async fn window_frame_ranges_preceding_following_desc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c4) OVER(ORDER BY c2 DESC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -607,7 +607,7 @@ async fn window_frame_ranges_preceding_following_desc() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_asc_desc_large() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT
                 SUM(c5) OVER (ORDER BY c2 ASC, c6 DESC)
@@ -631,7 +631,7 @@ async fn window_frame_order_by_asc_desc_large() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_desc_large() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT
                 SUM(c5) OVER (ORDER BY c2 DESC, c6 ASC)
@@ -656,7 +656,7 @@ async fn window_frame_order_by_desc_large() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_null_timestamp_order_by() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
                 SUM(c1) OVER (ORDER BY c2 DESC)
@@ -680,7 +680,7 @@ async fn window_frame_order_by_null_timestamp_order_by() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_null_desc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
                 COUNT(c2) OVER (ORDER BY c1 DESC RANGE BETWEEN 5 PRECEDING AND 3 FOLLOWING)
@@ -704,7 +704,7 @@ async fn window_frame_order_by_null_desc() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_null_asc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
                 COUNT(c2) OVER (ORDER BY c1 RANGE BETWEEN 5 PRECEDING AND 3 FOLLOWING)
@@ -729,7 +729,7 @@ async fn window_frame_order_by_null_asc() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_null_asc_null_first() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
                 COUNT(c2) OVER (ORDER BY c1 NULLS FIRST RANGE BETWEEN 5 PRECEDING AND 3 FOLLOWING)
@@ -753,7 +753,7 @@ async fn window_frame_order_by_null_asc_null_first() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_null_desc_null_last() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
                 COUNT(c2) OVER (ORDER BY c1 DESC NULLS LAST RANGE BETWEEN 5 PRECEDING AND 3 FOLLOWING)
@@ -777,7 +777,7 @@ async fn window_frame_order_by_null_desc_null_last() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_rows_order_by_null() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_null_cases_csv(&ctx).await?;
     let sql = "SELECT
         SUM(c1) OVER (ORDER BY c3 RANGE BETWEEN 10 PRECEDING AND 11 FOLLOWING) as a,
@@ -838,7 +838,7 @@ async fn window_frame_rows_order_by_null() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_rows_preceding_with_unique_partition() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c4) OVER(PARTITION BY c1 ORDER BY c9 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -864,7 +864,7 @@ async fn window_frame_rows_preceding_with_unique_partition() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_preceding_following() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c4) OVER(ORDER BY c2 RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING),\
@@ -891,7 +891,7 @@ async fn window_frame_ranges_preceding_following() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_string_check() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(LENGTH(c13)) OVER(ORDER BY c13), \
@@ -917,7 +917,7 @@ async fn window_frame_ranges_string_check() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_order_by_unique() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c5) OVER (ORDER BY c5), \
@@ -946,7 +946,7 @@ async fn window_frame_order_by_unique() -> Result<()> {
 ///
 // #[tokio::test]
 // async fn window_frame_order_by_non_unique() -> Result<()> {
-//     let ctx = SessionContext::new();
+//     let ctx = create_test_ctx();
 //     register_aggregate_csv(&ctx).await?;
 //     let sql = "SELECT \
 //                c2, \
@@ -974,7 +974,7 @@ async fn window_frame_order_by_unique() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_unbounded_preceding_following() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c2) OVER (ORDER BY c2 RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING), \
@@ -1000,7 +1000,7 @@ async fn window_frame_ranges_unbounded_preceding_following() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_preceding_and_preceding() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c2) OVER (ORDER BY c2 RANGE BETWEEN 3 PRECEDING AND 1 PRECEDING), \
@@ -1026,7 +1026,7 @@ async fn window_frame_ranges_preceding_and_preceding() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_unbounded_preceding_following_diff_col() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT \
                SUM(c2) OVER (ORDER BY c2 RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING), \
@@ -1052,7 +1052,7 @@ async fn window_frame_ranges_unbounded_preceding_following_diff_col() -> Result<
 
 #[tokio::test]
 async fn window_frame_partition_by_order_by_desc() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT
                SUM(c4) OVER(PARTITION BY c1 ORDER BY c2 DESC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
@@ -1077,7 +1077,7 @@ async fn window_frame_partition_by_order_by_desc() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_ranges_unbounded_preceding_err() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     // execute the query
     let df = ctx
@@ -1100,7 +1100,7 @@ async fn window_frame_ranges_unbounded_preceding_err() -> Result<()> {
 
 #[tokio::test]
 async fn window_frame_groups_query() -> Result<()> {
-    let ctx = SessionContext::new();
+    let ctx = create_test_ctx();
     register_aggregate_csv(&ctx).await?;
     // execute the query
     let df = ctx


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/3695

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


Our tests currently ignore failing optimizer rules, so we are not catching regressions.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Replace `SessionContext::new()` with a call to a new `create_test_ctx()` function, which does not skip failing optimizer rules
- Create a `create_test_ctx_skip_failing_optimizer_rules` function to use in the tests that would otherwise fail due to existing optimizer bugs:

```
    sql::group_by::csv_query_having_without_group_by
    sql::joins::equijoin_implicit_syntax_with_filter
    sql::joins::equijoin_left_and_condition_from_left
    sql::joins::equijoin_right_and_condition_from_left
    sql::joins::equijoin_right_and_condition_from_right
    sql::joins::reduce_left_join_1
    sql::joins::reduce_left_join_2
    sql::joins::reduce_left_join_3
    sql::joins::self_join_non_equijoin
    sql::select::csv_select_nested
    sql::select::csv_select_nested_without_aliases
    sql::select::unprojected_filter
    sql::timestamp::cast_string_to_time
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->