### PR TITLE
Improve Error Handling and Readibility for downcasting `StructArray`

### DIFF
--- a/benchmarks/src/tpch.rs
+++ b/benchmarks/src/tpch.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use arrow::array::{
-    Array, ArrayRef, Date32Array, Decimal128Array, Float64Array, Int32Array, Int64Array,
-    StringArray,
+    Array, ArrayRef, Decimal128Array, Float64Array, Int32Array, Int64Array, StringArray,
 };
 use arrow::record_batch::RecordBatch;
 use datafusion::common::cast::as_date32_array;
@@ -440,9 +439,9 @@ fn col_to_scalar(column: &ArrayRef, row_index: usize) -> ScalarValue {
             ScalarValue::Decimal128(Some(array.value(row_index)), *p, *s)
         }
         DataType::Date32 => {
-            let array = match as_date32_array(column){
+            let array = match as_date32_array(column) {
                 Ok(array) => array,
-                Err(e) => panic!("{}", e)
+                Err(e) => panic!("{}", e),
             };
             ScalarValue::Date32(Some(array.value(row_index)))
         }

--- a/benchmarks/src/tpch.rs
+++ b/benchmarks/src/tpch.rs
@@ -20,6 +20,7 @@ use arrow::array::{
     StringArray,
 };
 use arrow::record_batch::RecordBatch;
+use datafusion::common::cast::as_date32_array;
 use std::fs;
 use std::ops::{Div, Mul};
 use std::path::Path;
@@ -439,7 +440,10 @@ fn col_to_scalar(column: &ArrayRef, row_index: usize) -> ScalarValue {
             ScalarValue::Decimal128(Some(array.value(row_index)), *p, *s)
         }
         DataType::Date32 => {
-            let array = column.as_any().downcast_ref::<Date32Array>().unwrap();
+            let array = match as_date32_array(column){
+                Ok(array) => array,
+                Err(e) => panic!("{}", e)
+            };
             ScalarValue::Date32(Some(array.value(row_index)))
         }
         DataType::Utf8 => {

--- a/benchmarks/src/tpch.rs
+++ b/benchmarks/src/tpch.rs
@@ -19,13 +19,13 @@ use arrow::array::{
     Array, ArrayRef, Decimal128Array, Float64Array, Int32Array, Int64Array, StringArray,
 };
 use arrow::record_batch::RecordBatch;
-use datafusion::common::cast::as_date32_array;
 use std::fs;
 use std::ops::{Div, Mul};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
+use datafusion::common::cast::as_date32_array;
 use datafusion::common::ScalarValue;
 use datafusion::logical_expr::Cast;
 use datafusion::prelude::*;
@@ -439,10 +439,7 @@ fn col_to_scalar(column: &ArrayRef, row_index: usize) -> ScalarValue {
             ScalarValue::Decimal128(Some(array.value(row_index)), *p, *s)
         }
         DataType::Date32 => {
-            let array = match as_date32_array(column) {
-                Ok(array) => array,
-                Err(e) => panic!("{}", e),
-            };
+            let array = as_date32_array(column).unwrap();
             ScalarValue::Date32(Some(array.value(row_index)))
         }
         DataType::Utf8 => {

--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -37,7 +37,7 @@ pub fn as_date32_array(array: &dyn Array) -> Result<&Date32Array, DataFusionErro
 pub fn as_struct_array(array: &dyn Array) -> Result<&StructArray, DataFusionError> {
     array.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
         DataFusionError::Internal(format!(
-            "Expected a Date32Array, got: {}",
+            "Expected a StructArray, got: {}",
             array.data_type()
         ))
     })

--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -21,11 +21,21 @@
 //! kernels in arrow-rs such as `as_boolean_array` do.
 
 use crate::DataFusionError;
-use arrow::array::{Array, Date32Array};
+use arrow::array::{Array, Date32Array, StructArray};
 
 // Downcast ArrayRef to Date32Array
 pub fn as_date32_array(array: &dyn Array) -> Result<&Date32Array, DataFusionError> {
     array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "Expected a Date32Array, got: {}",
+            array.data_type()
+        ))
+    })
+}
+
+// Downcast ArrayRef to Date32Array
+pub fn as_struct_array(array: &dyn Array) -> Result<&StructArray, DataFusionError> {
+    array.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
         DataFusionError::Internal(format!(
             "Expected a Date32Array, got: {}",
             array.data_type()

--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -33,7 +33,7 @@ pub fn as_date32_array(array: &dyn Array) -> Result<&Date32Array, DataFusionErro
     })
 }
 
-// Downcast ArrayRef to Date32Array
+// Downcast ArrayRef to StructArray
 pub fn as_struct_array(array: &dyn Array) -> Result<&StructArray, DataFusionError> {
     array.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
         DataFusionError::Internal(format!(

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3604,7 +3604,7 @@ mod tests {
         // iter_to_array for struct scalars
         let array =
             ScalarValue::iter_to_array(vec![s0.clone(), s1.clone(), s2.clone()]).unwrap();
-        let array =  as_struct_array(&array).unwrap();
+        let array = as_struct_array(&array).unwrap();
         let expected = StructArray::from(vec![
             (
                 field_a.clone(),

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3604,11 +3604,7 @@ mod tests {
         // iter_to_array for struct scalars
         let array =
             ScalarValue::iter_to_array(vec![s0.clone(), s1.clone(), s2.clone()]).unwrap();
-        let array = match as_struct_array(&array) {
-            Ok(array) => array,
-            Err(e) => panic!("{}", e),
-        };
-
+        let array =  as_struct_array(&array).unwrap();
         let expected = StructArray::from(vec![
             (
                 field_a.clone(),

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -39,6 +39,7 @@ use arrow::{
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime};
 use ordered_float::OrderedFloat;
 
+use crate::cast::as_struct_array;
 use crate::delta::shift_months;
 use crate::error::{DataFusionError, Result};
 
@@ -2008,15 +2009,7 @@ impl ScalarValue {
                 Self::Dictionary(key_type.clone(), Box::new(value))
             }
             DataType::Struct(fields) => {
-                let array =
-                    array
-                        .as_any()
-                        .downcast_ref::<StructArray>()
-                        .ok_or_else(|| {
-                            DataFusionError::Internal(
-                                "Failed to downcast ArrayRef to StructArray".to_string(),
-                            )
-                        })?;
+                let array = as_struct_array(array)?;
                 let mut field_values: Vec<ScalarValue> = Vec::new();
                 for col_index in 0..array.num_columns() {
                     let col_array = array.column(col_index);
@@ -3611,7 +3604,10 @@ mod tests {
         // iter_to_array for struct scalars
         let array =
             ScalarValue::iter_to_array(vec![s0.clone(), s1.clone(), s2.clone()]).unwrap();
-        let array = array.as_any().downcast_ref::<StructArray>().unwrap();
+        let array = match as_struct_array(&array) {
+            Ok(array) => array,
+            Err(e) => panic!("{}", e),
+        };
 
         let expected = StructArray::from(vec![
             (

--- a/datafusion/physical-expr/src/expressions/get_indexed_field.rs
+++ b/datafusion/physical-expr/src/expressions/get_indexed_field.rs
@@ -19,7 +19,7 @@
 
 use crate::PhysicalExpr;
 use arrow::array::Array;
-use arrow::array::{ListArray, StructArray};
+use arrow::array::ListArray;
 use arrow::compute::concat;
 
 use crate::physical_expr::down_cast_any_ref;
@@ -27,6 +27,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cast::as_struct_array;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
@@ -122,7 +123,7 @@ impl PhysicalExpr for GetIndexedFieldExpr {
                 }
             }
             (DataType::Struct(_), ScalarValue::Utf8(Some(k))) => {
-                let as_struct_array = array.as_any().downcast_ref::<StructArray>().unwrap();
+                let as_struct_array = as_struct_array(&array)?;
                 match as_struct_array.column_by_name(k) {
                     None => Err(DataFusionError::Execution(format!("get indexed field {} not found in struct", k))),
                     Some(col) => Ok(ColumnarValue::Array(col.clone()))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3152.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
It is very clear in the issue but there are different schemas while downcasting an ArrayRef to a related arrow array type. This is the second PR of improving downcasting of `StructArray`.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- `as_struct_array` function is implemented in `datafusion\common\src\cast.rs`
- Refactor necessary parts
- Passed related test

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
I don't think so.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->