### PR TITLE
Pin Python  `setuptools`  in the CI to fix integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -194,7 +194,14 @@ jobs:
           python-version: "3.10"
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip wheel
+          # setuptools is normally only intended to serve as a build-time dependency
+          # but since numpy uses it internally and currently accessing methods that
+          # are removed from newer versions of setuptools we have a pin on it as well.
+          #
+          # TODO: this should be removed as soon as https://github.com/numpy/numpy/issues/22623
+          # is resolved and numpy version in integration-tests/requirements.txt is updated.
+          python -m pip install --upgrade "setuptools<=65.5.1"
           python -m pip install -r integration-tests/requirements.txt
       - name: Allow access of psql
         run: |


### PR DESCRIPTION
Closes #4294. More details are presented here (and in the referenced issue): https://github.com/apache/arrow-datafusion/issues/4294#issuecomment-1321227006. The proper solution for this would be awaiting numpy to pin the dependency since they are the ones using setuptools (even though we install it, just as a build time dependency) but since that might take a while this simply ensures that the CI is unblocked. If/when upstream is fixed, we can then remove this pin and update our numpy version.