### PR TITLE
Allow listing tables to be created via TableFactories

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::borrow::Borrow;
-use std::collections::HashMap;
 use clap::Parser;
+use datafusion::datasource::datasource::TableProviderFactory;
+use datafusion::datasource::file_format::file_type::FileType;
+use datafusion::datasource::listing_table_factory::ListingTableFactory;
 use datafusion::datasource::object_store::ObjectStoreRegistry;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::SessionConfig;
@@ -28,14 +29,10 @@ use datafusion_cli::{
     exec, print_format::PrintFormat, print_options::PrintOptions, DATAFUSION_CLI_VERSION,
 };
 use mimalloc::MiMalloc;
+use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
-use datafusion::catalog::listing_schema::ListingSchemaProvider;
-use datafusion::datasource::datasource::TableProviderFactory;
-use datafusion::datasource::file_format::file_type::FileType;
-use datafusion::datasource::listing_table_factory::ListingTableFactory;
-use datafusion::test_util::TestTableFactory;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -100,7 +97,7 @@ pub async fn main() -> Result<()> {
 
     if let Some(ref path) = args.data_path {
         let p = Path::new(path);
-        env::set_current_dir(&p).unwrap();
+        env::set_current_dir(p).unwrap();
     };
 
     let mut session_config = SessionConfig::from_env().with_information_schema(true);
@@ -112,20 +109,7 @@ pub async fn main() -> Result<()> {
     let runtime_env = create_runtime_env()?;
     let mut ctx =
         SessionContext::with_config_rt(session_config.clone(), Arc::new(runtime_env));
-
-    let cat_names = ctx.catalog_names().clone();
-    for cat_name in cat_names.iter() {
-        let cat = ctx.catalog(cat_name.as_str()).
-            ok_or(DataFusionError::Internal("Catalog not found!".to_string()))?;
-        for schema_name in cat.schema_names() {
-            let schema = cat.schema(schema_name.as_str())
-                .ok_or(DataFusionError::Internal("Schema not found!".to_string()))?;
-            let lister = schema.as_any().downcast_ref::<ListingSchemaProvider>();
-            if let Some(lister) = lister {
-                lister.refresh(&ctx.state()).await?;
-            }
-        }
-    }
+    ctx.refresh_catalogs().await?;
 
     let mut print_options = PrintOptions {
         format: args.format,
@@ -165,18 +149,29 @@ pub async fn main() -> Result<()> {
 fn create_runtime_env() -> Result<RuntimeEnv> {
     let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> =
         HashMap::new();
-    table_factories.insert("csv".to_string(), Arc::new(ListingTableFactory::new(FileType::CSV)));
-    table_factories.insert("parquet".to_string(), Arc::new(ListingTableFactory::new(FileType::PARQUET)));
-    table_factories.insert("avro".to_string(), Arc::new(ListingTableFactory::new(FileType::AVRO)));
-    table_factories.insert("json".to_string(), Arc::new(ListingTableFactory::new(FileType::JSON)));
+    table_factories.insert(
+        "csv".to_string(),
+        Arc::new(ListingTableFactory::new(FileType::CSV)),
+    );
+    table_factories.insert(
+        "parquet".to_string(),
+        Arc::new(ListingTableFactory::new(FileType::PARQUET)),
+    );
+    table_factories.insert(
+        "avro".to_string(),
+        Arc::new(ListingTableFactory::new(FileType::AVRO)),
+    );
+    table_factories.insert(
+        "json".to_string(),
+        Arc::new(ListingTableFactory::new(FileType::JSON)),
+    );
 
     let object_store_provider = DatafusionCliObjectStoreProvider {};
     let object_store_registry =
         ObjectStoreRegistry::new_with_provider(Some(Arc::new(object_store_provider)));
-    let rn_config =
-        RuntimeConfig::new()
-            .with_object_store_registry(Arc::new(object_store_registry))
-            .with_table_factories(table_factories);
+    let rn_config = RuntimeConfig::new()
+        .with_object_store_registry(Arc::new(object_store_registry))
+        .with_table_factories(table_factories);
     RuntimeEnv::new(rn_config)
 }
 

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -141,7 +141,13 @@ mod tests {
         assert!(err.to_string().contains("Generic S3 error: Missing region"));
 
         env::set_var("AWS_REGION", "us-east-1");
-        assert!(provider.get_by_url(&Url::from_str(s3).unwrap()).is_ok());
+        let url = Url::from_str(s3).expect("Unable to parse s3 url");
+        let res = provider.get_by_url(&url);
+        let msg = match res {
+            Err(e) => format!("{}", e),
+            Ok(_) => "".to_string()
+        };
+        assert_eq!("".to_string(), msg); // Fail with error message
         env::remove_var("AWS_REGION");
     }
 }

--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -107,9 +107,9 @@ mod tests {
         let batch = RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(Int32Array::from_slice(&[1, 2, 3])),
-                Arc::new(Int32Array::from_slice(&[4, 5, 6])),
-                Arc::new(Int32Array::from_slice(&[7, 8, 9])),
+                Arc::new(Int32Array::from_slice([1, 2, 3])),
+                Arc::new(Int32Array::from_slice([4, 5, 6])),
+                Arc::new(Int32Array::from_slice([7, 8, 9])),
             ],
         )
         .unwrap();
@@ -137,9 +137,9 @@ mod tests {
         let batch = RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(Int32Array::from_slice(&[1, 2, 3])),
-                Arc::new(Int32Array::from_slice(&[4, 5, 6])),
-                Arc::new(Int32Array::from_slice(&[7, 8, 9])),
+                Arc::new(Int32Array::from_slice([1, 2, 3])),
+                Arc::new(Int32Array::from_slice([4, 5, 6])),
+                Arc::new(Int32Array::from_slice([7, 8, 9])),
             ],
         )
         .unwrap();

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -92,5 +92,9 @@ pub trait TableProvider: Sync + Send {
 #[async_trait]
 pub trait TableProviderFactory: Sync + Send {
     /// Create a TableProvider with the given url
-    async fn create(&self, url: &str) -> Result<Arc<dyn TableProvider>>;
+    async fn create(
+        &self,
+        ctx: &SessionState,
+        url: &str,
+    ) -> Result<Arc<dyn TableProvider>>;
 }

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Factory for creating ListingTables with default options
+
+use crate::datasource::datasource::TableProviderFactory;
+use crate::datasource::file_format::avro::AvroFormat;
+use crate::datasource::file_format::csv::CsvFormat;
+use crate::datasource::file_format::file_type::{FileType, GetExt};
+use crate::datasource::file_format::json::JsonFormat;
+use crate::datasource::file_format::parquet::ParquetFormat;
+use crate::datasource::file_format::FileFormat;
+use crate::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use crate::datasource::TableProvider;
+use crate::execution::context::SessionState;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A `TableProviderFactory` capable of creating new `ListingTable`s
+pub struct ListingTableFactory {
+    file_type: FileType,
+}
+
+impl ListingTableFactory {
+    /// Creates a new `ListingTableFactory`
+    pub fn new(file_type: FileType) -> Self {
+        Self { file_type }
+    }
+}
+
+#[async_trait]
+impl TableProviderFactory for ListingTableFactory {
+    async fn create(
+        &self,
+        state: &SessionState,
+        url: &str,
+    ) -> datafusion_common::Result<Arc<dyn TableProvider>> {
+        let file_extension = self.file_type.get_ext();
+
+        let file_format: Arc<dyn FileFormat> = match self.file_type {
+            FileType::CSV => Arc::new(CsvFormat::default()),
+            FileType::PARQUET => Arc::new(ParquetFormat::default()),
+            FileType::AVRO => Arc::new(AvroFormat::default()),
+            FileType::JSON => Arc::new(JsonFormat::default()),
+        };
+
+        let options = ListingOptions {
+            format: file_format,
+            collect_stat: true,
+            file_extension: file_extension.to_owned(),
+            target_partitions: 1,
+            table_partition_cols: vec![],
+        };
+
+        let table_path = ListingTableUrl::parse(url)?;
+        let resolved_schema = options.infer_schema(state, &table_path).await?;
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(options)
+            .with_schema(resolved_schema);
+        let table = ListingTable::try_new(config)?;
+        Ok(Arc::new(table))
+    }
+}

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -23,6 +23,7 @@ pub mod default_table_source;
 pub mod empty;
 pub mod file_format;
 pub mod listing;
+pub mod listing_table_factory;
 pub mod memory;
 pub mod object_store;
 pub mod view;

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -486,7 +486,7 @@ impl SessionContext {
                     cmd.file_type
                 ))
             })?;
-        let table = (*factory).create(cmd.location.as_str()).await?;
+        let table = (*factory).create(&state, cmd.location.as_str()).await?;
         self.register_table(cmd.name.as_str(), table)?;
         let plan = LogicalPlanBuilder::empty(false).build()?;
         Ok(Arc::new(DataFrame::new(self.state.clone(), &plan)))
@@ -2284,7 +2284,7 @@ mod tests {
                 if let Some(listing) =
                     schema.as_any().downcast_ref::<ListingSchemaProvider>()
                 {
-                    listing.refresh().await.unwrap();
+                    listing.refresh(&ctx.state()).await.unwrap();
                     table_count = schema.table_names().len();
                 }
             }

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -284,6 +284,7 @@ pub struct TestTableFactory {}
 impl TableProviderFactory for TestTableFactory {
     async fn create(
         &self,
+        _state: &SessionState,
         url: &str,
     ) -> datafusion_common::Result<Arc<dyn TableProvider>> {
         Ok(Arc::new(TestTableProvider {

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -80,7 +80,7 @@ async fn query_cte_incorrect() -> Result<()> {
     assert!(plan.is_err());
     assert_eq!(
         format!("{}", plan.unwrap_err()),
-        "Error during planning: 'datafusion.public.t' not found"
+        "Error during planning: table 'datafusion.public.t' not found"
     );
 
     // forward referencing
@@ -89,7 +89,7 @@ async fn query_cte_incorrect() -> Result<()> {
     assert!(plan.is_err());
     assert_eq!(
         format!("{}", plan.unwrap_err()),
-        "Error during planning: 'datafusion.public.u' not found"
+        "Error during planning: table 'datafusion.public.u' not found"
     );
 
     // wrapping should hide u
@@ -98,7 +98,7 @@ async fn query_cte_incorrect() -> Result<()> {
     assert!(plan.is_err());
     assert_eq!(
         format!("{}", plan.unwrap_err()),
-        "Error during planning: 'datafusion.public.u' not found"
+        "Error during planning: table 'datafusion.public.u' not found"
     );
 
     Ok(())

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -271,7 +271,7 @@ async fn information_schema_describe_table_not_exists() {
     let err = plan_and_collect(&ctx, sql_all).await.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Error during planning: 'datafusion.public.table' not found"
+        "Error during planning: table 'datafusion.public.table' not found"
     );
 }
 
@@ -368,7 +368,7 @@ async fn information_schema_show_columns() {
     assert_eq!(
         err.to_string(),
         // Error propagates from SessionState::get_table_provider
-        "Error during planning: 'datafusion.public.T' not found"
+        "Error during planning: table 'datafusion.public.T' not found"
     );
 }
 
@@ -431,7 +431,7 @@ async fn information_schema_show_table_table_names() {
     assert_eq!(
         err.to_string(),
         // Error propagates from SessionState::get_table_provider
-        "Error during planning: 'datafusion.public.t2' not found"
+        "Error during planning: table 'datafusion.public.t2' not found"
     );
 
     let err = plan_and_collect(&ctx, "SHOW columns from datafusion.public.t2")
@@ -440,7 +440,7 @@ async fn information_schema_show_table_table_names() {
     assert_eq!(
         err.to_string(),
         // Error propagates from SessionState::get_table_provider
-        "Error during planning: 'datafusion.public.t2' not found"
+        "Error during planning: table 'datafusion.public.t2' not found"
     );
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4111.

# Rationale for this change

Described in issue.

# What changes are included in this PR?

Described in issue.

# Are there any user-facing changes?

They can register CSVs, parquets, jsons and avros from the datafusion-cli.