### PR TITLE
Build tests separately from running

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,10 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Build tests
+        run: |
+          export PATH=$PATH:$HOME/d/protoc/bin
+          cargo test --features avro,jit,scheduler,json --no-run
       - name: Run tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -147,7 +151,7 @@ jobs:
           mkdir -p benchmarks/data/answers
           git clone https://github.com/databricks/tpch-dbgen.git
           cd tpch-dbgen
-          make  
+          make
           ./dbgen -f -s 1
           mv *.tbl ../benchmarks/data
           mv ./answers/* ../benchmarks/data/answers/


### PR DESCRIPTION

# Which issue does this PR close?
re https://github.com/apache/arrow-datafusion/issues/3045


# Rationale for this change
I would like to know how long actually running tests takes (compared to building them) to see if there is any good way to break up / parallelize the datafusion CI to make it faster

![Screen Shot 2022-11-01 at 4 56 53 PM](https://user-images.githubusercontent.com/490673/199339443-9f9f87d8-2552-487c-93bc-c81a69631293.png)



# What changes are included in this PR?
Cargo build + test separately


# Are there any user-facing changes?
No