### PR TITLE
add `propagate_empty_relation` optimizer rule

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -419,6 +419,18 @@ impl LogicalPlanBuilder {
         Ok(Self::from(union_with_alias(self.plan.clone(), plan, None)?))
     }
 
+    pub fn union_with_alias(
+        &self,
+        plan: LogicalPlan,
+        alias: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self::from(union_with_alias(
+            self.plan.clone(),
+            plan,
+            alias,
+        )?))
+    }
+
     /// Apply a union, removing duplicate rows
     pub fn union_distinct(&self, plan: LogicalPlan) -> Result<Self> {
         // unwrap top-level Distincts, to avoid duplication

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1177,7 +1177,7 @@ pub struct Filter {
     /// The predicate expression, which must have Boolean type.
     predicate: Expr,
     /// The incoming logical plan
-    pub input: Arc<LogicalPlan>,
+    input: Arc<LogicalPlan>,
 }
 
 impl Filter {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1177,7 +1177,7 @@ pub struct Filter {
     /// The predicate expression, which must have Boolean type.
     predicate: Expr,
     /// The incoming logical plan
-    input: Arc<LogicalPlan>,
+    pub input: Arc<LogicalPlan>,
 }
 
 impl Filter {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1145,6 +1145,22 @@ impl Projection {
         })
     }
 
+    /// Create a new Projection using the specified output schema
+    pub fn new_from_schema(input: Arc<LogicalPlan>, schema: DFSchemaRef) -> Self {
+        let expr: Vec<Expr> = schema
+            .fields()
+            .iter()
+            .map(|field| field.qualified_column())
+            .map(Expr::Column)
+            .collect();
+        Self {
+            expr,
+            input,
+            schema,
+            alias: None,
+        }
+    }
+
     pub fn try_from_plan(plan: &LogicalPlan) -> datafusion_common::Result<&Projection> {
         match plan {
             LogicalPlan::Projection(it) => Ok(it),

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1146,7 +1146,11 @@ impl Projection {
     }
 
     /// Create a new Projection using the specified output schema
-    pub fn new_from_schema(input: Arc<LogicalPlan>, schema: DFSchemaRef) -> Self {
+    pub fn new_from_schema(
+        input: Arc<LogicalPlan>,
+        schema: DFSchemaRef,
+        alias: Option<String>,
+    ) -> Self {
         let expr: Vec<Expr> = schema
             .fields()
             .iter()
@@ -1157,7 +1161,7 @@ impl Projection {
             expr,
             input,
             schema,
-            alias: None,
+            alias,
         }
     }
 

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -26,6 +26,7 @@ pub mod inline_table_scan;
 pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod propagate_empty_relation;
 pub mod reduce_cross_join;
 pub mod reduce_outer_join;
 pub mod scalar_subquery_to_join;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -163,10 +163,10 @@ impl Optimizer {
             // subqueries to joins
             Arc::new(SimplifyExpressions::new()),
             Arc::new(EliminateFilter::new()),
-            Arc::new(PropagateEmptyRelation::new()),
             Arc::new(ReduceCrossJoin::new()),
             Arc::new(CommonSubexprEliminate::new()),
             Arc::new(EliminateLimit::new()),
+            Arc::new(PropagateEmptyRelation::new()),
             Arc::new(RewriteDisjunctivePredicate::new()),
         ];
         if config.filter_null_keys {

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -27,6 +27,7 @@ use crate::filter_push_down::FilterPushDown;
 use crate::inline_table_scan::InlineTableScan;
 use crate::limit_push_down::LimitPushDown;
 use crate::projection_push_down::ProjectionPushDown;
+use crate::propagate_empty_relation::PropagateEmptyRelation;
 use crate::reduce_cross_join::ReduceCrossJoin;
 use crate::reduce_outer_join::ReduceOuterJoin;
 use crate::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
@@ -162,6 +163,7 @@ impl Optimizer {
             // subqueries to joins
             Arc::new(SimplifyExpressions::new()),
             Arc::new(EliminateFilter::new()),
+            Arc::new(PropagateEmptyRelation::new()),
             Arc::new(ReduceCrossJoin::new()),
             Arc::new(CommonSubexprEliminate::new()),
             Arc::new(EliminateLimit::new()),

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -41,11 +41,10 @@ impl OptimizerRule for PropagateEmptyRelation {
         // optimize child plans first
         let optimized_children_plan =
             utils::optimize_children(self, plan, optimizer_config)?;
-        let optimized_plan_opt = match optimized_children_plan {
+        let optimized_plan_opt = match &optimized_children_plan {
             LogicalPlan::Projection(_)
             | LogicalPlan::Filter(_)
             | LogicalPlan::Window(_)
-            | LogicalPlan::Aggregate(_)
             | LogicalPlan::Sort(_)
             | LogicalPlan::Join(_)
             | LogicalPlan::CrossJoin(_)

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -111,11 +111,16 @@ impl OptimizerRule for PropagateEmptyRelation {
                         schema: plan.schema().clone(),
                     }))
                 } else if new_inputs.len() == 1 {
-                    Ok(LogicalPlan::Projection(Projection::new_from_schema(
-                        Arc::new((**(union.inputs.get(0).unwrap())).clone()),
-                        plan.schema().clone(),
-                        union.alias.clone(),
-                    )))
+                    let child = (**(union.inputs.get(0).unwrap())).clone();
+                    if child.schema().eq(plan.schema()) {
+                        Ok(child)
+                    } else {
+                        Ok(LogicalPlan::Projection(Projection::new_from_schema(
+                            Arc::new(child),
+                            plan.schema().clone(),
+                            union.alias.clone(),
+                        )))
+                    }
                 } else {
                     Ok(LogicalPlan::Union(Union {
                         inputs: new_inputs,

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -61,7 +61,7 @@ impl OptimizerRule for PropagateEmptyRelation {
     }
 
     fn name(&self) -> &str {
-        "eliminate_limit"
+        "propagate_empty_relation"
     }
 }
 

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_common::Result;
+use datafusion_expr::logical_plan::LogicalPlan;
+
+use crate::{utils, OptimizerConfig, OptimizerRule};
+
+/// Optimization rule that bottom-up to eliminate plan by propagating empty_relation.
+#[derive(Default)]
+pub struct PropagateEmptyRelation;
+
+impl PropagateEmptyRelation {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for PropagateEmptyRelation {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        optimizer_config: &mut OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        // optimize child plans first
+        let optimized_children_plan =
+            utils::optimize_children(self, plan, optimizer_config)?;
+        let optimized_plan_opt = match optimized_children_plan {
+            LogicalPlan::Projection(_)
+            | LogicalPlan::Filter(_)
+            | LogicalPlan::Window(_)
+            | LogicalPlan::Aggregate(_)
+            | LogicalPlan::Sort(_)
+            | LogicalPlan::Join(_)
+            | LogicalPlan::CrossJoin(_)
+            | LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::SubqueryAlias(_)
+            | LogicalPlan::Limit(_) => empty_child(&optimized_children_plan),
+            _ => None,
+        };
+
+        match optimized_plan_opt {
+            Some(optimized_plan) => Ok(optimized_plan),
+            None => Ok(optimized_children_plan),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "eliminate_limit"
+    }
+}
+
+fn empty_child(plan: &LogicalPlan) -> Option<LogicalPlan> {
+    let inputs = plan.inputs();
+
+    if inputs.len() == 1 {
+        let input = inputs.get(0)?;
+        match input {
+            LogicalPlan::EmptyRelation(empty) => {
+                if !empty.produce_one_row {
+                    Some((*input).clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    } else if inputs.len() == 2 {
+        let left = inputs.get(0)?;
+        let right = inputs.get(1)?;
+        let left_opt = match left {
+            LogicalPlan::EmptyRelation(empty) => {
+                if !empty.produce_one_row {
+                    Some((*left).clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if left_opt.is_some() {
+            return left_opt;
+        }
+        match right {
+            LogicalPlan::EmptyRelation(empty) => {
+                if !empty.produce_one_row {
+                    Some((*right).clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{logical_plan::builder::LogicalPlanBuilder, Expr};
+
+    use super::*;
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = PropagateEmptyRelation::new();
+        let optimized_plan = rule
+            .optimize(plan, &mut OptimizerConfig::new())
+            .expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+        assert_eq!(plan.schema(), optimized_plan.schema());
+    }
+
+    #[test]
+    fn propagate_empty() {
+        let filter_true = Expr::Literal(ScalarValue::Boolean(Some(true)));
+
+        let plan = LogicalPlanBuilder::empty(false)
+            .filter(filter_true.clone())
+            .unwrap()
+            .filter(filter_true.clone())
+            .unwrap()
+            .filter(filter_true)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        // No aggregate / scan / limit
+        let expected = "EmptyRelation";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+}

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -260,7 +260,7 @@ fn timestamp_nano_ts_utc_predicates() {
 
 #[test]
 fn propagate_empty_relation() {
-    let sql = "select col_int32 from test join ( select col_int32 from test where false ) as ta1 on test.col_int32 = ta1.col_int32;";
+    let sql = "SELECT col_int32 FROM test JOIN ( SELECT col_int32 FROM test WHERE false ) AS ta1 ON test.col_int32 = ta1.col_int32;";
     let plan = test_sql(sql).unwrap();
     // when children exist EmptyRelation, it will bottom-up propagate.
     let expected = "EmptyRelation";

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -258,6 +258,15 @@ fn timestamp_nano_ts_utc_predicates() {
     assert_eq!(expected, format!("{:?}", plan));
 }
 
+#[test]
+fn propagate_empty_relation() {
+    let sql = "select col_int32 from test join ( select col_int32 from test where false ) as ta1 on test.col_int32 = ta1.col_int32;";
+    let plan = test_sql(sql).unwrap();
+    // when children exist EmptyRelation, it will bottom-up propagate.
+    let expected = "EmptyRelation";
+    assert_eq!(expected, format!("{:?}", plan));
+}
+
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
     // parse the SQL
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3864.

We can propagate `empty_relation` to eliminate useless plan.

This is a bottom-up rule.

```sql
| logical_plan after eliminate_filter| Projection: t1.column1                        |
|                                    |   Inner Join: t1.column1 = ta1.column1        |
|                                    |     TableScan: t1                             |
|                                    |     Projection: ta1.column1, alias=ta1        |
|                                    |       Projection: t2.column1, alias=ta1       |
|                                    |         Inner Join: t2.column1 = ta2.column1  |
|                                    |           TableScan: t2                       |
|                                    |           Projection: ta2.column1, alias=ta2  |
|                                    |             Projection: t3.column1, alias=ta2 |
|                                    |               EmptyRelation                   |
| logical_plan after eliminate_limit | EmptyRelation                                 |
```

# Rationale for this change

# What changes are included in this PR?


# Are these changes tested?


# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->