### PR TITLE
Add metrics for parquet page level skipping

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -538,9 +538,7 @@ pub(crate) mod test_util {
             // All batches write in to one file, each batch must have same schema.
             let mut output = NamedTempFile::new().expect("creating temp file");
             let mut builder = WriterProperties::builder();
-            // todo https://github.com/apache/arrow-rs/issues/2941 release change to row limit.
-            builder = builder.set_data_pagesize_limit(1);
-            builder = builder.set_write_batch_size(1);
+            builder = builder.set_data_page_row_count_limit(2);
             let proper = builder.build();
             let mut writer =
                 ArrowWriter::try_new(&mut output, batches[0].schema(), Some(proper))

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1723,7 +1723,6 @@ mod tests {
 
         let metrics = rt.parquet_exec.metrics().unwrap();
 
-        // todo fix this  https://github.com/apache/arrow-rs/issues/2941 release change to row limit.
         // assert the batches and some metrics
         let expected = vec![
             "+-----+", "| int |", "+-----+", "| 3   |", "| 4   |", "| 5   |", "+-----+",

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1726,11 +1726,10 @@ mod tests {
         // todo fix this  https://github.com/apache/arrow-rs/issues/2941 release change to row limit.
         // assert the batches and some metrics
         let expected = vec![
-            "+-----+", "| int |", "+-----+", "|     |", "| 1   |", "| 2   |", "| 3   |",
-            "| 4   |", "| 5   |", "+-----+",
+            "+-----+", "| int |", "+-----+", "| 3 |", "| 4 |", "| 5 |", "+-----+",
         ];
         assert_batches_sorted_eq!(expected, &rt.batches.unwrap());
-        assert_eq!(get_value(&metrics, "page_index_rows_filtered"), 0);
+        assert_eq!(get_value(&metrics, "page_index_rows_filtered"), 3);
         assert!(
             get_value(&metrics, "page_index_eval_time") > 0,
             "no eval time in metrics: {:#?}",

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -449,7 +449,7 @@ impl FileOpener for ParquetOpener {
             // page index pruning: if all data on individual pages can
             // be ruled using page metadata, rows from other columns
             // with that range can be skipped as well
-            if let Some(row_selection) = enable_page_index
+            if let Some(row_selection) = (enable_page_index && !row_groups.is_empty())
                 .then(|| {
                     page_filter::build_page_filter(
                         pruning_predicate.as_ref(),
@@ -919,7 +919,7 @@ mod tests {
         datasource::file_format::{parquet::ParquetFormat, FileFormat},
         physical_plan::collect,
     };
-    use arrow::array::Float32Array;
+    use arrow::array::{Float32Array, Int32Array};
     use arrow::datatypes::DataType::Decimal128;
     use arrow::record_batch::RecordBatch;
     use arrow::{
@@ -960,9 +960,16 @@ mod tests {
         predicate: Option<Expr>,
         pushdown_predicate: bool,
     ) -> Result<Vec<RecordBatch>> {
-        round_trip(batches, projection, schema, predicate, pushdown_predicate)
-            .await
-            .batches
+        round_trip(
+            batches,
+            projection,
+            schema,
+            predicate,
+            pushdown_predicate,
+            false,
+        )
+        .await
+        .batches
     }
 
     /// Writes each RecordBatch as an individual parquet file and then
@@ -974,6 +981,7 @@ mod tests {
         schema: Option<SchemaRef>,
         predicate: Option<Expr>,
         pushdown_predicate: bool,
+        page_index_predicate: bool,
     ) -> RoundTripResult {
         let file_schema = match schema {
             Some(schema) => schema,
@@ -983,7 +991,7 @@ mod tests {
             ),
         };
 
-        let (meta, _files) = store_parquet(batches).await.unwrap();
+        let (meta, _files) = store_parquet(batches, page_index_predicate).await.unwrap();
         let file_groups = meta.into_iter().map(Into::into).collect();
 
         // prepare the scan
@@ -1006,6 +1014,10 @@ mod tests {
             parquet_exec = parquet_exec
                 .with_pushdown_filters(true)
                 .with_reorder_filters(true);
+        }
+
+        if page_index_predicate {
+            parquet_exec = parquet_exec.with_enable_page_index(true);
         }
 
         let session_ctx = SessionContext::new();
@@ -1225,7 +1237,8 @@ mod tests {
         let filter = col("c2").eq(lit(2_i64));
 
         // read/write them files:
-        let rt = round_trip(vec![batch1, batch2], None, None, Some(filter), true).await;
+        let rt =
+            round_trip(vec![batch1, batch2], None, None, Some(filter), true, false).await;
         let expected = vec![
             "+----+----+----+",
             "| c1 | c3 | c2 |",
@@ -1374,7 +1387,8 @@ mod tests {
         let filter = col("c2").eq(lit(1_i64));
 
         // read/write them files:
-        let rt = round_trip(vec![batch1, batch2], None, None, Some(filter), true).await;
+        let rt =
+            round_trip(vec![batch1, batch2], None, None, Some(filter), true, false).await;
 
         let expected = vec![
             "+----+----+",
@@ -1696,6 +1710,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn parquet_page_index_exec_metrics() {
+        let c1: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), None, Some(2)]));
+        let c2: ArrayRef = Arc::new(Int32Array::from(vec![Some(3), Some(4), Some(5)]));
+        let batch1 = create_batch(vec![("int", c1.clone())]);
+        let batch2 = create_batch(vec![("int", c2.clone())]);
+
+        let filter = col("int").eq(lit(4_i32));
+
+        let rt =
+            round_trip(vec![batch1, batch2], None, None, Some(filter), false, true).await;
+
+        let metrics = rt.parquet_exec.metrics().unwrap();
+
+        // todo fix this  https://github.com/apache/arrow-rs/issues/2941 release change to row limit.
+        // assert the batches and some metrics
+        let expected = vec![
+            "+-----+", "| int |", "+-----+", "|     |", "| 1   |", "| 2   |", "| 3   |",
+            "| 4   |", "| 5   |", "+-----+",
+        ];
+        assert_batches_sorted_eq!(expected, &rt.batches.unwrap());
+        assert_eq!(get_value(&metrics, "page_index_rows_filtered"), 0);
+        assert!(
+            get_value(&metrics, "page_index_eval_time") > 0,
+            "no eval time in metrics: {:#?}",
+            metrics
+        );
+    }
+
+    #[tokio::test]
     async fn parquet_exec_metrics() {
         let c1: ArrayRef = Arc::new(StringArray::from(vec![
             Some("Foo"),
@@ -1714,7 +1757,7 @@ mod tests {
         let filter = col("c1").not_eq(lit("bar"));
 
         // read/write them files:
-        let rt = round_trip(vec![batch1], None, None, Some(filter), true).await;
+        let rt = round_trip(vec![batch1], None, None, Some(filter), true, false).await;
 
         let metrics = rt.parquet_exec.metrics().unwrap();
 

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1726,7 +1726,7 @@ mod tests {
         // todo fix this  https://github.com/apache/arrow-rs/issues/2941 release change to row limit.
         // assert the batches and some metrics
         let expected = vec![
-            "+-----+", "| int |", "+-----+", "| 3 |", "| 4 |", "| 5 |", "+-----+",
+            "+-----+", "| int |", "+-----+", "| 3   |", "| 4   |", "| 5   |", "+-----+",
         ];
         assert_batches_sorted_eq!(expected, &rt.batches.unwrap());
         assert_eq!(get_value(&metrics, "page_index_rows_filtered"), 3);

--- a/datafusion/core/src/physical_plan/file_format/parquet/metrics.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet/metrics.rs
@@ -35,6 +35,10 @@ pub struct ParquetFileMetrics {
     pub pushdown_rows_filtered: Count,
     /// Total time spent evaluating pushdown filters
     pub pushdown_eval_time: Time,
+    /// Total rows filtered out by parquet page index
+    pub page_index_rows_filtered: Count,
+    /// Total time spent evaluating parquet page index filters
+    pub page_index_eval_time: Time,
 }
 
 impl ParquetFileMetrics {
@@ -63,6 +67,13 @@ impl ParquetFileMetrics {
         let pushdown_eval_time = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
             .subset_time("pushdown_eval_time", partition);
+        let page_index_rows_filtered = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .counter("page_index_rows_filtered", partition);
+
+        let page_index_eval_time = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .subset_time("page_index_eval_time", partition);
 
         Self {
             predicate_evaluation_errors,
@@ -70,6 +81,8 @@ impl ParquetFileMetrics {
             bytes_scanned,
             pushdown_rows_filtered,
             pushdown_eval_time,
+            page_index_rows_filtered,
+            page_index_eval_time,
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: yangjiang <yangjiang@ebay.com>

# Which issue does this PR close?

Closes #4086 .

# Rationale for this change

we can get metric like
```
ParquetExec: limit=None, partitions=[Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet],
  predicate=l_shipdate_min@0 <= 8037, projection=[l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], metrics=[output_rows=1020000, elapsed_compute=1ns, spill_count=0, spilled_bytes=0, mem_used=0, 
  pushdown_rows_filtered{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=0, 
   page_index_rows_filtered{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=5000000, predicate_evaluation_errors{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=0, row_groups_pruned{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=0, bytes_scanned{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=13198873, num_predicate_creation_errors=0, time_elapsed_scanning=114.532731ms, time_elapsed_processing=3.561757295s, pushdown_eval_time{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=2ns, 

   page_index_eval_time{filename=Users/yangjiang/test-data/1g_tpch_pageIndex/lineitem/part-00000-7d2abab2-a301-4452-9f1d-c641e7f15af4-c000.snappy.parquet}=475.372µs, time_elapsed_opening=58.666766ms] |
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
We i try to create single column with multi pages,  i think there is a bug in page size check.  but i found https://github.com/apache/arrow-rs/issues/2941 add  page row number check(not release).

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->