### PR TITLE
Change cast error from Internal to NotImplemented

### DIFF
--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -131,7 +131,7 @@ pub fn cast_with_options(
     } else if can_cast_types(&expr_type, &cast_type) {
         Ok(Arc::new(CastExpr::new(expr, cast_type, cast_options)))
     } else {
-        Err(DataFusionError::Internal(format!(
+        Err(DataFusionError::NotImplemented(format!(
             "Unsupported CAST from {:?} to {:?}",
             expr_type, cast_type
         )))

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -107,7 +107,7 @@ pub fn try_cast(
     } else if can_cast_types(&expr_type, &cast_type) {
         Ok(Arc::new(TryCastExpr::new(expr, cast_type)))
     } else {
-        Err(DataFusionError::Internal(format!(
+        Err(DataFusionError::NotImplemented(format!(
             "Unsupported CAST from {:?} to {:?}",
             expr_type, cast_type
         )))


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/3922

 # Rationale for this change
Reporting an InternalError is confusing 

# What changes are included in this PR?
Change InternalError to NotImplemented when a particular cast is not supported

# Are there any user-facing changes?
different error