### PR TITLE
minor: Use Operator::swap

### DIFF
--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -841,7 +841,7 @@ fn build_statistics_expr(expr_builder: &mut PruningExpressionBuilder) -> Result<
             }
             // other expressions are not supported
             _ => return Err(DataFusionError::Plan(
-                "expressions} other than (neq, eq, gt, gteq, lt, lteq) are not supported"
+                "expressions other than (neq, eq, gt, gteq, lt, lteq) are not supported"
                     .to_string(),
             )),
         };

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -445,7 +445,7 @@ impl<'a> PruningExpressionBuilder<'a> {
         let (column_expr, scalar_expr, columns, correct_operator) =
             match (left_columns.len(), right_columns.len()) {
                 (1, 0) => (left, right, left_columns, op),
-                (0, 1) => (right, left, right_columns, reverse_operator(op)),
+                (0, 1) => (right, left, right_columns, reverse_operator(op)?),
                 _ => {
                     // if more than one column used in expression - not supported
                     return Err(DataFusionError::Plan(
@@ -547,7 +547,7 @@ fn rewrite_expr_to_prunable(
         // `-col > lit()`  --> `col < -lit()`
         Expr::Negative(c) => {
             let (left, op, right) = rewrite_expr_to_prunable(c, op, scalar_expr, schema)?;
-            Ok((left, reverse_operator(op), Expr::Negative(Box::new(right))))
+            Ok((left, reverse_operator(op)?, Expr::Negative(Box::new(right))))
         }
         // `!col = true` --> `col = !true`
         Expr::Not(c) => {
@@ -560,7 +560,7 @@ fn rewrite_expr_to_prunable(
             return match c.as_ref() {
                 Expr::Column(_) => Ok((
                     c.as_ref().clone(),
-                    reverse_operator(op),
+                    reverse_operator(op)?,
                     Expr::Not(Box::new(scalar_expr.clone())),
                 )),
                 _ => Err(DataFusionError::Plan(format!(
@@ -641,14 +641,13 @@ fn rewrite_column_expr(
     })
 }
 
-fn reverse_operator(op: Operator) -> Operator {
-    match op {
-        Operator::Lt => Operator::Gt,
-        Operator::Gt => Operator::Lt,
-        Operator::LtEq => Operator::GtEq,
-        Operator::GtEq => Operator::LtEq,
-        _ => op,
-    }
+fn reverse_operator(op: Operator) -> Result<Operator> {
+    op.swap().ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "Could not reverse operator {} while building pruning predicate",
+            op
+        ))
+    })
 }
 
 /// Given a column reference to `column`, returns a pruning
@@ -842,7 +841,7 @@ fn build_statistics_expr(expr_builder: &mut PruningExpressionBuilder) -> Result<
             }
             // other expressions are not supported
             _ => return Err(DataFusionError::Plan(
-                "expressions other than (neq, eq, gt, gteq, lt, lteq) are not supported"
+                "expressions} other than (neq, eq, gt, gteq, lt, lteq) are not supported"
                     .to_string(),
             )),
         };


### PR DESCRIPTION
# Which issue does this PR close?
N/A

# Rationale for this change
While reviewing https://github.com/apache/arrow-datafusion/pull/3912 from @isidentical  I noticed there was some duplication of "reverse the operator" logic in DataFusion

Less duplication I think leads to easier to understand code


# What changes are included in this PR?
Use `Operator::swap()`  in pruning predicate rather than another copy

# Are there any user-facing changes?
