### PR TITLE
Fix clippy by avoiding deprecated functions in chrono

### DIFF
--- a/datafusion/common/src/delta.rs
+++ b/datafusion/common/src/delta.rs
@@ -105,75 +105,186 @@ mod tests {
 
     #[test]
     fn test_shift_months() {
-        let base = NaiveDate::from_ymd(2020, 1, 31);
+        let base = NaiveDate::from_ymd_opt(2020, 1, 31).unwrap();
 
-        assert_eq!(shift_months(base, 0), NaiveDate::from_ymd(2020, 1, 31));
-        assert_eq!(shift_months(base, 1), NaiveDate::from_ymd(2020, 2, 29));
-        assert_eq!(shift_months(base, 2), NaiveDate::from_ymd(2020, 3, 31));
-        assert_eq!(shift_months(base, 3), NaiveDate::from_ymd(2020, 4, 30));
-        assert_eq!(shift_months(base, 4), NaiveDate::from_ymd(2020, 5, 31));
-        assert_eq!(shift_months(base, 5), NaiveDate::from_ymd(2020, 6, 30));
-        assert_eq!(shift_months(base, 6), NaiveDate::from_ymd(2020, 7, 31));
-        assert_eq!(shift_months(base, 7), NaiveDate::from_ymd(2020, 8, 31));
-        assert_eq!(shift_months(base, 8), NaiveDate::from_ymd(2020, 9, 30));
-        assert_eq!(shift_months(base, 9), NaiveDate::from_ymd(2020, 10, 31));
-        assert_eq!(shift_months(base, 10), NaiveDate::from_ymd(2020, 11, 30));
-        assert_eq!(shift_months(base, 11), NaiveDate::from_ymd(2020, 12, 31));
-        assert_eq!(shift_months(base, 12), NaiveDate::from_ymd(2021, 1, 31));
-        assert_eq!(shift_months(base, 13), NaiveDate::from_ymd(2021, 2, 28));
+        assert_eq!(
+            shift_months(base, 0),
+            NaiveDate::from_ymd_opt(2020, 1, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 1),
+            NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 2),
+            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 3),
+            NaiveDate::from_ymd_opt(2020, 4, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 4),
+            NaiveDate::from_ymd_opt(2020, 5, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 5),
+            NaiveDate::from_ymd_opt(2020, 6, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 6),
+            NaiveDate::from_ymd_opt(2020, 7, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 7),
+            NaiveDate::from_ymd_opt(2020, 8, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 8),
+            NaiveDate::from_ymd_opt(2020, 9, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 9),
+            NaiveDate::from_ymd_opt(2020, 10, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 10),
+            NaiveDate::from_ymd_opt(2020, 11, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 11),
+            NaiveDate::from_ymd_opt(2020, 12, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 12),
+            NaiveDate::from_ymd_opt(2021, 1, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 13),
+            NaiveDate::from_ymd_opt(2021, 2, 28).unwrap()
+        );
 
-        assert_eq!(shift_months(base, -1), NaiveDate::from_ymd(2019, 12, 31));
-        assert_eq!(shift_months(base, -2), NaiveDate::from_ymd(2019, 11, 30));
-        assert_eq!(shift_months(base, -3), NaiveDate::from_ymd(2019, 10, 31));
-        assert_eq!(shift_months(base, -4), NaiveDate::from_ymd(2019, 9, 30));
-        assert_eq!(shift_months(base, -5), NaiveDate::from_ymd(2019, 8, 31));
-        assert_eq!(shift_months(base, -6), NaiveDate::from_ymd(2019, 7, 31));
-        assert_eq!(shift_months(base, -7), NaiveDate::from_ymd(2019, 6, 30));
-        assert_eq!(shift_months(base, -8), NaiveDate::from_ymd(2019, 5, 31));
-        assert_eq!(shift_months(base, -9), NaiveDate::from_ymd(2019, 4, 30));
-        assert_eq!(shift_months(base, -10), NaiveDate::from_ymd(2019, 3, 31));
-        assert_eq!(shift_months(base, -11), NaiveDate::from_ymd(2019, 2, 28));
-        assert_eq!(shift_months(base, -12), NaiveDate::from_ymd(2019, 1, 31));
-        assert_eq!(shift_months(base, -13), NaiveDate::from_ymd(2018, 12, 31));
+        assert_eq!(
+            shift_months(base, -1),
+            NaiveDate::from_ymd_opt(2019, 12, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -2),
+            NaiveDate::from_ymd_opt(2019, 11, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -3),
+            NaiveDate::from_ymd_opt(2019, 10, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -4),
+            NaiveDate::from_ymd_opt(2019, 9, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -5),
+            NaiveDate::from_ymd_opt(2019, 8, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -6),
+            NaiveDate::from_ymd_opt(2019, 7, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -7),
+            NaiveDate::from_ymd_opt(2019, 6, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -8),
+            NaiveDate::from_ymd_opt(2019, 5, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -9),
+            NaiveDate::from_ymd_opt(2019, 4, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -10),
+            NaiveDate::from_ymd_opt(2019, 3, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -11),
+            NaiveDate::from_ymd_opt(2019, 2, 28).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -12),
+            NaiveDate::from_ymd_opt(2019, 1, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -13),
+            NaiveDate::from_ymd_opt(2018, 12, 31).unwrap()
+        );
 
-        assert_eq!(shift_months(base, 1265), NaiveDate::from_ymd(2125, 6, 30));
+        assert_eq!(
+            shift_months(base, 1265),
+            NaiveDate::from_ymd_opt(2125, 6, 30).unwrap()
+        );
     }
 
     #[test]
     fn test_shift_months_with_overflow() {
-        let base = NaiveDate::from_ymd(2020, 12, 31);
+        let base = NaiveDate::from_ymd_opt(2020, 12, 31).unwrap();
 
         assert_eq!(shift_months(base, 0), base);
-        assert_eq!(shift_months(base, 1), NaiveDate::from_ymd(2021, 1, 31));
-        assert_eq!(shift_months(base, 2), NaiveDate::from_ymd(2021, 2, 28));
-        assert_eq!(shift_months(base, 12), NaiveDate::from_ymd(2021, 12, 31));
-        assert_eq!(shift_months(base, 18), NaiveDate::from_ymd(2022, 6, 30));
+        assert_eq!(
+            shift_months(base, 1),
+            NaiveDate::from_ymd_opt(2021, 1, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 2),
+            NaiveDate::from_ymd_opt(2021, 2, 28).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 12),
+            NaiveDate::from_ymd_opt(2021, 12, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, 18),
+            NaiveDate::from_ymd_opt(2022, 6, 30).unwrap()
+        );
 
-        assert_eq!(shift_months(base, -1), NaiveDate::from_ymd(2020, 11, 30));
-        assert_eq!(shift_months(base, -2), NaiveDate::from_ymd(2020, 10, 31));
-        assert_eq!(shift_months(base, -10), NaiveDate::from_ymd(2020, 2, 29));
-        assert_eq!(shift_months(base, -12), NaiveDate::from_ymd(2019, 12, 31));
-        assert_eq!(shift_months(base, -18), NaiveDate::from_ymd(2019, 6, 30));
+        assert_eq!(
+            shift_months(base, -1),
+            NaiveDate::from_ymd_opt(2020, 11, 30).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -2),
+            NaiveDate::from_ymd_opt(2020, 10, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -10),
+            NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -12),
+            NaiveDate::from_ymd_opt(2019, 12, 31).unwrap()
+        );
+        assert_eq!(
+            shift_months(base, -18),
+            NaiveDate::from_ymd_opt(2019, 6, 30).unwrap()
+        );
     }
 
     #[test]
     fn test_shift_months_datetime() {
-        let date = NaiveDate::from_ymd(2020, 1, 31);
-        let o_clock = NaiveTime::from_hms(1, 2, 3);
+        let date = NaiveDate::from_ymd_opt(2020, 1, 31).unwrap();
+        let o_clock = NaiveTime::from_hms_opt(1, 2, 3).unwrap();
 
         let base = NaiveDateTime::new(date, o_clock);
 
         assert_eq!(
             shift_months(base, 0).date(),
-            NaiveDate::from_ymd(2020, 1, 31)
+            NaiveDate::from_ymd_opt(2020, 1, 31).unwrap(),
         );
         assert_eq!(
             shift_months(base, 1).date(),
-            NaiveDate::from_ymd(2020, 2, 29)
+            NaiveDate::from_ymd_opt(2020, 2, 29).unwrap(),
         );
         assert_eq!(
             shift_months(base, 2).date(),
-            NaiveDate::from_ymd(2020, 3, 31)
+            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
         );
         assert_eq!(shift_months(base, 0).time(), o_clock);
         assert_eq!(shift_months(base, 1).time(), o_clock);

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -613,7 +613,7 @@ mod tests {
             },
             ObjectMeta {
                 location: Path::from("mybucket/tablepath/part1=val2/file.parquet"),
-                last_modified: to_timstamp_millis(0).unwrap(),
+                last_modified: to_timestamp_millis(0).unwrap(),
                 size: 100,
             },
         ];

--- a/datafusion/core/tests/parquet/row_group_pruning.rs
+++ b/datafusion/core/tests/parquet/row_group_pruning.rs
@@ -134,7 +134,7 @@ async fn prune_date64() {
     let date = "2020-01-02"
         .parse::<chrono::NaiveDate>()
         .unwrap()
-        .and_time(chrono::NaiveTime::from_hms(0, 0, 0));
+        .and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap());
     let date = ScalarValue::Date64(Some(date.timestamp_millis()));
 
     let output = ContextWithParquet::new(Scenario::Dates)
@@ -935,7 +935,7 @@ fn make_date_batch(offset: Duration) -> RecordBatch {
                 let t = t
                     .parse::<chrono::NaiveDate>()
                     .unwrap()
-                    .and_time(chrono::NaiveTime::from_hms(0, 0, 0));
+                    .and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap());
                 let t = t + offset;
                 t.timestamp_millis()
             })

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -580,7 +580,10 @@ async fn register_tpch_csv_data(
                 DataType::Date32 => {
                     let sb = col.as_any_mut().downcast_mut::<Date32Builder>().unwrap();
                     let dt = NaiveDate::parse_from_str(val.trim(), "%Y-%m-%d").unwrap();
-                    let dt = dt.sub(NaiveDate::from_ymd(1970, 1, 1)).num_days() as i32;
+                    let dt = dt
+                        .sub(NaiveDate::from_ymd_opt(1970, 1, 1))
+                        .unwrap()
+                        .num_days() as i32;
                     sb.append_value(dt);
                 }
                 DataType::Int32 => {

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -581,8 +581,7 @@ async fn register_tpch_csv_data(
                     let sb = col.as_any_mut().downcast_mut::<Date32Builder>().unwrap();
                     let dt = NaiveDate::parse_from_str(val.trim(), "%Y-%m-%d").unwrap();
                     let dt = dt
-                        .sub(NaiveDate::from_ymd_opt(1970, 1, 1))
-                        .unwrap()
+                        .sub(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
                         .num_days() as i32;
                     sb.append_value(dt);
                 }

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -890,7 +890,7 @@ async fn group_by_timestamp_millis() -> Result<()> {
         ),
         Field::new("count", DataType::Int32, false),
     ]));
-    let base_dt = Utc.ymd(2018, 7, 1).and_hms(6, 0, 0); // 2018-Jul-01 06:00
+    let base_dt = Utc.ymd_opt(2018, 7, 1).unwrap().and_hms(6, 0, 0); // 2018-Jul-01 06:00
     let hour1 = Duration::hours(1);
     let timestamps = vec![
         base_dt.timestamp_millis(),

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -890,7 +890,7 @@ async fn group_by_timestamp_millis() -> Result<()> {
         ),
         Field::new("count", DataType::Int32, false),
     ]));
-    let base_dt = Utc.ymd_opt(2018, 7, 1).unwrap().and_hms(6, 0, 0); // 2018-Jul-01 06:00
+    let base_dt = Utc.with_ymd_and_hms(2018, 7, 1, 6, 0, 0).unwrap(); // 2018-Jul-01 06:00
     let hour1 = Duration::hours(1);
     let timestamps = vec![
         base_dt.timestamp_millis(),

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -270,8 +270,8 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
     let plan = sql_to_rel.sql_statement_to_plan(statement.clone()).unwrap();
 
     // hard code the return value of now()
-    let now_time =
-        DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1666615693, 0), Utc);
+    let ts = NaiveDateTime::from_timestamp_opt(1666615693, 0).unwrap();
+    let now_time = DateTime::<Utc>::from_utc(ts, Utc);
     let mut config = OptimizerConfig::new()
         .with_skip_failing_rules(false)
         .with_query_execution_start_time(now_time);

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -195,7 +195,10 @@ pub fn make_current_date(
     now_ts: DateTime<Utc>,
 ) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
     let days = Some(
-        now_ts.num_days_from_ce() - NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce(),
+        now_ts.num_days_from_ce()
+            - NaiveDate::from_ymd_opt(1970, 1, 1)
+                .unwrap()
+                .num_days_from_ce(),
     );
     move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Date32(days)))
 }

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -268,42 +268,42 @@ mod tests {
 
     #[test]
     fn add_11_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, 11);
         assert_eq!(format!("{:?}", actual).as_str(), "2000-12-01");
     }
 
     #[test]
     fn add_12_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, 12);
         assert_eq!(format!("{:?}", actual).as_str(), "2001-01-01");
     }
 
     #[test]
     fn add_13_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, 13);
         assert_eq!(format!("{:?}", actual).as_str(), "2001-02-01");
     }
 
     #[test]
     fn sub_11_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, -11);
         assert_eq!(format!("{:?}", actual).as_str(), "1999-02-01");
     }
 
     #[test]
     fn sub_12_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, -12);
         assert_eq!(format!("{:?}", actual).as_str(), "1999-01-01");
     }
 
     #[test]
     fn sub_13_months() {
-        let prior = NaiveDate::from_ymd(2000, 1, 1);
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
         let actual = shift_months(prior, -13);
         assert_eq!(format!("{:?}", actual).as_str(), "1998-12-01");
     }
@@ -321,7 +321,7 @@ mod tests {
         // assert
         match res {
             ColumnarValue::Scalar(ScalarValue::Date32(Some(d))) => {
-                let epoch = NaiveDate::from_ymd(1970, 1, 1);
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let res = epoch.add(Duration::days(d as i64));
                 assert_eq!(format!("{:?}", res).as_str(), "1970-01-02");
             }
@@ -346,7 +346,7 @@ mod tests {
         // assert
         match res {
             ColumnarValue::Scalar(ScalarValue::Date32(Some(d))) => {
-                let epoch = NaiveDate::from_ymd(1970, 1, 1);
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let res = epoch.add(Duration::days(d as i64));
                 assert_eq!(format!("{:?}", res).as_str(), "1968-12-01");
             }
@@ -372,7 +372,7 @@ mod tests {
         // assert
         match res {
             ColumnarValue::Scalar(ScalarValue::Date64(Some(d))) => {
-                let epoch = NaiveDate::from_ymd(1970, 1, 1);
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let res = epoch.add(Duration::milliseconds(d as i64));
                 assert_eq!(format!("{:?}", res).as_str(), "1969-12-16");
             }
@@ -397,7 +397,7 @@ mod tests {
         // assert
         match res {
             ColumnarValue::Scalar(ScalarValue::Date32(Some(d))) => {
-                let epoch = NaiveDate::from_ymd(1970, 1, 1);
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let res = epoch.add(Duration::days(d as i64));
                 assert_eq!(format!("{:?}", res).as_str(), "1970-02-01");
             }
@@ -422,7 +422,7 @@ mod tests {
         // assert
         match res {
             ColumnarValue::Scalar(ScalarValue::Date32(Some(d))) => {
-                let epoch = NaiveDate::from_ymd(1970, 1, 1);
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let res = epoch.add(Duration::days(d as i64));
                 assert_eq!(format!("{:?}", res).as_str(), "1968-12-17");
             }


### PR DESCRIPTION
# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/4187

# Rationale for this change
Clippy failing on master

# What changes are included in this PR?
Switch to use non deprecated functions (that don't panic internally). Will note the actual code changes

# Are these changes tested?

covered in existing tests

# Are there any user-facing changes?

Some better error messages when timestamp conversion fails