### PR TITLE
MINOR: enable `dyn_cmp_dict` feature on arrow for physical expr crate

### DIFF
--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -64,6 +64,7 @@ unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "^1.2", features = ["v4"] }
 
 [dev-dependencies]
+arrow = { version = "26.0.0", features = ["prettyprint", "dyn_cmp_dict"] }
 criterion = "0.4"
 rand = "0.8"
 


### PR DESCRIPTION
Seems like when we are executing the test suite for the physical exprs in a standalone way (which I tend to do quite a lot 😄), it fails with a test requiring a specific feature from `arrow-rs` (`dyn_cmp_dict`). It is already turned on for `datafusion-core`, so ideally this should not change anything.

```
 $ cargo test --package datafusion-physical-expr                                                                                                     1,135s
[...]

failures:

---- expressions::binary::tests::test_dictionary_type_to_array_coersion stdout ----
thread 'expressions::binary::tests::test_dictionary_type_to_array_coersion' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/test/src/lib.rs:184:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    expressions::binary::tests::test_dictionary_type_to_array_coersion

test result: FAILED. 345 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.25s

error: test failed, to rerun pass '-p datafusion-physical-expr --lib'
```

```
 $ cargo test --package datafusion-physical-expr --lib -- expressions::binary::tests::test_dictionary_type_to_array_coersion --exact --nocapture      129ms
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/lib.rs (target/debug/deps/datafusion_physical_expr-e292b53aa0ae60cf)

running 1 test
Error: ArrowError(CastError("Comparing array of type Dictionary(Int32, Utf8) with array of type Dictionary(Int32, Utf8) requires \"dyn_cmp_dict\" feature"))
```
