### PR TITLE
Infer the count of maximum distinct values from min/max

### DIFF
--- a/datafusion/core/src/physical_plan/join_utils.rs
+++ b/datafusion/core/src/physical_plan/join_utils.rs
@@ -489,18 +489,9 @@ fn get_int_range(min: ScalarValue, max: ScalarValue) -> Option<usize> {
         _ => None,
     }
     // The delta (directly) is not the real range, since it does not include the
-    // first term if it is different from the final term.
+    // first term.
     // E.g. (min=2, max=4) -> (4 - 2) -> 2, but the actual result should be 3 (1, 2, 3).
-    //
-    // On the other hand if both min and max are the same value, we should not do this
-    // since it is already accounted for: (min=2, max=2) -> (2 - 2) -> 0
-    .map(|open_ended_range| {
-        if min == max {
-            open_ended_range
-        } else {
-            open_ended_range + 1
-        }
-    })
+    .map(|open_ended_range| open_ended_range + 1)
 }
 
 enum OnceFutState<T> {
@@ -772,6 +763,12 @@ mod tests {
                 (10, Some(0), Some(10), Some(5)),
                 Some(20), // It would have been ten if we have used abs(range(left))
             ),
+            // range(left) = 1, range(right) = 1
+            (
+                (10, Some(1), Some(1), None),
+                (10, Some(1), Some(1), None),
+                Some(100),
+            ),
             //
             // Edge cases
             // ==========
@@ -816,12 +813,6 @@ mod tests {
             (
                 (10, Some(1), Some(10), Some(0)),
                 (10, Some(1), Some(10), Some(0)),
-                None,
-            ),
-            // range(left) = 0, range(right) = 0
-            (
-                (10, Some(1), Some(1), None),
-                (10, Some(1), Some(1), None),
                 None,
             ),
         ];

--- a/datafusion/core/src/physical_plan/join_utils.rs
+++ b/datafusion/core/src/physical_plan/join_utils.rs
@@ -22,6 +22,7 @@ use crate::logical_expr::JoinType;
 use crate::physical_plan::expressions::Column;
 use arrow::datatypes::{Field, Schema};
 use arrow::error::ArrowError;
+use datafusion_common::ScalarValue;
 use datafusion_physical_expr::PhysicalExpr;
 use futures::future::{BoxFuture, Shared};
 use futures::{ready, FutureExt};
@@ -423,7 +424,9 @@ fn estimate_inner_join_cardinality(
             return None;
         }
 
-        let max_distinct = max(left_stat.distinct_count, right_stat.distinct_count);
+        let left_max_distinct = max_distinct_count(left_num_rows, left_stat.clone());
+        let right_max_distinct = max_distinct_count(right_num_rows, right_stat.clone());
+        let max_distinct = max(left_max_distinct, right_max_distinct);
         if max_distinct > join_selectivity {
             // Seems like there are a few implementations of this algorithm that implement
             // exponential decay for the selectivity (like Hive's Optiq Optimizer). Needs
@@ -445,6 +448,59 @@ fn estimate_inner_join_cardinality(
         // overestimation using just the cartesian product).
         _ => None,
     }
+}
+
+/// Estimate the number of maximum distinct values that can be present in the
+/// given column from its statistics.
+///
+/// If distinct_count is available, uses it directly. If the column numeric, and
+/// has min/max values, then they might be used as a fallback option. Otherwise,
+/// returns None.
+fn max_distinct_count(num_rows: usize, stats: ColumnStatistics) -> Option<usize> {
+    match (stats.distinct_count, stats.max_value, stats.min_value) {
+        (Some(_), _, _) => stats.distinct_count,
+        (_, Some(max), Some(min)) => {
+            // Note that float support is intentionally omitted here, since the computation
+            // of a range between two float values is not trivial and the result would be
+            // highly inaccurate.
+            let numeric_range = get_int_range(min, max)?;
+
+            // The number can never be greater than the number of rows we have (minus
+            // the nulls, since they don't count as distinct values).
+            let ceiling = num_rows - stats.null_count.unwrap_or(0);
+            Some(numeric_range.min(ceiling))
+        }
+        _ => None,
+    }
+}
+
+/// Return the numeric range between the given min and max values.
+fn get_int_range(min: ScalarValue, max: ScalarValue) -> Option<usize> {
+    let delta = &max.sub(&min).ok()?;
+    match delta {
+        ScalarValue::Int8(Some(delta)) if *delta >= 0 => Some(*delta as usize),
+        ScalarValue::Int16(Some(delta)) if *delta >= 0 => Some(*delta as usize),
+        ScalarValue::Int32(Some(delta)) if *delta >= 0 => Some(*delta as usize),
+        ScalarValue::Int64(Some(delta)) if *delta >= 0 => Some(*delta as usize),
+        ScalarValue::UInt8(Some(delta)) => Some(*delta as usize),
+        ScalarValue::UInt16(Some(delta)) => Some(*delta as usize),
+        ScalarValue::UInt32(Some(delta)) => Some(*delta as usize),
+        ScalarValue::UInt64(Some(delta)) => Some(*delta as usize),
+        _ => None,
+    }
+    // The delta (directly) is not the real range, since it does not include the
+    // first term if it is different from the final term.
+    // E.g. (min=2, max=4) -> (4 - 2) -> 2, but the actual result should be 3 (1, 2, 3).
+    //
+    // On the other hand if both min and max are the same value, we should not do this
+    // since it is already accounted for: (min=2, max=2) -> (2 - 2) -> 0
+    .map(|open_ended_range| {
+        if min == max {
+            open_ended_range
+        } else {
+            open_ended_range + 1
+        }
+    })
 }
 
 enum OnceFutState<T> {
@@ -626,19 +682,19 @@ mod tests {
     }
 
     fn create_column_stats(
-        min: Option<u64>,
-        max: Option<u64>,
+        min: Option<i64>,
+        max: Option<i64>,
         distinct_count: Option<usize>,
     ) -> ColumnStatistics {
         ColumnStatistics {
             distinct_count,
-            min_value: min.map(|size| ScalarValue::UInt64(Some(size))),
-            max_value: max.map(|size| ScalarValue::UInt64(Some(size))),
+            min_value: min.map(|size| ScalarValue::Int64(Some(size))),
+            max_value: max.map(|size| ScalarValue::Int64(Some(size))),
             ..Default::default()
         }
     }
 
-    type PartialStats = (usize, u64, u64, Option<usize>);
+    type PartialStats = (usize, Option<i64>, Option<i64>, Option<usize>);
 
     // This is mainly for validating the all edge cases of the estimation, but
     // more advanced (and real world test cases) are below where we need some control
@@ -650,40 +706,135 @@ mod tests {
             // | left(rows, min, max, distinct), right(rows, min, max, distinct), expected |
             // -----------------------------------------------------------------------------
 
-            // distinct(left) is None OR distinct(right) is None
+            // Cardinality computation
+            // =======================
             //
-            // len(left) = len(right), len(left) * len(right)
-            ((10, 0, 10, None), (10, 0, 10, None), None),
-            // len(left) > len(right) OR len(left) < len(right), len(left) * len(right)
-            ((10, 0, 10, None), (5, 0, 10, None), None),
-            ((5, 0, 10, None), (10, 0, 10, None), None),
-            ((10, 0, 10, None), (5, 0, 10, None), None),
-            ((5, 0, 10, None), (10, 0, 10, None), None),
-            // min(left) > max(right) OR min(right) > max(left), None
-            ((10, 0, 10, None), (10, 11, 20, None), None),
-            ((10, 11, 20, None), (10, 0, 10, None), None),
-            ((10, 5, 10, None), (10, 11, 3, None), None),
-            ((10, 10, 5, None), (10, 3, 7, None), None),
-            // distinct(left) is not None AND distinct(right) is not None
+            // distinct(left) == NaN, distinct(right) == NaN
+            (
+                (10, Some(1), Some(10), None),
+                (10, Some(1), Some(10), None),
+                Some(10),
+            ),
+            // range(left) > range(right)
+            (
+                (10, Some(6), Some(10), None),
+                (10, Some(8), Some(10), None),
+                Some(20),
+            ),
+            // range(right) > range(left)
+            (
+                (10, Some(8), Some(10), None),
+                (10, Some(6), Some(10), None),
+                Some(20),
+            ),
+            // range(left) > len(left), range(right) > len(right)
+            (
+                (10, Some(1), Some(15), None),
+                (20, Some(1), Some(40), None),
+                Some(10),
+            ),
+            // When we have distinct count.
+            (
+                (10, Some(1), Some(10), Some(10)),
+                (10, Some(1), Some(10), Some(10)),
+                Some(10),
+            ),
+            // distinct(left) > distinct(right)
+            (
+                (10, Some(1), Some(10), Some(5)),
+                (10, Some(1), Some(10), Some(2)),
+                Some(20),
+            ),
+            // distinct(right) > distinct(left)
+            (
+                (10, Some(1), Some(10), Some(2)),
+                (10, Some(1), Some(10), Some(5)),
+                Some(20),
+            ),
+            // min(left) < 0 (range(left) > range(right))
+            (
+                (10, Some(-5), Some(5), None),
+                (10, Some(1), Some(5), None),
+                Some(10),
+            ),
+            // min(right) < 0, max(right) < 0 (range(right) > range(left))
+            (
+                (10, Some(-25), Some(-20), None),
+                (10, Some(-25), Some(-15), None),
+                Some(10),
+            ),
+            // range(left) < 0, range(right) >= 0
+            // (there isn't a case where both left and right ranges are negative
+            //  so one of them is always going to work, this just proves negative
+            //  ranges with bigger absolute values are not are not accidentally used).
+            (
+                (10, Some(10), Some(0), None),
+                (10, Some(0), Some(10), Some(5)),
+                Some(20), // It would have been ten if we have used abs(range(left))
+            ),
             //
-            // len(left) = len(right), len(left) * len(right) / max(distinct(left), distinct(right))
-            ((10, 0, 10, Some(5)), (10, 0, 10, Some(5)), Some(20)),
-            ((10, 0, 10, Some(10)), (10, 0, 10, Some(5)), Some(10)),
-            ((10, 0, 10, Some(5)), (10, 0, 10, Some(10)), Some(10)),
+            // Edge cases
+            // ==========
+            //
+            // No column level stats.
+            ((10, None, None, None), (10, None, None, None), None),
+            // No min or max (or both).
+            ((10, None, None, Some(3)), (10, None, None, Some(3)), None),
+            (
+                (10, Some(2), None, Some(3)),
+                (10, None, Some(5), Some(3)),
+                None,
+            ),
+            (
+                (10, None, Some(3), Some(3)),
+                (10, Some(1), None, Some(3)),
+                None,
+            ),
+            ((10, None, Some(3), None), (10, Some(1), None, None), None),
+            // Non overlapping min/max.
+            (
+                (10, Some(0), Some(10), None),
+                (10, Some(11), Some(20), None),
+                None,
+            ),
+            (
+                (10, Some(11), Some(20), None),
+                (10, Some(0), Some(10), None),
+                None,
+            ),
+            (
+                (10, Some(5), Some(10), Some(10)),
+                (10, Some(11), Some(3), Some(10)),
+                None,
+            ),
+            (
+                (10, Some(10), Some(5), Some(10)),
+                (10, Some(3), Some(7), Some(10)),
+                None,
+            ),
+            // distinct(left) = 0, distinct(right) = 0
+            (
+                (10, Some(1), Some(10), Some(0)),
+                (10, Some(1), Some(10), Some(0)),
+                None,
+            ),
+            // range(left) = 0, range(right) = 0
+            (
+                (10, Some(1), Some(1), None),
+                (10, Some(1), Some(1), None),
+                None,
+            ),
         ];
 
         for (left_info, right_info, expected_cardinality) in cases {
             let left_num_rows = left_info.0;
-            let left_col_stats = vec![create_column_stats(
-                Some(left_info.1),
-                Some(left_info.2),
-                left_info.3,
-            )];
+            let left_col_stats =
+                vec![create_column_stats(left_info.1, left_info.2, left_info.3)];
 
             let right_num_rows = right_info.0;
             let right_col_stats = vec![create_column_stats(
-                Some(right_info.1),
-                Some(right_info.2),
+                right_info.1,
+                right_info.2,
                 right_info.3,
             )];
 
@@ -736,6 +887,29 @@ mod tests {
         assert_eq!(
             estimate_inner_join_cardinality(400, 400, left_col_stats, right_col_stats),
             Some((400 * 400) / 200)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_inner_join_cardinality_decimal_range() -> Result<()> {
+        let left_col_stats = vec![ColumnStatistics {
+            distinct_count: None,
+            min_value: Some(ScalarValue::Decimal128(Some(32500), 14, 4)),
+            max_value: Some(ScalarValue::Decimal128(Some(35000), 14, 4)),
+            ..Default::default()
+        }];
+
+        let right_col_stats = vec![ColumnStatistics {
+            distinct_count: None,
+            min_value: Some(ScalarValue::Decimal128(Some(33500), 14, 4)),
+            max_value: Some(ScalarValue::Decimal128(Some(34000), 14, 4)),
+            ..Default::default()
+        }];
+
+        assert_eq!(
+            estimate_inner_join_cardinality(100, 100, left_col_stats, right_col_stats),
+            None
         );
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3813.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This was a point that came out during the initial join cardinality computation PR ([link](https://github.com/apache/arrow-datafusion/pull/3787#discussion_r992751749)) where the logic only gave an estimate when the distinct count information was available directly in the statistics. This was effective for certain use cases where the distinct count was already calculated (e.g. propagated statistics from stuff like aggregates) but for statistics that originate from initial user input, having `distinct_count` is very unlikely (e.g. there is no way to save distinct count when exporting a parquet file from pandas, none of the official backends [pyarrow/fastparquet] even support such a thing in their write APIs). So one main thing we can do is actually use `min`/`max` values (which are nearly universal at this point) to calculate the maximum possible distinct count (which is actually what we need for selectivity).

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
A fallback option for inferring the maximum distinct count when the actual distinct count information is not available. It only works with numeric values (more specifically, integers) at this point (we can technically determine the range for timestamps or floats, but neither of them feels close to accurate since that would be essentially brute forcing every possible value within the precision boundaries, something that feels very unlikely to happen in real world, but open for discussion).

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No backwards incompatible changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->