### PR TITLE
Support binary boolean operators with nulls

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -98,8 +98,12 @@ pub fn coerce_types(
         | Operator::BitwiseShiftRight
         | Operator::BitwiseShiftLeft => bitwise_coercion(lhs_type, rhs_type),
         Operator::And | Operator::Or => match (lhs_type, rhs_type) {
-            // logical binary boolean operators can only be evaluated in bools
+            // logical binary boolean operators can only be evaluated in bools or nulls
             (DataType::Boolean, DataType::Boolean) => Some(DataType::Boolean),
+            (DataType::Null, DataType::Null) => Some(DataType::Null),
+            (DataType::Boolean, DataType::Null) | (DataType::Null, DataType::Boolean) => {
+                Some(DataType::Boolean)
+            }
             _ => None,
         },
         // logical comparison operators have their own rules, and always return a boolean
@@ -1021,6 +1025,30 @@ mod tests {
             DataType::Boolean,
             Operator::Or,
             DataType::Boolean
+        );
+        test_coercion_binary_rule!(
+            DataType::Boolean,
+            DataType::Null,
+            Operator::And,
+            DataType::Boolean
+        );
+        test_coercion_binary_rule!(
+            DataType::Boolean,
+            DataType::Null,
+            Operator::Or,
+            DataType::Boolean
+        );
+        test_coercion_binary_rule!(
+            DataType::Null,
+            DataType::Null,
+            Operator::Or,
+            DataType::Null
+        );
+        test_coercion_binary_rule!(
+            DataType::Null,
+            DataType::Null,
+            Operator::And,
+            DataType::Null
         );
         Ok(())
     }

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1050,6 +1050,18 @@ mod tests {
             Operator::And,
             DataType::Null
         );
+        test_coercion_binary_rule!(
+            DataType::Null,
+            DataType::Boolean,
+            Operator::And,
+            DataType::Boolean
+        );
+        test_coercion_binary_rule!(
+            DataType::Null,
+            DataType::Boolean,
+            Operator::Or,
+            DataType::Boolean
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Signed-off-by: yangjiang <yangjiang@ebay.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4241.

# Rationale for this change

in spark:
```
spark-sql> select null or true;
true
Time taken: 0.65 seconds, Fetched 1 row(s)
spark-sql> select null or false;
NULL
Time taken: 0.076 seconds, Fetched 1 row(s)
```
in pg:
```
postgres=# select true or NULL test;
 test
------
 t
(1 row)

postgres=# select false or NULL test;
 test
------

(1 row)
```
After this change in datafusion
```
❯ select NULL or false;
+------------------------+
| NULL OR Boolean(false) |
+------------------------+
|                        |
+------------------------+
1 row in set. Query took 0.067 seconds.
❯ select NULL or true;
+-----------------------+
| NULL OR Boolean(true) |
+-----------------------+
| true                  |
+-----------------------+
1 row in set. Query took 0.003 seconds.
```
Also test with `AND` 

# What changes are included in this PR?

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->