### PR TITLE
Remove sqllogictests CI run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -517,31 +517,3 @@ jobs:
           # If you encounter an error, run './dev/update_config_docs.sh' and commit
           ./dev/update_config_docs.sh
           git diff --exit-code
-
-  # Run sqllogictests
-  sql-logic-tests:
-    name: run sqllogictests
-    needs: [linux-build-lib]
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: /github/home/.cargo
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - name: Run sqllogictests
-        run: cargo test -p datafusion --test sqllogictests


### PR DESCRIPTION
There's no need for a separate CI run as sqllogictests already run as part of cargo test here: https://github.com/apache/arrow-datafusion/blob/master/.github/workflows/rust.yml#L71

