### PR TITLE
Add `LogicalPlan::ViewTable` support in `datafusion-proto`

### DIFF
--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -59,6 +59,16 @@ impl ViewTable {
 
         Ok(view)
     }
+
+    /// Get definition ref
+    pub fn definition(&self) -> &Option<String> {
+        &self.definition
+    }
+
+    /// Get logical_plan ref
+    pub fn logical_plan(&self) -> &LogicalPlan {
+        &self.logical_plan
+    }
 }
 
 #[async_trait]

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -69,6 +69,7 @@ message LogicalPlanNode {
     SubqueryAliasNode subquery_alias = 21;
     CreateViewNode create_view = 22;
     DistinctNode distinct = 23;
+    ViewTableScanNode view_scan = 24;
   }
 }
 
@@ -107,6 +108,14 @@ message ListingTableScanNode {
     ParquetFormat parquet = 11;
     AvroFormat avro = 12;
   }
+}
+
+message ViewTableScanNode {
+  string table_name = 1;
+  LogicalPlanNode input = 2;
+  datafusion.Schema schema = 3;
+  ProjectionColumns projection = 4;
+  string definition = 5;
 }
 
 message ProjectionNode {

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -30,6 +30,7 @@ use datafusion::{
             avro::AvroFormat, csv::CsvFormat, parquet::ParquetFormat, FileFormat,
         },
         listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
+        view::ViewTable,
     },
     datasource::{provider_as_source, source_as_provider},
     prelude::SessionContext,
@@ -665,6 +666,37 @@ impl AsLogicalPlan for LogicalPlanNode {
                     into_logical_plan!(distinct.input, ctx, extension_codec)?;
                 LogicalPlanBuilder::from(input).distinct()?.build()
             }
+            LogicalPlanType::ViewScan(scan) => {
+                let schema: Schema = convert_required!(scan.schema)?;
+
+                let mut projection = None;
+                if let Some(columns) = &scan.projection {
+                    let column_indices = columns
+                        .columns
+                        .iter()
+                        .map(|name| schema.index_of(name))
+                        .collect::<Result<Vec<usize>, _>>()?;
+                    projection = Some(column_indices);
+                }
+
+                let input: LogicalPlan =
+                    into_logical_plan!(scan.input, ctx, extension_codec)?;
+
+                let definition = if !scan.definition.is_empty() {
+                    Some(scan.definition.clone())
+                } else {
+                    None
+                };
+
+                let provider = ViewTable::try_new(input, definition)?;
+
+                LogicalPlanBuilder::scan(
+                    &scan.table_name,
+                    provider_as_source(Arc::new(provider)),
+                    projection,
+                )?
+                .build()
+            }
         }
     }
 
@@ -775,6 +807,26 @@ impl AsLogicalPlan for LogicalPlanNode {
                                     as u32,
                             },
                         )),
+                    })
+                } else if let Some(view_table) = source.downcast_ref::<ViewTable>() {
+                    Ok(protobuf::LogicalPlanNode {
+                        logical_plan_type: Some(LogicalPlanType::ViewScan(Box::new(
+                            protobuf::ViewTableScanNode {
+                                table_name: table_name.to_owned(),
+                                input: Some(Box::new(
+                                    protobuf::LogicalPlanNode::try_from_logical_plan(
+                                        view_table.logical_plan(),
+                                        extension_codec,
+                                    )?,
+                                )),
+                                schema: Some(schema),
+                                projection,
+                                definition: view_table
+                                    .definition()
+                                    .clone()
+                                    .unwrap_or_else(|| "".to_string()),
+                            },
+                        ))),
                     })
                 } else {
                     Err(DataFusionError::Internal(format!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3874 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #3874 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add `ViewTableScanNode` in datafusion.proto file
* Modify `logical_plan` file for support scan view table
* Add `roundtrip_logical_plan_with_view_scan` test

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

None