### PR TITLE
Add `Substring(str [from int] [for int])` support in `datafusion-proto`

### DIFF
--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -403,6 +403,7 @@ scalar_expr!(SplitPart, split_part, expr, delimiter, index);
 scalar_expr!(StartsWith, starts_with, string, characters);
 scalar_expr!(Strpos, strpos, string, substring);
 scalar_expr!(Substr, substr, string, position);
+scalar_expr!(Substr, substring, string, position, count);
 scalar_expr!(ToHex, to_hex, string);
 scalar_expr!(Translate, translate, string, from, to);
 scalar_expr!(Trim, trim, string);
@@ -656,6 +657,7 @@ mod test {
         test_scalar_expr!(StartsWith, starts_with, string, characters);
         test_scalar_expr!(Strpos, strpos, string, substring);
         test_scalar_expr!(Substr, substr, string, position);
+        test_scalar_expr!(Substr, substring, string, position, count);
         test_scalar_expr!(ToHex, to_hex, string);
         test_scalar_expr!(Translate, translate, string, from, to);
         test_scalar_expr!(Trim, trim, string);

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -1140,6 +1140,7 @@ pub fn parse_expr(
                 )),
                 ScalarFunction::Substr => {
                     if args.len() > 2 {
+                        assert_eq!(args.len(), 3);
                         Ok(substring(
                             parse_expr(&args[0], registry)?,
                             parse_expr(&args[1], registry)?,

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -39,10 +39,11 @@ use datafusion_expr::{
     logical_plan::{PlanType, StringifiedPlan},
     lower, lpad, ltrim, md5, now, nullif, octet_length, power, random, regexp_match,
     regexp_replace, repeat, replace, reverse, right, round, rpad, rtrim, sha224, sha256,
-    sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr, tan,
-    to_hex, to_timestamp_micros, to_timestamp_millis, to_timestamp_seconds, translate,
-    trim, trunc, upper, AggregateFunction, Between, BuiltInWindowFunction,
-    BuiltinScalarFunction, Case, Expr, GetIndexedField, GroupingSet,
+    sha384, sha512, signum, sin, split_part, sqrt, starts_with, strpos, substr,
+    substring, tan, to_hex, to_timestamp_micros, to_timestamp_millis,
+    to_timestamp_seconds, translate, trim, trunc, upper, AggregateFunction, Between,
+    BuiltInWindowFunction, BuiltinScalarFunction, Case, Expr, GetIndexedField,
+    GroupingSet,
     GroupingSet::GroupingSets,
     Like, Operator, WindowFrame, WindowFrameBound, WindowFrameUnits,
 };
@@ -1137,10 +1138,20 @@ pub fn parse_expr(
                     parse_expr(&args[0], registry)?,
                     parse_expr(&args[1], registry)?,
                 )),
-                ScalarFunction::Substr => Ok(substr(
-                    parse_expr(&args[0], registry)?,
-                    parse_expr(&args[1], registry)?,
-                )),
+                ScalarFunction::Substr => {
+                    if args.len() > 2 {
+                        Ok(substring(
+                            parse_expr(&args[0], registry)?,
+                            parse_expr(&args[1], registry)?,
+                            parse_expr(&args[2], registry)?,
+                        ))
+                    } else {
+                        Ok(substr(
+                            parse_expr(&args[0], registry)?,
+                            parse_expr(&args[1], registry)?,
+                        ))
+                    }
+                }
                 ScalarFunction::ToHex => Ok(to_hex(parse_expr(&args[0], registry)?)),
                 ScalarFunction::ToTimestampMillis => {
                     Ok(to_timestamp_millis(parse_expr(&args[0], registry)?))

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -67,7 +67,8 @@ mod roundtrip_tests {
     use datafusion_expr::logical_plan::{Extension, UserDefinedLogicalNode};
     use datafusion_expr::{
         col, lit, Accumulator, AggregateFunction, AggregateState,
-        BuiltinScalarFunction::Sqrt, Expr, LogicalPlan, Operator, Volatility,
+        BuiltinScalarFunction::{Sqrt, Substr},
+        Expr, LogicalPlan, Operator, Volatility,
     };
     use prost::Message;
     use std::any::Any;
@@ -1148,5 +1149,24 @@ mod roundtrip_tests {
 
         let ctx = SessionContext::new();
         roundtrip_expr_test(test_expr, ctx);
+    }
+
+    #[test]
+    fn roundtrip_substr() {
+        // substr(string, position)
+        let test_expr = Expr::ScalarFunction {
+            fun: Substr,
+            args: vec![col("col"), lit(1_i64)],
+        };
+
+        // substr(string, position, count)
+        let test_expr_with_count = Expr::ScalarFunction {
+            fun: Substr,
+            args: vec![col("col"), lit(1_i64), lit(1_i64)],
+        };
+
+        let ctx = SessionContext::new();
+        roundtrip_expr_test(test_expr, ctx.clone());
+        roundtrip_expr_test(test_expr_with_count, ctx);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3901 and https://github.com/apache/arrow-ballista/issues/375

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #3901 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add `substring` expr to support `Substring(str [from int] [for int])`
* Modify `from_proto.rs` to support `Substring(str [from int] [for int])`
* Add `roundtrip_substr` test

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

None