### PR TITLE
WindowAggExec output ordering is fixed

### DIFF
--- a/datafusion/core/src/physical_optimizer/enforcement.rs
+++ b/datafusion/core/src/physical_optimizer/enforcement.rs
@@ -901,7 +901,7 @@ fn ensure_distribution_and_ordering(
 }
 
 /// Check the required ordering requirements are satisfied by the provided PhysicalSortExprs.
-fn ordering_satisfy<F: FnOnce() -> EquivalenceProperties>(
+pub fn ordering_satisfy<F: FnOnce() -> EquivalenceProperties>(
     provided: Option<&[PhysicalSortExpr]>,
     required: Option<&[PhysicalSortExpr]>,
     equal_properties: F,

--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -122,7 +122,9 @@ impl ExecutionPlan for WindowAggExec {
     }
 
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        self.input.output_ordering()
+        // This executor maintains input order, and has required input_ordering filled
+        // hence output_ordering would be `required_input_ordering`
+        self.required_input_ordering()[0]
     }
 
     fn maintains_input_order(&self) -> bool {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4438.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We can't rely on the current `output_ordering` result unless we pass from the `BasicEnforcement` optimization pass. Hence  `output_ordering` of the `WindowAggExec` would give the wrong result during physical plan [planner](https://github.com/apache/arrow-datafusion/blob/fdc83e8524df30ac5d0ae097572b7c48dc686ba9/datafusion/core/src/physical_plan/planner.rs#L463)

# What changes are included in this PR?
Since `WindowAggExec` maintains input order and requires specific ordering, output ordering would be required input ordering. I have changed code to reflect that (By this way we can rely on `output_ordering` information of `WindowAggExec` even if there is currently no `SortExec` before it in the physical plan)


# Are these changes tested?

N.A

# Are there any user-facing changes?

N.A

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->