### PR TITLE
fix panic on to_hex function for negative numbers

### DIFF
--- a/datafusion/physical-expr/src/string_expressions.rs
+++ b/datafusion/physical-expr/src/string_expressions.rs
@@ -586,3 +586,51 @@ pub fn uuid(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     let array = GenericStringArray::<i32>::from_iter_values(values);
     Ok(ColumnarValue::Array(Arc::new(array)))
 }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::string_expressions;
+    use arrow::{array::Int32Array, datatypes::Int32Type};
+
+    use super::*;
+
+    #[test]
+    // Test to_hex function for zero
+    fn to_hex_zero() -> Result<()> {
+        let array = vec![0].into_iter().collect::<Int32Array>();
+        let array_ref = Arc::new(array);
+        let hex_value_arc = string_expressions::to_hex::<Int32Type>(&[array_ref])?;
+        let hex_value = as_string_array(&hex_value_arc)?;
+        let expected = StringArray::from(vec![Some("0")]);
+        assert_eq!(&expected, hex_value);
+
+        Ok(())
+    }
+
+    #[test]
+    // Test to_hex function for positive number
+    fn to_hex_positive_number() -> Result<()> {
+        let array = vec![100].into_iter().collect::<Int32Array>();
+        let array_ref = Arc::new(array);
+        let hex_value_arc = string_expressions::to_hex::<Int32Type>(&[array_ref])?;
+        let hex_value = as_string_array(&hex_value_arc)?;
+        let expected = StringArray::from(vec![Some("64")]);
+        assert_eq!(&expected, hex_value);
+
+        Ok(())
+    }
+
+    #[test]
+    // Test to_hex function for negative number
+    fn to_hex_negative_number() -> Result<()> {
+        let array = vec![-1].into_iter().collect::<Int32Array>();
+        let array_ref = Arc::new(array);
+        let hex_value_arc = string_expressions::to_hex::<Int32Type>(&[array_ref])?;
+        let hex_value = as_string_array(&hex_value_arc)?;
+        let expected = StringArray::from(vec![Some("ffffffffffffffff")]);
+        assert_eq!(&expected, hex_value);
+
+        Ok(())
+    }
+}

--- a/datafusion/physical-expr/src/string_expressions.rs
+++ b/datafusion/physical-expr/src/string_expressions.rs
@@ -544,9 +544,22 @@ where
     let result = integer_array
         .iter()
         .map(|integer| {
-            integer.map(|integer| format!("{:x}", integer.to_usize().unwrap()))
+            if let Some(value) = integer {
+                if let Some(value_usize) = value.to_usize() {
+                    Ok(Some(format!("{:x}", value_usize)))
+                } else if let Some(value_isize) = value.to_isize() {
+                    Ok(Some(format!("{:x}", value_isize)))
+                } else {
+                    Err(DataFusionError::Internal(format!(
+                        "Unsupported data type {:?} for function to_hex",
+                        integer,
+                    )))
+                }
+            } else {
+                Ok(None)
+            }
         })
-        .collect::<GenericStringArray<i32>>();
+        .collect::<Result<GenericStringArray<i32>>>()?;
 
     Ok(Arc::new(result) as ArrayRef)
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4339.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Better control for `to_hex` function
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Now it returns error if it can't cast. There was a `unwrap` usage before this change
