### PR TITLE
Clarify initial example with respect to capitalization

### DIFF
--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -19,9 +19,7 @@
 
 # Example Usage
 
-In this example some simple processing is performed on a csv file. Please be aware that all identifiers are made lower-case in SQL, so if your csv file has capital letters (ex: Name) you should put your column name in double quotes or the example won't work.
-
-The following example uses [this file](../../../datafusion/core/tests/capitalized_example.csv)
+In this example some simple processing is performed on the [`example.csv`](../../../datafusion/core/tests/example.csv) file.
 
 ## Update `Cargo.toml`
 
@@ -31,6 +29,62 @@ Add the following to your `Cargo.toml` file:
 datafusion = "11.0"
 tokio = "1.0"
 ```
+
+## Run a SQL query against data stored in a CSV:
+
+```rust
+use datafusion::prelude::*;
+
+#[tokio::main]
+async fn main() -> datafusion::error::Result<()> {
+  // register the table
+  let ctx = SessionContext::new();
+  ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new()).await?;
+
+  // create a plan to run a SQL query
+  let df = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100").await?;
+
+  // execute and print results
+  df.show().await?;
+  Ok(())
+}
+```
+
+## Use the DataFrame API to process data stored in a CSV:
+
+```rust
+use datafusion::prelude::*;
+
+#[tokio::main]
+async fn main() -> datafusion::error::Result<()> {
+  // create the dataframe
+  let ctx = SessionContext::new();
+  let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
+
+  let df = df.filter(col("a").lt_eq(col("b")))?
+           .aggregate(vec![col("a")], vec![min(col("b"))])?;
+
+  // execute and print results
+  df.show_limit(100).await?;
+  Ok(())
+}
+```
+
+## Output from both examples
+
+```text
++---+--------+
+| a | MIN(b) |
++---+--------+
+| 1 | 2      |
++---+--------+
+```
+
+# Identifiers and Capitalization
+
+Please be aware that all identifiers are effectively made lower-case in SQL, so if your csv file has capital letters (ex: `Name`) you must put your column name in double quotes or the examples won't work.
+
+To illustrate this behavior, consider the [`capitalized_example.csv`](../../../datafusion/core/tests/capitalized_example.csv) file:
 
 ## Run a SQL query against data stored in a CSV:
 


### PR DESCRIPTION
# Which issue does this PR close?
RE https://github.com/apache/arrow-datafusion/issues/2374

 # Rationale for this change
Keep the initial example simple, yet still hi lighting the common pitfall of SQL capitalization

Per suggestion https://github.com/apache/arrow-datafusion/pull/3385#issuecomment-1276685509

# What changes are included in this PR?
Rework initial example so the example with capitalization added by @nanicpc in https://github.com/apache/arrow-datafusion/pull/3385 is after the example without changes

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->