### PR TITLE
Use limit() function instead of show_limit() in the first example

### DIFF
--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -62,10 +62,11 @@ async fn main() -> datafusion::error::Result<()> {
   let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).await?;
 
   let df = df.filter(col("a").lt_eq(col("b")))?
-           .aggregate(vec![col("a")], vec![min(col("b"))])?;
+           .aggregate(vec![col("a")], vec![min(col("b"))])?
+           .limit(0, Some(100))?;
 
   // execute and print results
-  df.show_limit(100).await?;
+  df.show().await?;
   Ok(())
 }
 ```
@@ -118,10 +119,11 @@ async fn main() -> datafusion::error::Result<()> {
   let df = ctx.read_csv("tests/capitalized_example.csv", CsvReadOptions::new()).await?;
 
   let df = df.filter(col("A").lt_eq(col("c")))?
-           .aggregate(vec![col("A")], vec![min(col("b"))])?;
+           .aggregate(vec![col("A")], vec![min(col("b"))])?
+           .limit(0, Some(100))?;
 
   // execute and print results
-  df.show_limit(100).await?;
+  df.show().await?;
   Ok(())
 }
 ```


### PR DESCRIPTION

# Which issue does this PR close?

Closes #.

# Rationale for this change

This change makes the SQL and DataFrame (DF) examples at https://arrow.apache.org/datafusion/user-guide/example-usage.html more similar.
Currently the SQL example uses `LIMIT 100`  while the DF one collects all results and then just prints the first 100 via `show_limit(100)`.

# What changes are included in this PR?

The sample DF code now uses `limit()` instead of `show_limit()`. 

# Are these changes tested?

No.

# Are there any user-facing changes?

No