### PR TITLE
fix: do NOT convert errors to strings but keep the type

### DIFF
--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -59,22 +59,16 @@ impl Command {
     ) -> Result<()> {
         let now = Instant::now();
         match self {
-            Self::Help => print_options
-                .print_batches(&[all_commands_info()], now)
-                .map_err(|e| DataFusionError::Execution(e.to_string())),
+            Self::Help => print_options.print_batches(&[all_commands_info()], now),
             Self::ListTables => {
                 let df = ctx.sql("SHOW TABLES").await?;
                 let batches = df.collect().await?;
-                print_options
-                    .print_batches(&batches, now)
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))
+                print_options.print_batches(&batches, now)
             }
             Self::DescribeTable(name) => {
                 let df = ctx.sql(&format!("SHOW COLUMNS FROM {}", name)).await?;
                 let batches = df.collect().await?;
-                print_options
-                    .print_batches(&batches, now)
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))
+                print_options.print_batches(&batches, now)
             }
             Self::Include(filename) => {
                 if let Some(filename) = filename {

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -146,8 +146,8 @@ fn create_runtime_env() -> Result<RuntimeEnv> {
     let object_store_provider = DatafusionCliObjectStoreProvider {};
     let object_store_registry =
         ObjectStoreRegistry::new_with_provider(Some(Arc::new(object_store_provider)));
-    let rn_config = RuntimeConfig::new()
-        .with_object_store_registry(Arc::new(object_store_registry));
+    let rn_config =
+        RuntimeConfig::new().with_object_store_registry(Arc::new(object_store_registry));
     RuntimeEnv::new(rn_config)
 }
 

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -60,7 +60,7 @@ fn build_s3_object_store(url: &Url) -> Result<Arc<dyn object_store::ObjectStore>
     let host = get_host_name(url)?;
     match AmazonS3Builder::from_env().with_bucket_name(host).build() {
         Ok(s3) => Ok(Arc::new(s3)),
-        Err(err) => Err(DataFusionError::Execution(err.to_string())),
+        Err(err) => Err(DataFusionError::External(Box::new(err))),
     }
 }
 
@@ -73,7 +73,7 @@ fn build_gcs_object_store(url: &Url) -> Result<Arc<dyn object_store::ObjectStore
     }
     match builder.build() {
         Ok(gcs) => Ok(Arc::new(gcs)),
-        Err(err) => Err(DataFusionError::Execution(err.to_string())),
+        Err(err) => Err(DataFusionError::External(Box::new(err))),
     }
 }
 

--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -49,7 +49,7 @@ macro_rules! batches_to_json {
             writer.write_batches($batches)?;
             writer.finish()?;
         }
-        String::from_utf8(bytes).map_err(|e| DataFusionError::Execution(e.to_string()))?
+        String::from_utf8(bytes).map_err(|e| DataFusionError::External(Box::new(e)))?
     }};
 }
 
@@ -64,8 +64,8 @@ fn print_batches_with_sep(batches: &[RecordBatch], delimiter: u8) -> Result<Stri
             writer.write(batch)?;
         }
     }
-    let formatted = String::from_utf8(bytes)
-        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    let formatted =
+        String::from_utf8(bytes).map_err(|e| DataFusionError::External(Box::new(e)))?;
     Ok(formatted)
 }
 

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -103,9 +103,9 @@ impl TableProviderFactory for ListingTableFactory {
                 .table_partition_cols
                 .iter()
                 .map(|col| {
-                    schema.field_with_name(col).map_err(|arrow_err| {
-                        DataFusionError::Execution(arrow_err.to_string())
-                    })
+                    schema
+                        .field_with_name(col)
+                        .map_err(DataFusionError::ArrowError)
                 })
                 .collect::<datafusion_common::Result<Vec<_>>>()?
                 .into_iter()

--- a/datafusion/physical-expr/src/regex_expressions.rs
+++ b/datafusion/physical-expr/src/regex_expressions.rs
@@ -136,7 +136,7 @@ pub fn regexp_replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
                                     patterns.insert(pattern.to_string(), re.clone());
                                     Ok(re)
                                 },
-                                Err(err) => Err(DataFusionError::Execution(err.to_string())),
+                                Err(err) => Err(DataFusionError::External(Box::new(err))),
                             }
                         }
                     };
@@ -182,7 +182,7 @@ pub fn regexp_replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
                                     patterns.insert(pattern, re.clone());
                                     Ok(re)
                                 },
-                                Err(err) => Err(DataFusionError::Execution(err.to_string())),
+                                Err(err) => Err(DataFusionError::External(Box::new(err))),
                             }
                         }
                     };
@@ -254,8 +254,8 @@ fn _regexp_replace_static_pattern_replace<T: OffsetSizeTrait>(
         None => (pattern.to_string(), 1),
     };
 
-    let re = Regex::new(&pattern)
-        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+    let re =
+        Regex::new(&pattern).map_err(|err| DataFusionError::External(Box::new(err)))?;
 
     // Replaces the posix groups in the replacement string
     // with rust ones.
@@ -522,7 +522,7 @@ mod tests {
         let pattern_err = re.expect_err("broken pattern should have failed");
         assert_eq!(
             pattern_err.to_string(),
-            "Execution error: regex parse error:\n    [\n    ^\nerror: unclosed character class"
+            "External error: regex parse error:\n    [\n    ^\nerror: unclosed character class"
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4434.

# Rationale for this change
Now that DF emits `ResourceExhausted` errors for out-of-memory situations, it would be nice if the API user could somehow detect this situation (e.g. to convert this to a suitable HTTP status code).

# What changes are included in this PR?
Convert a bunch of `Execution` errors into typed errors.

# Are these changes tested?
**:warning: Consensus required prior to merging :warning:**

None. I'm not really sure how we want to prevent regressions here. It's just too many errors. I somewhat check-able rule (via some regex script?!) would be: "no `Execution\(.+\.to_string`". Shall I add this to the `lint` CI workflow?

# Are there any user-facing changes?
Errors types slightly changed. This also changes error texts a bit.