### PR TITLE
MINOR: Document SHOW ALL in the users guide

### DIFF
--- a/docs/source/user-guide/sql/information_schema.md
+++ b/docs/source/user-guide/sql/information_schema.md
@@ -24,7 +24,7 @@ views of the ISO SQL `information_schema` schema or the DataFusion specific `SHO
 
 To show tables in the DataFusion catalog, use the `SHOW TABLES` command or the `information_schema.tables` view:
 
-```text
+```sql
 > show tables;
 or
 > select * from information_schema.tables;
@@ -41,7 +41,7 @@ or
 
 To show the schema of a table in DataFusion, use the `SHOW COLUMNS` command or the `information_schema.columns` view:
 
-```text
+```sql
 > show columns from t;
 or
 > select table_catalog, table_schema, table_name, column_name, data_type, is_nullable from information_schema.columns;
@@ -50,4 +50,23 @@ or
 +---------------+--------------+------------+-------------+-----------+-------------+
 | datafusion    | public       | t1         | Int64(1)    | Int64     | NO          |
 +---------------+--------------+------------+-------------+-----------+-------------+
+```
+
+To show the current session configuration options, use the `SHOW ALL` command or the `information_schema.df_settings` view:
+
+```sql
+❯ select * from information_schema.df_settings;
+
++-------------------------------------------------+---------+
+| name                                            | setting |
++-------------------------------------------------+---------+
+| datafusion.execution.batch_size                 | 8192    |
+| datafusion.execution.coalesce_batches           | true    |
+| datafusion.execution.coalesce_target_batch_size | 4096    |
+| datafusion.execution.time_zone                  | UTC     |
+| datafusion.explain.logical_plan_only            | false   |
+| datafusion.explain.physical_plan_only           | false   |
+| datafusion.optimizer.filter_null_join_keys      | false   |
+| datafusion.optimizer.skip_failed_rules          | true    |
++-------------------------------------------------+---------+
 ```


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
I love `SHOW ALL` added by @waitingkuo in https://github.com/apache/arrow-datafusion/pull/3455 and I want more people to know about it


# What changes are included in this PR?
Document SHOW ALL in the users guide 

# Are there any user-facing changes?
Docs