### PR TITLE
Fix `Cte` in `from` clause with duplicated cte name

### DIFF
--- a/datafusion-examples/examples/memtable.rs
+++ b/datafusion-examples/examples/memtable.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     // Register the in-memory table containing the data
     ctx.register_table("users", Arc::new(mem_table))?;
 
-    let dataframe = ctx.sql("select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH source AS (select 1 as e) SELECT * FROM source) t2, (WITH source AS (select 1 as e) SELECT * FROM source) t3;").await?;
+    let dataframe = ctx.sql("SELECT * FROM users;").await?;
 
     timeout(Duration::from_secs(10), async move {
         let result = dataframe.collect().await.unwrap();

--- a/datafusion-examples/examples/memtable.rs
+++ b/datafusion-examples/examples/memtable.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     // Register the in-memory table containing the data
     ctx.register_table("users", Arc::new(mem_table))?;
 
-    let dataframe = ctx.sql("SELECT * FROM users;").await?;
+    let dataframe = ctx.sql("select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH source AS (select 1 as e) SELECT * FROM source) t2, (WITH source AS (select 1 as e) SELECT * FROM source) t3;").await?;
 
     timeout(Duration::from_secs(10), async move {
         let result = dataframe.collect().await.unwrap();

--- a/datafusion/core/tests/sqllogictests/test_files/cte.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/cte.slt
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+query II
+select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH source AS (select 1 as e) SELECT * FROM source) t2
+----
+1 1

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -662,7 +662,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         ctes: &mut HashMap<String, LogicalPlan>,
         outer_query_schema: Option<&DFSchema>,
     ) -> Result<LogicalPlan> {
-        // From clause may exist CTEs, we should separate them with global CTEs.
+        // From clause may exist CTEs, we should separate them from global CTEs.
         // CTEs in from clause are allowed to be duplicated.
         // Such as `select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1, (WITH source AS (select 1 as e) SELECT * FROM source) t2;` which is valid.
         let origin_ctes = (*ctes).clone();

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -665,6 +665,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // From clause may exist CTEs, we should separate them from global CTEs.
         // CTEs in from clause are allowed to be duplicated.
         // Such as `select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1, (WITH source AS (select 1 as e) SELECT * FROM source) t2;` which is valid.
+        // So always use original global CTEs to plan CTEs in from clause.
+        // Btw, don't need to add CTEs in from to global CTEs.
         let origin_ctes = ctes.clone();
         let left = self.create_relation(t.relation, ctes, outer_query_schema)?;
         match t.joins.len() {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -665,11 +665,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // From clause may exist CTEs, we should separate them from global CTEs.
         // CTEs in from clause are allowed to be duplicated.
         // Such as `select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1, (WITH source AS (select 1 as e) SELECT * FROM source) t2;` which is valid.
-        let origin_ctes = (*ctes).clone();
+        let origin_ctes = ctes.clone();
         let left = self.create_relation(t.relation, ctes, outer_query_schema)?;
         match t.joins.len() {
             0 => {
-                *ctes = origin_ctes.clone();
+                *ctes = origin_ctes;
                 Ok(left)
             }
             _ => {
@@ -686,7 +686,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     left =
                         self.parse_relation_join(left, join, ctes, outer_query_schema)?;
                 }
-                *ctes = origin_ctes.clone();
+                *ctes = origin_ctes;
                 Ok(left)
             }
         }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -662,11 +662,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         ctes: &mut HashMap<String, LogicalPlan>,
         outer_query_schema: Option<&DFSchema>,
     ) -> Result<LogicalPlan> {
+        // From clause may exist CTEs, we should separate them with global CTEs.
+        // CTEs in from clause are allowed to be duplicated.
+        // Such as `select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1, (WITH source AS (select 1 as e) SELECT * FROM source) t2;` which is valid.
+        let origin_ctes = (*ctes).clone();
         let left = self.create_relation(t.relation, ctes, outer_query_schema)?;
         match t.joins.len() {
-            0 => Ok(left),
+            0 => {
+                *ctes = origin_ctes.clone();
+                Ok(left)
+            }
             _ => {
                 let mut joins = t.joins.into_iter();
+                *ctes = origin_ctes.clone();
                 let mut left = self.parse_relation_join(
                     left,
                     joins.next().unwrap(), // length of joins > 0
@@ -674,9 +682,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     outer_query_schema,
                 )?;
                 for join in joins {
+                    *ctes = origin_ctes.clone();
                     left =
                         self.parse_relation_join(left, join, ctes, outer_query_schema)?;
                 }
+                *ctes = origin_ctes.clone();
                 Ok(left)
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No. I found the bug in databend. Then I tested DF and found the same bug 🤣 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`From` clause may exist CTEs, we should separate them from global CTEs.
 
CTEs in from clause are allowed to be duplicated.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, use sqllogictest!

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No