### PR TITLE
refactor code about `subquery_alias` and `expr-alias`.

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1137,21 +1137,17 @@ mod ci {
                                 Box::new(trim(col(Field::name(field)))),
                                 DataType::Float64,
                             )));
-                            Expr::Alias(
-                                Box::new(Expr::Cast(Cast::new(
-                                    inner_cast,
-                                    Field::data_type(field).to_owned(),
-                                ))),
-                                Field::name(field).to_string(),
-                            )
-                        }
-                        _ => Expr::Alias(
-                            Box::new(Expr::Cast(Cast::new(
-                                Box::new(trim(col(Field::name(field)))),
+                            Expr::Cast(Cast::new(
+                                inner_cast,
                                 Field::data_type(field).to_owned(),
-                            ))),
-                            Field::name(field).to_string(),
-                        ),
+                            ))
+                            .alias(Field::name(field))
+                        }
+                        _ => Expr::Cast(Cast::new(
+                            Box::new(trim(col(Field::name(field)))),
+                            Field::data_type(field).to_owned(),
+                        ))
+                        .alias(Field::name(field)),
                     }
                 })
                 .collect::<Vec<Expr>>(),

--- a/benchmarks/src/tpch.rs
+++ b/benchmarks/src/tpch.rs
@@ -498,20 +498,14 @@ pub async fn transform_actual_result(
                                 fun: datafusion::logical_expr::BuiltinScalarFunction::Round,
                                 args: vec![col(Field::name(field)).mul(lit(100))],
                             }.div(lit(100)));
-                            Expr::Alias(
-                                Box::new(Expr::Cast(Cast::new(
+                            Expr::Cast(Cast::new(
                                     round,
                                     DataType::Decimal128(15, 2),
-                                ))),
-                                field.name().to_string(),
-                            )
+                                )).alias(field.name())
                         }
                         DataType::Utf8 => {
                             // if string, then trim it like the answers got trimmed
-                            Expr::Alias(
-                                Box::new(trim(col(Field::name(field)))),
-                                field.name().to_string(),
-                            )
+                            trim(col(Field::name(field))).alias(field.name())
                         }
                         _ => {
                             col(field.name())

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -663,7 +663,7 @@ impl DataFrame {
             LogicalPlanBuilder::window_plan(self.plan.clone(), window_func_exprs)?
         };
 
-        let new_column = Expr::Alias(Box::new(expr), name.to_string());
+        let new_column = expr.alias(name);
         let mut col_exists = false;
         let mut fields: Vec<Expr> = plan
             .schema()

--- a/datafusion/expr/src/expr_rewriter.rs
+++ b/datafusion/expr/src/expr_rewriter.rs
@@ -537,10 +537,7 @@ pub fn coerce_plan_expr_for_schema(
                     (
                         LogicalPlan::Projection(Projection { input, .. }),
                         Expr::Alias(e, alias),
-                    ) => Ok(Expr::Alias(
-                        Box::new(e.clone().cast_to(new_type, input.schema())?),
-                        alias.clone(),
-                    )),
+                    ) => Ok(e.clone().cast_to(new_type, input.schema())?.alias(alias)),
                     _ => expr.cast_to(new_type, plan.schema()),
                 }
             } else {

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -928,7 +928,7 @@ pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalP
     }))
 }
 
-/// Project with optional alias
+/// Create Projection
 /// # Errors
 /// This function errors under any of the following conditions:
 /// * Two or more expressions have the same name

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -674,7 +674,7 @@ pub fn columnize_expr(e: Expr, input_schema: &DFSchema) -> Expr {
     match e {
         Expr::Column(_) => e,
         Expr::Alias(inner_expr, name) => {
-            Expr::Alias(Box::new(columnize_expr(*inner_expr, input_schema)), name)
+            columnize_expr(*inner_expr, input_schema).alias(name)
         }
         Expr::Cast(Cast { expr, data_type }) => Expr::Cast(Cast {
             expr: Box::new(columnize_expr(*expr, input_schema)),

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -179,7 +179,8 @@ fn optimize_where_in(
     }
     let projection = alias_cols(&subqry_cols);
     let subqry_plan = subqry_plan
-        .project_with_alias(projection, Some(subqry_alias.clone()))?
+        .project(projection)?
+        .alias(&subqry_alias)?
         .build()?;
     debug!("subquery plan:\n{}", subqry_plan.display_indent());
 

--- a/datafusion/optimizer/src/inline_table_scan.rs
+++ b/datafusion/optimizer/src/inline_table_scan.rs
@@ -54,10 +54,9 @@ impl OptimizerRule for InlineTableScan {
                     // Recursively apply optimization
                     let plan =
                         utils::optimize_children(self, sub_plan, _optimizer_config)?;
-                    let plan = LogicalPlanBuilder::from(plan).project_with_alias(
-                        vec![Expr::Wildcard],
-                        Some(table_name.to_string()),
-                    )?;
+                    let plan = LogicalPlanBuilder::from(plan)
+                        .project(vec![Expr::Wildcard])?
+                        .alias(table_name)?;
                     plan.build()
                 } else {
                     // No plan available, return with table scan as is

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1124,7 +1124,8 @@ mod tests {
     fn union_all_on_projection() -> Result<()> {
         let table_scan = test_table_scan()?;
         let table = LogicalPlanBuilder::from(table_scan)
-            .project_with_alias(vec![col("a").alias("b")], Some("test2".to_string()))?;
+            .project(vec![col("a").alias("b")])?
+            .alias("test2")?;
 
         let plan = table
             .union(table.build()?)?
@@ -2236,8 +2237,10 @@ mod tests {
     fn test_propagation_of_optimized_inner_filters_with_projections() -> Result<()> {
         // SELECT a FROM (SELECT 1 AS a) b WHERE b.a = 1
         let plan = LogicalPlanBuilder::empty(true)
-            .project_with_alias(vec![lit(0i64).alias("a")], Some("b".to_owned()))?
-            .project_with_alias(vec![col("b.a")], Some("b".to_owned()))?
+            .project(vec![lit(0i64).alias("a")])?
+            .alias("b")?
+            .project(vec![col("b.a")])?
+            .alias("b")?
             .filter(col("b.a").eq(lit(1i64)))?
             .project(vec![col("b.a")])?
             .build()?;

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -271,7 +271,8 @@ fn optimize_scalar(
         .collect();
     let subqry_plan = subqry_plan
         .aggregate(group_by, aggr.aggr_expr.clone())?
-        .project_with_alias(proj, Some(subqry_alias.clone()))?
+        .project(proj)?
+        .alias(&subqry_alias)?
         .build()?;
 
     // qualify the join columns for outside the subquery

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -503,10 +503,7 @@ mod tests {
     fn multiple_now_expr() {
         let table_scan = test_table_scan();
         let time = Utc::now();
-        let proj = vec![
-            now_expr(),
-            Expr::Alias(Box::new(now_expr()), "t2".to_string()),
-        ];
+        let proj = vec![now_expr(), now_expr().alias("t2")];
         let plan = LogicalPlanBuilder::from(table_scan)
             .project(proj)
             .unwrap()

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -400,7 +400,8 @@ mod tests {
         let table_scan = test_table_scan()?;
         let plan = LogicalPlanBuilder::from(table_scan)
             .filter(in_subquery(col("c"), test_subquery_with_name("sq_inner")?))?
-            .project_with_alias(vec![col("b"), col("c")], Some("wrapped".to_string()))?
+            .project(vec![col("b"), col("c")])?
+            .alias("wrapped")?
             .filter(or(
                 binary_expr(col("b"), Operator::Lt, lit(30_u32)),
                 in_subquery(col("c"), test_subquery_with_name("sq_outer")?),

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -39,6 +39,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 use datafusion_common::{context, Column, DataFusionError};
+use datafusion_expr::logical_plan::builder::project_with_alias;
 use datafusion_expr::{
     logical_plan::{
         Aggregate, CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateView,
@@ -328,16 +329,15 @@ impl AsLogicalPlan for LogicalPlanNode {
                     .iter()
                     .map(|expr| parse_expr(expr, ctx))
                     .collect::<Result<Vec<_>, _>>()?;
-                LogicalPlanBuilder::from(input)
-                    .project_with_alias(
-                        x,
-                        projection.optional_alias.as_ref().map(|a| match a {
-                            protobuf::projection_node::OptionalAlias::Alias(alias) => {
-                                alias.clone()
-                            }
-                        }),
-                    )?
-                    .build()
+                project_with_alias(
+                    input,
+                    x,
+                    projection.optional_alias.as_ref().map(|a| match a {
+                        protobuf::projection_node::OptionalAlias::Alias(alias) => {
+                            alias.clone()
+                        }
+                    }),
+                )
             }
             LogicalPlanType::Selection(selection) => {
                 let input: LogicalPlan =

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -45,7 +45,9 @@ use datafusion_common::{
 use datafusion_expr::expr::{Between, BinaryExpr, Case, Cast, GroupingSet, Like};
 use datafusion_expr::expr_rewriter::normalize_col;
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas;
-use datafusion_expr::logical_plan::builder::{project_with_alias, with_alias};
+use datafusion_expr::logical_plan::builder::{
+    project_with_alias, with_alias, with_alias_owned,
+};
 use datafusion_expr::logical_plan::Join as HashJoin;
 use datafusion_expr::logical_plan::JoinConstraint as HashJoinConstraint;
 use datafusion_expr::logical_plan::{
@@ -857,9 +859,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 (
                     match (cte, self.schema_provider.get_table_provider(table_ref)) {
                         (Some(cte_plan), _) => match table_alias {
-                            Some(cte_alias) => {
-                                Ok(with_alias(cte_plan.clone(), cte_alias))
-                            }
+                            Some(cte_alias) => with_alias(cte_plan, &cte_alias),
                             _ => Ok(cte_plan.clone()),
                         },
                         (_, Ok(provider)) => {
@@ -888,7 +888,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 )?;
 
                 let plan = match normalized_alias {
-                    Some(alias) => with_alias(logical_plan, alias),
+                    Some(alias) => with_alias_owned(logical_plan, &alias)?,
                     _ => logical_plan,
                 };
                 (plan, alias)
@@ -932,14 +932,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 columns_alias.len(),
             )))
         } else {
-            Ok(LogicalPlanBuilder::from(plan.clone())
-                .project_with_alias(
-                    plan.schema().fields().iter().zip(columns_alias.iter()).map(
-                        |(field, ident)| col(field.name()).alias(normalize_ident(ident)),
-                    ),
-                    Some(normalize_ident(&alias.name)),
-                )?
-                .build()?)
+            LogicalPlanBuilder::from(plan.clone())
+                .project(plan.schema().fields().iter().zip(columns_alias.iter()).map(
+                    |(field, ident)| col(field.name()).alias(normalize_ident(ident)),
+                ))?
+                .alias(&normalize_ident(&alias.name))?
+                .build()
         }
     }
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -45,9 +45,7 @@ use datafusion_common::{
 use datafusion_expr::expr::{Between, BinaryExpr, Case, Cast, GroupingSet, Like};
 use datafusion_expr::expr_rewriter::normalize_col;
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas;
-use datafusion_expr::logical_plan::builder::{
-    project_with_alias, with_alias, with_alias_owned,
-};
+use datafusion_expr::logical_plan::builder::{project, subquery_alias, subquery_alias_owned};
 use datafusion_expr::logical_plan::Join as HashJoin;
 use datafusion_expr::logical_plan::JoinConstraint as HashJoinConstraint;
 use datafusion_expr::logical_plan::{
@@ -859,7 +857,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 (
                     match (cte, self.schema_provider.get_table_provider(table_ref)) {
                         (Some(cte_plan), _) => match table_alias {
-                            Some(cte_alias) => with_alias(cte_plan, &cte_alias),
+                            Some(cte_alias) => subquery_alias(cte_plan, &cte_alias),
                             _ => Ok(cte_plan.clone()),
                         },
                         (_, Ok(provider)) => {
@@ -888,7 +886,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 )?;
 
                 let plan = match normalized_alias {
-                    Some(alias) => with_alias_owned(logical_plan, &alias)?,
+                    Some(alias) => subquery_alias_owned(logical_plan, &alias)?,
                     _ => logical_plan,
                 };
                 (plan, alias)
@@ -1176,7 +1174,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         };
 
         // final projection
-        let plan = project_with_alias(plan, select_exprs_post_aggr, alias)?;
+        let mut plan = project(plan, select_exprs_post_aggr)?;
+        plan = match alias {
+            Some(alias) => subquery_alias_owned(plan, &alias)?,
+            None => plan,
+        };
 
         // process distinct clause
         let plan = if select.distinct {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -45,7 +45,9 @@ use datafusion_common::{
 use datafusion_expr::expr::{Between, BinaryExpr, Case, Cast, GroupingSet, Like};
 use datafusion_expr::expr_rewriter::normalize_col;
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas;
-use datafusion_expr::logical_plan::builder::{project, subquery_alias, subquery_alias_owned};
+use datafusion_expr::logical_plan::builder::{
+    project, subquery_alias, subquery_alias_owned,
+};
 use datafusion_expr::logical_plan::Join as HashJoin;
 use datafusion_expr::logical_plan::JoinConstraint as HashJoinConstraint;
 use datafusion_expr::logical_plan::{


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

re https://github.com/apache/arrow-datafusion/issues/4483

When I was in the process of investigating the reasons for duplicate Projects and duplicate aliases, I find the code of create subquery_alias or expr-alias use multiple method.

After refactor it, we can easily find all code of create `alias`  

# Rationale for this change

refactor code about subquery_alias and expr-alias. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->