### PR TITLE
Implement current_date scalar function

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -156,6 +156,8 @@ pub enum BuiltinScalarFunction {
     FromUnixtime,
     ///now
     Now,
+    ///current_date
+    CurrentDate,
     /// translate
     Translate,
     /// trim
@@ -176,7 +178,9 @@ impl BuiltinScalarFunction {
     pub fn supports_zero_argument(&self) -> bool {
         matches!(
             self,
-            BuiltinScalarFunction::Random | BuiltinScalarFunction::Now
+            BuiltinScalarFunction::Random
+                | BuiltinScalarFunction::Now
+                | BuiltinScalarFunction::CurrentDate
         )
     }
     /// Returns the [Volatility] of the builtin function.
@@ -254,6 +258,7 @@ impl BuiltinScalarFunction {
 
             // Stable builtin functions
             BuiltinScalarFunction::Now => Volatility::Stable,
+            BuiltinScalarFunction::CurrentDate => Volatility::Stable,
 
             // Volatile builtin functions
             BuiltinScalarFunction::Random => Volatility::Volatile,
@@ -309,6 +314,7 @@ impl FromStr for BuiltinScalarFunction {
             "concat" => BuiltinScalarFunction::Concat,
             "concat_ws" => BuiltinScalarFunction::ConcatWithSeparator,
             "chr" => BuiltinScalarFunction::Chr,
+            "current_date" => BuiltinScalarFunction::CurrentDate,
             "date_part" | "datepart" => BuiltinScalarFunction::DatePart,
             "date_trunc" | "datetrunc" => BuiltinScalarFunction::DateTrunc,
             "date_bin" => BuiltinScalarFunction::DateBin,

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -452,6 +452,14 @@ pub fn now() -> Expr {
     }
 }
 
+/// Returns current UTC date in default format yyyy-MM-dd
+pub fn current_date() -> Expr {
+    Expr::ScalarFunction {
+        fun: BuiltinScalarFunction::CurrentDate,
+        args: vec![],
+    }
+}
+
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 pub fn case(expr: Expr) -> CaseBuilder {
     CaseBuilder::new(Some(Box::new(expr)), vec![], vec![], None)

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -452,7 +452,7 @@ pub fn now() -> Expr {
     }
 }
 
-/// Returns current UTC date in default format yyyy-MM-dd
+/// Returns current UTC date as a [`DataType::Date32`] value
 pub fn current_date() -> Expr {
     Expr::ScalarFunction {
         fun: BuiltinScalarFunction::CurrentDate,

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -221,6 +221,7 @@ pub fn return_type(
             TimeUnit::Nanosecond,
             Some("UTC".to_owned()),
         )),
+        BuiltinScalarFunction::CurrentDate => Ok(DataType::Date32),
         BuiltinScalarFunction::Translate => {
             utf8_to_str_type(&input_expr_types[0], "translate")
         }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -184,6 +184,21 @@ pub fn make_now(
     }
 }
 
+/// Create an implementation of `current_date()` that always returns the
+/// specified current date.
+///
+/// The semantics of `current_date()` require it to return the same value
+/// wherever it appears within a single statement. This value is
+/// chosen during planning time.
+pub fn make_current_date(
+    now_ts: DateTime<Utc>,
+) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
+    let days = Some(
+        now_ts.num_days_from_ce() - NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce(),
+    );
+    move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Date32(days)))
+}
+
 fn quarter_month(date: &NaiveDateTime) -> u32 {
     1 + 3 * ((date.month() - 1) / 3)
 }

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -427,6 +427,12 @@ pub fn create_physical_fun(
                 execution_props.query_execution_start_time,
             ))
         }
+        BuiltinScalarFunction::CurrentDate => {
+            // bind value for now at plan time
+            Arc::new(datetime_expressions::make_current_date(
+                execution_props.query_execution_start_time,
+            ))
+        }
         BuiltinScalarFunction::InitCap => Arc::new(|args| match args[0].data_type() {
             DataType::Utf8 => {
                 make_scalar_function(string_expressions::initcap::<i32>)(args)

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -428,7 +428,7 @@ pub fn create_physical_fun(
             ))
         }
         BuiltinScalarFunction::CurrentDate => {
-            // bind value for now at plan time
+            // bind value for current_date at plan time
             Arc::new(datetime_expressions::make_current_date(
                 execution_props.query_execution_start_time,
             ))

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -494,6 +494,7 @@ enum ScalarFunction {
   Atan2=67;
   DateBin=68;
   ArrowTypeof=69;
+  CurrentDate=70;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -429,6 +429,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::ToTimestampMicros => Self::ToTimestampMicros,
             ScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
             ScalarFunction::Now => Self::Now,
+            ScalarFunction::CurrentDate => Self::CurrentDate,
             ScalarFunction::Translate => Self::Translate,
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
             ScalarFunction::Coalesce => Self::Coalesce,

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -9617,6 +9617,7 @@ impl serde::Serialize for ScalarFunction {
             Self::Atan2 => "Atan2",
             Self::DateBin => "DateBin",
             Self::ArrowTypeof => "ArrowTypeof",
+            Self::CurrentDate => "CurrentDate",
         };
         serializer.serialize_str(variant)
     }
@@ -9698,6 +9699,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
             "Atan2",
             "DateBin",
             "ArrowTypeof",
+            "CurrentDate",
         ];
 
         struct GeneratedVisitor;
@@ -9810,6 +9812,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
                     "Atan2" => Ok(ScalarFunction::Atan2),
                     "DateBin" => Ok(ScalarFunction::DateBin),
                     "ArrowTypeof" => Ok(ScalarFunction::ArrowTypeof),
+                    "CurrentDate" => Ok(ScalarFunction::CurrentDate),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1222,6 +1222,7 @@ pub enum ScalarFunction {
     Atan2 = 67,
     DateBin = 68,
     ArrowTypeof = 69,
+    CurrentDate = 70,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1300,6 +1301,7 @@ impl ScalarFunction {
             ScalarFunction::Atan2 => "Atan2",
             ScalarFunction::DateBin => "DateBin",
             ScalarFunction::ArrowTypeof => "ArrowTypeof",
+            ScalarFunction::CurrentDate => "CurrentDate",
         }
     }
 }

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1178,6 +1178,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::ToTimestampMicros => Self::ToTimestampMicros,
             BuiltinScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
             BuiltinScalarFunction::Now => Self::Now,
+            BuiltinScalarFunction::CurrentDate => Self::CurrentDate,
             BuiltinScalarFunction::Translate => Self::Translate,
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,
             BuiltinScalarFunction::Coalesce => Self::Coalesce,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3981

# Rationale for this change
DataFusion users need to be able to use the current date to calculate things like "all data in the last 30 days"
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Scalar current_date function
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->