### PR TITLE
fix: return error for  unsupported SQL

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1048,12 +1048,41 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: CreateCatalog".to_string(),
                     ))
                 }
-                | LogicalPlan::CreateMemoryTable(_) | LogicalPlan::DropTable(_) | LogicalPlan::DropView(_) | LogicalPlan::CreateView(_) => {
-                    // Create a dummy exec.
-                    Ok(Arc::new(EmptyExec::new(
-                        false,
-                        SchemaRef::new(Schema::empty()),
-                    )))
+                LogicalPlan::CreateMemoryTable(_) => {
+                    // There is no default plan for "CREATE MEMORY TABLE".
+                    // It must be handled at a higher level (so
+                    // that the schema can be registered with
+                    // the context)
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: CreateMemoryTable".to_string(),
+                    ))
+                }
+                LogicalPlan::DropTable(_) => {
+                    // There is no default plan for "DROP TABLE".
+                    // It must be handled at a higher level (so
+                    // that the schema can be registered with
+                    // the context)
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: DropTable".to_string(),
+                    ))
+                }
+                LogicalPlan::DropView(_) => {
+                    // There is no default plan for "DROP VIEW".
+                    // It must be handled at a higher level (so
+                    // that the schema can be registered with
+                    // the context)
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: DropView".to_string(),
+                    ))
+                }
+                LogicalPlan::CreateView(_) => {
+                    // There is no default plan for "CREATE VIEW".
+                    // It must be handled at a higher level (so
+                    // that the schema can be registered with
+                    // the context)
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: CreateView".to_string(),
+                    ))
                 }
                 LogicalPlan::Explain (_) => Err(DataFusionError::Internal(
                     "Unsupported logical plan: Explain must be root of the plan".to_string(),

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -171,6 +171,5 @@ async fn unsupported_sql_returns_error() -> Result<()> {
         "Internal error: Unsupported logical plan: DropTable. \
         This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
     );
-
     Ok(())
 }

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -136,3 +136,41 @@ async fn invalid_qualified_table_references() -> Result<()> {
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn unsupported_sql_returns_error() -> Result<()> {
+    let ctx = SessionContext::new();
+    register_aggregate_csv(&ctx).await?;
+    // create view
+    let sql = "create view test_view as select * from aggregate_test_100";
+    let plan = ctx.create_logical_plan(sql);
+    let physical_plan = ctx.create_physical_plan(&plan.unwrap()).await;
+    assert!(physical_plan.is_err());
+    assert_eq!(
+        format!("{}", physical_plan.unwrap_err()),
+        "Internal error: Unsupported logical plan: CreateView. \
+        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+    );
+    // // drop view
+    let sql = "drop view test_view";
+    let plan = ctx.create_logical_plan(sql);
+    let physical_plan = ctx.create_physical_plan(&plan.unwrap()).await;
+    assert!(physical_plan.is_err());
+    assert_eq!(
+        format!("{}", physical_plan.unwrap_err()),
+        "Internal error: Unsupported logical plan: DropView. \
+        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+    );
+    // // drop table
+    let sql = "drop table aggregate_test_100";
+    let plan = ctx.create_logical_plan(sql);
+    let physical_plan = ctx.create_physical_plan(&plan.unwrap()).await;
+    assert!(physical_plan.is_err());
+    assert_eq!(
+        format!("{}", physical_plan.unwrap_err()),
+        "Internal error: Unsupported logical plan: DropTable. \
+        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3873 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Refer to this issue #3873 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Make some unsupported SQL queries return errors
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->