### PR TITLE
reuse code `utils::optimize_children` instead of redundant implementation

### DIFF
--- a/datafusion/optimizer/src/eliminate_filter.rs
+++ b/datafusion/optimizer/src/eliminate_filter.rs
@@ -18,11 +18,10 @@
 //! Optimizer rule to replace `where false` on a plan with an empty relation.
 //! This saves time in planning and executing the query.
 //! Note that this rule should be applied after simplify expressions optimizer rule.
-use crate::{OptimizerConfig, OptimizerRule};
+use crate::{utils, OptimizerConfig, OptimizerRule};
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
     logical_plan::{EmptyRelation, LogicalPlan},
-    utils::from_plan,
     Expr,
 };
 
@@ -61,13 +60,7 @@ impl OptimizerRule for EliminateFilter {
             })),
             None => {
                 // Apply the optimization to all inputs of the plan
-                let inputs = plan.inputs();
-                let new_inputs = inputs
-                    .iter()
-                    .map(|plan| self.optimize(plan, _optimizer_config))
-                    .collect::<Result<Vec<_>>>()?;
-
-                from_plan(plan, &plan.expressions(), &new_inputs)
+                utils::optimize_children(self, plan, _optimizer_config)
             }
         }
     }

--- a/datafusion/optimizer/src/inline_table_scan.rs
+++ b/datafusion/optimizer/src/inline_table_scan.rs
@@ -18,11 +18,9 @@
 //! Optimizer rule to replace TableScan references
 //! such as DataFrames and Views and inlines the LogicalPlan
 //! to support further optimization
-use crate::{OptimizerConfig, OptimizerRule};
+use crate::{utils, OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
-use datafusion_expr::{
-    logical_plan::LogicalPlan, utils::from_plan, Expr, LogicalPlanBuilder, TableScan,
-};
+use datafusion_expr::{logical_plan::LogicalPlan, Expr, LogicalPlanBuilder, TableScan};
 
 /// Optimization rule that inlines TableScan that provide a [LogicalPlan]
 /// ([DataFrame] / [ViewTable])
@@ -36,54 +34,44 @@ impl InlineTableScan {
     }
 }
 
-/// Inline
-fn inline_table_scan(plan: &LogicalPlan) -> Result<LogicalPlan> {
-    match plan {
-        // Match only on scans without filter / projection / fetch
-        // Views and DataFrames won't have those added
-        // during the early stage of planning
-        LogicalPlan::TableScan(TableScan {
-            source,
-            table_name,
-            filters,
-            fetch: None,
-            ..
-        }) if filters.is_empty() => {
-            if let Some(sub_plan) = source.get_logical_plan() {
-                // Recursively apply optimization
-                let plan = inline_table_scan(sub_plan)?;
-                let plan = LogicalPlanBuilder::from(plan).project_with_alias(
-                    vec![Expr::Wildcard],
-                    Some(table_name.to_string()),
-                )?;
-                plan.build()
-            } else {
-                // No plan available, return with table scan as is
-                Ok(plan.clone())
-            }
-        }
-
-        // Rest: Recurse
-        _ => {
-            // apply the optimization to all inputs of the plan
-            let inputs = plan.inputs();
-            let new_inputs = inputs
-                .iter()
-                .map(|plan| inline_table_scan(plan))
-                .collect::<Result<Vec<_>>>()?;
-
-            from_plan(plan, &plan.expressions(), &new_inputs)
-        }
-    }
-}
-
 impl OptimizerRule for InlineTableScan {
     fn optimize(
         &self,
         plan: &LogicalPlan,
         _optimizer_config: &mut OptimizerConfig,
     ) -> Result<LogicalPlan> {
-        inline_table_scan(plan)
+        match plan {
+            // Match only on scans without filter / projection / fetch
+            // Views and DataFrames won't have those added
+            // during the early stage of planning
+            LogicalPlan::TableScan(TableScan {
+                source,
+                table_name,
+                filters,
+                fetch: None,
+                ..
+            }) if filters.is_empty() => {
+                if let Some(sub_plan) = source.get_logical_plan() {
+                    // Recursively apply optimization
+                    let plan =
+                        utils::optimize_children(self, sub_plan, _optimizer_config)?;
+                    let plan = LogicalPlanBuilder::from(plan).project_with_alias(
+                        vec![Expr::Wildcard],
+                        Some(table_name.to_string()),
+                    )?;
+                    plan.build()
+                } else {
+                    // No plan available, return with table scan as is
+                    Ok(plan.clone())
+                }
+            }
+
+            // Rest: Recurse
+            _ => {
+                // apply the optimization to all inputs of the plan
+                utils::optimize_children(self, plan, _optimizer_config)
+            }
+        }
     }
 
     fn name(&self) -> &str {

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -17,12 +17,12 @@
 
 //! single distinct to group by optimizer rule
 
-use crate::{OptimizerConfig, OptimizerRule};
+use crate::{utils, OptimizerConfig, OptimizerRule};
 use datafusion_common::{DFSchema, Result};
 use datafusion_expr::{
     col,
     logical_plan::{Aggregate, LogicalPlan, Projection},
-    utils::{columnize_expr, from_plan},
+    utils::columnize_expr,
     Expr, ExprSchemable,
 };
 use hashbrown::HashSet;
@@ -52,131 +52,6 @@ impl SingleDistinctToGroupBy {
     pub fn new() -> Self {
         Self {}
     }
-}
-
-fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
-    match plan {
-        LogicalPlan::Aggregate(Aggregate {
-            input,
-            aggr_expr,
-            schema,
-            group_expr,
-        }) => {
-            if is_single_distinct_agg(plan)? && !contains_grouping_set(group_expr) {
-                // alias all original group_by exprs
-                let mut group_expr_alias = Vec::with_capacity(group_expr.len());
-                let mut inner_group_exprs = group_expr
-                    .iter()
-                    .enumerate()
-                    .map(|(i, group_expr)| {
-                        let alias_str = format!("group_alias_{}", i);
-                        let alias_expr = group_expr.clone().alias(&alias_str);
-                        group_expr_alias.push((alias_str, schema.fields()[i].clone()));
-                        alias_expr
-                    })
-                    .collect::<Vec<_>>();
-
-                // and they can be referenced by the alias in the outer aggr plan
-                let outer_group_exprs = group_expr_alias
-                    .iter()
-                    .map(|(alias, _)| col(alias))
-                    .collect::<Vec<_>>();
-
-                // replace the distinct arg with alias
-                let mut group_fields_set = HashSet::new();
-                let new_aggr_exprs = aggr_expr
-                    .iter()
-                    .map(|aggr_expr| match aggr_expr {
-                        Expr::AggregateFunction {
-                            fun, args, filter, ..
-                        } => {
-                            // is_single_distinct_agg ensure args.len=1
-                            if group_fields_set.insert(args[0].display_name()?) {
-                                inner_group_exprs
-                                    .push(args[0].clone().alias(SINGLE_DISTINCT_ALIAS));
-                            }
-                            Ok(Expr::AggregateFunction {
-                                fun: fun.clone(),
-                                args: vec![col(SINGLE_DISTINCT_ALIAS)],
-                                distinct: false, // intentional to remove distinct here
-                                filter: filter.clone(),
-                            })
-                        }
-                        _ => Ok(aggr_expr.clone()),
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                // construct the inner AggrPlan
-                let inner_fields = inner_group_exprs
-                    .iter()
-                    .map(|expr| expr.to_field(input.schema()))
-                    .collect::<Result<Vec<_>>>()?;
-                let inner_schema = DFSchema::new_with_metadata(
-                    inner_fields,
-                    input.schema().metadata().clone(),
-                )?;
-                let grouped_aggr = LogicalPlan::Aggregate(Aggregate::try_new(
-                    input.clone(),
-                    inner_group_exprs,
-                    Vec::new(),
-                )?);
-                let inner_agg = optimize_children(&grouped_aggr)?;
-
-                let outer_aggr_schema = Arc::new(DFSchema::new_with_metadata(
-                    outer_group_exprs
-                        .iter()
-                        .chain(new_aggr_exprs.iter())
-                        .map(|expr| expr.to_field(&inner_schema))
-                        .collect::<Result<Vec<_>>>()?,
-                    input.schema().metadata().clone(),
-                )?);
-
-                // so the aggregates are displayed in the same way even after the rewrite
-                // this optimizer has two kinds of alias:
-                // - group_by aggr
-                // - aggr expr
-                let mut alias_expr: Vec<Expr> = Vec::new();
-                for (alias, original_field) in group_expr_alias {
-                    alias_expr.push(col(&alias).alias(original_field.qualified_name()));
-                }
-                for (i, expr) in new_aggr_exprs.iter().enumerate() {
-                    alias_expr.push(columnize_expr(
-                        expr.clone().alias(
-                            schema.clone().fields()[i + group_expr.len()]
-                                .qualified_name(),
-                        ),
-                        &outer_aggr_schema,
-                    ));
-                }
-
-                let outer_aggr = LogicalPlan::Aggregate(Aggregate::try_new(
-                    Arc::new(inner_agg),
-                    outer_group_exprs,
-                    new_aggr_exprs,
-                )?);
-
-                Ok(LogicalPlan::Projection(Projection::try_new_with_schema(
-                    alias_expr,
-                    Arc::new(outer_aggr),
-                    schema.clone(),
-                    None,
-                )?))
-            } else {
-                optimize_children(plan)
-            }
-        }
-        _ => optimize_children(plan),
-    }
-}
-
-fn optimize_children(plan: &LogicalPlan) -> Result<LogicalPlan> {
-    let expr = plan.expressions();
-    let inputs = plan.inputs();
-    let new_inputs = inputs
-        .iter()
-        .map(|plan| optimize(plan))
-        .collect::<Result<Vec<_>>>()?;
-    from_plan(plan, &expr, &new_inputs)
 }
 
 /// Check whether all aggregate exprs are distinct on a single field.
@@ -213,7 +88,122 @@ impl OptimizerRule for SingleDistinctToGroupBy {
         plan: &LogicalPlan,
         _optimizer_config: &mut OptimizerConfig,
     ) -> Result<LogicalPlan> {
-        optimize(plan)
+        match plan {
+            LogicalPlan::Aggregate(Aggregate {
+                input,
+                aggr_expr,
+                schema,
+                group_expr,
+            }) => {
+                if is_single_distinct_agg(plan)? && !contains_grouping_set(group_expr) {
+                    // alias all original group_by exprs
+                    let mut group_expr_alias = Vec::with_capacity(group_expr.len());
+                    let mut inner_group_exprs = group_expr
+                        .iter()
+                        .enumerate()
+                        .map(|(i, group_expr)| {
+                            let alias_str = format!("group_alias_{}", i);
+                            let alias_expr = group_expr.clone().alias(&alias_str);
+                            group_expr_alias
+                                .push((alias_str, schema.fields()[i].clone()));
+                            alias_expr
+                        })
+                        .collect::<Vec<_>>();
+
+                    // and they can be referenced by the alias in the outer aggr plan
+                    let outer_group_exprs = group_expr_alias
+                        .iter()
+                        .map(|(alias, _)| col(alias))
+                        .collect::<Vec<_>>();
+
+                    // replace the distinct arg with alias
+                    let mut group_fields_set = HashSet::new();
+                    let new_aggr_exprs = aggr_expr
+                        .iter()
+                        .map(|aggr_expr| match aggr_expr {
+                            Expr::AggregateFunction {
+                                fun, args, filter, ..
+                            } => {
+                                // is_single_distinct_agg ensure args.len=1
+                                if group_fields_set.insert(args[0].display_name()?) {
+                                    inner_group_exprs.push(
+                                        args[0].clone().alias(SINGLE_DISTINCT_ALIAS),
+                                    );
+                                }
+                                Ok(Expr::AggregateFunction {
+                                    fun: fun.clone(),
+                                    args: vec![col(SINGLE_DISTINCT_ALIAS)],
+                                    distinct: false, // intentional to remove distinct here
+                                    filter: filter.clone(),
+                                })
+                            }
+                            _ => Ok(aggr_expr.clone()),
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+
+                    // construct the inner AggrPlan
+                    let inner_fields = inner_group_exprs
+                        .iter()
+                        .map(|expr| expr.to_field(input.schema()))
+                        .collect::<Result<Vec<_>>>()?;
+                    let inner_schema = DFSchema::new_with_metadata(
+                        inner_fields,
+                        input.schema().metadata().clone(),
+                    )?;
+                    let grouped_aggr = LogicalPlan::Aggregate(Aggregate::try_new(
+                        input.clone(),
+                        inner_group_exprs,
+                        Vec::new(),
+                    )?);
+                    let inner_agg =
+                        utils::optimize_children(self, &grouped_aggr, _optimizer_config)?;
+
+                    let outer_aggr_schema = Arc::new(DFSchema::new_with_metadata(
+                        outer_group_exprs
+                            .iter()
+                            .chain(new_aggr_exprs.iter())
+                            .map(|expr| expr.to_field(&inner_schema))
+                            .collect::<Result<Vec<_>>>()?,
+                        input.schema().metadata().clone(),
+                    )?);
+
+                    // so the aggregates are displayed in the same way even after the rewrite
+                    // this optimizer has two kinds of alias:
+                    // - group_by aggr
+                    // - aggr expr
+                    let mut alias_expr: Vec<Expr> = Vec::new();
+                    for (alias, original_field) in group_expr_alias {
+                        alias_expr
+                            .push(col(&alias).alias(original_field.qualified_name()));
+                    }
+                    for (i, expr) in new_aggr_exprs.iter().enumerate() {
+                        alias_expr.push(columnize_expr(
+                            expr.clone().alias(
+                                schema.clone().fields()[i + group_expr.len()]
+                                    .qualified_name(),
+                            ),
+                            &outer_aggr_schema,
+                        ));
+                    }
+
+                    let outer_aggr = LogicalPlan::Aggregate(Aggregate::try_new(
+                        Arc::new(inner_agg),
+                        outer_group_exprs,
+                        new_aggr_exprs,
+                    )?);
+
+                    Ok(LogicalPlan::Projection(Projection::try_new_with_schema(
+                        alias_expr,
+                        Arc::new(outer_aggr),
+                        schema.clone(),
+                        None,
+                    )?))
+                } else {
+                    utils::optimize_children(self, plan, _optimizer_config)
+                }
+            }
+            _ => utils::optimize_children(self, plan, _optimizer_config),
+        }
     }
     fn name(&self) -> &str {
         "single_distinct_aggregation_to_group_by"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4120.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Each rule implement `optimize_children` inside themselves.

We can reuse code `utils::optimize_children` instead of redundant implementation.

It's also related with #3972, I will remove all optimize_children in it.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->