### PR TITLE
Handle cardinality estimation for disjoint inner and outer joins

### DIFF
--- a/datafusion/core/src/physical_plan/join_utils.rs
+++ b/datafusion/core/src/physical_plan/join_utils.rs
@@ -362,6 +362,7 @@ fn estimate_join_cardinality(
                 right_num_rows,
                 left_col_stats,
                 right_col_stats,
+                left_stats.is_exact && right_stats.is_exact,
             )?;
 
             // The cardinality for inner join can also be used to estimate
@@ -407,6 +408,7 @@ fn estimate_inner_join_cardinality(
     right_num_rows: usize,
     left_col_stats: Vec<ColumnStatistics>,
     right_col_stats: Vec<ColumnStatistics>,
+    is_exact: bool,
 ) -> Option<usize> {
     // The algorithm here is partly based on the non-histogram selectivity estimation
     // from Spark's Catalyst optimizer.
@@ -416,12 +418,10 @@ fn estimate_inner_join_cardinality(
         if (left_stat.min_value.clone()? > right_stat.max_value.clone()?)
             || (left_stat.max_value.clone()? < right_stat.min_value.clone()?)
         {
-            // If there is no overlap, then we can not accurately estimate
-            // the join cardinality. We could in theory use this information
-            // to point out the join will not produce any rows, but that would
-            // require some extra information (namely whether the statistics are
-            // exact). For now, we just give up.
-            return None;
+            // If there is no overlap in any of the join columns, that means the join
+            // itself is disjoint and the cardinality is 0. Though we can only assume
+            // this when the statistics are exact (since it is a very strong assumption).
+            return if is_exact { Some(0) } else { None };
         }
 
         let left_max_distinct = max_distinct_count(left_num_rows, left_stat.clone());
@@ -664,10 +664,12 @@ mod tests {
     fn create_stats(
         num_rows: Option<usize>,
         column_stats: Option<Vec<ColumnStatistics>>,
+        is_exact: bool,
     ) -> Statistics {
         Statistics {
             num_rows,
             column_statistics: column_stats,
+            is_exact,
             ..Default::default()
         }
     }
@@ -788,7 +790,7 @@ mod tests {
                 None,
             ),
             ((10, None, Some(3), None), (10, Some(1), None, None), None),
-            // Non overlapping min/max.
+            // Non overlapping min/max (when exact=False).
             (
                 (10, Some(0), Some(10), None),
                 (10, Some(11), Some(20), None),
@@ -835,6 +837,7 @@ mod tests {
                     right_num_rows,
                     left_col_stats.clone(),
                     right_col_stats.clone(),
+                    false,
                 ),
                 expected_cardinality
             );
@@ -844,8 +847,8 @@ mod tests {
             let join_on = vec![(Column::new("a", 0), Column::new("b", 0))];
             let partial_join_stats = estimate_join_cardinality(
                 &join_type,
-                create_stats(Some(left_num_rows), Some(left_col_stats.clone())),
-                create_stats(Some(right_num_rows), Some(right_col_stats.clone())),
+                create_stats(Some(left_num_rows), Some(left_col_stats.clone()), false),
+                create_stats(Some(right_num_rows), Some(right_col_stats.clone()), false),
                 &join_on,
             );
 
@@ -876,7 +879,13 @@ mod tests {
         // We have statistics about 4 columns, where the highest distinct
         // count is 200, so we are going to pick it.
         assert_eq!(
-            estimate_inner_join_cardinality(400, 400, left_col_stats, right_col_stats),
+            estimate_inner_join_cardinality(
+                400,
+                400,
+                left_col_stats,
+                right_col_stats,
+                false
+            ),
             Some((400 * 400) / 200)
         );
         Ok(())
@@ -899,7 +908,13 @@ mod tests {
         }];
 
         assert_eq!(
-            estimate_inner_join_cardinality(100, 100, left_col_stats, right_col_stats),
+            estimate_inner_join_cardinality(
+                100,
+                100,
+                left_col_stats,
+                right_col_stats,
+                false
+            ),
             None
         );
         Ok(())
@@ -945,8 +960,73 @@ mod tests {
 
             let partial_join_stats = estimate_join_cardinality(
                 &join_type,
-                create_stats(Some(1000), Some(left_col_stats.clone())),
-                create_stats(Some(2000), Some(right_col_stats.clone())),
+                create_stats(Some(1000), Some(left_col_stats.clone()), false),
+                create_stats(Some(2000), Some(right_col_stats.clone()), false),
+                &join_on,
+            )
+            .unwrap();
+            assert_eq!(partial_join_stats.num_rows, expected_num_rows);
+            assert_eq!(
+                partial_join_stats.column_statistics,
+                [left_col_stats.clone(), right_col_stats.clone()].concat()
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_cardinality_when_one_column_is_disjoint() -> Result<()> {
+        // Left table (rows=1000)
+        //   a: min=0, max=100, distinct=100
+        //   b: min=0, max=500, distinct=500
+        //   x: min=1000, max=10000, distinct=None
+        //
+        // Right table (rows=2000)
+        //   c: min=0, max=100, distinct=50
+        //   d: min=0, max=2000, distinct=2500 (how? some inexact statistics)
+        //   y: min=0, max=100, distinct=None
+        //
+        // Join on a=c, x=y (ignores b/d) where x and y does not intersect
+
+        let left_col_stats = vec![
+            create_column_stats(Some(0), Some(100), Some(100)),
+            create_column_stats(Some(0), Some(500), Some(500)),
+            create_column_stats(Some(1000), Some(10000), None),
+        ];
+
+        let right_col_stats = vec![
+            create_column_stats(Some(0), Some(100), Some(50)),
+            create_column_stats(Some(0), Some(2000), Some(2500)),
+            create_column_stats(Some(0), Some(100), None),
+        ];
+
+        let join_on = vec![
+            (Column::new("a", 0), Column::new("c", 0)),
+            (Column::new("x", 2), Column::new("y", 2)),
+        ];
+
+        let cases = vec![
+            // Join type, expected cardinality
+            //
+            // When an inner join is disjoint, that means it won't
+            // produce any rows.
+            (JoinType::Inner, 0),
+            // But left/right outer joins will produce at least
+            // the amount of rows from the left/right side.
+            (JoinType::Left, 1000),
+            (JoinType::Right, 2000),
+            // And a full outer join will produce at least the combination
+            // of the rows above (minus the cardinality of the inner join, which
+            // is 0).
+            (JoinType::Full, 3000),
+        ];
+
+        for (join_type, expected_num_rows) in cases {
+            let partial_join_stats = estimate_join_cardinality(
+                &join_type,
+                create_stats(Some(1000), Some(left_col_stats.clone()), true),
+                create_stats(Some(2000), Some(right_col_stats.clone()), true),
                 &join_on,
             )
             .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3802 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When we know for a fact that an inner join is disjoint, we can estimate the cardinality of an inner join with (at least) one disjoint column as `0`. From there, we can derive the cardinality of a left/right and full outer joins.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
We now take an `is_exact` flag in `estimate_join_cardinality` which is only `true` when both left and right are originating directly from table providers (which might change in the future if we collect more statistics during materialization points both in DF and Ballista, and somehow adaptively optimize the parent plans according to that). If that `is_exact` flag is true and if we identify a disjoint column when calculating the inner join cardinality, we now infer the cardinality of an inner join as 0. 

Since the cardinality of left/right/full outer joins can be derived from the inner join's cardinality (e.g. a disjoint left outer join would result with the number of rows from the left side), this PR also adds support for inferring their cardinality. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->