### PR TITLE
Config Cleanup: Remove TaskProperties and KV structure, keep key=value serialization 

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -916,7 +916,7 @@ async fn do_sort(
         schema.clone(),
         expr,
         metrics_set,
-        Arc::new(context.session_config()),
+        Arc::new(context.session_config().clone()),
         context.runtime_env(),
         fetch,
     );


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/4349

# Rationale for this change

Step 1 of N in unraveling the gordian knot of datafusion configuration

While there is a need to serialize/deserialize session state as key=value pairs in SessionContext, there is no reason these key / value pairs need to be kept in the actual TaskContext after it is created and having the different representation makes the eventual unification of configuration that much harder. 



# What changes are included in this PR?
1. Remove duplication in `From` impls
2. 

# Are these changes tested?

covered by existing tests

# Are there any user-facing changes?

If you use TaskProperties directly you'll be impacted, but I don't think anyone does. It is not used by ballista https://github.com/search?q=repo%3Aapache%2Farrow-ballista%20KVPairs&type=code
 
@mingmwang  this code was originally added by you in  https://github.com/apache/arrow-datafusion/pull/1987 -- can you take a look ?