### PR TITLE
Remove type coercions from ScalarValue and aggregation function code

### DIFF
--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -230,7 +230,6 @@ impl RowAccumulator for AvgRowAccumulator {
 
         // sum
         sum::add_to_row(
-            &self.sum_datatype,
             self.state_index() + 1,
             accessor,
             &sum::sum_batch(values, &self.sum_datatype)?,
@@ -249,12 +248,8 @@ impl RowAccumulator for AvgRowAccumulator {
         accessor.add_u64(self.state_index(), delta);
 
         // sum
-        sum::add_to_row(
-            &self.sum_datatype,
-            self.state_index() + 1,
-            accessor,
-            &sum::sum_batch(&states[1], &self.sum_datatype)?,
-        )?;
+        let difference = sum::sum_batch(&states[1], &self.sum_datatype)?;
+        sum::add_to_row(self.state_index() + 1, accessor, &difference)?;
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -301,8 +301,7 @@ mod tests {
             array,
             DataType::Decimal128(10, 0),
             Avg,
-            ScalarValue::Decimal128(Some(35000), 14, 4),
-            DataType::Decimal128(14, 4)
+            ScalarValue::Decimal128(Some(35000), 14, 4)
         )
     }
 
@@ -318,8 +317,7 @@ mod tests {
             array,
             DataType::Decimal128(10, 0),
             Avg,
-            ScalarValue::Decimal128(Some(32500), 14, 4),
-            DataType::Decimal128(14, 4)
+            ScalarValue::Decimal128(Some(32500), 14, 4)
         )
     }
 
@@ -337,21 +335,14 @@ mod tests {
             array,
             DataType::Decimal128(10, 0),
             Avg,
-            ScalarValue::Decimal128(None, 14, 4),
-            DataType::Decimal128(14, 4)
+            ScalarValue::Decimal128(None, 14, 4)
         )
     }
 
     #[test]
     fn avg_i32() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Avg,
-            ScalarValue::from(3_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Int32, Avg, ScalarValue::from(3_f64))
     }
 
     #[test]
@@ -363,63 +354,33 @@ mod tests {
             Some(4),
             Some(5),
         ]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Avg,
-            ScalarValue::from(3.25f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Int32, Avg, ScalarValue::from(3.25f64))
     }
 
     #[test]
     fn avg_i32_all_nulls() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Avg,
-            ScalarValue::Float64(None),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Int32, Avg, ScalarValue::Float64(None))
     }
 
     #[test]
     fn avg_u32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(UInt32Array::from(vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32]));
-        generic_test_op!(
-            a,
-            DataType::UInt32,
-            Avg,
-            ScalarValue::from(3.0f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::UInt32, Avg, ScalarValue::from(3.0f64))
     }
 
     #[test]
     fn avg_f32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float32Array::from(vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32]));
-        generic_test_op!(
-            a,
-            DataType::Float32,
-            Avg,
-            ScalarValue::from(3_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float32, Avg, ScalarValue::from(3_f64))
     }
 
     #[test]
     fn avg_f64() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
-        generic_test_op!(
-            a,
-            DataType::Float64,
-            Avg,
-            ScalarValue::from(3_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float64, Avg, ScalarValue::from(3_f64))
     }
 }

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -217,8 +217,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Correlation,
-            ScalarValue::from(0.9819805060619659),
-            DataType::Float64
+            ScalarValue::from(0.9819805060619659_f64)
         )
     }
 
@@ -233,8 +232,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Correlation,
-            ScalarValue::from(0.17066403719657236),
-            DataType::Float64
+            ScalarValue::from(0.17066403719657236_f64)
         )
     }
 
@@ -249,8 +247,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Correlation,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 
@@ -269,8 +266,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Correlation,
-            ScalarValue::from(0.9860135594710389),
-            DataType::Float64
+            ScalarValue::from(0.9860135594710389_f64)
         )
     }
 
@@ -285,8 +281,7 @@ mod tests {
             DataType::Int32,
             DataType::Int32,
             Correlation,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 
@@ -300,8 +295,7 @@ mod tests {
             DataType::UInt32,
             DataType::UInt32,
             Correlation,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 
@@ -315,8 +309,7 @@ mod tests {
             DataType::Float32,
             DataType::Float32,
             Correlation,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 
@@ -333,8 +326,7 @@ mod tests {
             DataType::Int32,
             DataType::Int32,
             Correlation,
-            ScalarValue::from(0.1889822365046137),
-            DataType::Float64
+            ScalarValue::from(0.1889822365046137_f64)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -210,13 +210,7 @@ mod tests {
     #[test]
     fn count_elements() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Count,
-            ScalarValue::from(5i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Int32, Count, ScalarValue::from(5i64))
     }
 
     #[test]
@@ -229,13 +223,7 @@ mod tests {
             Some(3),
             None,
         ]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Count,
-            ScalarValue::from(3i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Int32, Count, ScalarValue::from(3i64))
     }
 
     #[test]
@@ -243,51 +231,27 @@ mod tests {
         let a: ArrayRef = Arc::new(BooleanArray::from(vec![
             None, None, None, None, None, None, None, None,
         ]));
-        generic_test_op!(
-            a,
-            DataType::Boolean,
-            Count,
-            ScalarValue::from(0i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Boolean, Count, ScalarValue::from(0i64))
     }
 
     #[test]
     fn count_empty() -> Result<()> {
         let a: Vec<bool> = vec![];
         let a: ArrayRef = Arc::new(BooleanArray::from(a));
-        generic_test_op!(
-            a,
-            DataType::Boolean,
-            Count,
-            ScalarValue::from(0i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Boolean, Count, ScalarValue::from(0i64))
     }
 
     #[test]
     fn count_utf8() -> Result<()> {
         let a: ArrayRef =
             Arc::new(StringArray::from(vec!["a", "bb", "ccc", "dddd", "ad"]));
-        generic_test_op!(
-            a,
-            DataType::Utf8,
-            Count,
-            ScalarValue::from(5i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Utf8, Count, ScalarValue::from(5i64))
     }
 
     #[test]
     fn count_large_utf8() -> Result<()> {
         let a: ArrayRef =
             Arc::new(LargeStringArray::from(vec!["a", "bb", "ccc", "dddd", "ad"]));
-        generic_test_op!(
-            a,
-            DataType::LargeUtf8,
-            Count,
-            ScalarValue::from(5i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::LargeUtf8, Count, ScalarValue::from(5i64))
     }
 }

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -397,8 +397,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             CovariancePop,
-            ScalarValue::from(0.6666666666666666),
-            DataType::Float64
+            ScalarValue::from(0.6666666666666666_f64)
         )
     }
 
@@ -413,8 +412,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Covariance,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 
@@ -429,8 +427,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             Covariance,
-            ScalarValue::from(0.9033333333333335_f64),
-            DataType::Float64
+            ScalarValue::from(0.9033333333333335_f64)
         )
     }
 
@@ -445,8 +442,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             CovariancePop,
-            ScalarValue::from(0.6022222222222223_f64),
-            DataType::Float64
+            ScalarValue::from(0.6022222222222223_f64)
         )
     }
 
@@ -465,8 +461,7 @@ mod tests {
             DataType::Float64,
             DataType::Float64,
             CovariancePop,
-            ScalarValue::from(0.7616666666666666),
-            DataType::Float64
+            ScalarValue::from(0.7616666666666666_f64)
         )
     }
 
@@ -481,8 +476,7 @@ mod tests {
             DataType::Int32,
             DataType::Int32,
             CovariancePop,
-            ScalarValue::from(0.6666666666666666_f64),
-            DataType::Float64
+            ScalarValue::from(0.6666666666666666_f64)
         )
     }
 
@@ -496,8 +490,7 @@ mod tests {
             DataType::UInt32,
             DataType::UInt32,
             CovariancePop,
-            ScalarValue::from(0.6666666666666666_f64),
-            DataType::Float64
+            ScalarValue::from(0.6666666666666666_f64)
         )
     }
 
@@ -511,8 +504,7 @@ mod tests {
             DataType::Float32,
             DataType::Float32,
             CovariancePop,
-            ScalarValue::from(0.6666666666666666_f64),
-            DataType::Float64
+            ScalarValue::from(0.6666666666666666_f64)
         )
     }
 
@@ -527,8 +519,7 @@ mod tests {
             DataType::Int32,
             DataType::Int32,
             CovariancePop,
-            ScalarValue::from(1_f64),
-            DataType::Float64
+            ScalarValue::from(1_f64)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -227,13 +227,7 @@ mod tests {
     #[test]
     fn stddev_f64_1() -> Result<()> {
         let a: ArrayRef = Arc::new(Float64Array::from(vec![1_f64, 2_f64]));
-        generic_test_op!(
-            a,
-            DataType::Float64,
-            StddevPop,
-            ScalarValue::from(0.5_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float64, StddevPop, ScalarValue::from(0.5_f64))
     }
 
     #[test]
@@ -243,8 +237,7 @@ mod tests {
             a,
             DataType::Float64,
             StddevPop,
-            ScalarValue::from(0.7760297817881877),
-            DataType::Float64
+            ScalarValue::from(0.7760297817881877_f64)
         )
     }
 
@@ -256,8 +249,7 @@ mod tests {
             a,
             DataType::Float64,
             StddevPop,
-            ScalarValue::from(std::f64::consts::SQRT_2),
-            DataType::Float64
+            ScalarValue::from(std::f64::consts::SQRT_2)
         )
     }
 
@@ -268,8 +260,7 @@ mod tests {
             a,
             DataType::Float64,
             Stddev,
-            ScalarValue::from(0.9504384952922168),
-            DataType::Float64
+            ScalarValue::from(0.9504384952922168_f64)
         )
     }
 
@@ -280,8 +271,7 @@ mod tests {
             a,
             DataType::Int32,
             StddevPop,
-            ScalarValue::from(std::f64::consts::SQRT_2),
-            DataType::Float64
+            ScalarValue::from(std::f64::consts::SQRT_2)
         )
     }
 
@@ -293,8 +283,7 @@ mod tests {
             a,
             DataType::UInt32,
             StddevPop,
-            ScalarValue::from(std::f64::consts::SQRT_2),
-            DataType::Float64
+            ScalarValue::from(std::f64::consts::SQRT_2)
         )
     }
 
@@ -306,8 +295,7 @@ mod tests {
             a,
             DataType::Float32,
             StddevPop,
-            ScalarValue::from(std::f64::consts::SQRT_2),
-            DataType::Float64
+            ScalarValue::from(std::f64::consts::SQRT_2)
         )
     }
 
@@ -341,8 +329,7 @@ mod tests {
             a,
             DataType::Int32,
             StddevPop,
-            ScalarValue::from(1.479019945774904),
-            DataType::Float64
+            ScalarValue::from(1.479019945774904_f64)
         )
     }
 

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -221,65 +221,16 @@ pub(crate) fn add_to_row(
     s: &ScalarValue,
 ) -> Result<()> {
     match (dt, s) {
-        // float64 coerces everything to f64
         (DataType::Float64, ScalarValue::Float64(rhs)) => {
             sum_row!(index, accessor, rhs, f64)
         }
-        (DataType::Float64, ScalarValue::Float32(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::Int64(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::Int32(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::Int16(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::Int8(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::UInt64(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::UInt32(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::UInt16(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        (DataType::Float64, ScalarValue::UInt8(rhs)) => {
-            sum_row!(index, accessor, rhs, f64)
-        }
-        // float32 has no cast
         (DataType::Float32, ScalarValue::Float32(rhs)) => {
             sum_row!(index, accessor, rhs, f32)
         }
-        // u64 coerces u* to u64
         (DataType::UInt64, ScalarValue::UInt64(rhs)) => {
             sum_row!(index, accessor, rhs, u64)
         }
-        (DataType::UInt64, ScalarValue::UInt32(rhs)) => {
-            sum_row!(index, accessor, rhs, u64)
-        }
-        (DataType::UInt64, ScalarValue::UInt16(rhs)) => {
-            sum_row!(index, accessor, rhs, u64)
-        }
-        (DataType::UInt64, ScalarValue::UInt8(rhs)) => {
-            sum_row!(index, accessor, rhs, u64)
-        }
-        // i64 coerces i* to i64
         (DataType::Int64, ScalarValue::Int64(rhs)) => {
-            sum_row!(index, accessor, rhs, i64)
-        }
-        (DataType::Int64, ScalarValue::Int32(rhs)) => {
-            sum_row!(index, accessor, rhs, i64)
-        }
-        (DataType::Int64, ScalarValue::Int16(rhs)) => {
-            sum_row!(index, accessor, rhs, i64)
-        }
-        (DataType::Int64, ScalarValue::Int8(rhs)) => {
             sum_row!(index, accessor, rhs, i64)
         }
         e => {
@@ -414,8 +365,7 @@ mod tests {
             array,
             DataType::Decimal128(10, 0),
             Sum,
-            ScalarValue::Decimal128(Some(15), 20, 0),
-            DataType::Decimal128(20, 0)
+            ScalarValue::Decimal128(Some(15), 20, 0)
         )
     }
 
@@ -442,8 +392,7 @@ mod tests {
             array,
             DataType::Decimal128(35, 0),
             Sum,
-            ScalarValue::Decimal128(Some(13), 38, 0),
-            DataType::Decimal128(38, 0)
+            ScalarValue::Decimal128(Some(13), 38, 0)
         )
     }
 
@@ -465,21 +414,14 @@ mod tests {
             array,
             DataType::Decimal128(10, 0),
             Sum,
-            ScalarValue::Decimal128(None, 20, 0),
-            DataType::Decimal128(20, 0)
+            ScalarValue::Decimal128(None, 20, 0)
         )
     }
 
     #[test]
     fn sum_i32() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Sum,
-            ScalarValue::from(15i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Int32, Sum, ScalarValue::from(15i32))
     }
 
     #[test]
@@ -491,63 +433,33 @@ mod tests {
             Some(4),
             Some(5),
         ]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Sum,
-            ScalarValue::from(13i64),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Int32, Sum, ScalarValue::from(13i32))
     }
 
     #[test]
     fn sum_i32_all_nulls() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            Sum,
-            ScalarValue::Int64(None),
-            DataType::Int64
-        )
+        generic_test_op!(a, DataType::Int32, Sum, ScalarValue::Int32(None))
     }
 
     #[test]
     fn sum_u32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(UInt32Array::from(vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32]));
-        generic_test_op!(
-            a,
-            DataType::UInt32,
-            Sum,
-            ScalarValue::from(15u64),
-            DataType::UInt64
-        )
+        generic_test_op!(a, DataType::UInt32, Sum, ScalarValue::from(15u32))
     }
 
     #[test]
     fn sum_f32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float32Array::from(vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32]));
-        generic_test_op!(
-            a,
-            DataType::Float32,
-            Sum,
-            ScalarValue::from(15_f32),
-            DataType::Float32
-        )
+        generic_test_op!(a, DataType::Float32, Sum, ScalarValue::from(15_f32))
     }
 
     #[test]
     fn sum_f64() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
-        generic_test_op!(
-            a,
-            DataType::Float64,
-            Sum,
-            ScalarValue::from(15_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float64, Sum, ScalarValue::from(15_f64))
     }
 }

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -168,12 +168,11 @@ fn sum_decimal_batch(values: &ArrayRef, precision: u8, scale: u8) -> Result<Scal
         return Ok(ScalarValue::Decimal128(None, precision, scale));
     }
 
-    let mut result = 0_i128;
-    for i in 0..array.len() {
-        if array.is_valid(i) {
-            result += array.value(i).as_i128();
-        }
-    }
+    let result = array.into_iter().fold(0_i128, |s, element| match element {
+        Some(v) => s + v.as_i128(),
+        None => s,
+    });
+
     Ok(ScalarValue::Decimal128(Some(result), precision, scale))
 }
 
@@ -206,38 +205,37 @@ pub(crate) fn sum_batch(values: &ArrayRef, sum_type: &DataType) -> Result<Scalar
 macro_rules! sum_row {
     ($INDEX:ident, $ACC:ident, $DELTA:expr, $TYPE:ident) => {{
         paste::item! {
-            match $DELTA {
-                None => {}
-                Some(v) => $ACC.[<add_ $TYPE>]($INDEX, *v as $TYPE)
+            if let Some(v) = $DELTA {
+                $ACC.[<add_ $TYPE>]($INDEX, *v)
             }
         }
     }};
 }
 
 pub(crate) fn add_to_row(
-    dt: &DataType,
     index: usize,
     accessor: &mut RowAccessor,
     s: &ScalarValue,
 ) -> Result<()> {
-    match (dt, s) {
-        (DataType::Float64, ScalarValue::Float64(rhs)) => {
+    match s {
+        ScalarValue::Float64(rhs) => {
             sum_row!(index, accessor, rhs, f64)
         }
-        (DataType::Float32, ScalarValue::Float32(rhs)) => {
+        ScalarValue::Float32(rhs) => {
             sum_row!(index, accessor, rhs, f32)
         }
-        (DataType::UInt64, ScalarValue::UInt64(rhs)) => {
+        ScalarValue::UInt64(rhs) => {
             sum_row!(index, accessor, rhs, u64)
         }
-        (DataType::Int64, ScalarValue::Int64(rhs)) => {
+        ScalarValue::Int64(rhs) => {
             sum_row!(index, accessor, rhs, i64)
         }
-        e => {
-            return Err(DataFusionError::Internal(format!(
+        _ => {
+            let msg = format!(
                 "Row sum updater is not expected to receive a scalar {:?}",
-                e
-            )));
+                s
+            );
+            return Err(DataFusionError::Internal(msg));
         }
     }
     Ok(())
@@ -254,18 +252,16 @@ impl Accumulator for SumAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
         self.count += (values.len() - values.data().null_count()) as u64;
-        self.sum = self
-            .sum
-            .add(&sum_batch(values, &self.sum.get_datatype())?)?;
+        let delta = sum_batch(values, &self.sum.get_datatype())?;
+        self.sum = self.sum.add(&delta)?;
         Ok(())
     }
 
     fn retract_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
         self.count -= (values.len() - values.data().null_count()) as u64;
-        self.sum = self
-            .sum
-            .sub(&sum_batch(values, &self.sum.get_datatype())?)?;
+        let delta = sum_batch(values, &self.sum.get_datatype())?;
+        self.sum = self.sum.sub(&delta)?;
         Ok(())
     }
 
@@ -304,12 +300,8 @@ impl RowAccumulator for SumRowAccumulator {
         accessor: &mut RowAccessor,
     ) -> Result<()> {
         let values = &values[0];
-        add_to_row(
-            &self.datatype,
-            self.index,
-            accessor,
-            &sum_batch(values, &self.datatype)?,
-        )?;
+        let delta = sum_batch(values, &self.datatype)?;
+        add_to_row(self.index, accessor, &delta)?;
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -200,7 +200,7 @@ mod tests {
     }
 
     macro_rules! generic_test_sum_distinct {
-        ($ARRAY:expr, $DATATYPE:expr, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
+        ($ARRAY:expr, $DATATYPE:expr, $EXPECTED:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $DATATYPE, true)]);
 
             let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![$ARRAY])?;
@@ -208,7 +208,7 @@ mod tests {
             let agg = Arc::new(DistinctSum::new(
                 vec![col("a", &schema)?],
                 "count_distinct_a".to_string(),
-                $EXPECTED_DATATYPE,
+                $EXPECTED.get_datatype(),
             ));
             let actual = aggregate(&batch, agg)?;
             let expected = ScalarValue::from($EXPECTED);
@@ -241,12 +241,7 @@ mod tests {
             Some(2),
             Some(3),
         ]));
-        generic_test_sum_distinct!(
-            array,
-            DataType::Int32,
-            ScalarValue::from(6i64),
-            DataType::Int64
-        )
+        generic_test_sum_distinct!(array, DataType::Int32, ScalarValue::from(6_i32))
     }
 
     #[test]
@@ -258,24 +253,14 @@ mod tests {
             Some(3_u32),
             None,
         ]));
-        generic_test_sum_distinct!(
-            array,
-            DataType::UInt32,
-            ScalarValue::from(4i64),
-            DataType::Int64
-        )
+        generic_test_sum_distinct!(array, DataType::UInt32, ScalarValue::from(4_u32))
     }
 
     #[test]
     fn sum_distinct_f64() -> Result<()> {
         let array: ArrayRef =
             Arc::new(Float64Array::from(vec![1_f64, 1_f64, 3_f64, 3_f64, 3_f64]));
-        generic_test_sum_distinct!(
-            array,
-            DataType::Float64,
-            ScalarValue::from(4_f64),
-            DataType::Float64
-        )
+        generic_test_sum_distinct!(array, DataType::Float64, ScalarValue::from(4_f64))
     }
 
     #[test]
@@ -289,8 +274,7 @@ mod tests {
         generic_test_sum_distinct!(
             array,
             DataType::Decimal128(35, 0),
-            ScalarValue::Decimal128(Some(1), 38, 0),
-            DataType::Decimal128(38, 0)
+            ScalarValue::Decimal128(Some(1), 38, 0)
         )
     }
 }

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -326,8 +326,7 @@ mod tests {
             a,
             DataType::Float64,
             VariancePop,
-            ScalarValue::from(0.25_f64),
-            DataType::Float64
+            ScalarValue::from(0.25_f64)
         )
     }
 
@@ -335,26 +334,14 @@ mod tests {
     fn variance_f64_2() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
-        generic_test_op!(
-            a,
-            DataType::Float64,
-            VariancePop,
-            ScalarValue::from(2_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float64, VariancePop, ScalarValue::from(2_f64))
     }
 
     #[test]
     fn variance_f64_3() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float64Array::from(vec![1_f64, 2_f64, 3_f64, 4_f64, 5_f64]));
-        generic_test_op!(
-            a,
-            DataType::Float64,
-            Variance,
-            ScalarValue::from(2.5_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float64, Variance, ScalarValue::from(2.5_f64))
     }
 
     #[test]
@@ -364,47 +351,28 @@ mod tests {
             a,
             DataType::Float64,
             Variance,
-            ScalarValue::from(0.9033333333333333_f64),
-            DataType::Float64
+            ScalarValue::from(0.9033333333333333_f64)
         )
     }
 
     #[test]
     fn variance_i32() -> Result<()> {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
-        generic_test_op!(
-            a,
-            DataType::Int32,
-            VariancePop,
-            ScalarValue::from(2_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Int32, VariancePop, ScalarValue::from(2_f64))
     }
 
     #[test]
     fn variance_u32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(UInt32Array::from(vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32]));
-        generic_test_op!(
-            a,
-            DataType::UInt32,
-            VariancePop,
-            ScalarValue::from(2.0f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::UInt32, VariancePop, ScalarValue::from(2.0f64))
     }
 
     #[test]
     fn variance_f32() -> Result<()> {
         let a: ArrayRef =
             Arc::new(Float32Array::from(vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32]));
-        generic_test_op!(
-            a,
-            DataType::Float32,
-            VariancePop,
-            ScalarValue::from(2_f64),
-            DataType::Float64
-        )
+        generic_test_op!(a, DataType::Float32, VariancePop, ScalarValue::from(2_f64))
     }
 
     #[test]
@@ -437,8 +405,7 @@ mod tests {
             a,
             DataType::Int32,
             VariancePop,
-            ScalarValue::from(2.1875f64),
-            DataType::Float64
+            ScalarValue::from(2.1875_f64)
         )
     }
 

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -101,6 +101,9 @@ pub(crate) mod tests {
     /// macro to perform an aggregation and verify the result.
     #[macro_export]
     macro_rules! generic_test_op {
+        ($ARRAY:expr, $DATATYPE:expr, $OP:ident, $EXPECTED:expr) => {
+            generic_test_op!($ARRAY, $DATATYPE, $OP, $EXPECTED, $EXPECTED.get_datatype())
+        };
         ($ARRAY:expr, $DATATYPE:expr, $OP:ident, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $DATATYPE, true)]);
 
@@ -123,6 +126,17 @@ pub(crate) mod tests {
     /// macro to perform an aggregation with two inputs and verify the result.
     #[macro_export]
     macro_rules! generic_test_op2 {
+        ($ARRAY1:expr, $ARRAY2:expr, $DATATYPE1:expr, $DATATYPE2:expr, $OP:ident, $EXPECTED:expr) => {
+            generic_test_op2!(
+                $ARRAY1,
+                $ARRAY2,
+                $DATATYPE1,
+                $DATATYPE2,
+                $OP,
+                $EXPECTED,
+                $EXPECTED.get_datatype()
+            )
+        };
         ($ARRAY1:expr, $ARRAY2:expr, $DATATYPE1:expr, $DATATYPE2:expr, $OP:ident, $EXPECTED:expr, $EXPECTED_DATATYPE:expr) => {{
             let schema = Schema::new(vec![
                 Field::new("a", $DATATYPE1, true),


### PR DESCRIPTION
# Which issue does this PR close?

Improves the situation on #2447.

 # Rationale for this change
There is an ongoing effort to reduce/eliminate type coercions in places like `ScalarValue` code, aggregation code and other downstream places (see #2355). The situation we want obtain is to move as many coercions as possible upstream to the extent that we can (see discussions in PR #3570).

This PR improves the current situation by sanitizing `ScalarValue` code and implementation of aggregation functions to remove the coercions therein. For the former, there is only one coercion left (in `try_from_value` function), the need for which arises due to an upstream hardcoding (which we will attempt to fix in the near future).

In many cases, this PR makes the code raise a compile-time error when performing "unsafe" operations that require a coercion (and forces the programmer to add the coercion explicitly). For example, one will get a compile time error if one tries to subtract an unsigned value from an uninitialized `ScalarValue`, or divide such a value to a decimal value -- this wasn't the case before.

# What changes are included in this PR?
As we were removing unnecessary coercions from the codebase, we encountered a "silent upcasting" behavior in the `sum` function, which promotes narrow types to 64-bit types *unconditionally*:

https://github.com/apache/arrow-datafusion/blob/57312284c082c914dd5e1edaa5c1fe3dbe4f222d/datafusion/physical-expr/src/aggregate/sum.rs#L217-L235

We are not 100% sure why this behavior was there, but removing it does not seem to result in any ill-effects. If anyone can tell us why such coercions are necessary, we can add them back in.

# Are there any user-facing changes?
No.