### PR TITLE
remove access methods of Filter and make field pub.

### DIFF
--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -88,7 +88,7 @@ impl OptimizerRule for MyRule {
                 let predicate = predicate.rewrite(&mut expr_rewriter)?;
                 Ok(LogicalPlan::Filter(Filter::try_new(
                     predicate,
-                    filter.input.clone(),
+                    filter.input,
                 )?))
             }
             _ => Ok(plan.clone()),

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -84,11 +84,11 @@ impl OptimizerRule for MyRule {
         match plan {
             LogicalPlan::Filter(filter) => {
                 let mut expr_rewriter = MyExprRewriter {};
-                let predicate = filter.predicate().clone();
+                let predicate = filter.predicate.clone();
                 let predicate = predicate.rewrite(&mut expr_rewriter)?;
                 Ok(LogicalPlan::Filter(Filter::try_new(
                     predicate,
-                    filter.input().clone(),
+                    filter.input.clone(),
                 )?))
             }
             _ => Ok(plan.clone()),

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -756,12 +756,12 @@ impl DefaultPhysicalPlanner {
                     )?))
                 }
                 LogicalPlan::Filter(filter) => {
-                    let physical_input = self.create_initial_plan(filter.input(), session_state).await?;
+                    let physical_input = self.create_initial_plan(&filter.input, session_state).await?;
                     let input_schema = physical_input.as_ref().schema();
-                    let input_dfschema = filter.input().schema();
+                    let input_dfschema = filter.input.schema();
 
                     let runtime_expr = self.create_physical_expr(
-                        filter.predicate(),
+                        &filter.predicate,
                         input_dfschema,
                         &input_schema,
                         session_state,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1236,16 +1236,6 @@ impl Filter {
             _ => plan_err!("Could not coerce into Filter!"),
         }
     }
-
-    /// Access the filter predicate expression
-    pub fn predicate(&self) -> &Expr {
-        &self.predicate
-    }
-
-    /// Access the filter input plan
-    pub fn input(&self) -> &Arc<LogicalPlan> {
-        &self.input
-    }
 }
 
 /// Window its input based on a set of window spec and window function (e.g. SUM or RANK)

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1193,9 +1193,9 @@ pub struct SubqueryAlias {
 #[derive(Clone)]
 pub struct Filter {
     /// The predicate expression, which must have Boolean type.
-    predicate: Expr,
+    pub predicate: Expr,
     /// The incoming logical plan
-    input: Arc<LogicalPlan>,
+    pub input: Arc<LogicalPlan>,
 }
 
 impl Filter {

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -120,8 +120,8 @@ impl OptimizerRule for CommonSubexprEliminate {
                 )?))
             }
             LogicalPlan::Filter(filter) => {
-                let input = filter.input();
-                let predicate = filter.predicate();
+                let input = &filter.input;
+                let predicate = &filter.predicate;
                 let input_schema = Arc::clone(input.schema());
                 let mut id_array = vec![];
                 expr_to_identifier(
@@ -134,7 +134,7 @@ impl OptimizerRule for CommonSubexprEliminate {
                 let (mut new_expr, new_input) = self.rewrite_expr(
                     &[&[predicate.clone()]],
                     &[&[id_array]],
-                    filter.input(),
+                    &filter.input,
                     &mut expr_set,
                     optimizer_config,
                 )?;

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -83,8 +83,8 @@ impl OptimizerRule for DecorrelateWhereIn {
     ) -> datafusion_common::Result<LogicalPlan> {
         match plan {
             LogicalPlan::Filter(filter) => {
-                let predicate = filter.predicate();
-                let filter_input = filter.input();
+                let predicate = &filter.predicate;
+                let filter_input = &filter.input;
 
                 // Apply optimizer rule to current input
                 let optimized_input = self.optimize(filter_input, optimizer_config)?;
@@ -150,18 +150,18 @@ fn optimize_where_in(
     let mut other_subqry_exprs = vec![];
     if let LogicalPlan::Filter(subqry_filter) = (*subqry_input).clone() {
         // split into filters
-        let subqry_filter_exprs = split_conjunction(subqry_filter.predicate());
+        let subqry_filter_exprs = split_conjunction(&subqry_filter.predicate);
         verify_not_disjunction(&subqry_filter_exprs)?;
 
         // Grab column names to join on
         let (col_exprs, other_exprs) =
-            find_join_exprs(subqry_filter_exprs, subqry_filter.input().schema())
+            find_join_exprs(subqry_filter_exprs, subqry_filter.input.schema())
                 .map_err(|e| context!("column correlation not found", e))?;
         if !col_exprs.is_empty() {
             // it's correlated
-            subqry_input = subqry_filter.input().clone();
+            subqry_input = subqry_filter.input.clone();
             (outer_cols, subqry_cols, join_filters) =
-                exprs_to_join_cols(&col_exprs, subqry_filter.input().schema(), false)
+                exprs_to_join_cols(&col_exprs, subqry_filter.input.schema(), false)
                     .map_err(|e| context!("column correlation not found", e))?;
             other_subqry_exprs = other_exprs;
         }

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -62,7 +62,7 @@ impl OptimizerRule for EliminateCrossJoin {
     ) -> Result<LogicalPlan> {
         match plan {
             LogicalPlan::Filter(filter) => {
-                let input = (**filter.input()).clone();
+                let input = filter.input.as_ref().clone();
 
                 let mut possible_join_keys: Vec<(Column, Column)> = vec![];
                 let mut all_inputs: Vec<LogicalPlan> = vec![];
@@ -86,7 +86,7 @@ impl OptimizerRule for EliminateCrossJoin {
                     }
                 }
 
-                let predicate = filter.predicate();
+                let predicate = &filter.predicate;
                 // join keys are handled locally
                 let mut all_join_keys: HashSet<(Column, Column)> = HashSet::new();
 

--- a/datafusion/optimizer/src/eliminate_filter.rs
+++ b/datafusion/optimizer/src/eliminate_filter.rs
@@ -43,10 +43,8 @@ impl OptimizerRule for EliminateFilter {
         _optimizer_config: &mut OptimizerConfig,
     ) -> Result<LogicalPlan> {
         let predicate_and_input = match plan {
-            LogicalPlan::Filter(filter) => match filter.predicate() {
-                Expr::Literal(ScalarValue::Boolean(Some(v))) => {
-                    Some((*v, filter.input()))
-                }
+            LogicalPlan::Filter(filter) => match filter.predicate {
+                Expr::Literal(ScalarValue::Boolean(Some(v))) => Some((v, &filter.input)),
                 _ => None,
             },
             _ => None,

--- a/datafusion/optimizer/src/eliminate_outer_join.rs
+++ b/datafusion/optimizer/src/eliminate_outer_join.rs
@@ -68,12 +68,12 @@ impl OptimizerRule for EliminateOuterJoin {
         optimizer_config: &mut OptimizerConfig,
     ) -> Result<LogicalPlan> {
         match plan {
-            LogicalPlan::Filter(filter) => match filter.input().as_ref() {
+            LogicalPlan::Filter(filter) => match filter.input.as_ref() {
                 LogicalPlan::Join(join) => {
                     let mut non_nullable_cols: Vec<Column> = vec![];
 
                     extract_non_nullable_columns(
-                        filter.predicate(),
+                        &filter.predicate,
                         &mut non_nullable_cols,
                         join.left.schema(),
                         join.right.schema(),

--- a/datafusion/optimizer/src/rewrite_disjunctive_predicate.rs
+++ b/datafusion/optimizer/src/rewrite_disjunctive_predicate.rs
@@ -131,12 +131,12 @@ impl OptimizerRule for RewriteDisjunctivePredicate {
     ) -> Result<LogicalPlan> {
         match plan {
             LogicalPlan::Filter(filter) => {
-                let predicate = predicate(filter.predicate())?;
+                let predicate = predicate(&filter.predicate)?;
                 let rewritten_predicate = rewrite_predicate(predicate);
                 let rewritten_expr = normalize_predicate(rewritten_predicate);
                 Ok(LogicalPlan::Filter(Filter::try_new(
                     rewritten_expr,
-                    Arc::new(Self::optimize(self, filter.input(), _optimizer_config)?),
+                    Arc::new(Self::optimize(self, &filter.input, _optimizer_config)?),
                 )?))
             }
             _ => utils::optimize_children(self, plan, _optimizer_config),

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -57,10 +57,10 @@ impl OptimizerRule for SubqueryFilterToJoin {
         match plan {
             LogicalPlan::Filter(filter) => {
                 // Apply optimizer rule to current input
-                let optimized_input = self.optimize(filter.input(), optimizer_config)?;
+                let optimized_input = self.optimize(&filter.input, optimizer_config)?;
 
                 // Splitting filter expression into components by AND
-                let filters = utils::split_conjunction(filter.predicate());
+                let filters = utils::split_conjunction(&filter.predicate);
 
                 // Searching for subquery-based filters
                 let (subquery_filters, regular_filters): (Vec<&Expr>, Vec<&Expr>) =
@@ -79,7 +79,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
 
                 if !subqueries_in_regular.is_empty() {
                     return Ok(LogicalPlan::Filter(Filter::try_new(
-                        filter.predicate().clone(),
+                        filter.predicate.clone(),
                         Arc::new(optimized_input),
                     )?));
                 };
@@ -151,7 +151,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
                     Ok(plan) => plan,
                     Err(_) => {
                         return Ok(LogicalPlan::Filter(Filter::try_new(
-                            filter.predicate().clone(),
+                            filter.predicate.clone(),
                             Arc::new(optimized_input),
                         )?))
                     }

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -975,14 +975,14 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::Filter(filter) => {
                 let input: protobuf::LogicalPlanNode =
                     protobuf::LogicalPlanNode::try_from_logical_plan(
-                        filter.input().as_ref(),
+                        filter.input.as_ref(),
                         extension_codec,
                     )?;
                 Ok(protobuf::LogicalPlanNode {
                     logical_plan_type: Some(LogicalPlanType::Selection(Box::new(
                         protobuf::SelectionNode {
                             input: Some(Box::new(input)),
-                            expr: Some(filter.predicate().try_into()?),
+                            expr: Some((&(filter.predicate)).try_into()?),
                         },
                     ))),
                 })


### PR DESCRIPTION
# Which issue does this PR close?

Filter has access method which function like `get()` in `object-oriented`.

Rust don't need like `get()` method for struct. Because default immutable.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->