### PR TITLE
Improve expression simplification by running it twice

### DIFF
--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -106,12 +106,11 @@ fn simplify_demo() -> Result<()> {
         col("i") + lit(3)
     );
 
-    // TODO uncomment when https://github.com/apache/arrow-datafusion/issues/1160 is done
     // (i * 0) > 5 --> false (only if null)
-    // assert_eq!(
-    //     simplifier.simplify((col("i") * lit(0)).gt(lit(5)))?,
-    //     lit(false)
-    // );
+    assert_eq!(
+        simplifier.simplify((col("i") * lit(0)).gt(lit(5)))?,
+        lit(false)
+    );
 
     // Logical simplification
 


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/arrow-datafusion/pull/3741~

# Which issue does this PR close?
re https://github.com/apache/arrow-datafusion/issues/3740
re https://github.com/apache/arrow-datafusion/issues/1160

 # Rationale for this change
There are some fairly simple expressions that should be simplified but yet are not because additional simplifications are unlocked by the constant propagator. 

For example
```
 (i * 0) > 5
```
is only simplified to
```
0 > 5
```

Because the flow is 
* constant evaluator runs on` (i * 0) > 5` which can not do anything,
* simplfy runs on ` (i * 0) > 5` and rewrites to `0 > 5`

Now, if the constant evaluator can run again it will result in `false` which is great. However, it is not run again and thus there is the issue.

I hit the same basic embarrassment while making the example in re https://github.com/apache/arrow-datafusion/issues/1160 

The challenges with a fully general solution to this issue are described  https://github.com/apache/arrow-datafusion/issues/1160. However, we have had good luck in IOx simply running the simplification / constant prop twice



# What changes are included in this PR?
1. run evaluator / constant prop twice
2. Add some more tests


# Are there any user-facing changes?
Better constant propagation
