### PR TITLE
Linearize binary expressions to reduce proto tree complexity

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -409,8 +409,10 @@ message AliasNode {
 }
 
 message BinaryExprNode {
-  LogicalExprNode l = 1;
-  LogicalExprNode r = 2;
+  // Represents the operands from the left inner most expression
+  // to the right outer most expression where each of them are chained
+  // with the operator 'op'.
+  repeated LogicalExprNode operands = 1;
   string op = 3;
 }
 

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -1464,21 +1464,15 @@ impl serde::Serialize for BinaryExprNode {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if self.l.is_some() {
-            len += 1;
-        }
-        if self.r.is_some() {
+        if !self.operands.is_empty() {
             len += 1;
         }
         if !self.op.is_empty() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("datafusion.BinaryExprNode", len)?;
-        if let Some(v) = self.l.as_ref() {
-            struct_ser.serialize_field("l", v)?;
-        }
-        if let Some(v) = self.r.as_ref() {
-            struct_ser.serialize_field("r", v)?;
+        if !self.operands.is_empty() {
+            struct_ser.serialize_field("operands", &self.operands)?;
         }
         if !self.op.is_empty() {
             struct_ser.serialize_field("op", &self.op)?;
@@ -1493,15 +1487,13 @@ impl<'de> serde::Deserialize<'de> for BinaryExprNode {
         D: serde::Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
-            "l",
-            "r",
+            "operands",
             "op",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
-            L,
-            R,
+            Operands,
             Op,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -1524,8 +1516,7 @@ impl<'de> serde::Deserialize<'de> for BinaryExprNode {
                         E: serde::de::Error,
                     {
                         match value {
-                            "l" => Ok(GeneratedField::L),
-                            "r" => Ok(GeneratedField::R),
+                            "operands" => Ok(GeneratedField::Operands),
                             "op" => Ok(GeneratedField::Op),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -1546,22 +1537,15 @@ impl<'de> serde::Deserialize<'de> for BinaryExprNode {
                 where
                     V: serde::de::MapAccess<'de>,
             {
-                let mut l__ = None;
-                let mut r__ = None;
+                let mut operands__ = None;
                 let mut op__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
-                        GeneratedField::L => {
-                            if l__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("l"));
+                        GeneratedField::Operands => {
+                            if operands__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("operands"));
                             }
-                            l__ = map.next_value()?;
-                        }
-                        GeneratedField::R => {
-                            if r__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("r"));
-                            }
-                            r__ = map.next_value()?;
+                            operands__ = Some(map.next_value()?);
                         }
                         GeneratedField::Op => {
                             if op__.is_some() {
@@ -1572,8 +1556,7 @@ impl<'de> serde::Deserialize<'de> for BinaryExprNode {
                     }
                 }
                 Ok(BinaryExprNode {
-                    l: l__,
-                    r: r__,
+                    operands: operands__.unwrap_or_default(),
                     op: op__.unwrap_or_default(),
                 })
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -407,7 +407,7 @@ pub mod logical_expr_node {
         Literal(super::ScalarValue),
         /// binary expressions
         #[prost(message, tag="4")]
-        BinaryExpr(::prost::alloc::boxed::Box<super::BinaryExprNode>),
+        BinaryExpr(super::BinaryExprNode),
         /// aggregate expressions
         #[prost(message, tag="5")]
         AggregateExpr(::prost::alloc::boxed::Box<super::AggregateExprNode>),
@@ -554,10 +554,11 @@ pub struct AliasNode {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BinaryExprNode {
-    #[prost(message, optional, boxed, tag="1")]
-    pub l: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
-    #[prost(message, optional, boxed, tag="2")]
-    pub r: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
+    /// Represents the operands from the left inner most expression
+    /// to the right outer most expression where each of them are chained
+    /// with the operator 'op'.
+    #[prost(message, repeated, tag="1")]
+    pub operands: ::prost::alloc::vec::Vec<LogicalExprNode>,
     #[prost(string, tag="3")]
     pub op: ::prost::alloc::string::String,
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4066.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR tries to represent chained binary expressions (like `a AND b AND C` or `a + b + c`) in a linearized manner (so instead of `((a, AND, b), AND, c)`, they are represented as `([a, b, c], AND)`) which reduces the complexity of protobuf trees and help serialize some of the complex expressions that weren't possible to serialize before.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New representation of the binary expressions in serialized logical plans.

# Are there any user-facing changes?

This PR changes the structure in the logical plan, so not sure if this qualifies as an API change. If it might be better to actually do it without removing the existing fields from the protobuf declaration of `BinaryExpr`, we can also add a new field to the current form and represent all the extra operands there (but I think this one is much more straightforward).

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->