### PR TITLE
Add serde for plans with tables from `TableProviderFactory`s

### DIFF
--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -79,6 +79,6 @@ pub trait TableProvider: Sync + Send {
 /// from a directory of files only when that name is referenced.
 #[async_trait]
 pub trait TableProviderFactory: Sync + Send {
-    /// Create a TableProvider given name and url
+    /// Create a TableProvider with the given url
     async fn create(&self, url: &str) -> Result<Arc<dyn TableProvider>>;
 }

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -28,6 +28,7 @@ use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::logical_expr::Expr;
 use crate::physical_plan::ExecutionPlan;
+use crate::prelude::SessionContext;
 
 /// Source table
 #[async_trait]
@@ -80,5 +81,13 @@ pub trait TableProvider: Sync + Send {
 #[async_trait]
 pub trait TableProviderFactory: Sync + Send {
     /// Create a TableProvider given name and url
-    async fn create(&self, name: &str, url: &str) -> Result<Arc<dyn TableProvider>>;
+    async fn create(&self, url: &str) -> Result<Arc<dyn TableProvider>>;
+
+    /// Create a TableProvider during execution with schema already known from planning
+    fn with_schema(
+        &self,
+        ctx: &SessionContext,
+        schema: SchemaRef,
+        url: &str,
+    ) -> Result<Arc<dyn TableProvider>>;
 }

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -82,12 +82,4 @@ pub trait TableProvider: Sync + Send {
 pub trait TableProviderFactory: Sync + Send {
     /// Create a TableProvider given name and url
     async fn create(&self, url: &str) -> Result<Arc<dyn TableProvider>>;
-
-    /// Create a TableProvider during execution with schema already known from planning
-    fn with_schema(
-        &self,
-        ctx: &SessionContext,
-        schema: SchemaRef,
-        url: &str,
-    ) -> Result<Arc<dyn TableProvider>>;
 }

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -28,7 +28,6 @@ use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::logical_expr::Expr;
 use crate::physical_plan::ExecutionPlan;
-use crate::prelude::SessionContext;
 
 /// Source table
 #[async_trait]

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -337,17 +337,6 @@ impl TableProviderFactory for TestTableFactory {
             url: url.to_string(),
         }))
     }
-
-    fn with_schema(
-        &self,
-        _ctx: &SessionContext,
-        _schema: SchemaRef,
-        url: &str,
-    ) -> datafusion_common::Result<Arc<dyn TableProvider>> {
-        Ok(Arc::new(TestTableProvider {
-            url: url.to_string(),
-        }))
-    }
 }
 
 /// TableProvider for testing purposes

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -26,7 +26,6 @@ use crate::datasource::{empty::EmptyTable, provider_as_source, TableProvider};
 use crate::execution::context::SessionState;
 use crate::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
 use crate::physical_plan::ExecutionPlan;
-use crate::prelude::SessionContext;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion_common::DataFusionError;

--- a/datafusion/core/tests/sql/create_drop.rs
+++ b/datafusion/core/tests/sql/create_drop.rs
@@ -15,15 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
-use std::any::Any;
 use std::collections::HashMap;
 use std::io::Write;
 
 use datafusion::datasource::datasource::TableProviderFactory;
-use datafusion::execution::context::SessionState;
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use datafusion_expr::TableType;
+use datafusion::test_util::TestTableFactory;
 use tempfile::TempDir;
 
 use super::*;
@@ -369,49 +366,11 @@ async fn create_pipe_delimited_csv_table() -> Result<()> {
     Ok(())
 }
 
-struct TestTableProvider {}
-
-impl TestTableProvider {}
-
-#[async_trait]
-impl TableProvider for TestTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        unimplemented!("TestTableProvider is a stub for testing.")
-    }
-
-    fn schema(&self) -> SchemaRef {
-        unimplemented!("TestTableProvider is a stub for testing.")
-    }
-
-    fn table_type(&self) -> TableType {
-        unimplemented!("TestTableProvider is a stub for testing.")
-    }
-
-    async fn scan(
-        &self,
-        _ctx: &SessionState,
-        _projection: &Option<Vec<usize>>,
-        _filters: &[Expr],
-        _limit: Option<usize>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!("TestTableProvider is a stub for testing.")
-    }
-}
-
-struct TestTableFactory {}
-
-#[async_trait]
-impl TableProviderFactory for TestTableFactory {
-    async fn create(&self, _name: &str, _url: &str) -> Result<Arc<dyn TableProvider>> {
-        Ok(Arc::new(TestTableProvider {}))
-    }
-}
-
 #[tokio::test]
 async fn create_custom_table() -> Result<()> {
     let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> =
         HashMap::new();
-    table_factories.insert("DELTATABLE".to_string(), Arc::new(TestTableFactory {}));
+    table_factories.insert("deltatable".to_string(), Arc::new(TestTableFactory {}));
     let cfg = RuntimeConfig::new().with_table_factories(table_factories);
     let env = RuntimeEnv::new(cfg).unwrap();
     let ses = SessionConfig::new();

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -41,6 +41,7 @@ json = ["pbjson", "pbjson-build", "serde", "serde_json"]
 
 [dependencies]
 arrow = "25.0.0"
+async-trait = "0.1.41"
 datafusion = { path = "../core", version = "13.0.0" }
 datafusion-common = { path = "../common", version = "13.0.0" }
 datafusion-expr = { path = "../expr", version = "13.0.0" }

--- a/datafusion/proto/README.md
+++ b/datafusion/proto/README.md
@@ -63,7 +63,7 @@ async fn main() -> Result<()> {
         ?;
     let plan = ctx.table("t1")?.to_logical_plan()?;
     let bytes = logical_plan_to_bytes(&plan)?;
-    let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx)?;
+    let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx).await?;
     assert_eq!(format!("{:?}", plan), format!("{:?}", logical_round_trip));
     Ok(())
 }

--- a/datafusion/proto/examples/plan_serde.rs
+++ b/datafusion/proto/examples/plan_serde.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         .await?;
     let plan = ctx.table("t1")?.to_logical_plan()?;
     let bytes = logical_plan_to_bytes(&plan)?;
-    let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx)?;
+    let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx).await?;
     assert_eq!(format!("{:?}", plan), format!("{:?}", logical_round_trip));
     Ok(())
 }

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -70,6 +70,7 @@ message LogicalPlanNode {
     CreateViewNode create_view = 22;
     DistinctNode distinct = 23;
     ViewTableScanNode view_scan = 24;
+    CustomTableScanNode custom_scan = 25;
   }
 }
 
@@ -116,6 +117,15 @@ message ViewTableScanNode {
   datafusion.Schema schema = 3;
   ProjectionColumns projection = 4;
   string definition = 5;
+}
+
+// Logical Plan to Scan a CustomTableProvider registered at runtime
+message CustomTableScanNode {
+  string table_name = 1;
+  ProjectionColumns projection = 2;
+  datafusion.Schema schema = 3;
+  repeated datafusion.LogicalExprNode filters = 4;
+  bytes custom_table_data = 5;
 }
 
 message ProjectionNode {

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -19,6 +19,7 @@
 use crate::logical_plan::{AsLogicalPlan, LogicalExtensionCodec};
 use crate::{from_proto::parse_expr, protobuf};
 use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{Expr, Extension, LogicalPlan};
@@ -27,7 +28,6 @@ use prost::{
     Message,
 };
 use std::sync::Arc;
-use async_trait::async_trait;
 
 // Reexport Bytes which appears in the API
 use datafusion::execution::registry::FunctionRegistry;

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -206,7 +206,7 @@ impl LogicalExtensionCodec for DefaultExtensionCodec {
         _buf: &mut Vec<u8>,
     ) -> std::result::Result<(), DataFusionError> {
         Err(DataFusionError::NotImplemented(
-            "No extension codec provided".to_string(),
+            "No codec provided to for TableProviders".to_string(),
         ))
     }
 }

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -18,12 +18,15 @@
 //! Serialization / Deserialization to Bytes
 use crate::logical_plan::{AsLogicalPlan, LogicalExtensionCodec};
 use crate::{from_proto::parse_expr, protobuf};
+use arrow::datatypes::SchemaRef;
+use datafusion::datasource::TableProvider;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{Expr, Extension, LogicalPlan};
 use prost::{
     bytes::{Bytes, BytesMut},
     Message,
 };
+use std::sync::Arc;
 
 // Reexport Bytes which appears in the API
 use datafusion::execution::registry::FunctionRegistry;
@@ -176,6 +179,27 @@ impl LogicalExtensionCodec for DefaultExtensionCodec {
     }
 
     fn try_encode(&self, _node: &Extension, _buf: &mut Vec<u8>) -> Result<()> {
+        Err(DataFusionError::NotImplemented(
+            "No extension codec provided".to_string(),
+        ))
+    }
+
+    fn try_decode_table_provider(
+        &self,
+        _buf: &[u8],
+        _schema: SchemaRef,
+        _ctx: &SessionContext,
+    ) -> std::result::Result<Arc<dyn TableProvider>, DataFusionError> {
+        Err(DataFusionError::NotImplemented(
+            "No extension codec provided".to_string(),
+        ))
+    }
+
+    fn try_encode_table_provider(
+        &self,
+        _node: Arc<dyn TableProvider>,
+        _buf: &mut Vec<u8>,
+    ) -> std::result::Result<(), DataFusionError> {
         Err(DataFusionError::NotImplemented(
             "No extension codec provided".to_string(),
         ))

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -196,7 +196,7 @@ impl LogicalExtensionCodec for DefaultExtensionCodec {
         _ctx: &SessionContext,
     ) -> std::result::Result<Arc<dyn TableProvider>, DataFusionError> {
         Err(DataFusionError::NotImplemented(
-            "No extension codec provided".to_string(),
+            "No codec provided to for TableProviders".to_string(),
         ))
     }
 

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -28,6 +28,8 @@ use crate::{
 use arrow::datatypes::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
+use datafusion::execution::FunctionRegistry;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::{
     datasource::{
         file_format::{
@@ -52,8 +54,6 @@ use prost::bytes::BufMut;
 use prost::Message;
 use std::fmt::Debug;
 use std::sync::Arc;
-use datafusion::execution::FunctionRegistry;
-use datafusion::physical_plan::ExecutionPlan;
 
 fn byte_to_string(b: u8) -> Result<String, DataFusionError> {
     let b = &[b];

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -52,6 +52,8 @@ use prost::bytes::BufMut;
 use prost::Message;
 use std::fmt::Debug;
 use std::sync::Arc;
+use datafusion::execution::FunctionRegistry;
+use datafusion::physical_plan::ExecutionPlan;
 
 fn byte_to_string(b: u8) -> Result<String, DataFusionError> {
     let b = &[b];
@@ -96,6 +98,21 @@ pub trait AsLogicalPlan: Debug + Send + Sync + Clone {
     ) -> Result<Self, DataFusionError>
     where
         Self: Sized;
+}
+
+pub trait PhysicalExtensionCodec: Debug + Send + Sync {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        registry: &dyn FunctionRegistry,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError>;
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), DataFusionError>;
 }
 
 #[async_trait]

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
 use crate::protobuf::logical_plan_node::LogicalPlanType::CustomScan;
 use crate::protobuf::CustomTableScanNode;
 use crate::{
@@ -27,6 +26,7 @@ use crate::{
     to_proto,
 };
 use arrow::datatypes::{Schema, SchemaRef};
+use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::{
     datasource::{
@@ -470,11 +470,9 @@ impl AsLogicalPlan for LogicalPlanNode {
                     .iter()
                     .map(|expr| parse_expr(expr, ctx))
                     .collect::<Result<Vec<_>, _>>()?;
-                let provider = extension_codec.try_decode_table_provider(
-                    &scan.custom_table_data,
-                    schema,
-                    ctx,
-                ).await?;
+                let provider = extension_codec
+                    .try_decode_table_provider(&scan.custom_table_data, schema, ctx)
+                    .await?;
 
                 LogicalPlanBuilder::scan_with_filters(
                     &scan.table_name,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3906.

 # Rationale for this change

Described in issue.

# What changes are included in this PR?

Described in issue.

# Are there any user-facing changes?

Plans relying on `TableProviderFatory`s can be shipped.