### PR TITLE
Fix output schema generated by CommonSubExprEliminate

### DIFF
--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -19,7 +19,7 @@
 
 use crate::{OptimizerConfig, OptimizerRule};
 use arrow::datatypes::DataType;
-use datafusion_common::{DFField, DFSchema, DataFusionError, Result};
+use datafusion_common::{DFField, DFSchema, DFSchemaRef, DataFusionError, Result};
 use datafusion_expr::{
     col,
     expr_rewriter::{ExprRewritable, ExprRewriter, RewriteRecursion},
@@ -112,22 +112,10 @@ fn optimize(
             )?))
         }
         LogicalPlan::Filter(Filter { predicate, input }) => {
-            let schema = plan.schema().as_ref().clone();
-            let data_type = if let Ok(data_type) = predicate.get_type(&schema) {
-                data_type
-            } else {
-                // predicate type could not be resolved in schema, fall back to all schemas
-                let schemas = plan.all_schemas();
-                let all_schema =
-                    schemas.into_iter().fold(DFSchema::empty(), |mut lhs, rhs| {
-                        lhs.merge(rhs);
-                        lhs
-                    });
-                predicate.get_type(&all_schema)?
-            };
+            let schema = Arc::clone(input.schema());
 
             let mut id_array = vec![];
-            expr_to_identifier(predicate, &mut expr_set, &mut id_array, data_type)?;
+            expr_to_identifier(predicate, &mut expr_set, &mut id_array, schema)?;
 
             let (mut new_expr, new_input) = rewrite_expr(
                 &[&[predicate.clone()]],
@@ -260,9 +248,9 @@ fn to_arrays(
 ) -> Result<Vec<Vec<(usize, String)>>> {
     expr.iter()
         .map(|e| {
-            let data_type = e.get_type(input.schema())?;
+            let schema = Arc::clone(input.schema());
             let mut id_array = vec![];
-            expr_to_identifier(e, expr_set, &mut id_array, data_type)?;
+            expr_to_identifier(e, expr_set, &mut id_array, schema)?;
 
             Ok(id_array)
         })
@@ -370,7 +358,8 @@ struct ExprIdentifierVisitor<'a> {
     expr_set: &'a mut ExprSet,
     /// series number (usize) and identifier.
     id_array: &'a mut Vec<(usize, Identifier)>,
-    data_type: DataType,
+    schema: DFSchemaRef,
+    //todo: also look in all schemas
 
     // inner states
     visit_stack: Vec<VisitRecord>,
@@ -448,7 +437,7 @@ impl ExpressionVisitor for ExprIdentifierVisitor<'_> {
 
         self.id_array[idx] = (self.series_number, desc.clone());
         self.visit_stack.push(VisitRecord::ExprItem(desc.clone()));
-        let data_type = self.data_type.clone();
+        let data_type = expr.get_type(&self.schema)?;
         self.expr_set
             .entry(desc)
             .or_insert_with(|| (expr.clone(), 0, data_type))
@@ -462,12 +451,12 @@ fn expr_to_identifier(
     expr: &Expr,
     expr_set: &mut ExprSet,
     id_array: &mut Vec<(usize, Identifier)>,
-    data_type: DataType,
+    schema: DFSchemaRef,
 ) -> Result<()> {
     expr.accept(ExprIdentifierVisitor {
         expr_set,
         id_array,
-        data_type,
+        schema,
         visit_stack: vec![],
         node_count: 0,
         series_number: 0,
@@ -577,7 +566,8 @@ fn replace_common_expr(
 mod test {
     use super::*;
     use crate::test::*;
-    use datafusion_expr::logical_plan::JoinType;
+    use arrow::datatypes::{Field, Schema};
+    use datafusion_expr::logical_plan::{table_scan, JoinType};
     use datafusion_expr::{
         avg, binary_expr, col, lit, logical_plan::builder::LogicalPlanBuilder, sum,
         Operator,
@@ -605,8 +595,13 @@ mod test {
             lit(2),
         );
 
+        let schema = Arc::new(DFSchema::new_with_metadata(
+            vec![DFField::new(None, "a", DataType::Int64, false)],
+            Default::default(),
+        )?);
+
         let mut id_array = vec![];
-        expr_to_identifier(&expr, &mut HashMap::new(), &mut id_array, DataType::Int64)?;
+        expr_to_identifier(&expr, &mut HashMap::new(), &mut id_array, schema)?;
 
         let expected = vec![
             (9, "SUM(a + Utf8(\"1\")) - AVG(c) * Int32(2)Int32(2)SUM(a + Utf8(\"1\")) - AVG(c)AVG(c)cSUM(a + Utf8(\"1\"))a + Utf8(\"1\")Utf8(\"1\")a"),
@@ -795,5 +790,56 @@ mod test {
         for field in project_2.schema().fields() {
             assert!(field_set.insert(field.qualified_name()));
         }
+    }
+
+    #[test]
+    fn eliminated_subexpr_datatype() {
+        use datafusion_expr::cast;
+
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::UInt64, false),
+            Field::new("b", DataType::UInt64, false),
+            Field::new("c", DataType::UInt64, false),
+        ]);
+
+        let plan = table_scan(Some("table"), &schema, None)
+            .unwrap()
+            .filter(
+                cast(col("a"), DataType::Int64)
+                    .lt(lit(1_i64))
+                    .and(cast(col("a"), DataType::Int64).not_eq(lit(1_i64))),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let rule = CommonSubexprEliminate {};
+        let optimized_plan = rule.optimize(&plan, &mut OptimizerConfig::new()).unwrap();
+
+        let schema = optimized_plan.schema();
+        let fields_with_datatypes: Vec<_> = schema
+            .fields()
+            .iter()
+            .map(|field| (field.name(), field.data_type()))
+            .collect();
+        let formatted_fields_with_datatype = format!("{fields_with_datatypes:#?}");
+        let expected = r###"[
+    (
+        "CAST(table.a AS Int64)table.a",
+        Int64,
+    ),
+    (
+        "a",
+        UInt64,
+    ),
+    (
+        "b",
+        UInt64,
+    ),
+    (
+        "c",
+        UInt64,
+    ),
+]"###;
+        assert_eq!(expected, formatted_fields_with_datatype);
     }
 }

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -396,6 +396,9 @@ struct ExprIdentifierVisitor<'a> {
     input_schema: DFSchemaRef,
     /// all schemas in the logical plan, as a fall back if we cannot resolve an expression type
     /// from the input schema alone
+    // This fallback should never be necessary as the expression datatype should always be
+    // resolvable from the input schema of the node that's being optimized.
+    // todo: This can likely be removed if we are sure it's safe to do so.
     all_schemas: Vec<DFSchemaRef>,
 
     // inner states
@@ -478,7 +481,11 @@ impl ExpressionVisitor for ExprIdentifierVisitor<'_> {
         let data_type = if let Ok(data_type) = expr.get_type(&self.input_schema) {
             data_type
         } else {
-            // expression type could not be resolved in schema, fall back to all schemas
+            // Expression type could not be resolved in schema, fall back to all schemas.
+            //
+            // This fallback should never be necessary as the expression datatype should always be
+            // resolvable from the input schema of the node that's being optimized.
+            // todo: This else-branch can likely be removed if we are sure it's safe to do so.
             let merged_schema =
                 self.all_schemas
                     .iter()


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3635.

 # Rationale for this change

The optimization rule `CommonSubexprEliminate` produces a wrong output schema in many situations. If a logical plan depends on the output schema, it will simply be broken.

# What changes are included in this PR?

* In the `ExprIdentifierVisitor`, which is used to determine the datatype of every sub-expression, the datatype is now determined based on the schema of the logical plan _for every sub-expression individually_ instead of determining the datatype of the _overall expression_ and wrongly assigning it to every sub-expression.
* The `ExprIdentifierVisitor` now, accordingly, does not have a `datatype` attribute but, instead, `input_schema` and `all_schemas`.
  The latter is necessary for a fall-back logic, where if the datatype of a sub-expression cannot be determined using the input schema, we merge the schemas from all nodes of the overall logical plan and try again.
* A test is added to verify the correct datatype of the schema post optimization in the case of optimizing a `Filter` logical plan.

# Are there any user-facing changes?

No.