### PR TITLE
Minor: remove unecessary clippy allow

### DIFF
--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -540,7 +540,6 @@ fn remove_lowest_value(top_values: &mut BTreeMap<i64, String>) {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
 fn accumulate_batch(
     input_batch: &RecordBatch,
     mut top_values: BTreeMap<i64, String>,


### PR DESCRIPTION
Something I noticed while trolling the code