### PR TITLE
Throw error (not `panic`) if a listing table specifies an missing partition column

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -543,16 +543,15 @@ impl TableProvider for ListingTable {
             .table_partition_cols
             .iter()
             .map(|col| {
-                (
+                Ok((
                     col.0.to_owned(),
                     self.table_schema
-                        .field_with_name(&col.0)
-                        .unwrap()
+                        .field_with_name(&col.0)?
                         .data_type()
                         .clone(),
-                )
+                ))
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         // create the execution plan
         self.options


### PR DESCRIPTION
Closes #4350 