### PR TITLE
Simplify redundant predicates

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions.rs
+++ b/datafusion/optimizer/src/simplify_expressions.rs
@@ -741,6 +741,12 @@ impl<'a, S: SimplifyInfo> ExprRewriter for Simplifier<'a, S> {
             // Rules for OR
             //
 
+            // A OR A --> A
+            Expr::BinaryExpr(BinaryExpr {
+                left,
+                op: Or,
+                right,
+            }) if &left == &right => *left,
             // true OR A --> true (even if A is null)
             Expr::BinaryExpr(BinaryExpr {
                 left,
@@ -794,6 +800,12 @@ impl<'a, S: SimplifyInfo> ExprRewriter for Simplifier<'a, S> {
             // Rules for AND
             //
 
+            // A AND A --> A
+            Expr::BinaryExpr(BinaryExpr {
+                left,
+                op: And,
+                right,
+            }) if &left == &right => *left,
             // true AND A --> A
             Expr::BinaryExpr(BinaryExpr {
                 left,


### PR DESCRIPTION
Write rules to simplify both `a OR a` and `a AND a` to `a`.

Hello! I wanted to help with issue #3895. This is my attempt, but I'm not sure if this is the desired comparison of the `left` and `right` fields of the `BinaryExpr` struct. I hope this helps and I would appreciate any feedback!
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3895 .


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->