### PR TITLE
minor: improve optimizer logging and do not repeat rule name

### DIFF
--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -239,7 +239,11 @@ impl Optimizer {
                     }
                     Ok(None) => {
                         observer(&new_plan, rule.as_ref());
-                        log_plan(rule.name(), &new_plan);
+                        debug!(
+                            "Plan unchanged by optimizer rule '{}' (pass {})",
+                            rule.name(),
+                            i
+                        );
                     }
                     Err(ref e) => {
                         if optimizer_config.skip_failing_rules {


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

I am debugging something wrong in one of the optimizer passes it wasn't immediately obvious to me from the logging that some passes didn't change the plan at all. 

# What changes are included in this PR?

Do not log the plan for optimizer passes that didn't make changes

# Are these changes tested?
Not really

# Are there any user-facing changes?

no