### PR TITLE
Add try_optimize method

### DIFF
--- a/datafusion/optimizer/src/decorrelate_where_exists.rs
+++ b/datafusion/optimizer/src/decorrelate_where_exists.rs
@@ -75,7 +75,9 @@ impl OptimizerRule for DecorrelateWhereExists {
         plan: &LogicalPlan,
         optimizer_config: &mut OptimizerConfig,
     ) -> datafusion_common::Result<LogicalPlan> {
-        Ok(self.try_optimize(plan, optimizer_config)?.unwrap_or(plan.clone()))
+        Ok(self
+            .try_optimize(plan, optimizer_config)?
+            .unwrap_or_else(|| plan.clone()))
     }
 
     fn try_optimize(

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -55,7 +55,7 @@ pub trait OptimizerRule {
         plan: &LogicalPlan,
         optimizer_config: &mut OptimizerConfig,
     ) -> Result<Option<LogicalPlan>> {
-        self.optimize(plan, optimizer_config).map(|plan| Some(plan))
+        self.optimize(plan, optimizer_config).map(Some)
     }
 
     /// Rewrite `plan` to an optimized form. This method will eventually be deprecated and

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -129,3 +129,11 @@ pub fn assert_optimizer_err(
         }
     }
 }
+
+pub fn assert_optimization_skipped(
+    rule: &dyn OptimizerRule,
+    plan: &LogicalPlan,
+) {
+    let new_plan = rule.optimize(plan, &mut OptimizerConfig::new()).unwrap();
+    assert_eq!(format!("{}", plan.display_indent()), format!("{}", new_plan.display_indent()));
+}

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -130,10 +130,10 @@ pub fn assert_optimizer_err(
     }
 }
 
-pub fn assert_optimization_skipped(
-    rule: &dyn OptimizerRule,
-    plan: &LogicalPlan,
-) {
+pub fn assert_optimization_skipped(rule: &dyn OptimizerRule, plan: &LogicalPlan) {
     let new_plan = rule.optimize(plan, &mut OptimizerConfig::new()).unwrap();
-    assert_eq!(format!("{}", plan.display_indent()), format!("{}", new_plan.display_indent()));
+    assert_eq!(
+        format!("{}", plan.display_indent()),
+        format!("{}", new_plan.display_indent())
+    );
 }

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -46,7 +46,7 @@ pub fn optimize_children(
     let mut new_inputs = Vec::with_capacity(plan.inputs().len());
     for input in plan.inputs() {
         let new_input = optimizer.try_optimize(input, optimizer_config)?;
-        new_inputs.push(new_input.unwrap_or(input.clone()))
+        new_inputs.push(new_input.unwrap_or_else(|| input.clone()))
     }
     from_plan(plan, &new_exprs, &new_inputs)
 }

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -43,12 +43,11 @@ pub fn optimize_children(
     optimizer_config: &mut OptimizerConfig,
 ) -> Result<LogicalPlan> {
     let new_exprs = plan.expressions();
-    let new_inputs = plan
-        .inputs()
-        .into_iter()
-        .map(|plan| optimizer.optimize(plan, optimizer_config))
-        .collect::<Result<Vec<_>>>()?;
-
+    let mut new_inputs = Vec::with_capacity(plan.inputs().len());
+    for input in plan.inputs() {
+        let new_input = optimizer.try_optimize(input, optimizer_config)?;
+        new_inputs.push(new_input.unwrap_or(input.clone()))
+    }
     from_plan(plan, &new_exprs, &new_inputs)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/4209

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR aims to improve the API for optimizer rules by adding a new `try_optimize` method that returns `Result<Option<LogicalPlan>>` so that rules can now choose to return `Ok(None)` if the rule is not applicable to the plan.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `try_optimize` method to `Optimizer` trait with a default implementation that calls the existing `optimize` method for backwards compatibility
- Update `decorrelate_where_exists` to use this new approach

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Relevant unit tests updated to expect new behavior.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->