### PR TITLE
Teach a negative NULL expression to return NULL instead of an error

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -647,6 +647,24 @@ async fn test_not_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_negative_expressions() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "SELECT null, -null";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+------+----------+",
+        "| NULL | (- NULL) |",
+        "+------+----------+",
+        "|      |          |",
+        "+------+----------+",
+    ];
+
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_boolean_expressions() -> Result<()> {
     test_expression!("true", "true");
     test_expression!("false", "false");

--- a/datafusion/expr/src/type_coercion.rs
+++ b/datafusion/expr/src/type_coercion.rs
@@ -48,6 +48,11 @@ pub fn is_signed_numeric(dt: &DataType) -> bool {
     )
 }
 
+// Determine if a DataType is Null or not
+pub fn is_null(dt: &DataType) -> bool {
+    *dt == DataType::Null
+}
+
 /// Determine if a DataType is numeric or not
 pub fn is_numeric(dt: &DataType) -> bool {
     is_signed_numeric(dt)

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -30,7 +30,10 @@ use arrow::{
 
 use crate::PhysicalExpr;
 use datafusion_common::{DataFusionError, Result};
-use datafusion_expr::{type_coercion::is_signed_numeric, ColumnarValue};
+use datafusion_expr::{
+    type_coercion::{is_null, is_signed_numeric},
+    ColumnarValue,
+};
 
 /// Invoke a compute kernel on array(s)
 macro_rules! compute_op {
@@ -119,7 +122,9 @@ pub fn negative(
     input_schema: &Schema,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let data_type = arg.data_type(input_schema)?;
-    if !is_signed_numeric(&data_type) {
+    if is_null(&data_type) {
+        Ok(arg)
+    } else if !is_signed_numeric(&data_type) {
         Err(DataFusionError::Internal(
             format!("Can't create negative physical expr for (- '{:?}'), the type of child expr is {}, not signed numeric", arg, data_type),
         ))


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1192.

 # Rationale for this change
This is a bug fix.

# What changes are included in this PR?

# Are there any user-facing changes?
The expression -null now returns NULL.

There are no API changes that I am aware  #of.  