### PR TITLE
Enable Parquet Row and Page Filtering by default (WIP)

### DIFF
--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -240,20 +240,20 @@ impl BuiltInConfigs {
                 OPT_PARQUET_PUSHDOWN_FILTERS,
                 "If true, filter expressions are be applied during the parquet decoding operation to \
                  reduce the number of rows decoded.",
-                false,
+                true,
             ),
             ConfigDefinition::new_bool(
                 OPT_PARQUET_REORDER_FILTERS,
                 "If true, filter expressions evaluated during the parquet decoding opearation \
                  will be reordered heuristically to minimize the cost of evaluation. If false, \
                  the filters are applied in the same order as written in the query.",
-                false,
+                true,
             ),
             ConfigDefinition::new_bool(
                 OPT_PARQUET_ENABLE_PAGE_INDEX,
                 "If true, uses parquet data page level metadata (Page Index) statistics \
                  to reduce the number of rows decoded.",
-                false,
+                true,
             ),
             ConfigDefinition::new_bool(
                 OPT_OPTIMIZER_SKIP_FAILED_RULES,

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -803,7 +803,7 @@ mod tests {
         let file_groups = meta.into_iter().map(Into::into).collect();
 
         // prepare the scan
-        let parquet_exec = ParquetExec::new(
+        let mut parquet_exec = ParquetExec::new(
             FileScanConfig {
                 object_store_url: ObjectStoreUrl::local_filesystem(),
                 file_groups: vec![file_groups],

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -803,7 +803,7 @@ mod tests {
         let file_groups = meta.into_iter().map(Into::into).collect();
 
         // prepare the scan
-        let mut parquet_exec = ParquetExec::new(
+        let parquet_exec = ParquetExec::new(
             FileScanConfig {
                 object_store_url: ObjectStoreUrl::local_filesystem(),
                 file_groups: vec![file_groups],
@@ -817,13 +817,9 @@ mod tests {
             },
             predicate,
             None,
-        );
-
-        if pushdown_predicate {
-            parquet_exec = parquet_exec
-                .with_pushdown_filters(true)
-                .with_reorder_filters(true);
-        }
+        )
+        .with_pushdown_filters(pushdown_predicate)
+        .with_reorder_filters(pushdown_predicate);
 
         if page_index_predicate {
             parquet_exec = parquet_exec.with_enable_page_index(true);


### PR DESCRIPTION
Draft until
- [x] https://github.com/apache/arrow-datafusion/pull/3822 is merged
- [ ] We have completed testing / validation
-
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3463
closes https://github.com/apache/arrow-datafusion/issues/4085
re https://github.com/apache/arrow-datafusion/issues/3462


 # Rationale for this change
This PR turns on parquet scan predicate pushdown (see https://github.com/apache/arrow-datafusion/issues/3462) by default -- I am putting it up early as part of the testing process (so we can work through any issues it may uncover)

This feature promises to be one of the most significant performance improvements for DataFusion reading from parquet in a while. All the hard work was done by @Ted-Jiang @thinkharderdev  and @tustvold

# What changes are included in this PR?
Enable pushing filters into the scan directly

Note this feature can be disabled by setting the `datafusion.execution.parquet.pushdown_filters` configuration setting to false. 

# Are there any user-facing changes?
Hopefully faster performance
