### PR TITLE
CI: Add a new run to check whether `datafusion-cli` lock file is up-to-date

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Check workspace with all features
         run: |
           cargo check --workspace --benches --features avro,jit,scheduler,json
+      - name: Check Cargo.lock for datafusion-cli
+        run: |
+          cargo check --manifest-path datafusion-cli/Cargo.toml --locked
 
   # test the crate
   linux-test:

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,6 @@ cpp/Brewfile.lock.json
 target
 Cargo.lock
 !datafusion-cli/Cargo.lock
-!ballista-cli/Cargo.lock
 
 rusty-tags.vi
 .history

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1978,9 +1978,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac9c312566fdfc45a38ecf1924013c82af2a7d5315e46f67b1cc987f12be260"
+checksum = "0781f2b6bd03e5adf065c8e772b49eaea9f640d06a1b9130330fe8bd2563f4fd"
 dependencies = [
  "log",
 ]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3744.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This adds a new script (that only runs on the CI, so a classic `./dev/rust_lint.sh` doesn't waste its time on this check) that ensures the lock file for the datafusion-cli is up-to-date.