### PR TITLE
MINOR: error message parameter order incorrect

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -132,8 +132,8 @@ impl ExternalSorter {
                 let size_delta = size.checked_sub(new_size).ok_or_else(|| {
                     DataFusionError::Internal(format!(
                         "The size of the sorted batch is larger than the size of the input batch: {} > {}",
-                        size,
-                        new_size
+                        new_size,
+                        size
                     ))
                 })?;
                 self.shrink(size_delta);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/issues/3747

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Make error less confusing.

## Before

```
DataFusionError(Internal("The size of the sorted batch is larger than the size of the input batch: 2120 > 2312")) 
```

## After

```
DataFusionError(Internal("The size of the sorted batch is larger than the size of the input batch: 2312 > 2120")) 
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->