### PR TITLE
Add rule to reimplement `Eliminate cross join` and remove it in planner

### DIFF
--- a/benchmarks/expected-plans/q2.txt
+++ b/benchmarks/expected-plans/q2.txt
@@ -1,24 +1,25 @@
 Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST
   Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment
-    Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value
-      Inner Join: nation.n_regionkey = region.r_regionkey
-        Inner Join: supplier.s_nationkey = nation.n_nationkey
-          Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
-            Inner Join: part.p_partkey = partsupp.ps_partkey
-              Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8("%BRASS")
-                TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size]
-              TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
-            TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
-          TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
-        Filter: region.r_name = Utf8("EUROPE")
-          TableScan: region projection=[r_regionkey, r_name]
-      Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value, alias=__sq_1
-        Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
-          Inner Join: nation.n_regionkey = region.r_regionkey
-            Inner Join: supplier.s_nationkey = nation.n_nationkey
-              Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+    Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name
+      Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value
+        Inner Join: nation.n_regionkey = region.r_regionkey
+          Inner Join: supplier.s_nationkey = nation.n_nationkey
+            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+              Inner Join: part.p_partkey = partsupp.ps_partkey
+                Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8("%BRASS")
+                  TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size]
                 TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
-                TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
-              TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
-            Filter: region.r_name = Utf8("EUROPE")
-              TableScan: region projection=[r_regionkey, r_name]
+              TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
+            TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
+          Filter: region.r_name = Utf8("EUROPE")
+            TableScan: region projection=[r_regionkey, r_name]
+        Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value, alias=__sq_1
+          Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
+            Inner Join: nation.n_regionkey = region.r_regionkey
+              Inner Join: supplier.s_nationkey = nation.n_nationkey
+                Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+                  TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
+                  TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
+                TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
+              Filter: region.r_name = Utf8("EUROPE")
+                TableScan: region projection=[r_regionkey, r_name]

--- a/benchmarks/expected-plans/q8.txt
+++ b/benchmarks/expected-plans/q8.txt
@@ -3,23 +3,24 @@ Sort: all_nations.o_year ASC NULLS LAST
     Aggregate: groupBy=[[all_nations.o_year]], aggr=[[SUM(CASE WHEN all_nations.nation = Utf8("BRAZIL") THEN all_nations.volume ELSE Decimal128(Some(0),38,4) END) AS SUM(CASE WHEN all_nations.nation = Utf8("BRAZIL") THEN all_nations.volume ELSE Int64(0) END), SUM(all_nations.volume)]]
       Projection: o_year, volume, nation, alias=all_nations
         Projection: datepart(Utf8("YEAR"), orders.o_orderdate) AS o_year, CAST(lineitem.l_extendedprice AS Decimal128(38, 4)) * CAST(Decimal128(Some(100),23,2) - CAST(lineitem.l_discount AS Decimal128(23, 2)) AS Decimal128(38, 4)) AS volume, n2.n_name AS nation
-          Inner Join: n1.n_regionkey = region.r_regionkey
-            Inner Join: supplier.s_nationkey = n2.n_nationkey
-              Inner Join: customer.c_nationkey = n1.n_nationkey
-                Inner Join: orders.o_custkey = customer.c_custkey
-                  Inner Join: lineitem.l_orderkey = orders.o_orderkey
-                    Inner Join: lineitem.l_suppkey = supplier.s_suppkey
-                      Inner Join: part.p_partkey = lineitem.l_partkey
-                        Filter: part.p_type = Utf8("ECONOMY ANODIZED STEEL")
-                          TableScan: part projection=[p_partkey, p_type]
-                        TableScan: lineitem projection=[l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount]
-                      TableScan: supplier projection=[s_suppkey, s_nationkey]
-                    Filter: orders.o_orderdate >= Date32("9131") AND orders.o_orderdate <= Date32("9861")
-                      TableScan: orders projection=[o_orderkey, o_custkey, o_orderdate]
-                  TableScan: customer projection=[c_custkey, c_nationkey]
-                SubqueryAlias: n1
-                  TableScan: nation projection=[n_nationkey, n_regionkey]
-              SubqueryAlias: n2
-                TableScan: nation projection=[n_nationkey, n_name]
-            Filter: region.r_name = Utf8("AMERICA")
-              TableScan: region projection=[r_regionkey, r_name]
+          Projection: lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, n2.n_name
+            Inner Join: n1.n_regionkey = region.r_regionkey
+              Inner Join: supplier.s_nationkey = n2.n_nationkey
+                Inner Join: customer.c_nationkey = n1.n_nationkey
+                  Inner Join: orders.o_custkey = customer.c_custkey
+                    Inner Join: lineitem.l_orderkey = orders.o_orderkey
+                      Inner Join: lineitem.l_suppkey = supplier.s_suppkey
+                        Inner Join: part.p_partkey = lineitem.l_partkey
+                          Filter: part.p_type = Utf8("ECONOMY ANODIZED STEEL")
+                            TableScan: part projection=[p_partkey, p_type]
+                          TableScan: lineitem projection=[l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount]
+                        TableScan: supplier projection=[s_suppkey, s_nationkey]
+                      Filter: orders.o_orderdate >= Date32("9131") AND orders.o_orderdate <= Date32("9861")
+                        TableScan: orders projection=[o_orderkey, o_custkey, o_orderdate]
+                    TableScan: customer projection=[c_custkey, c_nationkey]
+                  SubqueryAlias: n1
+                    TableScan: nation projection=[n_nationkey, n_regionkey]
+                SubqueryAlias: n2
+                  TableScan: nation projection=[n_nationkey, n_name]
+              Filter: region.r_name = Utf8("AMERICA")
+                TableScan: region projection=[r_regionkey, r_name]

--- a/benchmarks/expected-plans/q9.txt
+++ b/benchmarks/expected-plans/q9.txt
@@ -3,15 +3,16 @@ Sort: profit.nation ASC NULLS LAST, profit.o_year DESC NULLS FIRST
     Aggregate: groupBy=[[profit.nation, profit.o_year]], aggr=[[SUM(profit.amount)]]
       Projection: nation, o_year, amount, alias=profit
         Projection: nation.n_name AS nation, datepart(Utf8("YEAR"), orders.o_orderdate) AS o_year, CAST(lineitem.l_extendedprice AS Decimal128(38, 4)) * CAST(Decimal128(Some(100),23,2) - CAST(lineitem.l_discount AS Decimal128(23, 2)) AS Decimal128(38, 4)) - CAST(partsupp.ps_supplycost * lineitem.l_quantity AS Decimal128(38, 4)) AS amount
-          Inner Join: supplier.s_nationkey = nation.n_nationkey
-            Inner Join: lineitem.l_orderkey = orders.o_orderkey
-              Inner Join: lineitem.l_suppkey = partsupp.ps_suppkey, lineitem.l_partkey = partsupp.ps_partkey
-                Inner Join: lineitem.l_suppkey = supplier.s_suppkey
-                  Inner Join: part.p_partkey = lineitem.l_partkey
-                    Filter: part.p_name LIKE Utf8("%green%")
-                      TableScan: part projection=[p_partkey, p_name]
-                    TableScan: lineitem projection=[l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount]
-                  TableScan: supplier projection=[s_suppkey, s_nationkey]
-                TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
-              TableScan: orders projection=[o_orderkey, o_orderdate]
-            TableScan: nation projection=[n_nationkey, n_name]
+          Projection: lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name
+            Inner Join: supplier.s_nationkey = nation.n_nationkey
+              Inner Join: lineitem.l_orderkey = orders.o_orderkey
+                Inner Join: lineitem.l_suppkey = partsupp.ps_suppkey, lineitem.l_partkey = partsupp.ps_partkey
+                  Inner Join: lineitem.l_suppkey = supplier.s_suppkey
+                    Inner Join: part.p_partkey = lineitem.l_partkey
+                      Filter: part.p_name LIKE Utf8("%green%")
+                        TableScan: part projection=[p_partkey, p_name]
+                      TableScan: lineitem projection=[l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount]
+                    TableScan: supplier projection=[s_suppkey, s_nationkey]
+                  TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
+                TableScan: orders projection=[o_orderkey, o_orderdate]
+              TableScan: nation projection=[n_nationkey, n_name]

--- a/datafusion/core/tests/sql/subqueries.rs
+++ b/datafusion/core/tests/sql/subqueries.rs
@@ -141,28 +141,29 @@ order by s_acctbal desc, n_name, s_name, p_partkey;"#;
     let actual = format!("{}", plan.display_indent());
     let expected = r#"Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST
   Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment
-    Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value
-      Inner Join: nation.n_regionkey = region.r_regionkey
-        Inner Join: supplier.s_nationkey = nation.n_nationkey
-          Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
-            Inner Join: part.p_partkey = partsupp.ps_partkey
-              Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8("%BRASS")
-                TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size], partial_filters=[part.p_size = Int32(15), part.p_type LIKE Utf8("%BRASS")]
-              TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
-            TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
-          TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
-        Filter: region.r_name = Utf8("EUROPE")
-          TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]
-      Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value, alias=__sq_1
-        Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
-          Inner Join: nation.n_regionkey = region.r_regionkey
-            Inner Join: supplier.s_nationkey = nation.n_nationkey
-              Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+    Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name
+      Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value
+        Inner Join: nation.n_regionkey = region.r_regionkey
+          Inner Join: supplier.s_nationkey = nation.n_nationkey
+            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+              Inner Join: part.p_partkey = partsupp.ps_partkey
+                Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8("%BRASS")
+                  TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size], partial_filters=[part.p_size = Int32(15), part.p_type LIKE Utf8("%BRASS")]
                 TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
-                TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
-              TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
-            Filter: region.r_name = Utf8("EUROPE")
-              TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]"#
+              TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
+            TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
+          Filter: region.r_name = Utf8("EUROPE")
+            TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]
+        Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value, alias=__sq_1
+          Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
+            Inner Join: nation.n_regionkey = region.r_regionkey
+              Inner Join: supplier.s_nationkey = nation.n_nationkey
+                Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+                  TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
+                  TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
+                TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
+              Filter: region.r_name = Utf8("EUROPE")
+                TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]"#
         .to_string();
     assert_eq!(actual, expected);
 

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -67,7 +67,7 @@ impl OptimizerRule for ReduceCrossJoin {
                 let mut possible_join_keys: Vec<(Column, Column)> = vec![];
                 let mut all_inputs: Vec<LogicalPlan> = vec![];
                 match &input {
-                    LogicalPlan::Join(join) if (join.join_type == JoinType::Inner)=> {
+                    LogicalPlan::Join(join) if (join.join_type == JoinType::Inner) => {
                         flatten_join_inputs(
                             &input,
                             &mut possible_join_keys,

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -67,14 +67,7 @@ impl OptimizerRule for ReduceCrossJoin {
                 let mut possible_join_keys: Vec<(Column, Column)> = vec![];
                 let mut all_inputs: Vec<LogicalPlan> = vec![];
                 match &input {
-                    LogicalPlan::Join(join) => {
-                        if join.join_type != JoinType::Inner {
-                            return utils::optimize_children(
-                                self,
-                                plan,
-                                _optimizer_config,
-                            );
-                        }
+                    LogicalPlan::Join(join) if (join.join_type == JoinType::Inner)=> {
                         flatten_join_inputs(
                             &input,
                             &mut possible_join_keys,

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -16,19 +16,19 @@
 // under the License.
 
 //! Optimizer rule to reduce cross join to inner join if join predicates are available in filters.
-use crate::{OptimizerConfig, OptimizerRule};
-use datafusion_common::{Column, Result};
+use crate::{utils, OptimizerConfig, OptimizerRule};
+use datafusion_common::{Column, DFSchema, DataFusionError, Result};
 use datafusion_expr::{
     and,
     expr::BinaryExpr,
     logical_plan::{CrossJoin, Filter, Join, JoinType, LogicalPlan},
     or,
     utils::can_hash,
-    utils::from_plan,
+    Projection,
 };
 use datafusion_expr::{Expr, Operator};
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 //use std::collections::HashMap;
 use datafusion_expr::logical_plan::JoinConstraint;
@@ -44,24 +44,7 @@ impl ReduceCrossJoin {
     }
 }
 
-impl OptimizerRule for ReduceCrossJoin {
-    fn optimize(
-        &self,
-        plan: &LogicalPlan,
-        _optimizer_config: &mut OptimizerConfig,
-    ) -> Result<LogicalPlan> {
-        let mut possible_join_keys: Vec<(Column, Column)> = vec![];
-        let mut all_join_keys = HashSet::new();
-
-        reduce_cross_join(self, plan, &mut possible_join_keys, &mut all_join_keys)
-    }
-
-    fn name(&self) -> &str {
-        "reduce_cross_join"
-    }
-}
-
-/// Attempt to reduce cross joins to inner joins.
+/// Attempt to reorder join tp reduce cross joins to inner joins.
 /// for queries:
 /// 'select ... from a, b where a.x = b.y and b.xx = 100;'
 /// 'select ... from a, b where (a.x = b.y and b.xx = 100) or (a.x = b.y and b.xx = 200);'
@@ -71,116 +54,199 @@ impl OptimizerRule for ReduceCrossJoin {
 /// join nodes appropriately
 /// This fix helps to improve the performance of TPCH Q19. issue#78
 ///
-fn reduce_cross_join(
-    _optimizer: &ReduceCrossJoin,
+impl OptimizerRule for ReduceCrossJoin {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        _optimizer_config: &mut OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        match plan {
+            LogicalPlan::Filter(filter) => {
+                let input = (**filter.input()).clone();
+
+                let mut possible_join_keys: Vec<(Column, Column)> = vec![];
+                let mut all_inputs: Vec<LogicalPlan> = vec![];
+                match &input {
+                    LogicalPlan::Join(join) => {
+                        if join.join_type != JoinType::Inner {
+                            return utils::optimize_children(
+                                self,
+                                plan,
+                                _optimizer_config,
+                            );
+                        }
+                        flatten_join_inputs(
+                            &input,
+                            &mut possible_join_keys,
+                            &mut all_inputs,
+                        )?;
+                    }
+                    LogicalPlan::CrossJoin(_) => {
+                        flatten_join_inputs(
+                            &input,
+                            &mut possible_join_keys,
+                            &mut all_inputs,
+                        )?;
+                    }
+                    _ => {
+                        return utils::optimize_children(self, plan, _optimizer_config);
+                    }
+                }
+
+                let predicate = filter.predicate();
+                // join keys are handled locally
+                let mut all_join_keys: HashSet<(Column, Column)> = HashSet::new();
+
+                extract_possible_join_keys(predicate, &mut possible_join_keys);
+
+                let mut left = all_inputs.remove(0);
+                while !all_inputs.is_empty() {
+                    left = find_inner_join(
+                        &left,
+                        &mut all_inputs,
+                        &mut possible_join_keys,
+                        &mut all_join_keys,
+                    )?;
+                }
+
+                left = utils::optimize_children(self, &left, _optimizer_config)?;
+                if plan.schema() != left.schema() {
+                    left = LogicalPlan::Projection(Projection::new_from_schema(
+                        Arc::new(left.clone()),
+                        plan.schema().clone(),
+                        None,
+                    ));
+                }
+
+                // if there are no join keys then do nothing.
+                if all_join_keys.is_empty() {
+                    Ok(LogicalPlan::Filter(Filter::try_new(
+                        predicate.clone(),
+                        Arc::new(left),
+                    )?))
+                } else {
+                    // remove join expressions from filter
+                    match remove_join_expressions(predicate, &all_join_keys)? {
+                        Some(filter_expr) => Ok(LogicalPlan::Filter(Filter::try_new(
+                            filter_expr,
+                            Arc::new(left),
+                        )?)),
+                        _ => Ok(left),
+                    }
+                }
+            }
+
+            _ => utils::optimize_children(self, plan, _optimizer_config),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "reduce_cross_join"
+    }
+}
+
+fn flatten_join_inputs(
     plan: &LogicalPlan,
+    possible_join_keys: &mut Vec<(Column, Column)>,
+    all_inputs: &mut Vec<LogicalPlan>,
+) -> Result<()> {
+    let children = match plan {
+        LogicalPlan::Join(join) => {
+            for join_keys in join.on.iter() {
+                possible_join_keys.push(join_keys.clone());
+            }
+            let left = &*(join.left);
+            let right = &*(join.right);
+            Ok::<Vec<&LogicalPlan>, DataFusionError>(vec![left, right])
+        }
+        LogicalPlan::CrossJoin(join) => {
+            let left = &*(join.left);
+            let right = &*(join.right);
+            Ok::<Vec<&LogicalPlan>, DataFusionError>(vec![left, right])
+        }
+        _ => {
+            return Err(DataFusionError::Plan(
+                "flatten_join_inputs just can call join/cross_join".to_string(),
+            ));
+        }
+    }?;
+
+    for child in children.iter() {
+        match *child {
+            LogicalPlan::Join(left_join) => {
+                if left_join.join_type == JoinType::Inner {
+                    flatten_join_inputs(child, possible_join_keys, all_inputs)?;
+                } else {
+                    all_inputs.push((*child).clone());
+                }
+            }
+            LogicalPlan::CrossJoin(_) => {
+                flatten_join_inputs(child, possible_join_keys, all_inputs)?;
+            }
+            _ => all_inputs.push((*child).clone()),
+        }
+    }
+    Ok(())
+}
+
+fn find_inner_join(
+    left: &LogicalPlan,
+    rights: &mut Vec<LogicalPlan>,
     possible_join_keys: &mut Vec<(Column, Column)>,
     all_join_keys: &mut HashSet<(Column, Column)>,
 ) -> Result<LogicalPlan> {
-    match plan {
-        LogicalPlan::Filter(filter) => {
-            let input = filter.input();
-            let predicate = filter.predicate();
-            // join keys are handled locally
-            let mut new_possible_join_keys: Vec<(Column, Column)> = vec![];
-            let mut new_all_join_keys = HashSet::new();
+    for (i, right) in rights.iter().enumerate() {
+        let mut join_keys = vec![];
 
-            extract_possible_join_keys(predicate, &mut new_possible_join_keys);
-
-            let new_plan = reduce_cross_join(
-                _optimizer,
-                input,
-                &mut new_possible_join_keys,
-                &mut new_all_join_keys,
-            )?;
-
-            // if there are no join keys then do nothing.
-            if new_all_join_keys.is_empty() {
-                Ok(LogicalPlan::Filter(Filter::try_new(
-                    predicate.clone(),
-                    Arc::new(new_plan),
-                )?))
-            } else {
-                // remove join expressions from filter
-                match remove_join_expressions(predicate, &new_all_join_keys)? {
-                    Some(filter_expr) => Ok(LogicalPlan::Filter(Filter::try_new(
-                        filter_expr,
-                        Arc::new(new_plan),
-                    )?)),
-                    _ => Ok(new_plan),
-                }
+        for (l, r) in &mut *possible_join_keys {
+            if left.schema().field_from_column(l).is_ok()
+                && right.schema().field_from_column(r).is_ok()
+                && can_hash(left.schema().field_from_column(l).unwrap().data_type())
+            {
+                join_keys.push((l.clone(), r.clone()));
+            } else if left.schema().field_from_column(r).is_ok()
+                && right.schema().field_from_column(l).is_ok()
+                && can_hash(left.schema().field_from_column(r).unwrap().data_type())
+            {
+                join_keys.push((r.clone(), l.clone()));
             }
         }
-        LogicalPlan::CrossJoin(cross_join) => {
-            let left_plan = reduce_cross_join(
-                _optimizer,
-                &cross_join.left,
-                possible_join_keys,
-                all_join_keys,
-            )?;
-            let right_plan = reduce_cross_join(
-                _optimizer,
-                &cross_join.right,
-                possible_join_keys,
-                all_join_keys,
-            )?;
-            // can we find a match?
-            let left_schema = left_plan.schema();
-            let right_schema = right_plan.schema();
-            let mut join_keys = vec![];
 
-            for (l, r) in possible_join_keys {
-                if left_schema.field_from_column(l).is_ok()
-                    && right_schema.field_from_column(r).is_ok()
-                    && can_hash(left_schema.field_from_column(l).unwrap().data_type())
-                {
-                    join_keys.push((l.clone(), r.clone()));
-                } else if left_schema.field_from_column(r).is_ok()
-                    && right_schema.field_from_column(l).is_ok()
-                    && can_hash(left_schema.field_from_column(r).unwrap().data_type())
-                {
-                    join_keys.push((r.clone(), l.clone()));
-                }
-            }
-
-            // if there are no join keys then do nothing.
-            if join_keys.is_empty() {
-                Ok(LogicalPlan::CrossJoin(CrossJoin {
-                    left: Arc::new(left_plan),
-                    right: Arc::new(right_plan),
-                    schema: cross_join.schema.clone(),
-                }))
-            } else {
-                // Keep track of join keys being pushed to Join nodes
-                all_join_keys.extend(join_keys.clone());
-
-                Ok(LogicalPlan::Join(Join {
-                    left: Arc::new(left_plan),
-                    right: Arc::new(right_plan),
-                    join_type: JoinType::Inner,
-                    join_constraint: JoinConstraint::On,
-                    on: join_keys,
-                    filter: None,
-                    schema: cross_join.schema.clone(),
-                    null_equals_null: false,
-                }))
-            }
-        }
-        _ => {
-            let expr = plan.expressions();
-
-            // apply the optimization to all inputs of the plan
-            let inputs = plan.inputs();
-            let new_inputs = inputs
-                .iter()
-                .map(|plan| {
-                    reduce_cross_join(_optimizer, plan, possible_join_keys, all_join_keys)
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            from_plan(plan, &expr, &new_inputs)
+        if !join_keys.is_empty() {
+            all_join_keys.extend(join_keys.clone());
+            let right = rights.remove(i);
+            let join_schema = Arc::new(build_join_schema(left, &right)?);
+            return Ok(LogicalPlan::Join(Join {
+                left: Arc::new(left.clone()),
+                right: Arc::new(right),
+                join_type: JoinType::Inner,
+                join_constraint: JoinConstraint::On,
+                on: join_keys,
+                filter: None,
+                schema: join_schema,
+                null_equals_null: false,
+            }));
         }
     }
+    let right = rights.remove(0);
+    let join_schema = Arc::new(build_join_schema(left, &right)?);
+
+    Ok(LogicalPlan::CrossJoin(CrossJoin {
+        left: Arc::new(left.clone()),
+        right: Arc::new(right),
+        schema: join_schema,
+    }))
+}
+
+fn build_join_schema(left: &LogicalPlan, right: &LogicalPlan) -> Result<DFSchema> {
+    // build join schema
+    let mut fields = vec![];
+    let mut metadata = HashMap::new();
+    fields.extend(left.schema().fields().clone());
+    fields.extend(right.schema().fields().clone());
+    metadata.extend(left.schema().metadata().clone());
+    metadata.extend(right.schema().metadata().clone());
+    DFSchema::new_with_metadata(fields, metadata)
 }
 
 fn intersect(
@@ -470,6 +536,53 @@ mod tests {
             "    TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
             "    TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
         ];
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    /// ```txt
+    /// filter: a.id = b.id and a.id = c.id
+    ///   cross_join a (bc)
+    ///     cross_join b c
+    /// ```
+    /// Without reorder, it will be
+    /// ```txt
+    ///   inner_join a (bc) on a.id = b.id and a.id = c.id
+    ///     cross_join b c
+    /// ```
+    /// Reorder it to be
+    /// ```txt
+    ///   inner_join (ab)c and a.id = c.id
+    ///     inner_join a b on a.id = b.id
+    /// ```
+    fn reorder_join_to_reduce_cross_join_multi_tables() -> Result<()> {
+        let t1 = test_table_scan_with_name("t1")?;
+        let t2 = test_table_scan_with_name("t2")?;
+        let t3 = test_table_scan_with_name("t3")?;
+
+        // could reduce to inner join
+        let plan = LogicalPlanBuilder::from(t1)
+            .cross_join(&t2)?
+            .cross_join(&t3)?
+            .filter(binary_expr(
+                binary_expr(col("t3.a").eq(col("t1.a")), And, col("t3.c").lt(lit(15u32))),
+                And,
+                binary_expr(col("t3.a").eq(col("t2.a")), And, col("t3.b").lt(lit(15u32))),
+            ))?
+            .build()?;
+
+        let expected = vec![
+            "Filter: t3.c < UInt32(15) AND t3.b < UInt32(15) [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "  Projection: t1.a, t1.b, t1.c, t2.a, t2.b, t2.c, t3.a, t3.b, t3.c [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "    Inner Join: t3.a = t2.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "      Inner Join: t1.a = t3.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "        TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
+            "        TableScan: t3 [a:UInt32, b:UInt32, c:UInt32]",
+            "      TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
+        ];
+
         assert_optimized_plan_eq(&plan, expected);
 
         Ok(())
@@ -849,14 +962,14 @@ mod tests {
 
         let expected = vec![
             "Filter: (t4.c < UInt32(15) OR t4.c = UInt32(688)) AND (t4.c < UInt32(15) OR t3.c = UInt32(688) OR t3.b = t4.b) [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "  Inner Join: t1.a = t3.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "    Filter: t2.c < UInt32(15) AND t2.c = UInt32(688) [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "      Inner Join: t1.a = t2.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "        TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
-            "        TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
-            "    Inner Join: t3.a = t4.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "  Inner Join: t3.a = t4.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "    Inner Join: t1.a = t3.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "      Filter: t2.c < UInt32(15) AND t2.c = UInt32(688) [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "        Inner Join: t1.a = t2.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "          TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
+            "          TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
             "      TableScan: t3 [a:UInt32, b:UInt32, c:UInt32]",
-            "      TableScan: t4 [a:UInt32, b:UInt32, c:UInt32]",
+            "    TableScan: t4 [a:UInt32, b:UInt32, c:UInt32]",
         ];
 
         assert_optimized_plan_eq(&plan, expected);
@@ -937,13 +1050,13 @@ mod tests {
 
         let expected = vec![
             "Filter: (t4.c < UInt32(15) OR t4.c = UInt32(688)) AND (t4.c < UInt32(15) OR t3.c = UInt32(688) OR t3.b = t4.b) AND t2.c < UInt32(15) AND t2.c = UInt32(688) [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "  Inner Join: t1.a = t3.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "    Inner Join: t1.a = t2.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
-            "      TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
-            "      TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
-            "    Inner Join: t3.a = t4.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "  Inner Join: t3.a = t4.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "    Inner Join: t1.a = t3.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "      Inner Join: t1.a = t2.a [a:UInt32, b:UInt32, c:UInt32, a:UInt32, b:UInt32, c:UInt32]",
+            "        TableScan: t1 [a:UInt32, b:UInt32, c:UInt32]",
+            "        TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
             "      TableScan: t3 [a:UInt32, b:UInt32, c:UInt32]",
-            "      TableScan: t4 [a:UInt32, b:UInt32, c:UInt32]",
+            "    TableScan: t4 [a:UInt32, b:UInt32, c:UInt32]",
         ];
 
         assert_optimized_plan_eq(&plan, expected);

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -107,7 +107,6 @@ impl OptimizerRule for ReduceCrossJoin {
                     left = LogicalPlan::Projection(Projection::new_from_schema(
                         Arc::new(left.clone()),
                         plan.schema().clone(),
-                        None,
                     ));
                 }
 

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod common_subexpr_eliminate;
 pub mod decorrelate_where_exists;
 pub mod decorrelate_where_in;
+pub mod eliminate_cross_join;
 pub mod eliminate_filter;
 pub mod eliminate_limit;
 pub mod filter_null_join_keys;
@@ -27,7 +28,6 @@ pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
 pub mod propagate_empty_relation;
-pub mod reduce_cross_join;
 pub mod reduce_outer_join;
 pub mod scalar_subquery_to_join;
 pub mod simplify_expressions;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -20,6 +20,7 @@
 use crate::common_subexpr_eliminate::CommonSubexprEliminate;
 use crate::decorrelate_where_exists::DecorrelateWhereExists;
 use crate::decorrelate_where_in::DecorrelateWhereIn;
+use crate::eliminate_cross_join::ReduceCrossJoin;
 use crate::eliminate_filter::EliminateFilter;
 use crate::eliminate_limit::EliminateLimit;
 use crate::filter_null_join_keys::FilterNullJoinKeys;
@@ -28,7 +29,6 @@ use crate::inline_table_scan::InlineTableScan;
 use crate::limit_push_down::LimitPushDown;
 use crate::projection_push_down::ProjectionPushDown;
 use crate::propagate_empty_relation::PropagateEmptyRelation;
-use crate::reduce_cross_join::ReduceCrossJoin;
 use crate::reduce_outer_join::ReduceOuterJoin;
 use crate::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
 use crate::scalar_subquery_to_join::ScalarSubqueryToJoin;

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -267,6 +267,23 @@ fn propagate_empty_relation() {
     assert_eq!(expected, format!("{:?}", plan));
 }
 
+#[test]
+fn join_keys_in_subquery_alias() {
+    let sql = "SELECT * FROM test AS A, ( SELECT col_int32 as key FROM test ) AS B where A.col_int32 = B.key;";
+    let plan = test_sql(sql).unwrap();
+    // when children exist EmptyRelation, it will bottom-up propagate.
+    let expected =  "Projection: a.col_int32, a.col_uint32, a.col_utf8, a.col_date32, a.col_date64, a.col_ts_nano_none, a.col_ts_nano_utc, b.key\
+    \n  Inner Join: a.col_int32 = b.key\
+    \n    Filter: a.col_int32 IS NOT NULL\
+    \n      SubqueryAlias: a\
+    \n        TableScan: test projection=[col_int32, col_uint32, col_utf8, col_date32, col_date64, col_ts_nano_none, col_ts_nano_utc]\
+    \n    Projection: key, alias=b\
+    \n      Projection: test.col_int32 AS key\
+    \n        Filter: test.col_int32 IS NOT NULL\
+    \n          TableScan: test projection=[col_int32]";
+    assert_eq!(expected, format!("{:?}", plan));
+}
+
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
     // parse the SQL
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -55,7 +55,11 @@ use datafusion_expr::logical_plan::{
     Partitioning, PlanType, SetVariable, ToStringifiedPlan,
 };
 use datafusion_expr::logical_plan::{Filter, Subquery};
-use datafusion_expr::utils::{can_hash, check_all_column_from_schema, expand_qualified_wildcard, expand_wildcard, expr_as_column_expr, find_aggregate_exprs, find_column_exprs, find_window_exprs, COUNT_STAR_EXPANSION, expr_to_columns};
+use datafusion_expr::utils::{
+    can_hash, check_all_column_from_schema, expand_qualified_wildcard, expand_wildcard,
+    expr_as_column_expr, expr_to_columns, find_aggregate_exprs, find_column_exprs,
+    find_window_exprs, COUNT_STAR_EXPANSION,
+};
 use datafusion_expr::Expr::Alias;
 use datafusion_expr::{
     cast, col, lit, AggregateFunction, AggregateUDF, Expr, ExprSchemable,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4176.
Part of #4267

- Current implementation of eliminate_cross_join is wrong. Because it can't rearrange join order. detail is inside #4176..
- remove the `eliminate_cross_join` from planner
- reimplement `eliminate_cross_join` to avoid to use `global-state`. In new implementation, we just depends only on the shape of the subtree.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Reimplement `Eliminate cross join`

# Are these changes tested?

Test `Reorder join` for eliminating cross join.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->