### PR TITLE
Fix: Fix build due to logical conflict

### DIFF
--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -120,14 +120,13 @@ impl OptimizerRule for PropagateEmptyRelation {
                         Ok(LogicalPlan::Projection(Projection::new_from_schema(
                             Arc::new(child),
                             optimized_children_plan.schema().clone(),
-                            union.alias.clone(),
+                            None,
                         )))
                     }
                 } else {
                     Ok(LogicalPlan::Union(Union {
                         inputs: new_inputs,
                         schema: union.schema.clone(),
-                        alias: union.alias.clone(),
                     }))
                 }
             }


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

There is a logical conflict in https://github.com/apache/arrow-datafusion/pull/4192 and https://github.com/apache/arrow-datafusion/pull/4212 (both from @jackwener  it turns out 😆 )

Without this fix master branch is broken: https://github.com/apache/arrow-datafusion/actions/runs/3483339533/jobs/5826711615
```
error[E0609]: no field `alias` on type `&datafusion_expr::Union`
   --> datafusion/optimizer/src/propagate_empty_relation.rs:123:35
    |
123 | ...                   union.alias.clone(),
    |                             ^^^^^ unknown field
    |
    = note: available fields are: `inputs`, `schema`

error[E0560]: struct `datafusion_expr::Union` has no field named `alias`
   --> datafusion/optimizer/src/propagate_empty_relation.rs:130:25
    |
130 |                         alias: union.alias.clone(),
    |                         ^^^^^ `datafusion_expr::Union` does not have this field
    |
    = note: available fields are: `inputs`, `schema`

error[E0609]: no field `alias` on type `&datafusion_expr::Union`
   --> datafusion/optimizer/src/propagate_empty_relation.rs:130:38
    |
130 |                         alias: union.alias.clone(),
    |                                      ^^^^^ unknown field
    |
    = note: available fields are: `inputs`, `schema`
```

# What changes are included in this PR?

remove unused union alias

# Are these changes tested?
Yes existing tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->