### PR TITLE
Avoid error with empty iterators used for `ScalarValue::iter_to_array`

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -1600,10 +1600,14 @@ impl ScalarValue {
         let mut valid = BooleanBufferBuilder::new(0);
         let mut flat_len = 0i32;
         for scalar in scalars {
-            if let ScalarValue::List(values, _) = scalar {
+            if let ScalarValue::List(values, field) = scalar {
                 match values {
                     Some(values) => {
-                        let element_array = ScalarValue::iter_to_array(values)?;
+                        let element_array = if !values.is_empty() {
+                            ScalarValue::iter_to_array(values)?
+                        } else {
+                            arrow::array::new_empty_array(field.data_type())
+                        };
 
                         // Add new offset index
                         flat_len += element_array.len() as i32;

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -479,8 +479,15 @@ fn create_batch_from_map(
                     results[i].push(acc.evaluate(&state_accessor).unwrap());
                 }
             }
-            for scalars in results {
-                columns.push(ScalarValue::iter_to_array(scalars)?);
+            for (scalars, field) in results
+                .into_iter()
+                .zip(output_schema.fields()[columns.len()..].iter())
+            {
+                if !scalars.is_empty() {
+                    columns.push(ScalarValue::iter_to_array(scalars)?);
+                } else {
+                    columns.push(arrow::array::new_empty_array(field.data_type()))
+                }
             }
         }
     }

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -479,10 +479,12 @@ fn create_batch_from_map(
                     results[i].push(acc.evaluate(&state_accessor).unwrap());
                 }
             }
-            for (scalars, field) in results
-                .into_iter()
-                .zip(output_schema.fields()[columns.len()..].iter())
-            {
+            // We skip over the first `columns.len()` elements.
+            //
+            // This shouldn't panic if the `output_schema` has enough fields.
+            let remaining_field_iterator = output_schema.fields()[columns.len()..].iter();
+
+            for (scalars, field) in results.into_iter().zip(remaining_field_iterator) {
                 if !scalars.is_empty() {
                     columns.push(ScalarValue::iter_to_array(scalars)?);
                 } else {

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -2314,3 +2314,37 @@ async fn aggregate_with_alias() -> Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn array_agg_zero() -> Result<()> {
+    let ctx = SessionContext::new();
+    // 2 different aggregate functions: avg and sum(distinct)
+    let sql = "SELECT ARRAY_AGG([]);";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+------------------------+",
+        "| ARRAYAGG(List([NULL])) |",
+        "+------------------------+",
+        "| []                     |",
+        "+------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn array_agg_one() -> Result<()> {
+    let ctx = SessionContext::new();
+    // 2 different aggregate functions: avg and sum(distinct)
+    let sql = "SELECT ARRAY_AGG([1]);";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+---------------------+",
+        "| ARRAYAGG(List([1])) |",
+        "+---------------------+",
+        "| [[1]]               |",
+        "+---------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4080.

# Rationale for this change

I've noticed that some calls to `ScalarValue::iter_to_array` could have an empty iterator as argument, which caused an error. 

# What changes are included in this PR?

In 2 places I found out that sometimes, `ScalarValue::iter_to_array` is called with an empty iterator. I made sure to use `arrow::array::new_empty_array` in this case.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

One of them is (the one about the `ScalarValue::List`).

I didn't find a good way to test the other one, as it seems to require some more insights into how the aggregation works internally.

# Are there any user-facing changes?

No, and no breaking changes.