### PR TITLE
MINOR: Add datafusion-cli documentation on showing configuration

### DIFF
--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -21,7 +21,7 @@
 
 The DataFusion CLI is a command-line interactive SQL utility that allows
 queries to be executed against any supported data files. It is a convenient way to
-try DataFusion out with your own data sources.
+try DataFusion out with your own data sources, and test out its SQL support.
 
 ## Example
 
@@ -230,4 +230,56 @@ Available commands inside DataFusion CLI are:
 
 ```bash
 > \h function_table
+```
+
+- Show configuration options
+
+```SQL
+> show all;
+
++-------------------------------------------------+---------+
+| name                                            | setting |
++-------------------------------------------------+---------+
+| datafusion.execution.batch_size                 | 8192    |
+| datafusion.execution.coalesce_batches           | true    |
+| datafusion.execution.coalesce_target_batch_size | 4096    |
+| datafusion.execution.time_zone                  | UTC     |
+| datafusion.explain.logical_plan_only            | false   |
+| datafusion.explain.physical_plan_only           | false   |
+| datafusion.optimizer.filter_null_join_keys      | false   |
+| datafusion.optimizer.skip_failed_rules          | true    |
++-------------------------------------------------+---------+
+
+```
+
+## Changing Configuration Options
+
+All available configuration options can be seen using `SHOW
+ALL` as described above.
+
+You can change the configuration options using environment
+variables. `datafusion-cli` looks in the corresponding environment
+variable with an upper case name and all `.` is converted to `_`.
+
+For example, to set `datafusion.execution.batch_size` to `1024` you
+would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable
+appropriately:
+
+```shell
+$ DATAFUSION_EXECUTION_BATCH_SIZE=1024 datafusion-cli
+DataFusion CLI v12.0.0
+❯ show all;
++-------------------------------------------------+---------+
+| name                                            | setting |
++-------------------------------------------------+---------+
+| datafusion.execution.batch_size                 | 1024    |
+| datafusion.execution.coalesce_batches           | true    |
+| datafusion.execution.coalesce_target_batch_size | 4096    |
+| datafusion.execution.time_zone                  | UTC     |
+| datafusion.explain.logical_plan_only            | false   |
+| datafusion.explain.physical_plan_only           | false   |
+| datafusion.optimizer.filter_null_join_keys      | false   |
+| datafusion.optimizer.skip_failed_rules          | true    |
++-------------------------------------------------+---------+
+8 rows in set. Query took 0.002 seconds.
 ```

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -254,8 +254,7 @@ Available commands inside DataFusion CLI are:
 
 ## Changing Configuration Options
 
-All available configuration options can be seen using `SHOW
-ALL` as described above.
+All available configuration options can be seen using `SHOW ALL` as described above.
 
 You can change the configuration options using environment
 variables. `datafusion-cli` looks in the corresponding environment


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change
I love `SHOW ALL` added by @waitingkuo in https://github.com/apache/arrow-datafusion/pull/3455

It also took me some rummaging around in the code to figure out how to control the settings. 

# What changes are included in this PR?
Document how to show/change config in datafusion-cli

# Are there any user-facing changes?
Docs