### PR TITLE
Use tournament loser tree for k-way sort-merging, increase merge speed by 50%

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/cursor.rs
+++ b/datafusion/core/src/physical_plan/sorts/cursor.rs
@@ -109,8 +109,14 @@ impl PartialOrd for SortKeyCursor {
 
 impl Ord for SortKeyCursor {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.current()
-            .cmp(&other.current())
-            .then_with(|| self.stream_idx.cmp(&other.stream_idx))
+        match (self.is_finished(), other.is_finished()) {
+            (true, true) => Ordering::Equal,
+            (_, true) => Ordering::Less,
+            (true, _) => Ordering::Greater,
+            _ => self
+                .current()
+                .cmp(&other.current())
+                .then_with(|| self.stream_idx.cmp(&other.stream_idx)),
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4300.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

running benchmarks with `cargo bench --bench merge`:

```
merge i64               time:   [8.0959 ms 8.2001 ms 8.3260 ms]
                        change: [-58.629% -57.906% -57.138%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

merge f64               time:   [8.2829 ms 8.3378 ms 8.4028 ms]
                        change: [-56.127% -55.475% -54.829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

merge utf8 low cardinality
                        time:   [7.5418 ms 7.6425 ms 7.7538 ms]
                        change: [-65.897% -65.335% -64.703%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

merge utf8 high cardinality
                        time:   [9.9438 ms 10.094 ms 10.257 ms]
                        change: [-52.043% -51.155% -50.249%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

merge utf8 tuple        time:   [20.197 ms 20.493 ms 20.826 ms]
                        change: [-40.663% -39.505% -38.279%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

merge utf8 dictionary   time:   [5.1537 ms 5.2135 ms 5.2788 ms]
                        change: [-72.062% -71.616% -71.137%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

merge utf8 dictionary tuple
                        time:   [7.9585 ms 8.0592 ms 8.1797 ms]
                        change: [-63.981% -63.324% -62.678%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

merge mixed utf8 dictionary tuple
                        time:   [14.528 ms 14.669 ms 14.829 ms]
                        change: [-43.886% -43.201% -42.489%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

merge mixed tuple       time:   [17.824 ms 18.068 ms 18.333 ms]
                        change: [-39.957% -38.888% -37.748%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

```
# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->