### PR TITLE
Improve error handling for array downcasting

### DIFF
--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -23,12 +23,13 @@
 use crate::{downcast_value, DataFusionError};
 use arrow::{
     array::{
-        Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, DictionaryArray,
-        Float32Array, Float64Array, GenericBinaryArray, GenericListArray, Int32Array,
-        Int64Array, LargeListArray, ListArray, MapArray, NullArray, OffsetSizeTrait,
-        PrimitiveArray, StringArray, StructArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
-        UInt32Array, UInt64Array, UnionArray,
+        Array, BinaryArray, BooleanArray, Date32Array, Date64Array, Decimal128Array,
+        DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array,
+        Float64Array, GenericBinaryArray, GenericListArray, GenericStringArray,
+        Int32Array, Int64Array, LargeListArray, ListArray, MapArray, NullArray,
+        OffsetSizeTrait, PrimitiveArray, StringArray, StructArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt32Array, UInt64Array, UnionArray,
     },
     datatypes::{ArrowDictionaryKeyType, ArrowPrimitiveType},
 };
@@ -176,4 +177,30 @@ pub fn as_timestamp_second_array(
 // Downcast ArrayRef to BinaryArray
 pub fn as_binary_array(array: &dyn Array) -> Result<&BinaryArray, DataFusionError> {
     Ok(downcast_value!(array, BinaryArray))
+}
+
+// Downcast ArrayRef to FixedSizeListArray
+pub fn as_fixed_size_list_array(
+    array: &dyn Array,
+) -> Result<&FixedSizeListArray, DataFusionError> {
+    Ok(downcast_value!(array, FixedSizeListArray))
+}
+
+// Downcast ArrayRef to FixedSizeListArray
+pub fn as_fixed_size_binary_array(
+    array: &dyn Array,
+) -> Result<&FixedSizeBinaryArray, DataFusionError> {
+    Ok(downcast_value!(array, FixedSizeBinaryArray))
+}
+
+// Downcast ArrayRef to Date64Array
+pub fn as_date64_array(array: &dyn Array) -> Result<&Date64Array, DataFusionError> {
+    Ok(downcast_value!(array, Date64Array))
+}
+
+// Downcast ArrayRef to GenericBinaryArray
+pub fn as_generic_string_array<T: OffsetSizeTrait>(
+    array: &dyn Array,
+) -> Result<&GenericStringArray<T>, DataFusionError> {
+    Ok(downcast_value!(array, GenericStringArray, T))
 }

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -26,7 +26,8 @@ use std::str::FromStr;
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
 use crate::cast::{
-    as_decimal128_array, as_dictionary_array, as_list_array, as_struct_array,
+    as_decimal128_array, as_dictionary_array, as_fixed_size_binary_array,
+    as_fixed_size_list_array, as_list_array, as_struct_array,
 };
 use crate::delta::shift_months;
 use crate::error::{DataFusionError, Result};
@@ -2109,8 +2110,7 @@ impl ScalarValue {
                 Self::Struct(Some(field_values), Box::new(fields.clone()))
             }
             DataType::FixedSizeList(nested_type, _len) => {
-                let list_array =
-                    array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+                let list_array = as_fixed_size_list_array(array)?;
                 let value = match list_array.is_null(index) {
                     true => None,
                     false => {
@@ -2124,10 +2124,7 @@ impl ScalarValue {
                 ScalarValue::new_list(value, nested_type.data_type().clone())
             }
             DataType::FixedSizeBinary(_) => {
-                let array = array
-                    .as_any()
-                    .downcast_ref::<FixedSizeBinaryArray>()
-                    .unwrap();
+                let array = as_fixed_size_binary_array(array)?;
                 let size = match array.data_type() {
                     DataType::FixedSizeBinary(size) => *size,
                     _ => unreachable!(),

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -21,10 +21,7 @@ use std::sync::Arc;
 
 use arrow::array::new_empty_array;
 use arrow::{
-    array::{
-        Array, ArrayBuilder, ArrayRef, Date64Array, Date64Builder, StringBuilder,
-        UInt64Builder,
-    },
+    array::{ArrayBuilder, ArrayRef, Date64Builder, StringBuilder, UInt64Builder},
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
@@ -40,7 +37,7 @@ use crate::{
 use super::PartitionedFile;
 use crate::datasource::listing::ListingTableUrl;
 use datafusion_common::{
-    cast::{as_string_array, as_uint64_array},
+    cast::{as_date64_array, as_string_array, as_uint64_array},
     Column, DataFusionError,
 };
 use datafusion_expr::{
@@ -341,11 +338,7 @@ fn batches_to_paths(batches: &[RecordBatch]) -> Result<Vec<PartitionedFile>> {
         .flat_map(|batch| {
             let key_array = as_string_array(batch.column(0)).unwrap();
             let length_array = as_uint64_array(batch.column(1)).unwrap();
-            let modified_array = batch
-                .column(2)
-                .as_any()
-                .downcast_ref::<Date64Array>()
-                .unwrap();
+            let modified_array = as_date64_array(batch.column(2)).unwrap();
 
             (0..batch.num_rows()).map(move |row| {
                 Ok(PartitionedFile {

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -261,6 +261,7 @@ mod tests {
     use crate::prelude::NdJsonReadOptions;
     use crate::prelude::*;
     use crate::test::partitioned_file_groups;
+    use datafusion_common::cast::{as_int32_array, as_int64_array};
     use rstest::*;
     use tempfile::TempDir;
     use url::Url;
@@ -362,11 +363,7 @@ mod tests {
         let batch = it.next().await.unwrap()?;
 
         assert_eq!(batch.num_rows(), 3);
-        let values = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
+        let values = as_int64_array(batch.column(0))?;
         assert_eq!(values.value(0), 1);
         assert_eq!(values.value(1), -10);
         assert_eq!(values.value(2), 2);
@@ -416,11 +413,7 @@ mod tests {
         let batch = it.next().await.unwrap()?;
 
         assert_eq!(batch.num_rows(), 3);
-        let values = batch
-            .column(missing_field_idx)
-            .as_any()
-            .downcast_ref::<arrow::array::Int32Array>()
-            .unwrap();
+        let values = as_int32_array(batch.column(missing_field_idx))?;
         assert_eq!(values.len(), 3);
         assert!(values.is_null(0));
         assert!(values.is_null(1));
@@ -471,11 +464,7 @@ mod tests {
         let batch = it.next().await.unwrap()?;
 
         assert_eq!(batch.num_rows(), 4);
-        let values = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
+        let values = as_int64_array(batch.column(0))?;
         assert_eq!(values.value(0), 1);
         assert_eq!(values.value(1), -10);
         assert_eq!(values.value(2), 2);

--- a/datafusion/physical-expr/src/crypto_expressions.rs
+++ b/datafusion/physical-expr/src/crypto_expressions.rs
@@ -18,20 +18,19 @@
 //! Crypto expressions
 
 use arrow::{
-    array::{
-        Array, ArrayRef, BinaryArray, GenericStringArray, OffsetSizeTrait, StringArray,
-    },
+    array::{Array, ArrayRef, BinaryArray, OffsetSizeTrait, StringArray},
     datatypes::DataType,
 };
 use blake2::{Blake2b512, Blake2s256, Digest};
 use blake3::Hasher as Blake3;
-use datafusion_common::cast::{as_binary_array, as_generic_binary_array};
+use datafusion_common::cast::{
+    as_binary_array, as_generic_binary_array, as_generic_string_array,
+};
 use datafusion_common::ScalarValue;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 use md5::Md5;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
-use std::any::type_name;
 use std::fmt::Write;
 use std::sync::Arc;
 use std::{fmt, str::FromStr};
@@ -167,15 +166,7 @@ impl DigestAlgorithm {
     where
         T: OffsetSizeTrait,
     {
-        let input_value = value
-            .as_any()
-            .downcast_ref::<GenericStringArray<T>>()
-            .ok_or_else(|| {
-                DataFusionError::Internal(format!(
-                    "could not cast value to {}",
-                    type_name::<GenericStringArray<T>>()
-                ))
-            })?;
+        let input_value = as_generic_string_array::<T>(value)?;
         let array: ArrayRef = match self {
             Self::Md5 => digest_to_array!(Md5, input_value),
             Self::Sha224 => digest_to_array!(Sha224, input_value),

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -17,7 +17,7 @@
 
 use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
-use arrow::array::{Array, ArrayRef, Date64Array};
+use arrow::array::{Array, ArrayRef};
 use arrow::compute::unary;
 use arrow::datatypes::{
     DataType, Date32Type, Date64Type, Schema, TimeUnit, TimestampMicrosecondType,
@@ -25,8 +25,9 @@ use arrow::datatypes::{
 };
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::{
-    as_date32_array, as_timestamp_microsecond_array, as_timestamp_millisecond_array,
-    as_timestamp_nanosecond_array, as_timestamp_second_array,
+    as_date32_array, as_date64_array, as_timestamp_microsecond_array,
+    as_timestamp_millisecond_array, as_timestamp_nanosecond_array,
+    as_timestamp_second_array,
 };
 use datafusion_common::scalar::{
     date32_add, date64_add, microseconds_add, milliseconds_add, nanoseconds_add,
@@ -194,7 +195,7 @@ pub fn evaluate_array(
             })) as ArrayRef
         }
         DataType::Date64 => {
-            let array = array.as_any().downcast_ref::<Date64Array>().unwrap();
+            let array = as_date64_array(&array)?;
             Arc::new(unary::<Date64Type, _, Date64Type>(array, |ms| {
                 date64_add(ms, scalar, sign).unwrap()
             })) as ArrayRef

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -778,13 +778,13 @@ mod tests {
     use crate::type_coercion::coerce;
     use arrow::{
         array::{
-            Array, ArrayRef, BinaryArray, BooleanArray, FixedSizeListArray, Float32Array,
-            Float64Array, Int32Array, StringArray, UInt32Array, UInt64Array,
+            Array, ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array,
+            Int32Array, StringArray, UInt32Array, UInt64Array,
         },
         datatypes::Field,
         record_batch::RecordBatch,
     };
-    use datafusion_common::cast::as_uint64_array;
+    use datafusion_common::cast::{as_fixed_size_list_array, as_uint64_array};
     use datafusion_common::{Result, ScalarValue};
 
     /// $FUNC function to test
@@ -2807,10 +2807,7 @@ mod tests {
         let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
-        let result = result
-            .as_any()
-            .downcast_ref::<FixedSizeListArray>()
-            .unwrap();
+        let result = as_fixed_size_list_array(&result)?;
 
         // value is correct
         assert_eq!(format!("{:?}", result.value(0)), expected);

--- a/datafusion/row/src/writer.rs
+++ b/datafusion/row/src/writer.rs
@@ -22,7 +22,9 @@ use arrow::array::*;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use arrow::util::bit_util::{round_upto_power_of_2, set_bit_raw, unset_bit_raw};
-use datafusion_common::cast::{as_binary_array, as_date32_array, as_string_array};
+use datafusion_common::cast::{
+    as_binary_array, as_date32_array, as_date64_array, as_string_array,
+};
 use datafusion_common::Result;
 use std::cmp::max;
 use std::sync::Arc;
@@ -339,7 +341,7 @@ pub(crate) fn write_field_date64(
     col_idx: usize,
     row_idx: usize,
 ) {
-    let from = from.as_any().downcast_ref::<Date64Array>().unwrap();
+    let from = as_date64_array(from).unwrap();
     to.set_date64(col_idx, from.value(row_idx));
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Discussed in #3152 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This is the new PR in a series to improve error handling for downcasting. I think we refactor all parts except macros. My next attempts will be refactoring feasible macros. Those are the macros that use ```is_any().downcast_ref::<$ARRAYTYPE>``` : 

![image](https://user-images.githubusercontent.com/15185911/205456795-69496947-b865-4994-92f6-0eee67738dcb.png)

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `as_xxx_array` functions for following types to downcast:
  - `FixedSizeListArray`
  - `FixedSizeBinaryArray`
  - `Date64Array`
  - `GenericStringArray`
- Refactor parts where old casting schema is used.