### PR TITLE
Optimize the `concat_ws` function

### DIFF
--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -19,7 +19,7 @@
 
 use crate::expr::{BinaryExpr, GroupingSet};
 use crate::{
-    aggregate_function, built_in_function, conditional_expressions::CaseBuilder, lit,
+    aggregate_function, built_in_function, conditional_expressions::CaseBuilder,
     logical_plan::Subquery, AccumulatorFunctionImplementation, AggregateUDF,
     BuiltinScalarFunction, Expr, LogicalPlan, Operator, ReturnTypeFunction,
     ScalarFunctionImplementation, ScalarUDF, Signature, StateTypeFunction, Volatility,
@@ -134,11 +134,11 @@ pub fn concat(args: &[Expr]) -> Expr {
 }
 
 /// Concatenates all but the first argument, with separators.
-/// The first argument is used as the separator string, and should not be NULL.
-/// Other NULL arguments are ignored.
-pub fn concat_ws(sep: impl Into<String>, values: &[Expr]) -> Expr {
-    let mut args = vec![lit(sep.into())];
-    args.extend_from_slice(values);
+/// The first argument is used as the separator.
+/// NULL arguments in `values` are ignored.
+pub fn concat_ws(sep: Expr, values: Vec<Expr>) -> Expr {
+    let mut args = values;
+    args.insert(0, sep);
     Expr::ScalarFunction {
         fun: built_in_function::BuiltinScalarFunction::ConcatWithSeparator,
         args,
@@ -524,6 +524,7 @@ pub fn call_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::lit;
 
     #[test]
     fn filter_is_null_and_is_not_null() {

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -53,6 +53,12 @@ impl Literal for String {
     }
 }
 
+impl Literal for &String {
+    fn lit(&self) -> Expr {
+        Expr::Literal(ScalarValue::Utf8(Some((*self).to_owned())))
+    }
+}
+
 impl Literal for Vec<u8> {
     fn lit(&self) -> Expr {
         Expr::Literal(ScalarValue::Binary(Some((*self).to_owned())))

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -978,7 +978,7 @@ mod test {
 
         // concat_ws
         {
-            let expr = concat_ws("-", &args);
+            let expr = concat_ws(lit("-"), args.to_vec());
 
             let plan =
                 LogicalPlan::Projection(Projection::try_new(vec![expr], empty, None)?);

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -212,6 +212,19 @@ fn concat_literals() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn concat_ws_literals() -> Result<()> {
+    let sql = "SELECT concat_ws('-', true, col_int32, false, null, 'hello', col_utf8, 12, '', 3.4) \
+        AS col
+        FROM test";
+    let plan = test_sql(sql)?;
+    let expected =
+        "Projection: concatwithseparator(Utf8(\"-\"), Utf8(\"1\"), CAST(test.col_int32 AS Utf8), Utf8(\"0-hello\"), test.col_utf8, Utf8(\"12--3.4\")) AS col\
+        \n  TableScan: test projection=[col_int32, col_utf8]";
+    assert_eq!(expected, format!("{:?}", plan));
+    Ok(())
+}
+
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
     // parse the SQL
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3856.
Closes #3857.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Simplify the `concat_ws` expression:
1. fold the whole expression to `null` if the delimiter is null
2. filter out `null` arguments
3. use `concat` to replace `concat_ws` if the delimiter is an empty string
4. concatenate contiguous literals if the delimiter is a literal.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->