### PR TITLE
add schema parameter to table provider factory create method

### DIFF
--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -289,6 +289,7 @@ impl TableProviderFactory for TestTableFactory {
     ) -> datafusion_common::Result<Arc<dyn TableProvider>> {
         Ok(Arc::new(TestTableProvider {
             url: cmd.location.to_string(),
+            schema: Arc::new(cmd.schema.as_ref().into()),
         }))
     }
 }
@@ -297,6 +298,8 @@ impl TableProviderFactory for TestTableFactory {
 pub struct TestTableProvider {
     /// URL of table files or folder
     pub url: String,
+    /// test table schema
+    pub schema: SchemaRef,
 }
 
 impl TestTableProvider {}
@@ -308,11 +311,7 @@ impl TableProvider for TestTableProvider {
     }
 
     fn schema(&self) -> SchemaRef {
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("b", DataType::Decimal128(15, 2), true),
-        ]);
-        Arc::new(schema)
+        self.schema.clone()
     }
 
     fn table_type(&self) -> TableType {

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -172,13 +172,16 @@ mod roundtrip_tests {
         fn try_decode_table_provider(
             &self,
             buf: &[u8],
-            _schema: SchemaRef,
+            schema: SchemaRef,
             _ctx: &SessionContext,
         ) -> Result<Arc<dyn TableProvider>, DataFusionError> {
             let msg = TestTableProto::decode(buf).map_err(|_| {
                 DataFusionError::Internal("Error decoding test table".to_string())
             })?;
-            let provider = TestTableProvider { url: msg.url };
+            let provider = TestTableProvider {
+                url: msg.url,
+                schema,
+            };
             Ok(Arc::new(provider))
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4142.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

`TableProviderFactory::create` is a public interface and change will be backward incompatible, but as this interface is in state of flux recently it would make sense to break it now 