### PR TITLE
Add get_window_frame in window_expr, show frame info in window_agg_exec

### DIFF
--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -268,7 +268,14 @@ impl ExecutionPlan for WindowAggExec {
                 let g: Vec<String> = self
                     .window_expr
                     .iter()
-                    .map(|e| format!("{}: {:?}", e.name().to_owned(), e.field()))
+                    .map(|e| {
+                        format!(
+                            "{}: {:?}, frame: {:?}",
+                            e.name().to_owned(),
+                            e.field(),
+                            e.get_window_frame()
+                        )
+                    })
                     .collect();
                 write!(f, "wdw=[{}]", g.join(", "))?;
             }

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -1628,8 +1628,8 @@ async fn test_window_agg_sort() -> Result<()> {
     let expected = {
         vec![
             "ProjectionExec: expr=[c9@3 as c9, SUM(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c9 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@0 as sum1, SUM(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c9 ASC NULLS LAST, aggregate_test_100.c8 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@1 as sum2]",
-            "  WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: None]",
-            "    WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: None]",
+            "  WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(UInt32(NULL)), end_bound: CurrentRow }]",
+            "    WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(UInt32(NULL)), end_bound: CurrentRow }]",
             "      SortExec: [c9@1 ASC NULLS LAST,c8@0 ASC NULLS LAST]",
         ]
     };

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -1628,8 +1628,8 @@ async fn test_window_agg_sort() -> Result<()> {
     let expected = {
         vec![
             "ProjectionExec: expr=[c9@3 as c9, SUM(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c9 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@0 as sum1, SUM(aggregate_test_100.c9) ORDER BY [aggregate_test_100.c9 ASC NULLS LAST, aggregate_test_100.c8 ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@1 as sum2]",
-            "  WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })]",
-            "    WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })]",
+            "  WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: None]",
+            "    WindowAggExec: wdw=[SUM(aggregate_test_100.c9): Ok(Field { name: \"SUM(aggregate_test_100.c9)\", data_type: UInt64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: None]",
             "      SortExec: [c9@1 ASC NULLS LAST,c8@0 ASC NULLS LAST]",
         ]
     };

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -152,7 +152,7 @@ impl WindowExpr for AggregateWindowExpr {
         &self.order_by
     }
 
-    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>> {
-        self.window_frame.as_ref()
+    fn get_window_frame(&self) -> &Arc<WindowFrame> {
+        &self.window_frame
     }
 }

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -151,4 +151,8 @@ impl WindowExpr for AggregateWindowExpr {
     fn order_by(&self) -> &[PhysicalSortExpr] {
         &self.order_by
     }
+
+    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>> {
+        self.window_frame.as_ref()
+    }
 }

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -134,7 +134,7 @@ impl WindowExpr for BuiltInWindowExpr {
         concat(&results).map_err(DataFusionError::ArrowError)
     }
 
-    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>> {
-        self.window_frame.as_ref()
+    fn get_window_frame(&self) -> &Arc<WindowFrame> {
+        &self.window_frame
     }
 }

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -133,4 +133,8 @@ impl WindowExpr for BuiltInWindowExpr {
         let results = results.iter().map(|i| i.as_ref()).collect::<Vec<_>>();
         concat(&results).map_err(DataFusionError::ArrowError)
     }
+
+    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>> {
+        self.window_frame.as_ref()
+    }
 }

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -130,5 +130,5 @@ pub trait WindowExpr: Send + Sync + Debug {
     }
 
     // Get window frame of this WindowExpr, None if absent
-    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>>;
+    fn get_window_frame(&self) -> &Arc<WindowFrame>;
 }

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -21,6 +21,7 @@ use arrow::compute::kernels::sort::{SortColumn, SortOptions};
 use arrow::record_batch::RecordBatch;
 use arrow::{array::ArrayRef, datatypes::Field};
 use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::WindowFrame;
 use std::any::Any;
 use std::fmt::Debug;
 use std::ops::Range;
@@ -127,4 +128,7 @@ pub trait WindowExpr: Send + Sync + Debug {
             order_by_columns.iter().map(|s| s.values.clone()).collect();
         Ok((values, order_bys))
     }
+
+    // Get window frame of this WindowExpr, None if absent
+    fn get_window_frame(&self) -> Option<&Arc<WindowFrame>>;
 }


### PR DESCRIPTION
Signed-off-by: yangjiang <yangjiang@ebay.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4509 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Need show window frame info in window_agg_exec
Before
```
explain SELECT s_suppkey, s_nationkey, s_acctbal, (sum(s_acctbal) over (
                                                                   ORDER BY s_acctbal DESC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)) wr
   FROM supplier

limit 10;
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                             |
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: supplier.s_suppkey, supplier.s_nationkey, supplier.s_acctbal, SUM(supplier.s_acctbal) ORDER BY [supplier.s_acctbal DESC NULLS FIRST] ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING AS wr                                  |
|               |   Limit: skip=0, fetch=10                                                                                                                                                                                                        |
|               |     WindowAggr: windowExpr=[[SUM(supplier.s_acctbal) ORDER BY [supplier.s_acctbal DESC NULLS FIRST] ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING]]                                                                                   |
|               |       TableScan: supplier projection=[s_suppkey, s_nationkey, s_acctbal]                                                                                                                                                         |
| physical_plan | ProjectionExec: expr=[s_suppkey@1 as s_suppkey, s_nationkey@2 as s_nationkey, s_acctbal@3 as s_acctbal, SUM(supplier.s_acctbal) ORDER BY [supplier.s_acctbal DESC NULLS FIRST] ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING@0 as wr] |
|               |   GlobalLimitExec: skip=0, fetch=10                                                                                                                                                                                              |
|               |     WindowAggExec: wdw=[SUM(supplier.s_acctbal): Ok(Field { name: "SUM(supplier.s_acctbal)", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None })]                                          |
|               |       SortExec: [s_acctbal@2 DESC]                                                                                                                                                                                               |
|               |         ParquetExec: limit=None, partitions=[**], projection=[s_suppkey, s_nationkey, s_acctbal]             |
|               |                                                                                                                                                                                                                                  |
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.192 seconds.
```
Now
```
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ***                                                                                                                                                                                                                                                            |
|               |     WindowAggExec: wdw=[SUM(supplier.s_acctbal): Ok(Field { name: "SUM(supplier.s_acctbal)", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: Some(WindowFrame { units: Rows, start_bound: Preceding(UInt64(1)), end_bound: Following(UInt64(1)) })] |
|               |       SortExec: [s_acctbal@2 DESC]                                                                                                                                                                                                                                                                  ***
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 rows in set. Query took 0.019 seconds.
```
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->