### PR TITLE
MINOR: Re-export Cast struct

### DIFF
--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -56,7 +56,9 @@ pub use accumulator::{Accumulator, AggregateState};
 pub use aggregate_function::AggregateFunction;
 pub use built_in_function::BuiltinScalarFunction;
 pub use columnar_value::{ColumnarValue, NullColumnarValue};
-pub use expr::{Between, BinaryExpr, Case, Expr, GetIndexedField, GroupingSet, Like};
+pub use expr::{
+    Between, BinaryExpr, Case, Cast, Expr, GetIndexedField, GroupingSet, Like,
+};
 pub use expr_fn::*;
 pub use expr_schema::ExprSchemable;
 pub use function::{


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow on from https://github.com/apache/arrow-datafusion/pull/3931

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

https://github.com/apache/arrow-datafusion/pull/3931 introduced new `Cast` struct but did not add a re-export at the root of `datafusion_expr` crate.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a re-export at the root of `datafusion_expr` crate.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->