### PR TITLE
Implement `current_time` scalar function

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1668,18 +1668,5 @@ async fn test_current_time() -> Result<()> {
         DataType::Time64(TimeUnit::Nanosecond)
     );
 
-    let sql = "select case when current_time() = cast(now() as time) then 'OK' else 'FAIL' end result";
-    let results = execute_to_batches(&ctx, sql).await;
-
-    let expected = vec![
-        "+--------+",
-        "| result |",
-        "+--------+",
-        "| OK     |",
-        "+--------+",
-    ];
-
-    assert_batches_eq!(expected, &results);
-
     Ok(())
 }

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1651,3 +1651,35 @@ async fn test_current_date() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_current_time() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select current_time() dt";
+    let results = execute_to_batches(&ctx, sql).await;
+    assert_eq!(
+        results[0]
+            .schema()
+            .field_with_name("dt")
+            .unwrap()
+            .data_type()
+            .to_owned(),
+        DataType::Time64(TimeUnit::Nanosecond)
+    );
+
+    let sql = "select case when current_time() = cast(now() as time) then 'OK' else 'FAIL' end result";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+--------+",
+        "| result |",
+        "+--------+",
+        "| OK     |",
+        "+--------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1668,5 +1668,17 @@ async fn test_current_time() -> Result<()> {
         DataType::Time64(TimeUnit::Nanosecond)
     );
 
+    let sql = "select case when current_time() = (now()::bigint % 86400000000000)::time then 'OK' else 'FAIL' end result";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+--------+",
+        "| result |",
+        "+--------+",
+        "| OK     |",
+        "+--------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
     Ok(())
 }

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -158,6 +158,8 @@ pub enum BuiltinScalarFunction {
     Now,
     ///current_date
     CurrentDate,
+    /// current_time
+    CurrentTime,
     /// translate
     Translate,
     /// trim
@@ -181,6 +183,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Random
                 | BuiltinScalarFunction::Now
                 | BuiltinScalarFunction::CurrentDate
+                | BuiltinScalarFunction::CurrentTime
         )
     }
     /// Returns the [Volatility] of the builtin function.
@@ -259,6 +262,7 @@ impl BuiltinScalarFunction {
             // Stable builtin functions
             BuiltinScalarFunction::Now => Volatility::Stable,
             BuiltinScalarFunction::CurrentDate => Volatility::Stable,
+            BuiltinScalarFunction::CurrentTime => Volatility::Stable,
 
             // Volatile builtin functions
             BuiltinScalarFunction::Random => Volatility::Volatile,
@@ -315,6 +319,7 @@ impl FromStr for BuiltinScalarFunction {
             "concat_ws" => BuiltinScalarFunction::ConcatWithSeparator,
             "chr" => BuiltinScalarFunction::Chr,
             "current_date" => BuiltinScalarFunction::CurrentDate,
+            "current_time" => BuiltinScalarFunction::CurrentTime,
             "date_part" | "datepart" => BuiltinScalarFunction::DatePart,
             "date_trunc" | "datetrunc" => BuiltinScalarFunction::DateTrunc,
             "date_bin" => BuiltinScalarFunction::DateBin,

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -460,6 +460,14 @@ pub fn current_date() -> Expr {
     }
 }
 
+/// Returns current UTC time as a [`DataType::Time64`] value
+pub fn current_time() -> Expr {
+    Expr::ScalarFunction {
+        fun: BuiltinScalarFunction::CurrentTime,
+        args: vec![],
+    }
+}
+
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 pub fn case(expr: Expr) -> CaseBuilder {
     CaseBuilder::new(Some(Box::new(expr)), vec![], vec![], None)

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -222,6 +222,7 @@ pub fn return_type(
             Some("UTC".to_owned()),
         )),
         BuiltinScalarFunction::CurrentDate => Ok(DataType::Date32),
+        BuiltinScalarFunction::CurrentTime => Ok(DataType::Time64(TimeUnit::Nanosecond)),
         BuiltinScalarFunction::Translate => {
             utf8_to_str_type(&input_expr_types[0], "translate")
         }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -200,6 +200,20 @@ pub fn make_current_date(
     move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Date32(days)))
 }
 
+/// Create an implementation of `current_time()` that always returns the
+/// specified current time.
+///
+/// The semantics of `current_time()` require it to return the same value
+/// wherever it appears within a single statement. This value is
+/// chosen during planning time.
+pub fn make_current_time(
+    now_ts: DateTime<Utc>,
+) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
+    let nano =
+        Duration::seconds(now_ts.num_seconds_from_midnight() as i64).num_nanoseconds();
+    move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Time64(nano)))
+}
+
 fn quarter_month(date: &NaiveDateTime) -> u32 {
     1 + 3 * ((date.month() - 1) / 3)
 }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -210,7 +210,7 @@ pub fn make_current_time(
     now_ts: DateTime<Utc>,
 ) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
     let nano =
-        Duration::seconds(now_ts.num_seconds_from_midnight() as i64).num_nanoseconds();
+        Some(now_ts.timestamp_nanos() % 86400000000000);
     move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Time64(nano)))
 }
 

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -209,8 +209,7 @@ pub fn make_current_date(
 pub fn make_current_time(
     now_ts: DateTime<Utc>,
 ) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
-    let nano =
-        Some(now_ts.timestamp_nanos() % 86400000000000);
+    let nano = Some(now_ts.timestamp_nanos() % 86400000000000);
     move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Time64(nano)))
 }
 

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -433,6 +433,12 @@ pub fn create_physical_fun(
                 execution_props.query_execution_start_time,
             ))
         }
+        BuiltinScalarFunction::CurrentTime => {
+            // bind value for current_time at plan time
+            Arc::new(datetime_expressions::make_current_time(
+                execution_props.query_execution_start_time,
+            ))
+        }
         BuiltinScalarFunction::InitCap => Arc::new(|args| match args[0].data_type() {
             DataType::Utf8 => {
                 make_scalar_function(string_expressions::initcap::<i32>)(args)

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -496,6 +496,7 @@ enum ScalarFunction {
   DateBin=68;
   ArrowTypeof=69;
   CurrentDate=70;
+  CurrentTime=71;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/from_proto.rs
+++ b/datafusion/proto/src/from_proto.rs
@@ -430,6 +430,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
             ScalarFunction::Now => Self::Now,
             ScalarFunction::CurrentDate => Self::CurrentDate,
+            ScalarFunction::CurrentTime => Self::CurrentTime,
             ScalarFunction::Translate => Self::Translate,
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
             ScalarFunction::Coalesce => Self::Coalesce,

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -9621,6 +9621,7 @@ impl serde::Serialize for ScalarFunction {
             Self::DateBin => "DateBin",
             Self::ArrowTypeof => "ArrowTypeof",
             Self::CurrentDate => "CurrentDate",
+            Self::CurrentTime => "CurrentTime",
         };
         serializer.serialize_str(variant)
     }
@@ -9703,6 +9704,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
             "DateBin",
             "ArrowTypeof",
             "CurrentDate",
+            "CurrentTime",
         ];
 
         struct GeneratedVisitor;
@@ -9816,6 +9818,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
                     "DateBin" => Ok(ScalarFunction::DateBin),
                     "ArrowTypeof" => Ok(ScalarFunction::ArrowTypeof),
                     "CurrentDate" => Ok(ScalarFunction::CurrentDate),
+                    "CurrentTime" => Ok(ScalarFunction::CurrentTime),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1225,6 +1225,7 @@ pub enum ScalarFunction {
     DateBin = 68,
     ArrowTypeof = 69,
     CurrentDate = 70,
+    CurrentTime = 71,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1304,6 +1305,7 @@ impl ScalarFunction {
             ScalarFunction::DateBin => "DateBin",
             ScalarFunction::ArrowTypeof => "ArrowTypeof",
             ScalarFunction::CurrentDate => "CurrentDate",
+            ScalarFunction::CurrentTime => "CurrentTime",
         }
     }
 }

--- a/datafusion/proto/src/to_proto.rs
+++ b/datafusion/proto/src/to_proto.rs
@@ -1179,6 +1179,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::ToTimestampSeconds => Self::ToTimestampSeconds,
             BuiltinScalarFunction::Now => Self::Now,
             BuiltinScalarFunction::CurrentDate => Self::CurrentDate,
+            BuiltinScalarFunction::CurrentTime => Self::CurrentTime,
             BuiltinScalarFunction::Translate => Self::Translate,
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,
             BuiltinScalarFunction::Coalesce => Self::Coalesce,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3982 .

# Rationale for this change
DataFusion users need to be able to use the current time to calculate things like "all data in the last 5 hours"
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Scalar `current_time` function

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->