### PR TITLE
Fix output_partitioning(), output_ordering(), equivalence_properties() in WindowAggExec, shift the Column indexes

### DIFF
--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -24,7 +24,7 @@ use crate::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet,
 };
 use crate::physical_plan::{
-    ColumnStatistics, DisplayFormatType, Distribution, EquivalenceProperties,
+    Column, ColumnStatistics, DisplayFormatType, Distribution, EquivalenceProperties,
     ExecutionPlan, Partitioning, PhysicalExpr, RecordBatchStream,
     SendableRecordBatchStream, Statistics, WindowExpr,
 };
@@ -35,6 +35,8 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
+use datafusion_physical_expr::rewrite::TreeNodeRewritable;
+use datafusion_physical_expr::EquivalentClass;
 use futures::stream::Stream;
 use futures::{ready, StreamExt};
 use log::debug;
@@ -58,6 +60,8 @@ pub struct WindowAggExec {
     pub partition_keys: Vec<Arc<dyn PhysicalExpr>>,
     /// Sort Keys
     pub sort_keys: Option<Vec<PhysicalSortExpr>>,
+    /// The output ordering
+    output_ordering: Option<Vec<PhysicalSortExpr>>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
 }
@@ -73,6 +77,35 @@ impl WindowAggExec {
     ) -> Result<Self> {
         let schema = create_schema(&input_schema, &window_expr)?;
         let schema = Arc::new(schema);
+        let window_expr_len = window_expr.len();
+        // Although WindowAggExec does not change the output ordering from the input, but can not return the output ordering
+        // from the input directly, need to adjust the column index to align with the new schema.
+        let output_ordering = input
+            .output_ordering()
+            .map(|sort_exprs| {
+                let new_sort_exprs: Result<Vec<PhysicalSortExpr>> = sort_exprs
+                    .iter()
+                    .map(|e| {
+                        let new_expr = e.expr.clone().transform_down(&|e| match e
+                            .as_any()
+                            .downcast_ref::<Column>()
+                        {
+                            Some(col) => Ok(Some(Arc::new(Column::new(
+                                col.name(),
+                                window_expr_len + col.index(),
+                            )))),
+                            None => Ok(None),
+                        });
+                        Ok(PhysicalSortExpr {
+                            expr: new_expr?,
+                            options: e.options,
+                        })
+                    })
+                    .collect();
+                new_sort_exprs
+            })
+            .map_or(Ok(None), |v| v.map(Some))?;
+
         Ok(Self {
             input,
             window_expr,
@@ -80,6 +113,7 @@ impl WindowAggExec {
             input_schema,
             partition_keys,
             sort_keys,
+            output_ordering,
             metrics: ExecutionPlanMetricsSet::new(),
         })
     }
@@ -116,14 +150,38 @@ impl ExecutionPlan for WindowAggExec {
 
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
-        // because we can have repartitioning using the partition keys
-        // this would be either 1 or more than 1 depending on the presense of
-        // repartitioning
-        self.input.output_partitioning()
+        // Although WindowAggExec does not change the output partitioning from the input, but can not return the output partitioning
+        // from the input directly, need to adjust the column index to align with the new schema.
+        let window_expr_len = self.window_expr.len();
+        let input_partitioning = self.input.output_partitioning();
+        match input_partitioning {
+            Partitioning::RoundRobinBatch(size) => Partitioning::RoundRobinBatch(size),
+            Partitioning::UnknownPartitioning(size) => {
+                Partitioning::UnknownPartitioning(size)
+            }
+            Partitioning::Hash(exprs, size) => {
+                let new_exprs = exprs
+                    .into_iter()
+                    .map(|expr| {
+                        expr.transform_down(
+                            &|e| match e.as_any().downcast_ref::<Column>() {
+                                Some(col) => Ok(Some(Arc::new(Column::new(
+                                    col.name(),
+                                    window_expr_len + col.index(),
+                                )))),
+                                None => Ok(None),
+                            },
+                        )
+                        .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+                Partitioning::Hash(new_exprs, size)
+            }
+        }
     }
 
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        self.input.output_ordering()
+        self.output_ordering.as_deref()
     }
 
     fn maintains_input_order(&self) -> bool {
@@ -146,7 +204,30 @@ impl ExecutionPlan for WindowAggExec {
     }
 
     fn equivalence_properties(&self) -> EquivalenceProperties {
-        self.input.equivalence_properties()
+        // Although WindowAggExec does not change the equivalence properties from the input, but can not return the equivalence properties
+        // from the input directly, need to adjust the column index to align with the new schema.
+        let window_expr_len = self.window_expr.len();
+        let mut new_properties = EquivalenceProperties::new(self.schema());
+        let new_eq_classes = self
+            .input
+            .equivalence_properties()
+            .classes()
+            .iter()
+            .map(|prop| {
+                let new_head = Column::new(
+                    prop.head().name(),
+                    window_expr_len + prop.head().index(),
+                );
+                let new_others = prop
+                    .others()
+                    .iter()
+                    .map(|col| Column::new(col.name(), window_expr_len + col.index()))
+                    .collect::<Vec<_>>();
+                EquivalentClass::new(new_head, new_others)
+            })
+            .collect::<Vec<_>>();
+        new_properties.extend(new_eq_classes);
+        new_properties
     }
 
     fn with_new_children(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4438.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->