### PR TITLE
Replace `&Option<T>` with `Option<&T>`

### DIFF
--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -118,7 +118,7 @@ impl Debug for CustomDataSource {
 impl CustomDataSource {
     pub(crate) async fn create_physical_plan(
         &self,
-        projections: &Option<Vec<usize>>,
+        projections: Option<&Vec<usize>>,
         schema: SchemaRef,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CustomExec::new(projections, schema, self.clone())))
@@ -177,7 +177,7 @@ impl TableProvider for CustomDataSource {
     async fn scan(
         &self,
         _state: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         // filters and limit can be used here to inject some push-down operations if needed
         _filters: &[Expr],
         _limit: Option<usize>,
@@ -194,11 +194,11 @@ struct CustomExec {
 
 impl CustomExec {
     fn new(
-        projections: &Option<Vec<usize>>,
+        projections: Option<&Vec<usize>>,
         schema: SchemaRef,
         db: CustomDataSource,
     ) -> Self {
-        let projected_schema = project_schema(&schema, projections.as_ref()).unwrap();
+        let projected_schema = project_schema(&schema, projections).unwrap();
         Self {
             db,
             projected_schema,

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2160,7 +2160,7 @@ impl ScalarValue {
     fn eq_array_decimal(
         array: &ArrayRef,
         index: usize,
-        value: &Option<i128>,
+        value: Option<&i128>,
         precision: u8,
         scale: i8,
     ) -> Result<bool> {
@@ -2196,8 +2196,14 @@ impl ScalarValue {
     pub fn eq_array(&self, array: &ArrayRef, index: usize) -> bool {
         match self {
             ScalarValue::Decimal128(v, precision, scale) => {
-                ScalarValue::eq_array_decimal(array, index, v, *precision, *scale)
-                    .unwrap()
+                ScalarValue::eq_array_decimal(
+                    array,
+                    index,
+                    v.as_ref(),
+                    *precision,
+                    *scale,
+                )
+                .unwrap()
             }
             ScalarValue::Boolean(val) => {
                 eq_array_primitive!(array, index, BooleanArray, val)

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -795,12 +795,11 @@ impl TableProvider for DataFrame {
     async fn scan(
         &self,
         _ctx: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut expr = projection
-            .as_ref()
             // construct projections
             .map_or_else(
                 || {

--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -61,7 +61,7 @@ pub trait TableProvider: Sync + Send {
     async fn scan(
         &self,
         ctx: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         // limit can be used to reduce the amount scanned
         // from the datasource as a performance optimization.

--- a/datafusion/core/src/datasource/empty.rs
+++ b/datafusion/core/src/datasource/empty.rs
@@ -69,12 +69,12 @@ impl TableProvider for EmptyTable {
     async fn scan(
         &self,
         _ctx: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // even though there is no data, projections apply
-        let projected_schema = project_schema(&self.schema, projection.as_ref())?;
+        let projected_schema = project_schema(&self.schema, projection)?;
         Ok(Arc::new(
             EmptyExec::new(false, projected_schema).with_partitions(self.partitions),
         ))

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -523,7 +523,7 @@ impl TableProvider for ListingTable {
     async fn scan(
         &self,
         ctx: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -533,7 +533,7 @@ impl TableProvider for ListingTable {
         // if no files need to be read, return an `EmptyExec`
         if partitioned_file_lists.is_empty() {
             let schema = self.schema();
-            let projected_schema = project_schema(&schema, projection.as_ref())?;
+            let projected_schema = project_schema(&schema, projection)?;
             return Ok(Arc::new(EmptyExec::new(false, projected_schema)));
         }
 
@@ -562,7 +562,7 @@ impl TableProvider for ListingTable {
                     file_schema: Arc::clone(&self.file_schema),
                     file_groups: partitioned_file_lists,
                     statistics,
-                    projection: projection.clone(),
+                    projection: projection.cloned(),
                     limit,
                     output_ordering: self.try_create_output_ordering()?,
                     table_partition_cols,
@@ -686,7 +686,7 @@ mod tests {
         let table = load_table(&ctx, "alltypes_plain.parquet").await?;
         let projection = None;
         let exec = table
-            .scan(&ctx.state(), &projection, &[], None)
+            .scan(&ctx.state(), projection, &[], None)
             .await
             .expect("Scan table");
 
@@ -716,7 +716,7 @@ mod tests {
             .with_schema(schema);
         let table = ListingTable::try_new(config)?;
 
-        let exec = table.scan(&state, &None, &[], None).await?;
+        let exec = table.scan(&state, None, &[], None).await?;
         assert_eq!(exec.statistics().num_rows, Some(8));
         assert_eq!(exec.statistics().total_byte_size, Some(671));
 
@@ -855,7 +855,7 @@ mod tests {
         let filter = Expr::not_eq(col("p1"), lit("v1"));
 
         let scan = table
-            .scan(&ctx.state(), &None, &[filter], None)
+            .scan(&ctx.state(), None, &[filter], None)
             .await
             .expect("Empty execution plan");
 

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -104,7 +104,7 @@ impl TableProvider for ViewTable {
     async fn scan(
         &self,
         state: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -61,8 +61,8 @@ impl ViewTable {
     }
 
     /// Get definition ref
-    pub fn definition(&self) -> &Option<String> {
-        &self.definition
+    pub fn definition(&self) -> Option<&String> {
+        self.definition.as_ref()
     }
 
     /// Get logical_plan ref

--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -181,8 +181,8 @@ fn swap_reverting_projection(
 }
 
 /// Swaps join sides for filter column indices and produces new JoinFilter
-fn swap_join_filter(filter: &Option<JoinFilter>) -> Option<JoinFilter> {
-    filter.as_ref().map(|filter| {
+fn swap_join_filter(filter: Option<&JoinFilter>) -> Option<JoinFilter> {
+    filter.map(|filter| {
         let column_indices = filter
             .column_indices()
             .iter()
@@ -334,7 +334,7 @@ fn try_collect_left(
                     Arc::clone(left),
                     Arc::clone(right),
                     hash_join.on().to_vec(),
-                    hash_join.filter().clone(),
+                    hash_join.filter().cloned(),
                     hash_join.join_type(),
                     PartitionMode::CollectLeft,
                     hash_join.null_equals_null(),
@@ -345,7 +345,7 @@ fn try_collect_left(
             Arc::clone(left),
             Arc::clone(right),
             hash_join.on().to_vec(),
-            hash_join.filter().clone(),
+            hash_join.filter().cloned(),
             hash_join.join_type(),
             PartitionMode::CollectLeft,
             hash_join.null_equals_null(),
@@ -377,7 +377,7 @@ fn partitioned_hash_join(hash_join: &HashJoinExec) -> Result<Arc<dyn ExecutionPl
             Arc::clone(left),
             Arc::clone(right),
             hash_join.on().to_vec(),
-            hash_join.filter().clone(),
+            hash_join.filter().cloned(),
             hash_join.join_type(),
             PartitionMode::Partitioned,
             hash_join.null_equals_null(),

--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -249,8 +249,8 @@ impl HashJoinExec {
     }
 
     /// Filters applied before join output
-    pub fn filter(&self) -> &Option<JoinFilter> {
-        &self.filter
+    pub fn filter(&self) -> Option<&JoinFilter> {
+        self.filter.as_ref()
     }
 
     /// How the join is performed
@@ -701,7 +701,7 @@ fn build_batch(
     left_data: &JoinLeftData,
     on_left: &[Column],
     on_right: &[Column],
-    filter: &Option<JoinFilter>,
+    filter: Option<&JoinFilter>,
     join_type: JoinType,
     schema: &Schema,
     column_indices: &[ColumnIndex],
@@ -1529,7 +1529,7 @@ impl HashJoinStream {
                         left_data,
                         &self.on_left,
                         &self.on_right,
-                        &self.filter,
+                        self.filter.as_ref(),
                         self.join_type,
                         &self.schema,
                         &self.column_indices,

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -480,7 +480,7 @@ impl DefaultPhysicalPlanner {
                     // referred to in the query
                     let filters = unnormalize_cols(filters.iter().cloned());
                     let unaliased: Vec<Expr> = filters.into_iter().map(unalias).collect();
-                    source.scan(session_state, projection, &unaliased, *fetch).await
+                    source.scan(session_state, projection.as_ref(), &unaliased, *fetch).await
                 }
                 LogicalPlan::Values(Values {
                     values,

--- a/datafusion/core/src/test_util.rs
+++ b/datafusion/core/src/test_util.rs
@@ -321,7 +321,7 @@ impl TableProvider for TestTableProvider {
     async fn scan(
         &self,
         _ctx: &SessionState,
-        _projection: &Option<Vec<usize>>,
+        _projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -193,12 +193,12 @@ impl TableProvider for CustomTableProvider {
     async fn scan(
         &self,
         _state: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CustomExecutionPlan {
-            projection: projection.clone(),
+            projection: projection.cloned(),
         }))
     }
 }

--- a/datafusion/core/tests/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/provider_filter_pushdown.rs
@@ -143,7 +143,7 @@ impl TableProvider for CustomProvider {
     async fn scan(
         &self,
         _state: &SessionState,
-        _: &Option<Vec<usize>>,
+        _: Option<&Vec<usize>>,
         filters: &[Expr],
         _: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/core/tests/row.rs
+++ b/datafusion/core/tests/row.rs
@@ -34,7 +34,7 @@ async fn test_with_parquet() -> Result<()> {
     let session_ctx = SessionContext::new();
     let task_ctx = session_ctx.task_ctx();
     let projection = Some(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
+    let exec = get_exec("alltypes_plain.parquet", projection.as_ref(), None).await?;
     let schema = exec.schema().clone();
 
     let batches = collect(exec, task_ctx).await?;
@@ -55,7 +55,7 @@ async fn test_with_parquet_word_aligned() -> Result<()> {
     let session_ctx = SessionContext::new();
     let task_ctx = session_ctx.task_ctx();
     let projection = Some(vec![0, 1, 2, 3, 4, 5, 6, 7]);
-    let exec = get_exec("alltypes_plain.parquet", &projection, None).await?;
+    let exec = get_exec("alltypes_plain.parquet", projection.as_ref(), None).await?;
     let schema = exec.schema().clone();
 
     let batches = collect(exec, task_ctx).await?;
@@ -73,7 +73,7 @@ async fn test_with_parquet_word_aligned() -> Result<()> {
 
 async fn get_exec(
     file_name: &str,
-    projection: &Option<Vec<usize>>,
+    projection: Option<&Vec<usize>>,
     limit: Option<usize>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let testdata = datafusion::test_util::parquet_test_data();
@@ -103,7 +103,7 @@ async fn get_exec(
                 file_schema,
                 file_groups,
                 statistics,
-                projection: projection.clone(),
+                projection: projection.cloned(),
                 limit,
                 table_partition_cols: vec![],
                 config_options: ConfigOptions::new().into_shareable(),

--- a/datafusion/core/tests/sql/information_schema.rs
+++ b/datafusion/core/tests/sql/information_schema.rs
@@ -191,7 +191,7 @@ async fn information_schema_tables_table_types() {
         async fn scan(
             &self,
             _ctx: &SessionState,
-            _: &Option<Vec<usize>>,
+            _: Option<&Vec<usize>>,
             _: &[Expr],
             _: Option<usize>,
         ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/core/tests/statistics.rs
+++ b/datafusion/core/tests/statistics.rs
@@ -75,7 +75,7 @@ impl TableProvider for StatisticsValidation {
     async fn scan(
         &self,
         _ctx: &SessionState,
-        projection: &Option<Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         // limit is ignored because it is not mandatory for a `TableProvider` to honor it
         _limit: Option<usize>,
@@ -86,7 +86,7 @@ impl TableProvider for StatisticsValidation {
             filters.len(),
             "Unsupported expressions should not be pushed down"
         );
-        let projection = match projection.clone() {
+        let projection = match projection.cloned() {
             Some(p) => p,
             None => (0..self.schema.fields().len()).collect(),
         };

--- a/datafusion/expr/src/type_coercion/other.rs
+++ b/datafusion/expr/src/type_coercion/other.rs
@@ -39,7 +39,7 @@ pub fn get_coerce_type_for_list(
 /// Returns the common data type for `then_types` and `else_type`
 pub fn get_coerce_type_for_case_when(
     then_types: &[DataType],
-    else_type: &Option<DataType>,
+    else_type: Option<&DataType>,
 ) -> Option<DataType> {
     let else_type = match else_type {
         None => then_types[0].clone(),

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -319,7 +319,7 @@ impl ExprRewriter for TypeCoercionRewriter {
                     Some(expr) => expr.get_type(&self.schema).map(Some),
                 }?;
                 let case_when_coerce_type =
-                    get_coerce_type_for_case_when(&then_types, &else_type);
+                    get_coerce_type_for_case_when(&then_types, else_type.as_ref());
                 match case_when_coerce_type {
                     None => Err(DataFusionError::Internal(format!(
                         "Failed to coerce then ({:?}) and else ({:?}) to common types in CASE WHEN expression",

--- a/datafusion/physical-expr/src/window/lead_lag.rs
+++ b/datafusion/physical-expr/src/window/lead_lag.rs
@@ -120,7 +120,7 @@ pub(crate) struct WindowShiftEvaluator {
 }
 
 fn create_empty_array(
-    value: &Option<ScalarValue>,
+    value: Option<&ScalarValue>,
     data_type: &DataType,
     size: usize,
 ) -> Result<ArrayRef> {
@@ -140,7 +140,7 @@ fn create_empty_array(
 fn shift_with_default_value(
     array: &ArrayRef,
     offset: i64,
-    value: &Option<ScalarValue>,
+    value: Option<&ScalarValue>,
 ) -> Result<ArrayRef> {
     use arrow::compute::concat;
 
@@ -172,7 +172,7 @@ impl PartitionEvaluator for WindowShiftEvaluator {
     fn evaluate_partition(&self, partition: Range<usize>) -> Result<ArrayRef> {
         let value = &self.values[0];
         let value = value.slice(partition.start, partition.end - partition.start);
-        shift_with_default_value(&value, self.shift_offset, &self.default_value)
+        shift_with_default_value(&value, self.shift_offset, self.default_value.as_ref())
     }
 }
 

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -929,7 +929,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                                 projection,
                                 definition: view_table
                                     .definition()
-                                    .clone()
+                                    .map(|s| s.to_string())
                                     .unwrap_or_default(),
                             },
                         ))),

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1129,7 +1129,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 self.aggregate(
                     plan,
                     &select_exprs,
-                    &having_expr_opt,
+                    having_expr_opt.as_ref(),
                     group_by_exprs,
                     aggr_exprs,
                 )?
@@ -1267,7 +1267,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         input: LogicalPlan,
         select_exprs: &[Expr],
-        having_expr_opt: &Option<Expr>,
+        having_expr_opt: Option<&Expr>,
         group_by_exprs: Vec<Expr>,
         aggr_exprs: Vec<Expr>,
     ) -> Result<(LogicalPlan, Vec<Expr>, Option<Expr>)> {


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4424 

Changed some occurrences of `&Option<T>` with `Option<&T>`

# Are there any user-facing changes?

There might be user facing changes as public functions are modified. Would leave it up to reviewers to add `api-change` tag.
