### PR TITLE
Add check to avoid underflow in memory manager

### DIFF
--- a/datafusion/core/src/execution/memory_manager/mod.rs
+++ b/datafusion/core/src/execution/memory_manager/mod.rs
@@ -330,11 +330,7 @@ impl MemoryManager {
 
     fn max_mem_for_requesters(&self) -> usize {
         let trk_total = self.get_tracker_total();
-        if trk_total < self.pool_size {
-            self.pool_size - trk_total
-        } else {
-            0_usize
-        }
+        self.pool_size.saturating_sub(trk_total)
     }
 
     /// Grow memory attempt from a consumer, return if we could grant that much to it

--- a/datafusion/core/src/execution/memory_manager/mod.rs
+++ b/datafusion/core/src/execution/memory_manager/mod.rs
@@ -330,7 +330,11 @@ impl MemoryManager {
 
     fn max_mem_for_requesters(&self) -> usize {
         let trk_total = self.get_tracker_total();
-        self.pool_size - trk_total
+        if trk_total < self.pool_size {
+            self.pool_size - trk_total
+        } else {
+            0_usize
+        }
     }
 
     /// Grow memory attempt from a consumer, return if we could grant that much to it
@@ -650,5 +654,15 @@ mod tests {
 
         let config = MemoryManagerConfig::try_new_limit(100000, 0.1).unwrap();
         assert_eq!(config.pool_size(), 10000);
+    }
+
+    #[tokio::test]
+    async fn test_memory_manager_underflow() {
+        let config = MemoryManagerConfig::try_new_limit(100, 0.5).unwrap();
+        let manager = MemoryManager::new(config);
+        manager.grow_tracker_usage(100);
+
+        manager.register_requester(&MemoryConsumerId::new(1));
+        assert!(!manager.can_grow_directly(20, 0));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4328 

# What changes are included in this PR?
Included a check to avoid underflow when available memory is calculated when consumers request additional memory. 

The trackers acquire memory independent of `MemoryManager` and communicates the memory acquired using the function `grow_tracker_usage`. The tracker can end up allocating more memory than what is defined in `MemoryManager.pool_size` This PR does not prevent trackers from allocating more memory than what is defined in `MemoryManager.pool_size`. Might be a candidate for future refactoring.

# Are these changes tested?

Added a test to avoid underflow.

