### PR TITLE
Don't add projection for semi joins in HashBuildProbeOrder

### DIFF
--- a/datafusion/core/src/physical_optimizer/hash_build_probe_order.rs
+++ b/datafusion/core/src/physical_optimizer/hash_build_probe_order.rs
@@ -174,6 +174,13 @@ impl PhysicalOptimizerRule for HashBuildProbeOrder {
                     *hash_join.partition_mode(),
                     hash_join.null_equals_null(),
                 )?;
+                if matches!(
+                    hash_join.join_type(),
+                    JoinType::LeftSemi | JoinType::RightSemi
+                ) {
+                    return Ok(Arc::new(new_join));
+                }
+
                 let proj = ProjectionExec::try_new(
                     swap_reverting_projection(&left.schema(), &right.schema()),
                     Arc::new(new_join),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4001

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->