### PR TITLE
Minor: pass `ParquetFileMetrics` to  `build_row_filter` in parquet

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -414,8 +414,7 @@ impl FileOpener for ParquetOpener {
                     table_schema.as_ref(),
                     builder.metadata(),
                     reorder_predicates,
-                    &file_metrics.pushdown_rows_filtered,
-                    &file_metrics.pushdown_eval_time,
+                    &file_metrics,
                 );
 
                 match row_filter {

--- a/datafusion/core/src/physical_plan/file_format/parquet/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet/row_filter.rs
@@ -33,6 +33,8 @@ use std::sync::Arc;
 
 use crate::physical_plan::metrics;
 
+use super::ParquetFileMetrics;
+
 /// This module contains utilities for enabling the pushdown of DataFusion filter predicates (which
 /// can be any DataFusion `Expr` that evaluates to a `BooleanArray`) to the parquet decoder level in `arrow-rs`.
 /// DataFusion will use a `ParquetRecordBatchStream` to read data from parquet into arrow `RecordBatch`es.
@@ -309,9 +311,11 @@ pub fn build_row_filter(
     table_schema: &Schema,
     metadata: &ParquetMetaData,
     reorder_predicates: bool,
-    rows_filtered: &metrics::Count,
-    time: &metrics::Time,
+    file_metrics: &ParquetFileMetrics,
 ) -> Result<Option<RowFilter>> {
+    let rows_filtered = &file_metrics.pushdown_rows_filtered;
+    let time = &file_metrics.pushdown_eval_time;
+
     let predicates = split_conjunction_owned(expr);
 
     let mut candidates: Vec<FilterCandidate> = predicates


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/3463

# Rationale for this change

Continue a somewhat OCD quest to get the parquet code to be internally consistent in structure


# What changes are included in this PR?

Change arguments to an internal function to match other modules

# Are these changes tested?

Covered by existing tests

# Are there any user-facing changes?

No.