### PR TITLE
Introduce public API to call type coercion

### DIFF
--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -41,3 +41,4 @@ pub mod test;
 pub mod unwrap_cast_in_comparison;
 
 pub use optimizer::{OptimizerConfig, OptimizerRule};
+pub use type_coercion::coerce_expr;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/3708


 # Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/3708 

# What changes are included in this PR?
1. Add a public `coerce_expr` function and a basic test 

Note I plan to add better documentation / examples via https://github.com/apache/arrow-datafusion/issues/3740 / https://github.com/apache/arrow-datafusion/pull/3741


# Are there any user-facing changes?
New API