### PR TITLE
Do not run labeler CI check if it would fail due to permissions

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -28,6 +28,9 @@ jobs:
   process:
     name: Process
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -28,6 +28,9 @@ jobs:
   process:
     name: Process
     runs-on: ubuntu-latest
+    # only run for users whose permissions allow them to update PRs
+    # otherwise labeler is failing:
+    # https://github.com/apache/arrow-datafusion/issues/3743
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3743

 # Rationale for this change
The labeler CI check started failing on most PRs recently which makes it hard to see if a PR has a real problem or not

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Copy https://github.com/apache/arrow-rs/pull/2844 (from @tustvold )

Which I think basically skips running the CI check if the user who submitted the PR doesn't have permissions to update labels on PRs. 

# Are there any user-facing changes?
I suspect the labeler will run less frequently. 

It would be neat if someone could go and sort out how to get it working again -- this PR just treats the symptom not the underlying cause