### PR TITLE
Use f64::total_cmp instead of OrderedFloat

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -595,7 +595,6 @@ dependencies = [
  "log",
  "num_cpus",
  "object_store",
- "ordered-float 3.3.0",
  "parking_lot",
  "parquet",
  "paste",
@@ -635,7 +634,6 @@ dependencies = [
  "arrow",
  "chrono",
  "object_store",
- "ordered-float 3.3.0",
  "parquet",
  "sqlparser",
 ]
@@ -685,7 +683,6 @@ dependencies = [
  "lazy_static",
  "md-5",
  "num-traits",
- "ordered-float 3.3.0",
  "paste",
  "rand",
  "regex",
@@ -1617,15 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f74e330193f90ec45e2b257fa3ef6df087784157ac1ad2c1e71c62837b03aa7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,7 +2248,7 @@ checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float 1.1.1",
+ "ordered-float",
 ]
 
 [[package]]

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -44,7 +44,6 @@ arrow = { version = "26.0.0", default-features = false }
 chrono = { version = "0.4", default-features = false }
 cranelift-module = { version = "0.89.0", optional = true }
 object_store = { version = "0.5.0", default-features = false, optional = true }
-ordered-float = "3.0"
 parquet = { version = "26.0.0", default-features = false, optional = true }
 pyo3 = { version = "0.17.1", optional = true }
 sqlparser = "0.26"

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -131,18 +131,18 @@ impl PartialEq for ScalarValue {
             (Boolean(v1), Boolean(v2)) => v1.eq(v2),
             (Boolean(_), _) => false,
             (Float32(v1), Float32(v2)) => {
-                // Handle NaN == NaN as true manually like in OrderedFloat 
+                // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
                     (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
-                    _ => v1.eq(&v2)
+                    _ => v1.eq(v2),
                 }
             }
             (Float32(_), _) => false,
             (Float64(v1), Float64(v2)) => {
-                // Handle NaN == NaN as true manually like in OrderedFloat 
+                // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
                     (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
-                    _ => v1.eq(&v2)
+                    _ => v1.eq(v2),
                 }
             }
             (Float64(_), _) => false,
@@ -223,13 +223,9 @@ impl PartialOrd for ScalarValue {
             (Decimal128(_, _, _), _) => None,
             (Boolean(v1), Boolean(v2)) => v1.partial_cmp(v2),
             (Boolean(_), _) => None,
-            (Float32(v1), Float32(v2)) => {
-                v1.partial_cmp(&v2)
-            }
+            (Float32(v1), Float32(v2)) => v1.partial_cmp(v2),
             (Float32(_), _) => None,
-            (Float64(v1), Float64(v2)) => {
-                v1.partial_cmp(&v2)
-            }
+            (Float64(v1), Float64(v2)) => v1.partial_cmp(v2),
             (Float64(_), _) => None,
             (Int8(v1), Int8(v2)) => v1.partial_cmp(v2),
             (Int8(_), _) => None,

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -129,17 +129,15 @@ impl PartialEq for ScalarValue {
             (Boolean(v1), Boolean(v2)) => v1.eq(v2),
             (Boolean(_), _) => false,
             (Float32(v1), Float32(v2)) => {
-                // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
-                    (Some(f1), Some(f2)) => f1.total_cmp(f2).is_eq(),
+                    (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
                     _ => v1.eq(v2),
                 }
             }
             (Float32(_), _) => false,
             (Float64(v1), Float64(v2)) => {
-                // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
-                    (Some(f1), Some(f2)) => f1.total_cmp(f2).is_eq(),
+                    (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
                     _ => v1.eq(v2),
                 }
             }
@@ -221,9 +219,9 @@ impl PartialOrd for ScalarValue {
             (Decimal128(_, _, _), _) => None,
             (Boolean(v1), Boolean(v2)) => v1.partial_cmp(v2),
             (Boolean(_), _) => None,
-            (Float32(v1), Float32(v2)) => v1.partial_cmp(v2),
+            (Float32(Some(f1)), Float32(Some(f2))) => Some(f1.total_cmp(f2)),
             (Float32(_), _) => None,
-            (Float64(v1), Float64(v2)) => v1.partial_cmp(v2),
+            (Float64(Some(f1)), Float64(Some(f2))) => Some(f1.total_cmp(f2)),
             (Float64(_), _) => None,
             (Int8(v1), Int8(v2)) => v1.partial_cmp(v2),
             (Int8(_), _) => None,
@@ -617,6 +615,7 @@ where
     intermediate.add(Duration::milliseconds(ms as i64))
 }
 
+//Float wrapper over f32/f64. Just because we cannot build std::hash::Hash for floats directly we have to do it through type wrapper
 struct Fl<T>(T);
 
 macro_rules! hash_float_value {

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -215,9 +215,15 @@ impl PartialOrd for ScalarValue {
             (Decimal128(_, _, _), _) => None,
             (Boolean(v1), Boolean(v2)) => v1.partial_cmp(v2),
             (Boolean(_), _) => None,
-            (Float32(Some(f1)), Float32(Some(f2))) => Some(f1.total_cmp(f2)),
+            (Float32(v1), Float32(v2)) => match (v1, v2) {
+                (Some(f1), Some(f2)) => Some(f1.total_cmp(f2)),
+                _ => v1.partial_cmp(v2),
+            },
             (Float32(_), _) => None,
-            (Float64(Some(f1)), Float64(Some(f2))) => Some(f1.total_cmp(f2)),
+            (Float64(v1), Float64(v2)) => match (v1, v2) {
+                (Some(f1), Some(f2)) => Some(f1.total_cmp(f2)),
+                _ => v1.partial_cmp(v2),
+            },
             (Float64(_), _) => None,
             (Int8(v1), Int8(v2)) => v1.partial_cmp(v2),
             (Int8(_), _) => None,

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -131,7 +131,7 @@ impl PartialEq for ScalarValue {
             (Float32(v1), Float32(v2)) => {
                 // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
-                    (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
+                    (Some(f1), Some(f2)) => f1.total_cmp(f2).is_eq(),
                     _ => v1.eq(v2),
                 }
             }
@@ -139,7 +139,7 @@ impl PartialEq for ScalarValue {
             (Float64(v1), Float64(v2)) => {
                 // Handle NaN == NaN as true manually like in OrderedFloat
                 match (v1, v2) {
-                    (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
+                    (Some(f1), Some(f2)) => f1.total_cmp(f2).is_eq(),
                     _ => v1.eq(v2),
                 }
             }

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -128,19 +128,15 @@ impl PartialEq for ScalarValue {
             (Decimal128(_, _, _), _) => false,
             (Boolean(v1), Boolean(v2)) => v1.eq(v2),
             (Boolean(_), _) => false,
-            (Float32(v1), Float32(v2)) => {
-                match (v1, v2) {
-                    (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
-                    _ => v1.eq(v2),
-                }
-            }
+            (Float32(v1), Float32(v2)) => match (v1, v2) {
+                (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
+                _ => v1.eq(v2),
+            },
             (Float32(_), _) => false,
-            (Float64(v1), Float64(v2)) => {
-                match (v1, v2) {
-                    (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
-                    _ => v1.eq(v2),
-                }
-            }
+            (Float64(v1), Float64(v2)) => match (v1, v2) {
+                (Some(f1), Some(f2)) => f1.to_bits() == f2.to_bits(),
+                _ => v1.eq(v2),
+            },
             (Float64(_), _) => false,
             (Int8(v1), Int8(v2)) => v1.eq(v2),
             (Int8(_), _) => false,

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -116,8 +116,7 @@ pub enum ScalarValue {
     Dictionary(Box<DataType>, Box<ScalarValue>),
 }
 
-// manual implementation of `PartialEq` that uses OrderedFloat to
-// get defined behavior for floating point
+// manual implementation of `PartialEq`
 impl PartialEq for ScalarValue {
     fn eq(&self, other: &Self) -> bool {
         use ScalarValue::*;
@@ -132,15 +131,19 @@ impl PartialEq for ScalarValue {
             (Boolean(v1), Boolean(v2)) => v1.eq(v2),
             (Boolean(_), _) => false,
             (Float32(v1), Float32(v2)) => {
-                let v1 = v1.map(OrderedFloat);
-                let v2 = v2.map(OrderedFloat);
-                v1.eq(&v2)
+                // Handle NaN == NaN as true manually like in OrderedFloat 
+                match (v1, v2) {
+                    (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
+                    _ => v1.eq(&v2)
+                }
             }
             (Float32(_), _) => false,
             (Float64(v1), Float64(v2)) => {
-                let v1 = v1.map(OrderedFloat);
-                let v2 = v2.map(OrderedFloat);
-                v1.eq(&v2)
+                // Handle NaN == NaN as true manually like in OrderedFloat 
+                match (v1, v2) {
+                    (Some(f1), Some(f2)) if f1.is_nan() && f2.is_nan() => true,
+                    _ => v1.eq(&v2)
+                }
             }
             (Float64(_), _) => false,
             (Int8(v1), Int8(v2)) => v1.eq(v2),
@@ -201,8 +204,7 @@ impl PartialEq for ScalarValue {
     }
 }
 
-// manual implementation of `PartialOrd` that uses OrderedFloat to
-// get defined behavior for floating point
+// manual implementation of `PartialOrd`
 impl PartialOrd for ScalarValue {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         use ScalarValue::*;
@@ -222,14 +224,10 @@ impl PartialOrd for ScalarValue {
             (Boolean(v1), Boolean(v2)) => v1.partial_cmp(v2),
             (Boolean(_), _) => None,
             (Float32(v1), Float32(v2)) => {
-                let v1 = v1.map(OrderedFloat);
-                let v2 = v2.map(OrderedFloat);
                 v1.partial_cmp(&v2)
             }
             (Float32(_), _) => None,
             (Float64(v1), Float64(v2)) => {
-                let v1 = v1.map(OrderedFloat);
-                let v2 = v2.map(OrderedFloat);
                 v1.partial_cmp(&v2)
             }
             (Float64(_), _) => None,

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -80,7 +80,6 @@ log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
 object_store = "0.5.0"
-ordered-float = "3.0"
 parking_lot = "0.12"
 parquet = { version = "26.0.0", features = ["arrow", "async"] }
 paste = "^1.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -55,7 +55,6 @@ itertools = { version = "0.10", features = ["use_std"] }
 lazy_static = { version = "^1.4.0" }
 md-5 = { version = "^0.10.0", optional = true }
 num-traits = { version = "0.2", default-features = false }
-ordered-float = "3.0"
 paste = "^1.0"
 rand = "0.8"
 regex = { version = "^1.4.3", optional = true }

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -266,9 +266,7 @@ impl ApproxPercentileAccumulator {
         self.digest = TDigest::merge_digests(digests);
     }
 
-    pub(crate) fn convert_to_float(
-        values: &ArrayRef,
-    ) -> Result<Vec<f64>> {
+    pub(crate) fn convert_to_float(values: &ArrayRef) -> Result<Vec<f64>> {
         match values.data_type() {
             DataType::Float64 => {
                 let array = downcast_value!(values, Float64Array);

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont_with_weight.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont_with_weight.rs
@@ -126,8 +126,8 @@ impl Accumulator for ApproxPercentileWithWeightAccumulator {
             weights.len(),
             "invalid number of values in means and weights"
         );
-        let means_f64 = ApproxPercentileAccumulator::convert_to_ordered_float(means)?;
-        let weights_f64 = ApproxPercentileAccumulator::convert_to_ordered_float(weights)?;
+        let means_f64 = ApproxPercentileAccumulator::convert_to_float(means)?;
+        let weights_f64 = ApproxPercentileAccumulator::convert_to_float(weights)?;
         let mut digests: Vec<TDigest> = vec![];
         for (mean, weight) in means_f64.iter().zip(weights_f64.iter()) {
             digests.push(TDigest::new_with_centroid(

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -437,11 +437,9 @@ mod tests {
             let mut state_vec =
                 state_to_vec!(&states[0], $DATA_TYPE, $PRIM_TYPE).unwrap();
 
-            dbg!(&state_vec);    
+            dbg!(&state_vec);
             state_vec.sort_by(|a, b| match (a, b) {
-                (Some(lhs), Some(rhs)) => {
-                    lhs.total_cmp(rhs)
-                }
+                (Some(lhs), Some(rhs)) => lhs.total_cmp(rhs),
                 _ => a.partial_cmp(b).unwrap(),
             });
 

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -410,7 +410,6 @@ mod tests {
 
     macro_rules! test_count_distinct_update_batch_floating_point {
         ($ARRAY_TYPE:ident, $DATA_TYPE:ident, $PRIM_TYPE:ty) => {{
-            use ordered_float::OrderedFloat;
             let values: Vec<Option<$PRIM_TYPE>> = vec![
                 Some(<$PRIM_TYPE>::INFINITY),
                 Some(<$PRIM_TYPE>::NAN),
@@ -437,9 +436,11 @@ mod tests {
 
             let mut state_vec =
                 state_to_vec!(&states[0], $DATA_TYPE, $PRIM_TYPE).unwrap();
+
+            dbg!(&state_vec);    
             state_vec.sort_by(|a, b| match (a, b) {
                 (Some(lhs), Some(rhs)) => {
-                    OrderedFloat::from(*lhs).cmp(&OrderedFloat::from(*rhs))
+                    lhs.total_cmp(rhs)
                 }
                 _ => a.partial_cmp(b).unwrap(),
             });

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -608,7 +608,8 @@ impl TDigest {
 
         let max = cast_scalar_f64!(&state[3]);
         let min = cast_scalar_f64!(&state[4]);
-        assert!(max.is_nan() || min.is_nan() || max >= min);
+
+        assert!(max.total_cmp(&min).is_ge());
 
         Self {
             max_size,
@@ -696,7 +697,7 @@ mod tests {
     #[test]
     fn test_merge_unsorted_against_uniform_distro() {
         let t = TDigest::new(100);
-        let values: Vec<_> = (1..=1_000_000).map(f64::from).map(|v| v as f64).collect();
+        let values: Vec<_> = (1..=1_000_000).map(f64::from).collect();
 
         let t = t.merge_unsorted_f64(values);
 
@@ -711,7 +712,7 @@ mod tests {
     #[test]
     fn test_merge_unsorted_against_skewed_distro() {
         let t = TDigest::new(100);
-        let mut values: Vec<_> = (1..=600_000).map(f64::from).map(|v| v as f64).collect();
+        let mut values: Vec<_> = (1..=600_000).map(f64::from).collect();
         values.resize(1_000_000, 1_000_000_f64);
 
         let t = t.merge_unsorted_f64(values);
@@ -728,7 +729,7 @@ mod tests {
 
         for _ in 1..=100 {
             let t = TDigest::new(100);
-            let values: Vec<_> = (1..=1_000).map(f64::from).map(|v| v as f64).collect();
+            let values: Vec<_> = (1..=1_000).map(f64::from).collect();
             let t = t.merge_unsorted_f64(values);
             digests.push(t)
         }

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -28,20 +28,18 @@
 //! [Facebook's Folly TDigest]: https://github.com/facebook/folly/blob/main/folly/stats/TDigest.h
 
 use arrow::datatypes::DataType;
-use datafusion_common::DataFusionError;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
-use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
 pub const DEFAULT_MAX_SIZE: usize = 100;
 
-// Cast a non-null [`ScalarValue::Float64`] to an [`OrderedFloat<f64>`], or
+// Cast a non-null [`ScalarValue::Float64`] to an [`f64`], or
 // panic.
 macro_rules! cast_scalar_f64 {
     ($value:expr ) => {
         match &$value {
-            ScalarValue::Float64(Some(v)) => OrderedFloat::from(*v),
+            ScalarValue::Float64(Some(v)) => *v,
             v => panic!("invalid type {:?}", v),
         }
     };
@@ -50,22 +48,22 @@ macro_rules! cast_scalar_f64 {
 /// This trait is implemented for each type a [`TDigest`] can operate on,
 /// allowing it to support both numerical rust types (obtained from
 /// `PrimitiveArray` instances), and [`ScalarValue`] instances.
-pub(crate) trait TryIntoOrderedF64 {
-    /// A fallible conversion of a possibly null `self` into a [`OrderedFloat<f64>`].
+pub(crate) trait TryIntoF64 {
+    /// A fallible conversion of a possibly null `self` into a [`f64`].
     ///
     /// If `self` is null, this method must return `Ok(None)`.
     ///
     /// If `self` cannot be coerced to the desired type, this method must return
     /// an `Err` variant.
-    fn try_as_f64(&self) -> Result<Option<OrderedFloat<f64>>>;
+    fn try_as_f64(&self) -> Result<Option<f64>>;
 }
 
-/// Generate an infallible conversion from `type` to an [`OrderedFloat<f64>`].
+/// Generate an infallible conversion from `type` to an [`f64`].
 macro_rules! impl_try_ordered_f64 {
     ($type:ty) => {
-        impl TryIntoOrderedF64 for $type {
-            fn try_as_f64(&self) -> Result<Option<OrderedFloat<f64>>> {
-                Ok(Some(OrderedFloat::from(*self as f64)))
+        impl TryIntoF64 for $type {
+            fn try_as_f64(&self) -> Result<Option<f64>> {
+                Ok(Some(*self as f64))
             }
         }
     };
@@ -82,33 +80,12 @@ impl_try_ordered_f64!(u32);
 impl_try_ordered_f64!(u16);
 impl_try_ordered_f64!(u8);
 
-impl TryIntoOrderedF64 for ScalarValue {
-    fn try_as_f64(&self) -> Result<Option<OrderedFloat<f64>>> {
-        match self {
-            ScalarValue::Float32(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::Float64(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::Int8(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::Int16(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::Int32(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::Int64(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::UInt8(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::UInt16(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::UInt32(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-            ScalarValue::UInt64(v) => Ok(v.map(|v| OrderedFloat::from(v as f64))),
-
-            got => Err(DataFusionError::NotImplemented(format!(
-                "Support for 'TryIntoOrderedF64' for data type {} is not implemented",
-                got
-            ))),
-        }
-    }
-}
 
 /// Centroid implementation to the cluster mentioned in the paper.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Centroid {
-    mean: OrderedFloat<f64>,
-    weight: OrderedFloat<f64>,
+    mean: f64,
+    weight: f64,
 }
 
 impl PartialOrd for Centroid {
@@ -117,64 +94,66 @@ impl PartialOrd for Centroid {
     }
 }
 
+impl Eq for Centroid {}
+
 impl Ord for Centroid {
     fn cmp(&self, other: &Centroid) -> Ordering {
-        self.mean.cmp(&other.mean)
+        self.mean.total_cmp(&other.mean)
     }
 }
 
 impl Centroid {
     pub(crate) fn new(
-        mean: impl Into<OrderedFloat<f64>>,
-        weight: impl Into<OrderedFloat<f64>>,
+        mean: f64,
+        weight: f64,
     ) -> Self {
         Centroid {
-            mean: mean.into(),
-            weight: weight.into(),
+            mean: mean,
+            weight: weight,
         }
     }
 
     #[inline]
-    pub(crate) fn mean(&self) -> OrderedFloat<f64> {
+    pub(crate) fn mean(&self) -> f64 {
         self.mean
     }
 
     #[inline]
-    pub(crate) fn weight(&self) -> OrderedFloat<f64> {
+    pub(crate) fn weight(&self) -> f64 {
         self.weight
     }
 
     pub(crate) fn add(
         &mut self,
-        sum: impl Into<OrderedFloat<f64>>,
-        weight: impl Into<OrderedFloat<f64>>,
+        sum: f64,
+        weight: f64,
     ) -> f64 {
-        let new_sum = sum.into() + self.weight * self.mean;
-        let new_weight = self.weight + weight.into();
+        let new_sum = sum + self.weight * self.mean;
+        let new_weight = self.weight + weight;
         self.weight = new_weight;
         self.mean = new_sum / new_weight;
-        new_sum.into_inner()
+        new_sum
     }
 }
 
 impl Default for Centroid {
     fn default() -> Self {
         Centroid {
-            mean: OrderedFloat::from(0.0),
-            weight: OrderedFloat::from(1.0),
+            mean: 0_f64,
+            weight: 1_f64,
         }
     }
 }
 
 /// T-Digest to be operated on.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct TDigest {
     centroids: Vec<Centroid>,
     max_size: usize,
-    sum: OrderedFloat<f64>,
-    count: OrderedFloat<f64>,
-    max: OrderedFloat<f64>,
-    min: OrderedFloat<f64>,
+    sum: f64,
+    count: f64,
+    max: f64,
+    min: f64,
 }
 
 impl TDigest {
@@ -182,10 +161,10 @@ impl TDigest {
         TDigest {
             centroids: Vec::new(),
             max_size,
-            sum: OrderedFloat::from(0.0),
-            count: OrderedFloat::from(0.0),
-            max: OrderedFloat::from(std::f64::NAN),
-            min: OrderedFloat::from(std::f64::NAN),
+            sum: 0_f64,
+            count: 0_f64,
+            max: std::f64::NAN,
+            min: std::f64::NAN,
         }
     }
 
@@ -194,7 +173,7 @@ impl TDigest {
             centroids: vec![centroid.clone()],
             max_size,
             sum: centroid.mean * centroid.weight,
-            count: OrderedFloat::from(1.0),
+            count: 1_f64,
             max: centroid.mean,
             min: centroid.mean,
         }
@@ -202,17 +181,17 @@ impl TDigest {
 
     #[inline]
     pub(crate) fn count(&self) -> f64 {
-        self.count.into_inner()
+        self.count
     }
 
     #[inline]
     pub(crate) fn max(&self) -> f64 {
-        self.max.into_inner()
+        self.max
     }
 
     #[inline]
     pub(crate) fn min(&self) -> f64 {
-        self.min.into_inner()
+        self.min
     }
 
     #[inline]
@@ -226,16 +205,16 @@ impl Default for TDigest {
         TDigest {
             centroids: Vec::new(),
             max_size: 100,
-            sum: OrderedFloat::from(0.0),
-            count: OrderedFloat::from(0.0),
-            max: OrderedFloat::from(std::f64::NAN),
-            min: OrderedFloat::from(std::f64::NAN),
+            sum: 0_f64,
+            count: 0_f64,
+            max: std::f64::NAN,
+            min: std::f64::NAN,
         }
     }
 }
 
 impl TDigest {
-    fn k_to_q(k: f64, d: f64) -> OrderedFloat<f64> {
+    fn k_to_q(k: f64, d: f64) -> f64 {
         let k_div_d = k / d;
         if k_div_d >= 0.5 {
             let base = 1.0 - k_div_d;
@@ -247,10 +226,10 @@ impl TDigest {
     }
 
     fn clamp(
-        v: OrderedFloat<f64>,
-        lo: OrderedFloat<f64>,
-        hi: OrderedFloat<f64>,
-    ) -> OrderedFloat<f64> {
+        v: f64,
+        lo: f64,
+        hi: f64,
+    ) -> f64 {
         if v > hi {
             hi
         } else if v < lo {
@@ -263,17 +242,18 @@ impl TDigest {
     #[cfg(test)]
     pub(crate) fn merge_unsorted_f64(
         &self,
-        unsorted_values: Vec<OrderedFloat<f64>>,
+        unsorted_values: Vec<f64>,
     ) -> TDigest {
         let mut values = unsorted_values;
-        values.sort();
+        values.sort_by(|a, b| a.total_cmp(b));
         self.merge_sorted_f64(&values)
     }
 
     pub(crate) fn merge_sorted_f64(
         &self,
-        sorted_values: &[OrderedFloat<f64>],
+        sorted_values: &[f64],
     ) -> TDigest {
+        dbg!(&sorted_values);
         #[cfg(debug_assertions)]
         debug_assert!(is_sorted(sorted_values), "unsorted input to TDigest");
 
@@ -282,14 +262,14 @@ impl TDigest {
         }
 
         let mut result = TDigest::new(self.max_size());
-        result.count = OrderedFloat::from(self.count() + (sorted_values.len() as f64));
+        result.count =self.count() + (sorted_values.len() as f64);
 
         let maybe_min = *sorted_values.first().unwrap();
         let maybe_max = *sorted_values.last().unwrap();
 
         if self.count() > 0.0 {
-            result.min = std::cmp::min(self.min, maybe_min);
-            result.max = std::cmp::max(self.max, maybe_max);
+            result.min = self.min.min(maybe_min);
+            result.max = self.max.max(maybe_max);
         } else {
             result.min = maybe_min;
             result.max = maybe_max;
@@ -318,8 +298,8 @@ impl TDigest {
 
         let mut weight_so_far = curr.weight();
 
-        let mut sums_to_merge = OrderedFloat::from(0.0);
-        let mut weights_to_merge = OrderedFloat::from(0.0);
+        let mut sums_to_merge = 0_f64;
+        let mut weights_to_merge = 0_f64;
 
         while iter_centroids.peek().is_some() || iter_sorted_values.peek().is_some() {
             let next: Centroid = if let Some(c) = iter_centroids.peek() {
@@ -341,9 +321,7 @@ impl TDigest {
                 sums_to_merge += next_sum;
                 weights_to_merge += next.weight();
             } else {
-                result.sum = OrderedFloat::from(
-                    result.sum.into_inner() + curr.add(sums_to_merge, weights_to_merge),
-                );
+                result.sum = result.sum + curr.add(sums_to_merge, weights_to_merge);
                 sums_to_merge = 0.0.into();
                 weights_to_merge = 0.0.into();
 
@@ -355,9 +333,7 @@ impl TDigest {
             }
         }
 
-        result.sum = OrderedFloat::from(
-            result.sum.into_inner() + curr.add(sums_to_merge, weights_to_merge),
-        );
+        result.sum = result.sum + curr.add(sums_to_merge, weights_to_merge);
         compressed.push(curr);
         compressed.shrink_to_fit();
         compressed.sort();
@@ -423,8 +399,8 @@ impl TDigest {
         let mut starts: Vec<usize> = Vec::with_capacity(digests.len());
 
         let mut count: f64 = 0.0;
-        let mut min = OrderedFloat::from(std::f64::INFINITY);
-        let mut max = OrderedFloat::from(std::f64::NEG_INFINITY);
+        let mut min = std::f64::INFINITY;
+        let mut max = std::f64::NEG_INFINITY;
 
         let mut start: usize = 0;
         for digest in digests.iter() {
@@ -432,8 +408,8 @@ impl TDigest {
 
             let curr_count: f64 = digest.count();
             if curr_count > 0.0 {
-                min = std::cmp::min(min, digest.min);
-                max = std::cmp::max(max, digest.max);
+                min = min.min(digest.min);
+                max = max.max(digest.max);
                 count += curr_count;
                 for centroid in &digest.centroids {
                     centroids.push(centroid.clone());
@@ -472,8 +448,8 @@ impl TDigest {
         let mut iter_centroids = centroids.iter_mut();
         let mut curr = iter_centroids.next().unwrap();
         let mut weight_so_far = curr.weight();
-        let mut sums_to_merge = OrderedFloat::from(0.0);
-        let mut weights_to_merge = OrderedFloat::from(0.0);
+        let mut sums_to_merge = 0_f64;
+        let mut weights_to_merge = 0_f64;
 
         for centroid in iter_centroids {
             weight_so_far += centroid.weight();
@@ -482,11 +458,9 @@ impl TDigest {
                 sums_to_merge += centroid.mean() * centroid.weight();
                 weights_to_merge += centroid.weight();
             } else {
-                result.sum = OrderedFloat::from(
-                    result.sum.into_inner() + curr.add(sums_to_merge, weights_to_merge),
-                );
-                sums_to_merge = OrderedFloat::from(0.0);
-                weights_to_merge = OrderedFloat::from(0.0);
+                result.sum = result.sum + curr.add(sums_to_merge, weights_to_merge);
+                sums_to_merge = 0_f64;
+                weights_to_merge = 0_f64;
                 compressed.push(curr.clone());
                 q_limit_times_count =
                     Self::k_to_q(k_limit, max_size as f64) * (count as f64);
@@ -495,14 +469,12 @@ impl TDigest {
             }
         }
 
-        result.sum = OrderedFloat::from(
-            result.sum.into_inner() + curr.add(sums_to_merge, weights_to_merge),
-        );
+        result.sum = result.sum + curr.add(sums_to_merge, weights_to_merge);
         compressed.push(curr.clone());
         compressed.shrink_to_fit();
         compressed.sort();
 
-        result.count = OrderedFloat::from(count as f64);
+        result.count = count as f64;
         result.min = min;
         result.max = max;
         result.centroids = compressed;
@@ -516,7 +488,7 @@ impl TDigest {
         }
 
         let count_ = self.count;
-        let rank = OrderedFloat::from(q) * count_;
+        let rank = q * count_;
 
         let mut pos: usize;
         let mut t;
@@ -542,7 +514,7 @@ impl TDigest {
             }
 
             pos = self.centroids.len() - 1;
-            t = OrderedFloat::from(0.0);
+            t = 0_f64;
 
             for (k, centroid) in self.centroids.iter().enumerate() {
                 if rank < t + centroid.weight() {
@@ -554,7 +526,7 @@ impl TDigest {
             }
         }
 
-        let mut delta = OrderedFloat::from(0.0);
+        let mut delta = 0_f64;
         let mut min = self.min;
         let mut max = self.max;
 
@@ -575,7 +547,7 @@ impl TDigest {
 
         let value = self.centroids[pos].mean()
             + ((rank - t) / self.centroids[pos].weight() - 0.5) * delta;
-        Self::clamp(value, min, max).into_inner()
+        Self::clamp(value, min, max)
     }
 
     /// This method decomposes the [`TDigest`] and its [`Centroid`] instances
@@ -618,16 +590,16 @@ impl TDigest {
         let centroids: Vec<_> = self
             .centroids
             .iter()
-            .flat_map(|c| [c.mean().into_inner(), c.weight().into_inner()])
+            .flat_map(|c| [c.mean(), c.weight()])
             .map(|v| ScalarValue::Float64(Some(v)))
             .collect();
 
         vec![
             ScalarValue::UInt64(Some(self.max_size as u64)),
-            ScalarValue::Float64(Some(self.sum.into_inner())),
-            ScalarValue::Float64(Some(self.count.into_inner())),
-            ScalarValue::Float64(Some(self.max.into_inner())),
-            ScalarValue::Float64(Some(self.min.into_inner())),
+            ScalarValue::Float64(Some(self.sum)),
+            ScalarValue::Float64(Some(self.count)),
+            ScalarValue::Float64(Some(self.max)),
+            ScalarValue::Float64(Some(self.min)),
             ScalarValue::new_list(Some(centroids), DataType::Float64),
         ]
     }
@@ -658,7 +630,7 @@ impl TDigest {
 
         let max = cast_scalar_f64!(&state[3]);
         let min = cast_scalar_f64!(&state[4]);
-        assert!(max >= min);
+        assert!(max.is_nan() || min.is_nan() || max >= min);
 
         Self {
             max_size,
@@ -672,8 +644,8 @@ impl TDigest {
 }
 
 #[cfg(debug_assertions)]
-fn is_sorted(values: &[OrderedFloat<f64>]) -> bool {
-    values.windows(2).all(|w| w[0] <= w[1])
+fn is_sorted(values: &[f64]) -> bool {
+    values.windows(2).all(|w| w[0].total_cmp(&w[1]).is_le())
 }
 
 #[cfg(test)]
@@ -717,7 +689,7 @@ mod tests {
     #[test]
     fn test_int64_uniform() {
         let values = (1i64..=1000)
-            .map(|v| OrderedFloat::from(v as f64))
+            .map(|v|v as f64)
             .collect();
 
         let t = TDigest::new(100);
@@ -737,7 +709,7 @@ mod tests {
         let mut t = TDigest::new(10);
 
         for v in vals {
-            t = t.merge_unsorted_f64(vec![OrderedFloat::from(v as f64)]);
+            t = t.merge_unsorted_f64(vec![v as f64]);
         }
 
         assert_error_bounds!(t, quantile = 0.5, want = 1.0);
@@ -750,7 +722,7 @@ mod tests {
         let t = TDigest::new(100);
         let values: Vec<_> = (1..=1_000_000)
             .map(f64::from)
-            .map(|v| OrderedFloat::from(v as f64))
+            .map(|v| v as f64)
             .collect();
 
         let t = t.merge_unsorted_f64(values);
@@ -768,10 +740,10 @@ mod tests {
         let t = TDigest::new(100);
         let mut values: Vec<_> = (1..=600_000)
             .map(f64::from)
-            .map(|v| OrderedFloat::from(v as f64))
+            .map(|v| v as f64)
             .collect();
         for _ in 0..400_000 {
-            values.push(OrderedFloat::from(1_000_000_f64));
+            values.push(1_000_000_f64);
         }
 
         let t = t.merge_unsorted_f64(values);
@@ -790,7 +762,7 @@ mod tests {
             let t = TDigest::new(100);
             let values: Vec<_> = (1..=1_000)
                 .map(f64::from)
-                .map(|v| OrderedFloat::from(v as f64))
+                .map(|v| v as f64)
                 .collect();
             let t = t.merge_unsorted_f64(values);
             digests.push(t)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4051 .

# Rationale for this change
See #4051 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->