### PR TITLE
Fix the panic when lpad/rpad parameter is negative

### DIFF
--- a/datafusion/core/tests/sql/unicode.rs
+++ b/datafusion/core/tests/sql/unicode.rs
@@ -49,7 +49,9 @@ async fn test_unicode_expressions() -> Result<()> {
     test_expression!("length('chars')", "5");
     test_expression!("length('josé')", "4");
     test_expression!("length(NULL)", "NULL");
+    test_expression!("lpad('hi', -1, 'xy')", "");
     test_expression!("lpad('hi', 5, 'xy')", "xyxhi");
+    test_expression!("lpad('hi', -1)", "");
     test_expression!("lpad('hi', 0)", "");
     test_expression!("lpad('hi', 21, 'abcdef')", "abcdefabcdefabcdefahi");
     test_expression!("lpad('hi', 5, 'xy')", "xyxhi");
@@ -71,7 +73,9 @@ async fn test_unicode_expressions() -> Result<()> {
     test_expression!("right('abcde', CAST(NULL AS INT))", "NULL");
     test_expression!("right(NULL, 2)", "NULL");
     test_expression!("right(NULL, CAST(NULL AS INT))", "NULL");
+    test_expression!("rpad('hi', -1, 'xy')", "");
     test_expression!("rpad('hi', 5, 'xy')", "hixyx");
+    test_expression!("rpad('hi', -1)", "");
     test_expression!("rpad('hi', 0)", "");
     test_expression!("rpad('hi', 21, 'abcdef')", "hiabcdefabcdefabcdefa");
     test_expression!("rpad('hi', 5, 'xy')", "hixyx");


### PR DESCRIPTION
When I pass a negative parameter to the lpad function, it panics. Because the function will cast i64 to usize, which causes Vec to be unable to allocate enough memory, resulting in 'panic: capacity overflow'.

```shell
DataFusion CLI v13.0.0
❯ select lpad('abc', -1, 'abc');
thread 'main' panicked at 'capacity overflow', library/alloc/src/raw_vec.rs:518:5
```

I refer to the implementation of postgres, in postges, length is limited to i32, too large length will throw an error.

In psql 14.5
```sql
SELECT lpad('abc', 2147483647, 'abc');
```
ERROR:  requested length too large
```sql
SELECT lpad('abc', -1);
```
 lpad

\------

(1 row)

----------

At first I changed the function signature.

But after I changed the function signature, calling this function requires troublesome cast.



# What changes are included in this PR?
So I can only change the inside of the function

if length < 0 length = 0;

if length > i32::MAX, an Error will be thrown

