### PR TITLE
Fix `ListingTableUrl` to decode percent

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -80,6 +80,7 @@ ordered-float = "3.0"
 parking_lot = "0.12"
 parquet = { version = "24.0.0", features = ["arrow", "async"] }
 paste = "^1.0"
+percent-encoding = "2.2.0"
 pin-project-lite = "^0.2.7"
 pyo3 = { version = "0.17.1", optional = true }
 rand = "0.8"

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -23,8 +23,8 @@ use glob::Pattern;
 use itertools::Itertools;
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
-use url::Url;
 use percent_encoding;
+use url::Url;
 
 /// A parsed URL identifying files for a listing table, see [`ListingTableUrl::parse`]
 /// for more information on the supported expressions
@@ -109,7 +109,8 @@ impl ListingTableUrl {
 
     /// Creates a new [`ListingTableUrl`] from a url and optional glob expression
     fn new(url: Url, glob: Option<Pattern>) -> Self {
-        let decoded_path = percent_encoding::percent_decode_str(url.path()).decode_utf8_lossy();
+        let decoded_path =
+            percent_encoding::percent_decode_str(url.path()).decode_utf8_lossy();
         let prefix = Path::from(decoded_path.as_ref());
         Self { url, prefix, glob }
     }

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -110,7 +110,7 @@ impl ListingTableUrl {
     /// Creates a new [`ListingTableUrl`] from a url and optional glob expression
     fn new(url: Url, glob: Option<Pattern>) -> Self {
         let decoded_path = percent_encoding::percent_decode_str(url.path()).decode_utf8_lossy();
-        let prefix = Path::parse(decoded_path).expect("should be URL safe");
+        let prefix = Path::from(decoded_path.as_ref());
         Self { url, prefix, glob }
     }
 

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -253,7 +253,6 @@ mod tests {
         assert_eq!(url.prefix.as_ref(), "with space/foo/bar");
     }
 
-
     #[test]
     fn test_prefix_s3() {
         let url = ListingTableUrl::parse("s3://bucket/foo/bar").unwrap();

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -249,8 +249,14 @@ mod tests {
         let child = Path::parse("/foob/bar").unwrap();
         assert!(url.strip_prefix(&child).is_none());
 
-        let url = ListingTableUrl::parse("file:///with space/foo/bar").unwrap();
-        assert_eq!(url.prefix.as_ref(), "with space/foo/bar");
+        let url = ListingTableUrl::parse("file:///foo/ bar").unwrap();
+        assert_eq!(url.prefix.as_ref(), "foo/ bar");
+
+        let url = ListingTableUrl::parse("file:///foo/bar?").unwrap();
+        assert_eq!(url.prefix.as_ref(), "foo/bar");
+
+        let url = ListingTableUrl::parse("file:///foo/😺").unwrap();
+        assert_eq!(url.prefix.as_ref(), "foo/%F0%9F%98%BA");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3589 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `percent_encoding` crate to `datafusion/core` to decode percent encoded url path.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->