### PR TITLE
Add TableProvider.statistics method

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! This module provides an interface for plan level statistics.
+//! This module provides data structures to represent statistics
 
 use crate::ScalarValue;
 
-/// Statistics for a physical plan node
+/// Statistics for a relation
 /// Fields are optional and can be inexact because the sources
 /// sometimes provide approximate estimates for performance reasons
 /// and the transformations output are not always predictable.
@@ -37,7 +37,7 @@ pub struct Statistics {
     pub is_exact: bool,
 }
 
-/// This table statistics are estimates about column
+/// Statistics for a column within a relation
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ColumnStatistics {
     /// Number of null values on column

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -21,6 +21,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion_common::Statistics;
 use datafusion_expr::LogicalPlan;
 pub use datafusion_expr::{TableProviderFilterPushDown, TableType};
 
@@ -76,6 +77,11 @@ pub trait TableProvider: Sync + Send {
         _filter: &Expr,
     ) -> Result<TableProviderFilterPushDown> {
         Ok(TableProviderFilterPushDown::Unsupported)
+    }
+
+    /// Get statistics for this table, if available
+    fn statistics(&self) -> Option<Statistics> {
+        None
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/3983

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I would like the ability for table providers to provide statistics that can be used in logical plan optimizations, such as join reordering.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add new TableProvider.statistics method

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No. The method has a default implementation.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->