### PR TITLE
Fix DESCRIBE statement qualified table issue

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -107,6 +107,7 @@ doc-comment = "0.3"
 env_logger = "0.9"
 parquet-test-utils = { path = "../../parquet-test-utils" }
 rstest = "0.15.0"
+test-case = "*"
 test-utils = { path = "../../test-utils" }
 
 [[bench]]

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -107,7 +107,6 @@ doc-comment = "0.3"
 env_logger = "0.9"
 parquet-test-utils = { path = "../../parquet-test-utils" }
 rstest = "0.15.0"
-test-case = "*"
 test-utils = { path = "../../test-utils" }
 
 [[bench]]

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -26,9 +26,9 @@ use datafusion::{
 };
 use datafusion_expr::Expr;
 
-use super::*;
+use rstest::rstest;
 
-use test_case::test_case;
+use super::*;
 
 #[tokio::test]
 async fn information_schema_tables_not_exist_by_default() {
@@ -242,20 +242,12 @@ async fn information_schema_show_tables_no_information_schema() {
     assert_eq!(err.to_string(), "Error during planning: SHOW TABLES is not supported unless information_schema is enabled");
 }
 
-#[test_case(
-    "datafusion.public.some_table";
-    "Fully qualified name")
-]
-#[test_case(
-    "public.some_table";
-    "Schema specified")
-]
-#[test_case(
-    "some_table";
-    "Bare table name")
-]
+#[rstest]
+#[case("datafusion.public.some_table")]
+#[case("public.some_table")]
+#[case("some_table")]
 #[tokio::test]
-async fn information_schema_describe_table(table_name: &str) {
+async fn information_schema_describe_table(#[case] table_name: &str) {
     let ctx =
         SessionContext::with_config(SessionConfig::new().with_information_schema(true));
 

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -20,7 +20,10 @@
 //! Declares a SQL parser based on sqlparser that handles custom formats that we need.
 
 use sqlparser::{
-    ast::{ColumnDef, ColumnOptionDef, Statement as SQLStatement, TableConstraint},
+    ast::{
+        ColumnDef, ColumnOptionDef, ObjectName, Statement as SQLStatement,
+        TableConstraint,
+    },
     dialect::{keywords::Keyword, Dialect, GenericDialect},
     parser::{Parser, ParserError},
     tokenizer::{Token, Tokenizer},
@@ -84,7 +87,7 @@ impl fmt::Display for CreateExternalTable {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DescribeTable {
     /// Table name
-    pub table_name: String,
+    pub table_name: ObjectName,
 }
 
 /// DataFusion Statement representations.
@@ -200,11 +203,7 @@ impl<'a> DFParser<'a> {
 
     pub fn parse_describe(&mut self) -> Result<Statement, ParserError> {
         let table_name = self.parser.parse_object_name()?;
-
-        let des = DescribeTable {
-            table_name: table_name.to_string(),
-        };
-        Ok(Statement::DescribeTable(des))
+        Ok(Statement::DescribeTable(DescribeTable { table_name }))
     }
 
     /// Parse a SQL CREATE statement


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4303.

# Rationale for this change

The simple fix for this is to split up the identifiers involved in the qualified table reference (schema and or catalog), and filter the `information_schema.columns` with that information, instead of using the table ref verbatim and filtering only by `table_name` column.

# What changes are included in this PR?

Extract the common information_schema `WHERE` qualifier construction, used in `SHOW COLUMNS` and `SHOW CREATE TABLE`, and  use it when planning the `DESCRIBE` statement.

Also add dev dependency to [test_case](https://docs.rs/test-case/0.3.1/test_case/) for more concise testing.

# Are these changes tested?

There are explicit tests for the partial and fully qualified table references in the `DESCRIBE` statement now.

# Are there any user-facing changes?

The `DESCRIBE` statement should return the correct result for partial or fully qualified table references.