### PR TITLE
Refactor downcasting functions with downcastvalue macro and improve error handling of `ListArray` downcasting

### DIFF
--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -20,132 +20,71 @@
 //! but provide an error message rather than a panic, as the corresponding
 //! kernels in arrow-rs such as `as_boolean_array` do.
 
-use crate::DataFusionError;
+use crate::{downcast_value, DataFusionError};
 use arrow::array::{
     Array, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
-    Int32Array, Int64Array, StringArray, StructArray, UInt32Array, UInt64Array,
+    Int32Array, Int64Array, ListArray, StringArray, StructArray, UInt32Array,
+    UInt64Array,
 };
 
 // Downcast ArrayRef to Date32Array
 pub fn as_date32_array(array: &dyn Array) -> Result<&Date32Array, DataFusionError> {
-    array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a Date32Array, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, Date32Array))
 }
 
 // Downcast ArrayRef to StructArray
 pub fn as_struct_array(array: &dyn Array) -> Result<&StructArray, DataFusionError> {
-    array.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a StructArray, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, StructArray))
 }
 
 // Downcast ArrayRef to Int32Array
 pub fn as_int32_array(array: &dyn Array) -> Result<&Int32Array, DataFusionError> {
-    array.as_any().downcast_ref::<Int32Array>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a Int32Array, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, Int32Array))
 }
 
 // Downcast ArrayRef to Int64Array
 pub fn as_int64_array(array: &dyn Array) -> Result<&Int64Array, DataFusionError> {
-    array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a Int64Array, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, Int64Array))
 }
 
 // Downcast ArrayRef to Decimal128Array
 pub fn as_decimal128_array(
     array: &dyn Array,
 ) -> Result<&Decimal128Array, DataFusionError> {
-    array
-        .as_any()
-        .downcast_ref::<Decimal128Array>()
-        .ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "Expected a Decimal128Array, got: {}",
-                array.data_type()
-            ))
-        })
+    Ok(downcast_value!(array, Decimal128Array))
 }
 
 // Downcast ArrayRef to Float32Array
 pub fn as_float32_array(array: &dyn Array) -> Result<&Float32Array, DataFusionError> {
-    array
-        .as_any()
-        .downcast_ref::<Float32Array>()
-        .ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "Expected a Float32Array, got: {}",
-                array.data_type()
-            ))
-        })
+    Ok(downcast_value!(array, Float32Array))
 }
 
 // Downcast ArrayRef to Float64Array
 pub fn as_float64_array(array: &dyn Array) -> Result<&Float64Array, DataFusionError> {
-    array
-        .as_any()
-        .downcast_ref::<Float64Array>()
-        .ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "Expected a Float64Array, got: {}",
-                array.data_type()
-            ))
-        })
+    Ok(downcast_value!(array, Float64Array))
 }
 
 // Downcast ArrayRef to StringArray
 pub fn as_string_array(array: &dyn Array) -> Result<&StringArray, DataFusionError> {
-    array.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a StringArray, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, StringArray))
 }
 
 // Downcast ArrayRef to UInt32Array
 pub fn as_uint32_array(array: &dyn Array) -> Result<&UInt32Array, DataFusionError> {
-    array.as_any().downcast_ref::<UInt32Array>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a UInt32Array, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, UInt32Array))
 }
 
 // Downcast ArrayRef to UInt64Array
 pub fn as_uint64_array(array: &dyn Array) -> Result<&UInt64Array, DataFusionError> {
-    array.as_any().downcast_ref::<UInt64Array>().ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Expected a UInt64Array, got: {}",
-            array.data_type()
-        ))
-    })
+    Ok(downcast_value!(array, UInt64Array))
 }
 
 // Downcast ArrayRef to BooleanArray
 pub fn as_boolean_array(array: &dyn Array) -> Result<&BooleanArray, DataFusionError> {
-    array
-        .as_any()
-        .downcast_ref::<BooleanArray>()
-        .ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "Expected a BooleanArray, got: {}",
-                array.data_type()
-            ))
-        })
+    Ok(downcast_value!(array, BooleanArray))
+}
+
+// Downcast ArrayRef to ListArray
+pub fn as_list_array(array: &dyn Array) -> Result<&ListArray, DataFusionError> {
+    Ok(downcast_value!(array, ListArray))
 }

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -975,7 +975,7 @@ mod test {
     use crate::arrow::array::Array;
     use crate::arrow::datatypes::{Field, TimeUnit};
     use crate::avro_to_arrow::{Reader, ReaderBuilder};
-    use arrow::array::{ListArray, TimestampMicrosecondArray};
+    use arrow::array::TimestampMicrosecondArray;
     use arrow::datatypes::DataType;
     use datafusion_common::cast::{as_int32_array, as_int64_array, as_list_array};
     use std::fs::File;

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -977,7 +977,7 @@ mod test {
     use crate::avro_to_arrow::{Reader, ReaderBuilder};
     use arrow::array::{ListArray, TimestampMicrosecondArray};
     use arrow::datatypes::DataType;
-    use datafusion_common::cast::{as_int32_array, as_int64_array};
+    use datafusion_common::cast::{as_int32_array, as_int64_array, as_list_array};
     use std::fs::File;
 
     fn build_reader(name: &str, batch_size: usize) -> Reader<File> {
@@ -1034,11 +1034,7 @@ mod test {
         let batch = reader.next().unwrap().unwrap();
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(batch.num_rows(), 3);
-        let a_array = batch
-            .column(col_id_index)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
+        let a_array = as_list_array(batch.column(col_id_index)).unwrap();
         assert_eq!(
             *a_array.data_type(),
             DataType::List(Box::new(Field::new("bigint", DataType::Int64, true)))

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -19,7 +19,7 @@ use std::{fs, path::Path};
 
 use ::parquet::arrow::ArrowWriter;
 use datafusion::datasource::listing::ListingOptions;
-use datafusion_common::cast::as_string_array;
+use datafusion_common::cast::{as_list_array, as_string_array};
 use tempfile::TempDir;
 
 use super::*;
@@ -235,16 +235,8 @@ async fn parquet_list_columns() {
     assert_eq!(2, batch.num_columns());
     assert_eq!(schema, batch.schema());
 
-    let int_list_array = batch
-        .column(0)
-        .as_any()
-        .downcast_ref::<ListArray>()
-        .unwrap();
-    let utf8_list_array = batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<ListArray>()
-        .unwrap();
+    let int_list_array = as_list_array(batch.column(0)).unwrap();
+    let utf8_list_array = as_list_array(batch.column(1)).unwrap();
 
     assert_eq!(
         int_list_array

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -226,11 +226,11 @@ mod tests {
     use crate::aggregate::utils::get_accum_scalar_values;
     use arrow::array::{
         ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, ListArray, UInt16Array, UInt32Array, UInt64Array,
-        UInt8Array,
+        Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
     };
     use arrow::array::{Int32Builder, ListBuilder, UInt64Builder};
     use arrow::datatypes::DataType;
+    use datafusion_common::cast::as_list_array;
 
     macro_rules! state_to_vec {
         ($LIST:expr, $DATA_TYPE:ident, $PRIM_TY:ty) => {{
@@ -380,7 +380,7 @@ mod tests {
         let agg = DistinctCount::new(
             arrays
                 .iter()
-                .map(|a| a.as_any().downcast_ref::<ListArray>().unwrap())
+                .map(|a| as_list_array(a).unwrap())
                 .map(|a| a.values().data_type().clone())
                 .collect::<Vec<_>>(),
             vec![],

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -2847,8 +2847,7 @@ mod tests {
     #[test]
     #[cfg(feature = "regex_expressions")]
     fn test_regexp_match() -> Result<()> {
-        use arrow::array::ListArray;
-        use datafusion_common::cast::as_string_array;
+        use datafusion_common::cast::{as_list_array, as_string_array};
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
         let execution_props = ExecutionProps::new();
 
@@ -2873,7 +2872,7 @@ mod tests {
         let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
-        let result = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let result = as_list_array(&result)?;
         let first_row = result.value(0);
         let first_row = as_string_array(&first_row)?;
 
@@ -2887,8 +2886,7 @@ mod tests {
     #[test]
     #[cfg(feature = "regex_expressions")]
     fn test_regexp_match_all_literals() -> Result<()> {
-        use arrow::array::ListArray;
-        use datafusion_common::cast::as_string_array;
+        use datafusion_common::cast::{as_list_array, as_string_array};
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let execution_props = ExecutionProps::new();
 
@@ -2913,7 +2911,7 @@ mod tests {
         let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
-        let result = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let result = as_list_array(&result)?;
         let first_row = result.value(0);
         let first_row = as_string_array(&first_row)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This is discussed in #3152. 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This is the new PR of improving error handling for downcasting. In #4261 we found out that there is a `downcast_value!` macro which also covers our casting functions. Implementing `as_xxx_array` function with `downcast_value!` is nearly decided for now for future PRs. This PR is small compared to last two PR because I want to hear your feedback about if my implementation is correct/desired?
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Refactor previous casting functions. Old function:
```rust
pub fn as_int32_array(array: &dyn Array) -> Result<&Int32Array, DataFusionError> {
    array.as_any().downcast_ref::<Int32Array>().ok_or_else(|| {
        DataFusionError::Internal(format!(
            "Expected a Int32Array, got: {}",
            array.data_type()
        ))
    })
```
New function:
```rust
pub fn as_int32_array(array: &dyn Array) -> Result<&Int32Array, DataFusionError> {
    Ok(downcast_value!(array, Int32Array))
}
```

- Refactor `ListArray` downcasting parts where following lines are used:
```rust
as_any().downcast_ref::<ListArray>().unwrap()
```


# Are these changes tested?
These changes passed related tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->