### PR TITLE
support `SET` variable

### DIFF
--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -362,7 +362,7 @@ impl ConfigOptions {
 
     /// set a `String` configuration option
     pub fn set_string(&mut self, key: &str, value: impl Into<String>) {
-        self.set(key, ScalarValue::Utf8(Some(value)))
+        self.set(key, ScalarValue::Utf8(Some(value.into())))
     }
 
     /// get a configuration option

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -361,7 +361,7 @@ impl ConfigOptions {
     }
 
     /// set a `String` configuration option
-    pub fn set_string(&mut self, key: &str, value: String) {
+    pub fn set_string(&mut self, key: &str, value: impl Into<String>) {
         self.set(key, ScalarValue::Utf8(Some(value)))
     }
 

--- a/datafusion/core/src/config.rs
+++ b/datafusion/core/src/config.rs
@@ -360,6 +360,11 @@ impl ConfigOptions {
         self.set(key, ScalarValue::UInt64(Some(value)))
     }
 
+    /// set a `String` configuration option
+    pub fn set_string(&mut self, key: &str, value: String) {
+        self.set(key, ScalarValue::Utf8(Some(value)))
+    }
+
     /// get a configuration option
     pub fn get(&self, key: &str) -> Option<ScalarValue> {
         self.options.get(key).cloned()

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -350,7 +350,7 @@ impl SessionContext {
                 let old_value =
                     config_options.read().get(&variable).ok_or_else(|| {
                         DataFusionError::Execution(format!(
-                            "Unknown Variable {}",
+                            "Can not SET variable: Unknown Variable {}",
                             variable
                         ))
                     })?;

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1097,6 +1097,11 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: CreateView".to_string(),
                     ))
                 }
+                LogicalPlan::SetVariable(_) => {
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: SetVariable must be root of the plan".to_string(),
+                    ))
+                }
                 LogicalPlan::Explain(_) => Err(DataFusionError::Internal(
                     "Unsupported logical plan: Explain must be root of the plan".to_string(),
                 )),

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -109,6 +109,7 @@ pub mod idenfifers;
 pub mod information_schema;
 pub mod parquet_schema;
 pub mod partitioned_csv;
+pub mod set_variable;
 pub mod subqueries;
 #[cfg(feature = "unicode_expressions")]
 pub mod unicode;

--- a/datafusion/core/tests/sql/set_variable.rs
+++ b/datafusion/core/tests/sql/set_variable.rs
@@ -108,7 +108,10 @@ async fn set_variable_unknown_variable() {
     let err = plan_and_collect(&ctx, "SET aabbcc to '1'")
         .await
         .unwrap_err();
-    assert_eq!(err.to_string(), "Execution error: Can not SET variable: Unknown Variable aabbcc");
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Can not SET variable: Unknown Variable aabbcc"
+    );
 }
 
 #[tokio::test]

--- a/datafusion/core/tests/sql/set_variable.rs
+++ b/datafusion/core/tests/sql/set_variable.rs
@@ -108,7 +108,7 @@ async fn set_variable_unknown_variable() {
     let err = plan_and_collect(&ctx, "SET aabbcc to '1'")
         .await
         .unwrap_err();
-    assert_eq!(err.to_string(), "Execution error: Unknown Variable aabbcc");
+    assert_eq!(err.to_string(), "Execution error: Can not SET variable: Unknown Variable aabbcc");
 }
 
 #[tokio::test]

--- a/datafusion/core/tests/sql/set_variable.rs
+++ b/datafusion/core/tests/sql/set_variable.rs
@@ -1,0 +1,293 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn set_variable_to_value() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.execution.batch_size to 1")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 1       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_variable_to_value_with_equal_sign() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.execution.batch_size = 1")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 1       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_variable_to_value_with_single_quoted_string() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.execution.batch_size to '1'")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 1       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_variable_to_value_case_insensitive() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.EXECUTION.batch_size to '1'")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 1       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_variable_unknown_variable() {
+    let ctx = SessionContext::new();
+
+    let err = plan_and_collect(&ctx, "SET aabbcc to '1'")
+        .await
+        .unwrap_err();
+    assert_eq!(err.to_string(), "Execution error: Unknown Variable aabbcc");
+}
+
+#[tokio::test]
+async fn set_bool_variable() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.execution.coalesce_batches to true")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.coalesce_batches")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------------+---------+",
+        "| name                                  | setting |",
+        "+---------------------------------------+---------+",
+        "| datafusion.execution.coalesce_batches | true    |",
+        "+---------------------------------------+---------+",
+    ];
+    assert_batches_eq!(expected, &result);
+
+    ctx.sql("SET datafusion.execution.coalesce_batches to 'false'")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.coalesce_batches")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------------+---------+",
+        "| name                                  | setting |",
+        "+---------------------------------------+---------+",
+        "| datafusion.execution.coalesce_batches | false   |",
+        "+---------------------------------------+---------+",
+    ];
+    assert_batches_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_bool_variable_bad_value() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    let err = plan_and_collect(&ctx, "SET datafusion.execution.coalesce_batches to 1")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Failed to parse 1 as bool"
+    );
+
+    let err = plan_and_collect(&ctx, "SET datafusion.execution.coalesce_batches to abc")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Failed to parse abc as bool"
+    );
+}
+
+#[tokio::test]
+async fn set_u64_variable() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    ctx.sql("SET datafusion.execution.batch_size to 0")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 0       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_eq!(expected, &result);
+
+    ctx.sql("SET datafusion.execution.batch_size to '1'")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 1       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_eq!(expected, &result);
+
+    ctx.sql("SET datafusion.execution.batch_size to +2")
+        .await
+        .unwrap();
+    let result = plan_and_collect(&ctx, "SHOW datafusion.execution.batch_size")
+        .await
+        .unwrap();
+    let expected = vec![
+        "+---------------------------------+---------+",
+        "| name                            | setting |",
+        "+---------------------------------+---------+",
+        "| datafusion.execution.batch_size | 2       |",
+        "+---------------------------------+---------+",
+    ];
+    assert_batches_eq!(expected, &result);
+}
+
+#[tokio::test]
+async fn set_u64_variable_bad_value() {
+    let ctx =
+        SessionContext::with_config(SessionConfig::new().with_information_schema(true));
+
+    let err = plan_and_collect(&ctx, "SET datafusion.execution.batch_size to -1")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Failed to parse -1 as u64"
+    );
+
+    let err = plan_and_collect(&ctx, "SET datafusion.execution.batch_size to abc")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Failed to parse abc as u64"
+    );
+
+    let err = plan_and_collect(&ctx, "SET datafusion.execution.batch_size to 0.1")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Execution error: Failed to parse 0.1 as u64"
+    );
+}
+
+#[tokio::test]
+async fn set_time_zone() {
+    // we don't support changing time zone for now until all time zone issues fixed and related function completed
+
+    let ctx = SessionContext::new();
+
+    // for full variable name
+    let err = plan_and_collect(&ctx, "set datafusion.execution.time_zone = '8'")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Error during planning: Changing Time Zone isn't supported yet"
+    );
+
+    // for alias time zone
+    let err = plan_and_collect(&ctx, "set time zone = '8'")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Error during planning: Changing Time Zone isn't supported yet"
+    );
+
+    // for alias timezone
+    let err = plan_and_collect(&ctx, "set timezone = '8'")
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Error during planning: Changing Time Zone isn't supported yet"
+    );
+}

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -72,7 +72,7 @@ pub use logical_plan::{
     CreateMemoryTable, CreateView, CrossJoin, Distinct, DropTable, DropView,
     EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
     LogicalPlan, LogicalPlanBuilder, Partitioning, PlanType, PlanVisitor, Projection,
-    Repartition, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
+    Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
     ToStringifiedPlan, Union, UserDefinedLogicalNode, Values, Window,
 };
 pub use nullif::SUPPORTED_NULLIF_TYPES;

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -25,9 +25,9 @@ pub use plan::{
     Aggregate, Analyze, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
     CreateMemoryTable, CreateView, CrossJoin, Distinct, DropTable, DropView,
     EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
-    LogicalPlan, Partitioning, PlanType, PlanVisitor, Projection, Repartition, Sort,
-    StringifiedPlan, Subquery, SubqueryAlias, TableScan, ToStringifiedPlan, Union,
-    Values, Window,
+    LogicalPlan, Partitioning, PlanType, PlanVisitor, Projection, Repartition,
+    SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
+    ToStringifiedPlan, Union, Values, Window,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1068,7 +1068,7 @@ pub struct DropView {
     pub schema: DFSchemaRef,
 }
 
-/// Set a Variable
+/// Set a Variable -- value in [`ConfigOptions`]
 #[derive(Clone)]
 pub struct SetVariable {
     /// The variable name

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -584,6 +584,7 @@ pub fn from_plan(
         | LogicalPlan::CreateExternalTable(_)
         | LogicalPlan::DropTable(_)
         | LogicalPlan::DropView(_)
+        | LogicalPlan::SetVariable(_)
         | LogicalPlan::CreateCatalogSchema(_)
         | LogicalPlan::CreateCatalog(_) => {
             // All of these plan types have no inputs / exprs so should not be called

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -226,6 +226,7 @@ fn optimize(
         | LogicalPlan::CreateCatalog(_)
         | LogicalPlan::DropTable(_)
         | LogicalPlan::DropView(_)
+        | LogicalPlan::SetVariable(_)
         | LogicalPlan::Distinct(_)
         | LogicalPlan::Extension { .. } => {
             // apply the optimization to all inputs of the plan

--- a/datafusion/optimizer/src/projection_push_down.rs
+++ b/datafusion/optimizer/src/projection_push_down.rs
@@ -485,6 +485,7 @@ fn optimize_plan(
         | LogicalPlan::CreateCatalog(_)
         | LogicalPlan::DropTable(_)
         | LogicalPlan::DropView(_)
+        | LogicalPlan::SetVariable(_)
         | LogicalPlan::CrossJoin(_)
         | LogicalPlan::Distinct(_)
         | LogicalPlan::Extension { .. } => {

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -1351,6 +1351,9 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::DropView(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DropView",
             )),
+            LogicalPlan::SetVariable(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for DropView",
+            )),
         }
     }
 }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -2529,7 +2529,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
         };
 
-        // need to set config here
         Ok(LogicalPlan::SetVariable(SetVariable {
             variable: variable_lower,
             value: value_string,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4067 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

to support
```bash
SET [VARIABLE] [TO | =] [VALUE | 'VALUE']
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

support u64 value
```bash
❯ set datafusion.execution.batch_size = 1;
0 rows in set. Query took 0.001 seconds.
❯ show datafusion.execution.batch_size;
+---------------------------------+---------+
| name                            | setting |
+---------------------------------+---------+
| datafusion.execution.batch_size | 1       |
+---------------------------------+---------+
1 row in set. Query took 0.013 seconds.
```

support bool 
```bash
❯ set datafusion.execution.coalesce_batches to false;
0 rows in set. Query took 0.000 seconds.
❯ show datafusion.execution.coalesce_batches;
+---------------------------------------+---------+
| name                                  | setting |
+---------------------------------------+---------+
| datafusion.execution.coalesce_batches | false   |
+---------------------------------------+---------+
1 row in set. Query took 0.007 seconds.
```
support single quoted string 
```bash
❯ set datafusion.execution.coalesce_batches to 'false';
0 rows in set. Query took 0.000 seconds.
❯ show datafusion.execution.coalesce_batches;
+---------------------------------------+---------+
| name                                  | setting |
+---------------------------------------+---------+
| datafusion.execution.coalesce_batches | false   |
+---------------------------------------+---------+
1 row in set. Query took 0.007 seconds.
```


support alias `TIME ZONE` and `TIMEZONE`

as discussed in https://github.com/apache/arrow-datafusion/issues/3148#issuecomment-1226105182
we disallow `set timezone` for now until timezone integration is full completed

```bash
❯ set time zone = 1;
Plan("Changing Time Zone isn't supported yet")
```

throw error for unknown variable
```bash
❯ set abc = 1;
Execution("Unknown Variable abc")
```

throw error for incorrect data type
```bash
❯ set datafusion.execution.batch_size = a;
Execution("Failed to parse a as u64")
```
```bash
❯ set datafusion.execution.batch_size = -1;
Execution("Failed to parse -1 as u64")
```

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->