### PR TITLE
Raise `Unsupported SQL type`` for `Time(WithTimeZone)` and `Time(Tz)`

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1554,3 +1554,78 @@ async fn cast_timestamp_to_timestamptz() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cast_to_time() -> Result<()> {
+    let ctx = SessionContext::new();
+    let sql = "SELECT 0::TIME";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+----------+",
+        "| Int64(0) |",
+        "+----------+",
+        "| 00:00:00 |",
+        "+----------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_to_time_with_time_zone_should_not_work() -> Result<()> {
+    // this should not work until we implement tz for DataType::Time64
+    let ctx = SessionContext::new();
+    let sql = "SELECT 0::TIME WITH TIME ZONE";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+----------+",
+        "| Int64(0) |",
+        "+----------+",
+        "| 00:00:00 |",
+        "+----------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_to_time_without_time_zone() -> Result<()> {
+
+    let ctx = SessionContext::new();
+    let sql = "SELECT 0::TIME WITHOUT TIME ZONE";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+----------+",
+        "| Int64(0) |",
+        "+----------+",
+        "| 00:00:00 |",
+        "+----------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_to_timetz_should_not_work() -> Result<()> {
+    // this should not work until we implement tz for DataType::Time64
+    let ctx = SessionContext::new();
+    let sql = "SELECT 0::TIMETZ";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+----------+",
+        "| Int64(0) |",
+        "+----------+",
+        "| 00:00:00 |",
+        "+----------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1578,23 +1578,18 @@ async fn test_cast_to_time_with_time_zone_should_not_work() -> Result<()> {
     // this should not work until we implement tz for DataType::Time64
     let ctx = SessionContext::new();
     let sql = "SELECT 0::TIME WITH TIME ZONE";
-    let actual = execute_to_batches(&ctx, sql).await;
+    let results = plan_and_collect(&ctx, sql).await.unwrap_err();
 
-    let expected = vec![
-        "+----------+",
-        "| Int64(0) |",
-        "+----------+",
-        "| 00:00:00 |",
-        "+----------+",
-    ];
-    assert_batches_eq!(expected, &actual);
+    assert_eq!(
+        results.to_string(),
+        "This feature is not implemented: Unsupported SQL type Time(WithTimeZone)"
+    );
 
     Ok(())
 }
 
 #[tokio::test]
 async fn test_cast_to_time_without_time_zone() -> Result<()> {
-
     let ctx = SessionContext::new();
     let sql = "SELECT 0::TIME WITHOUT TIME ZONE";
     let actual = execute_to_batches(&ctx, sql).await;
@@ -1616,16 +1611,11 @@ async fn test_cast_to_timetz_should_not_work() -> Result<()> {
     // this should not work until we implement tz for DataType::Time64
     let ctx = SessionContext::new();
     let sql = "SELECT 0::TIMETZ";
-    let actual = execute_to_batches(&ctx, sql).await;
+    let results = plan_and_collect(&ctx, sql).await.unwrap_err();
 
-    let expected = vec![
-        "+----------+",
-        "| Int64(0) |",
-        "+----------+",
-        "| 00:00:00 |",
-        "+----------+",
-    ];
-    assert_batches_eq!(expected, &actual);
-
+    assert_eq!(
+        results.to_string(),
+        "This feature is not implemented: Unsupported SQL type Time(Tz)"
+    );
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3715 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`time with time zone` and `timetz` now raise error
```bash
DataFusion CLI v12.0.0
❯ SELECT 0::TIME WITH TIME ZONE;
NotImplemented("Unsupported SQL type Time(WithTimeZone)")
❯ SELECT 0::TIMETZ;
NotImplemented("Unsupported SQL type Time(Tz)")
```


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->