### PR TITLE
Add ambiguous check for join

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3039,10 +3039,8 @@ fn ensure_any_column_reference_is_determined(
         });
 
     let duplicated_column_set = column_count_map
-        .iter()
-        .filter(|(_, count)| **count > 1usize)
-        .map(|(column, _)| column)
-        .cloned()
+        .into_iter()
+        .filter_map(|(column, count)| if count > 1 { Some(column) } else { None })
         .collect::<HashSet<String>>();
 
     // check if there is ambiguous column.

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3061,7 +3061,7 @@ fn ensure_any_column_reference_is_determined(
                     .ok()
             })
             .collect::<Vec<_>>();
-        Err(DataFusionError::Internal(format!(
+        Err(DataFusionError::Plan(format!(
             "reference \'{}\' is ambiguous, could be {};",
             column.name,
             maybe_field.join(","),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4197.

# Rationale for this change

When join condition is ambiguous, the `sql` will work.
It should throw an error, like PostgreSQL or Spark do.

For example, test0 and test1 both has c0 column:
```sql
❯ explain select t0.c0, t1.c0 from test0 as t0 inner join test0 as t1 on c0 = 1;
+---------------+-------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                        |
+---------------+-------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: t0.c0, t1.c0                                                                                    |
|               |   CrossJoin:                                                                                                |
|               |     Filter: t0.c0 = Int16(1)                                                                                |
|               |       SubqueryAlias: t0                                                                                     |
|               |         TableScan: test0 projection=[c0]                                                                    |
|               |     SubqueryAlias: t1                                                                                       |
|               |       TableScan: test0 projection=[c0]                                                                      |
```


# What changes are included in this PR?

Add ambiguous check for join condition.

# Are these changes tested?

Yes, test case is added.

# Are there any user-facing changes?

No