### PR TITLE
Improve error messages when memory is exhausted while sorting

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -291,7 +291,7 @@ impl MemoryConsumer for ExternalSorter {
             .metrics_set
             .new_intermediate_tracking(partition, self.runtime.clone());
 
-        let spillfile = self.runtime.disk_manager.create_tmp_file()?;
+        let spillfile = self.runtime.disk_manager.create_tmp_file("Sorting")?;
         let stream = in_mem_partial_sort(
             &mut in_mem_batches,
             self.schema.clone(),


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/4330


# Rationale for this change
The idea is to make it clearer what is going on to a user who sees this error message

# What changes are included in this PR?

Implement suggestions from https://github.com/apache/arrow-datafusion/pull/4330#discussion_r1029705473

# Are these changes tested?
Yes
# Are there any user-facing changes?
better error messages