### PR TITLE
add `{TDigest,ScalarValue,Accumulator}::size`

### DIFF
--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -153,6 +153,10 @@ impl Accumulator for GeometricMean {
             self.merge(&v)
         })
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }
 
 #[tokio::main]

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2291,7 +2291,8 @@ impl ScalarValue {
         }
     }
 
-    /// Estimate size if bytes including `Self`
+    /// Estimate size if bytes including `Self`. For values with internal containers such as `String`
+    /// includes the allocated size (`capacity`) rather than the current length (`len`)
     pub fn size(&self) -> usize {
         std::mem::size_of_val(&self)
             + match self {

--- a/datafusion/core/tests/user_defined_aggregates.rs
+++ b/datafusion/core/tests/user_defined_aggregates.rs
@@ -244,4 +244,8 @@ impl Accumulator for FirstSelector {
         // same logic is needed as in update_batch
         self.update_batch(states)
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }

--- a/datafusion/expr/src/accumulator.rs
+++ b/datafusion/expr/src/accumulator.rs
@@ -55,7 +55,9 @@ pub trait Accumulator: Send + Sync + Debug {
     /// returns its value based on its current state.
     fn evaluate(&self) -> Result<ScalarValue>;
 
-    /// Size in bytes including `Self`.
+    /// Allocated size required for this accumulator, in bytes, including `Self`.
+    /// Allocated means that for internal containers such as `Vec`, the `capacity` should be used
+    /// not the `len`
     fn size(&self) -> usize;
 }
 

--- a/datafusion/expr/src/accumulator.rs
+++ b/datafusion/expr/src/accumulator.rs
@@ -54,6 +54,9 @@ pub trait Accumulator: Send + Sync + Debug {
 
     /// returns its value based on its current state.
     fn evaluate(&self) -> Result<ScalarValue>;
+
+    /// Size in bytes including `Self`.
+    fn size(&self) -> usize;
 }
 
 /// Representation of internal accumulator state. Accumulators can potentially have a mix of

--- a/datafusion/physical-expr/src/aggregate/approx_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_distinct.rs
@@ -239,6 +239,11 @@ macro_rules! default_accumulator_impl {
         fn evaluate(&self) -> Result<ScalarValue> {
             Ok(ScalarValue::UInt64(Some(self.hll.count() as u64)))
         }
+
+        fn size(&self) -> usize {
+            // HLL has static size
+            std::mem::size_of_val(self)
+        }
     };
 }
 

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -355,6 +355,7 @@ impl ApproxPercentileAccumulator {
         }
     }
 }
+
 impl Accumulator for ApproxPercentileAccumulator {
     fn state(&self) -> Result<Vec<AggregateState>> {
         Ok(self
@@ -412,5 +413,10 @@ impl Accumulator for ApproxPercentileAccumulator {
         self.merge_digests(&states);
 
         Ok(())
+    }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::size_of_val(self) + self.digest.size()
     }
 }

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont_with_weight.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont_with_weight.rs
@@ -150,4 +150,10 @@ impl Accumulator for ApproxPercentileWithWeightAccumulator {
 
         Ok(())
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+            - std::mem::size_of_val(&self.approx_percentile_cont_accumulator)
+            + self.approx_percentile_cont_accumulator.size()
+    }
 }

--- a/datafusion/physical-expr/src/aggregate/array_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg.rs
@@ -156,13 +156,8 @@ impl Accumulator for ArrayAggAccumulator {
 
     fn size(&self) -> usize {
         // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
-        std::mem::size_of_val(self)
-            + (std::mem::size_of::<ScalarValue>() * self.values.capacity())
-            + self
-                .values
-                .iter()
-                .map(|sv| sv.size() - std::mem::size_of_val(sv))
-                .sum::<usize>()
+        std::mem::size_of_val(self) + ScalarValue::size_of_vec(&self.values)
+            - std::mem::size_of_val(&self.values)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/array_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg.rs
@@ -153,6 +153,17 @@ impl Accumulator for ArrayAggAccumulator {
             self.datatype.clone(),
         ))
     }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<ScalarValue>() * self.values.capacity())
+            + self
+                .values
+                .iter()
+                .map(|sv| sv.size() - std::mem::size_of_val(sv))
+                .sum::<usize>()
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -159,13 +159,8 @@ impl Accumulator for DistinctArrayAggAccumulator {
 
     fn size(&self) -> usize {
         // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
-        std::mem::size_of_val(self)
-            + (std::mem::size_of::<ScalarValue>() * self.values.capacity())
-            + self
-                .values
-                .iter()
-                .map(|sv| sv.size() - std::mem::size_of_val(sv))
-                .sum::<usize>()
+        std::mem::size_of_val(self) + ScalarValue::size_of_hashset(&self.values)
+            - std::mem::size_of_val(&self.values)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -156,6 +156,17 @@ impl Accumulator for DistinctArrayAggAccumulator {
             self.datatype.clone(),
         ))
     }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<ScalarValue>() * self.values.capacity())
+            + self
+                .values
+                .iter()
+                .map(|sv| sv.size() - std::mem::size_of_val(sv))
+                .sum::<usize>()
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -200,6 +200,10 @@ impl Accumulator for AvgAccumulator {
             )),
         }
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.sum) + self.sum.size()
+    }
 }
 
 #[derive(Debug)]

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -193,6 +193,15 @@ impl Accumulator for CorrelationAccumulator {
 
         Ok(ScalarValue::Float64(None))
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.covar)
+            + self.covar.size()
+            - std::mem::size_of_val(&self.stddev1)
+            + self.stddev1.size()
+            - std::mem::size_of_val(&self.stddev2)
+            + self.stddev2.size()
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -149,6 +149,10 @@ impl Accumulator for CountAccumulator {
     fn evaluate(&self) -> Result<ScalarValue> {
         Ok(ScalarValue::Int64(Some(self.count)))
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }
 
 #[derive(Debug)]

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -218,6 +218,25 @@ impl Accumulator for DistinctCountAccumulator {
             ))),
         }
     }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<DistinctScalarValues>() * self.values.capacity())
+            + self
+                .values
+                .iter()
+                .map(|vals| {
+                    (std::mem::size_of::<ScalarValue>() * vals.0.capacity())
+                        + vals
+                            .0
+                            .iter()
+                            .map(|sv| sv.size() - std::mem::size_of_val(sv))
+                            .sum::<usize>()
+                })
+                .sum::<usize>()
+            + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -227,12 +227,7 @@ impl Accumulator for DistinctCountAccumulator {
                 .values
                 .iter()
                 .map(|vals| {
-                    (std::mem::size_of::<ScalarValue>() * vals.0.capacity())
-                        + vals
-                            .0
-                            .iter()
-                            .map(|sv| sv.size() - std::mem::size_of_val(sv))
-                            .sum::<usize>()
+                    ScalarValue::size_of_vec(&vals.0) - std::mem::size_of_val(&vals.0)
                 })
                 .sum::<usize>()
             + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -373,6 +373,10 @@ impl Accumulator for CovarianceAccumulator {
             Ok(ScalarValue::Float64(Some(self.algo_const / count as f64)))
         }
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -183,6 +183,20 @@ impl Accumulator for MedianAccumulator {
             )),
         }
     }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::align_of_val(self)
+            + (std::mem::size_of::<ArrayRef>() * self.all_values.capacity())
+            + self
+                .all_values
+                .iter()
+                .map(|array_ref| {
+                    std::mem::size_of_val(array_ref.as_ref())
+                        + array_ref.get_array_memory_size()
+                })
+                .sum::<usize>()
+    }
 }
 
 /// Create an empty array

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -571,6 +571,10 @@ impl Accumulator for MaxAccumulator {
     fn evaluate(&self) -> Result<ScalarValue> {
         Ok(self.max.clone())
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.max) + self.max.size()
+    }
 }
 
 #[derive(Debug)]
@@ -734,6 +738,10 @@ impl Accumulator for MinAccumulator {
 
     fn evaluate(&self) -> Result<ScalarValue> {
         Ok(self.min.clone())
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.min) + self.min.size()
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -211,6 +211,11 @@ impl Accumulator for StddevAccumulator {
             )),
         }
     }
+
+    fn size(&self) -> usize {
+        std::mem::align_of_val(self) - std::mem::align_of_val(&self.variance)
+            + self.variance.size()
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -279,6 +279,10 @@ impl Accumulator for SumAccumulator {
             Ok(self.sum.clone())
         }
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.sum) + self.sum.size()
+    }
 }
 
 #[derive(Debug)]

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -178,9 +178,8 @@ impl Accumulator for DistinctSumAccumulator {
 
     fn size(&self) -> usize {
         // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
-        std::mem::size_of_val(self)
-            + (std::mem::size_of::<ScalarValue>() * self.hash_values.capacity())
-            + self.hash_values.iter().map(|sv| sv.size()).sum::<usize>()
+        std::mem::size_of_val(self) + ScalarValue::size_of_hashset(&self.hash_values)
+            - std::mem::size_of_val(&self.hash_values)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -175,6 +175,13 @@ impl Accumulator for DistinctSumAccumulator {
         }
         Ok(sum_value)
     }
+
+    fn size(&self) -> usize {
+        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<ScalarValue>() * self.hash_values.capacity())
+            + self.hash_values.iter().map(|sv| sv.size()).sum::<usize>()
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -187,6 +187,12 @@ impl TDigest {
     pub(crate) fn max_size(&self) -> usize {
         self.max_size
     }
+
+    /// Size in bytes including `Self`.
+    pub(crate) fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<Centroid>() * self.centroids.capacity())
+    }
 }
 
 impl Default for TDigest {
@@ -740,5 +746,13 @@ mod tests {
         assert_error_bounds!(t, quantile = 0.0, want = 1.0);
         assert_error_bounds!(t, quantile = 0.5, want = 500.0);
         assert_state_roundtrip!(t);
+    }
+
+    #[test]
+    fn test_size() {
+        let t = TDigest::new(10);
+        let t = t.merge_unsorted_f64(vec![0.0, 1.0]);
+
+        assert_eq!(t.size(), 96);
     }
 }

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -306,6 +306,10 @@ impl Accumulator for VarianceAccumulator {
             Ok(ScalarValue::Float64(Some(self.m2 / count as f64)))
         }
     }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -1226,6 +1226,10 @@ mod roundtrip_tests {
             fn evaluate(&self) -> datafusion::error::Result<ScalarValue> {
                 Ok(ScalarValue::Float64(None))
             }
+
+            fn size(&self) -> usize {
+                std::mem::size_of_val(self)
+            }
         }
 
         let dummy_agg = create_udaf(


### PR DESCRIPTION
# Which issue does this PR close?
None, but helps with #3940.

# Rationale for this change
I need some helper methods to determine in-mem sizes of certain objects.

# What changes are included in this PR?
Determine in-mem size of `TDigest`, `ScalarValue`, and `Accumulator`.

# Are these changes tested?
\-

# Are there any user-facing changes?
**:warning: Breaking Change: `Accumulator` now requires `fn size(&self) -> usize;`!**