### PR TITLE
fix: Scheduler panic routing errors

### DIFF
--- a/datafusion/core/src/scheduler/task.rs
+++ b/datafusion/core/src/scheduler/task.rs
@@ -108,17 +108,24 @@ impl Task {
         routable: &RoutablePipeline,
         error: DataFusionError,
     ) {
-        self.context.send_query_output(partition, Err(error));
-        if let Some(link) = routable.output {
-            trace!(
-                "Closing pipeline: {:?}, partition: {}, due to error",
-                link,
-                self.waker.partition,
-            );
+        match routable.output {
+            Some(link) => {
+                // The query output partitioning may not match the current pipeline's
+                // but the query output has at least one partition
+                // so send error to the first partition of the query output.
+                self.context.send_query_output(0, Err(error));
 
-            self.context.pipelines[link.pipeline]
-                .pipeline
-                .close(link.child, self.waker.partition);
+                trace!(
+                    "Closing pipeline: {:?}, partition: {}, due to error",
+                    link,
+                    self.waker.partition,
+                );
+
+                self.context.pipelines[link.pipeline]
+                    .pipeline
+                    .close(link.child, self.waker.partition);
+            }
+            None => self.context.send_query_output(partition, Err(error)),
         }
     }
 
@@ -303,6 +310,10 @@ impl ExecutionContext {
 
     /// Sends `output` to this query's output stream
     fn send_query_output(&self, partition: usize, output: Result<RecordBatch>) {
+        debug_assert!(
+            self.output.len() > partition,
+            "the specified partition exceeds the total number of output partitions"
+        );
         let _ = self.output[partition].unbounded_send(Some(output));
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4096 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The query output partition number may not equal current pipeline's output partition number, so send error to the partition of the query output will cause panic.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Because the query output has at least one partition，so we send error that thrown by non-output pipelines to the first partition of the query output.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->