### PR TITLE
Support to use Schedular in tpch benchmark

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,7 +34,7 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = "27.0.0"
-datafusion = { path = "../datafusion/core", version = "14.0.0" }
+datafusion = { path = "../datafusion/core", version = "14.0.0" , features = ["scheduler"]}
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,7 +34,7 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = "27.0.0"
-datafusion = { path = "../datafusion/core", version = "14.0.0" , features = ["scheduler"]}
+datafusion = { path = "../datafusion/core", version = "14.0.0", features = ["scheduler"] }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Support to test `Schedular`(the newest executor designed by @tustvold ) performance in tpch benchmark

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Support to use `Schedular` in tpch benchmark

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No need, I have checked in my local.

```
➜  benchmarks git:(master) ✗ cargo run --release --bin tpch -- benchmark datafusion --iterations 1 --path ~/parquet_data --format parquet --enable-scheduler --query 1
    Finished release [optimized] target(s) in 0.13s
     Running `/arrow-datafusion/target/release/tpch benchmark datafusion --iterations 1 --path /Users/xudong/parquet_data --format parquet --enable-scheduler --query 1`
Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(1), debug: false, iterations: 1, partitions: 2, batch_size: 8192, path: "/Users/xudong/parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: false, enable_scheduler: true }
Query 1 iteration 0 took 3847.1 ms and returned 4 rows
Query 1 avg time: 3847.15 ms
```

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No