### PR TITLE
Minor: Sort the output of SHOW ALL by config name

### DIFF
--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -693,15 +693,23 @@ async fn show_all() {
 
     let results = plan_and_collect(&ctx, sql).await.unwrap();
 
-    let expected_length = ctx
-        .state
-        .read()
-        .config
-        .config_options
-        .read()
-        .options()
-        .len();
-    assert_eq!(expected_length, results[0].num_rows());
+    // Has all the default values, should be in order by name
+    let expected = vec![
+        "+-------------------------------------------------+---------+",
+        "| name                                            | setting |",
+        "+-------------------------------------------------+---------+",
+        "| datafusion.execution.batch_size                 | 8192    |",
+        "| datafusion.execution.coalesce_batches           | true    |",
+        "| datafusion.execution.coalesce_target_batch_size | 4096    |",
+        "| datafusion.execution.time_zone                  | UTC     |",
+        "| datafusion.explain.logical_plan_only            | false   |",
+        "| datafusion.explain.physical_plan_only           | false   |",
+        "| datafusion.optimizer.filter_null_join_keys      | false   |",
+        "| datafusion.optimizer.skip_failed_rules          | true    |",
+        "+-------------------------------------------------+---------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
 }
 
 #[tokio::test]

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2416,7 +2416,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let variable_lower = variable.to_lowercase();
 
         let query = if variable_lower == "all" {
-            String::from("SELECT name, setting FROM information_schema.df_settings")
+            // Add an ORDER BY so the output comes out in a consistent order
+            String::from(
+                "SELECT name, setting FROM information_schema.df_settings ORDER BY name",
+            )
         } else if variable_lower == "timezone" || variable_lower == "time.zone" {
             // we could introduce alias in OptionDefinition if this string matching thing grows
             String::from("SELECT name, setting FROM information_schema.df_settings WHERE name = 'datafusion.execution.time_zone'")


### PR DESCRIPTION
 # Rationale for this change
Noticed while working on https://github.com/apache/arrow-datafusion/pull/3822

The `show all` command added by @waitingkuo in https://github.com/apache/arrow-datafusion/pull/3455 is awesome!

When I do `show all` I am trying to verify the setting of a particular configuration option. As coded now, the output comes out in some random order (hash value I suspect):



Before:

```shell
❯ show all;
+-------------------------------------------------+---------+
| name                                            | setting |
+-------------------------------------------------+---------+
| datafusion.execution.coalesce_target_batch_size | 4096    |
| datafusion.optimizer.filter_null_join_keys      | false   |
| datafusion.explain.physical_plan_only           | false   |
| datafusion.explain.logical_plan_only            | false   |
| datafusion.execution.coalesce_batches           | true    |
| datafusion.execution.batch_size                 | 8192    |
| datafusion.optimizer.skip_failed_rules          | true    |
| datafusion.execution.time_zone                  | UTC     |
+-------------------------------------------------+---------+
11 rows in set. Query took 0.005 seconds.
```

After: 🤗 
```shell
❯ show all;
+-------------------------------------------------+---------+
| name                                            | setting |
+-------------------------------------------------+---------+
| datafusion.execution.batch_size                 | 8192    |
| datafusion.execution.coalesce_batches           | true    |
| datafusion.execution.coalesce_target_batch_size | 4096    |
| datafusion.execution.time_zone                  | UTC     |
| datafusion.explain.logical_plan_only            | false   |
| datafusion.explain.physical_plan_only           | false   |
| datafusion.optimizer.filter_null_join_keys      | false   |
| datafusion.optimizer.skip_failed_rules          | true    |
+-------------------------------------------------+---------+
```


# What changes are included in this PR?
Add `ORDER BY` clause and test

# Are there any user-facing changes?
More helpful visibility into config options