### PR TITLE
Update minimum chrono dependency to 0.4.22

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -61,7 +61,7 @@ async-compression = { version = "0.3.14", features = ["bzip2", "gzip", "futures-
 async-trait = "0.1.41"
 bytes = "1.1"
 bzip2 = "0.4.3"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.22", default-features = false }
 datafusion-common = { path = "../common", version = "13.0.0", features = ["parquet", "object_store"] }
 datafusion-expr = { path = "../expr", version = "13.0.0" }
 datafusion-jit = { path = "../jit", version = "13.0.0", optional = true }

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -39,7 +39,7 @@ unicode_expressions = []
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.22", default-features = false }
 datafusion-common = { path = "../common", version = "13.0.0" }
 datafusion-expr = { path = "../expr", version = "13.0.0" }
 datafusion-physical-expr = { path = "../physical-expr", version = "13.0.0" }
@@ -50,4 +50,3 @@ log = "^0.4"
 ctor = "0.1.22"
 datafusion-sql = { path = "../sql", version = "13.0.0" }
 env_logger = "0.9.0"
-

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -43,7 +43,7 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 arrow = { version = "25.0.0", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.22", default-features = false }
 datafusion-common = { path = "../common", version = "13.0.0" }
 datafusion-expr = { path = "../expr", version = "13.0.0" }
 datafusion-row = { path = "../row", version = "13.0.0" }


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/3827

 # Rationale for this change
We rely on features in chrono that appeared in versions after 0.4

# What changes are included in this PR?
Increase minimum chrono version to 0.4.22

# Are there any user-facing changes?
Avoid build failures automatically