### PR TITLE
Collapse statistics in normal explain plan

### DIFF
--- a/datafusion/core/src/physical_plan/display.rs
+++ b/datafusion/core/src/physical_plan/display.rs
@@ -167,7 +167,7 @@ impl<'a, 'b> ExecutionPlanVisitor for IndentVisitor<'a, 'b> {
             ShowMetrics::Aggregated => {
                 if let Some(metrics) = plan.metrics() {
                     let metrics = metrics
-                        .aggregate_by_partition()
+                        .aggregate_by_name()
                         .sorted_for_display()
                         .timestamps_removed();
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/4144

# Rationale for this change

It is almost impossible to get any useful information out of `explain analyze` for a parquet exec when it has more than 1-2 files. See https://github.com/apache/arrow-datafusion/issues/4144 for examples

# What changes are included in this PR?

Collapses all the statisics from parquet exec with the same name when showing in explain plan

Before:
```
|                   |           ParquetExec: limit=None, partitions=[Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet], predicate=timestamp_col_max@0 > 1233446400000000000, projection=[id, float_col, timestamp_col], metrics=[output_rows=8, elapsed_compute=1ns, spill_count=0, spilled_bytes=0, mem_used=0, bytes_scanned{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=259, pushdown_rows_filtered{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=0, row_groups_pruned{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=0, predicate_evaluation_errors{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=0, page_index_rows_filtered{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=0, num_predicate_creation_errors=0, page_index_eval_time{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=2ns, time_elapsed_opening=558.733µs, time_elapsed_processing=1.103953ms, pushdown_eval_time{filename=Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet}=2ns, time_elapsed_scanning=656.927µs] |
```

After (still not great but easier easier):
```
|                   |           ParquetExec: limit=None, partitions=[Users/alamb/Software/arrow-datafusion2/parquet-testing/data/alltypes_plain.parquet], predicate=timestamp_col_max@0 > 1233446400000000000, projection=[id, float_col, timestamp_col], metrics=[output_rows=8, elapsed_compute=1ns, spill_count=0, spilled_bytes=0, mem_used=0, predicate_evaluation_errors=0, pushdown_rows_filtered=0, bytes_scanned=259, num_predicate_creation_errors=0, row_groups_pruned=0, page_index_rows_filtered=0, time_elapsed_opening=588.861µs, time_elapsed_scanning=644.732µs, time_elapsed_processing=1.115933ms, page_index_eval_time=2ns, pushdown_eval_time=2ns] |
```

# Are these changes tested?
Yes
# Are there any user-facing changes?
Yes