### PR TITLE
Improve FieldNotFound errors

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -34,6 +34,14 @@ pub struct Column {
 }
 
 impl Column {
+    /// Create Column from optional qualifier and name
+    pub fn new(relation: Option<impl Into<String>>, name: impl Into<String>) -> Self {
+        Self {
+            relation: relation.map(|r| r.into()),
+            name: name.into(),
+        }
+    }
+
     /// Create Column from unqualified name.
     pub fn from_name(name: impl Into<String>) -> Self {
         Self {
@@ -120,12 +128,11 @@ impl Column {
         }
 
         Err(DataFusionError::SchemaError(SchemaError::FieldNotFound {
-            qualifier: self.relation.clone(),
-            name: self.name,
+            field: Column::new(self.relation.clone(), self.name),
             valid_fields: Some(
                 schemas
                     .iter()
-                    .flat_map(|s| s.fields().iter().map(|f| f.qualified_name()))
+                    .flat_map(|s| s.fields().iter().map(|f| f.qualified_column()))
                     .collect(),
             ),
         }))

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -597,6 +597,18 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
+    fn qualifier_in_name() -> Result<()> {
+        let schema = DFSchema::try_from_qualified_schema("t1", &test_schema_1())?;
+        // lookup with unqualified name "t1.c0"
+        let err = schema.index_of_column_by_name(None, "t1.c0").err().unwrap();
+        assert_eq!(
+            "Schema error: No field named 't1.c0'. Valid fields are 't1'.'c0', 't1'.'c1'.",
+            &format!("{}", err)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn from_unqualified_field() {
         let field = Field::new("c0", DataType::Boolean, true);
         let field = DFField::from(field);
@@ -663,7 +675,7 @@ mod tests {
         assert!(join.is_err());
         assert_eq!(
             "Schema error: Schema contains duplicate \
-        qualified field name \'t1.c0\'",
+        qualified field name \'t1\'.\'c0\'",
             &format!("{}", join.err().unwrap())
         );
         Ok(())
@@ -712,7 +724,7 @@ mod tests {
         assert!(join.is_err());
         assert_eq!(
             "Schema error: Schema contains qualified \
-        field name \'t1.c0\' and unqualified field name \'c0\' which would be ambiguous",
+        field name \'t1\'.\'c0\' and unqualified field name \'c0\' which would be ambiguous",
             &format!("{}", join.err().unwrap())
         );
         Ok(())
@@ -722,7 +734,7 @@ mod tests {
     #[test]
     fn helpful_error_messages() -> Result<()> {
         let schema = DFSchema::try_from_qualified_schema("t1", &test_schema_1())?;
-        let expected_help = "Valid fields are \'t1.c0\', \'t1.c1\'.";
+        let expected_help = "Valid fields are \'t1\'.\'c0\', \'t1\'.\'c1\'.";
         // Pertinent message parts
         let expected_err_msg = "Fully qualified field name \'t1.c0\'";
         assert!(schema

--- a/datafusion/core/tests/sql/references.rs
+++ b/datafusion/core/tests/sql/references.rs
@@ -67,7 +67,7 @@ async fn qualified_table_references_and_fields() -> Result<()> {
     let error = ctx.create_logical_plan(sql).unwrap_err();
     assert_contains!(
         error.to_string(),
-        "No field named 'f1.c1'. Valid fields are 'test.f.c1', 'test.test.c2'"
+        "No field named 'f1'.'c1'. Valid fields are 'test'.'f.c1', 'test'.'test.c2'"
     );
 
     // however, enclosing it in double quotes is ok

--- a/datafusion/expr/src/expr_rewriter.rs
+++ b/datafusion/expr/src/expr_rewriter.rs
@@ -673,7 +673,7 @@ mod test {
             .to_string();
         assert_eq!(
             error,
-            "Schema error: No field named 'b'. Valid fields are 'tableA.a'."
+            "Schema error: No field named 'b'. Valid fields are 'tableA'.'a'."
         );
     }
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3589,8 +3589,8 @@ mod tests {
         let sql = "SELECT SUM(age) FROM person GROUP BY doesnotexist";
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!("Schema error: No field named 'doesnotexist'. Valid fields are 'SUM(person.age)', \
-        'person.id', 'person.first_name', 'person.last_name', 'person.age', 'person.state', \
-        'person.salary', 'person.birth_date', 'person.😀'.", format!("{}", err));
+        'person'.'id', 'person'.'first_name', 'person'.'last_name', 'person'.'age', 'person'.'state', \
+        'person'.'salary', 'person'.'birth_date', 'person'.'😀'.", format!("{}", err));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/4083

# Rationale for this change

It is confusing to get an error saying that field `'t1.c0'` does not exist but then states that field `'t1.c0`' is available. This happens when the qualifier is part of the field name and not in the qualifier field.

## Before

```
No field named 't1.c0'. Valid fields are 't1.c0', ...
```

## After

```
No field named 't1.c0'. Valid fields are 't1'.'c0', ...
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change error message formating to put quotes around qualifier and name rather than around the qualified name, so `'foo'.'bar'` rather than `'foo.bar'`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->