### PR TITLE
Enrich filter statistics with known column boundaries

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -719,7 +719,9 @@ impl PartialEq<dyn Any> for BinaryExpr {
 
 // Analyze the comparison between an expression (on the left) and a scalar value
 // (on the right). The new boundaries will indicate whether it is always true, always
-// false, or unknown (with a probablistic selectivity value attached).
+// false, or unknown (with a probablistic selectivity value attached). This operation
+// will also include the new upper/lower boundaries for the operand on the left if
+// they can be determined.
 fn analyze_expr_scalar_comparison(
     context: AnalysisContext,
     op: &Operator,
@@ -3180,8 +3182,8 @@ mod tests {
             let analysis_ctx =
                 analyze_expr_scalar_comparison(context, &operator, &left, right);
             let boundaries = analysis_ctx
-                .clone()
                 .boundaries
+                .as_ref()
                 .expect("Analysis must complete for this test!");
 
             assert_eq!(

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -26,7 +26,7 @@ use arrow::{
 };
 
 use crate::physical_expr::down_cast_any_ref;
-use crate::{AnalysisContext, ExprBoundaries, PhysicalExpr};
+use crate::{AnalysisContext, PhysicalExpr};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 
@@ -104,9 +104,10 @@ impl PhysicalExpr for Column {
     }
 
     /// Return the boundaries of this column, if known.
-    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
+    fn analyze(&self, context: AnalysisContext) -> AnalysisContext {
         assert!(self.index < context.column_boundaries.len());
-        context.column_boundaries[self.index].clone()
+        let col_bounds = context.column_boundaries[self.index].clone();
+        context.with_boundaries(col_bounds)
     }
 }
 
@@ -290,7 +291,7 @@ mod test {
     #[test]
     fn stats_bounds_analysis() -> Result<()> {
         let (schema, statistics) = get_test_table_stats();
-        let mut context = AnalysisContext::from_statistics(&schema, &statistics);
+        let context = AnalysisContext::from_statistics(&schema, &statistics);
 
         let cases = [
             // (name, index, expected boundaries)
@@ -317,8 +318,8 @@ mod test {
 
         for (name, index, expected) in cases {
             let col = Column::new(name, index);
-            let boundaries = col.boundaries(&mut context);
-            assert_eq!(boundaries, expected);
+            let test_ctx = col.analyze(context.clone());
+            assert_eq!(test_ctx.boundaries, expected);
         }
 
         Ok(())

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -104,7 +104,7 @@ impl PhysicalExpr for Column {
     }
 
     /// Return the boundaries of this column, if known.
-    fn boundaries(&self, context: &AnalysisContext) -> Option<ExprBoundaries> {
+    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
         assert!(self.index < context.column_boundaries.len());
         context.column_boundaries[self.index].clone()
     }
@@ -290,7 +290,7 @@ mod test {
     #[test]
     fn stats_bounds_analysis() -> Result<()> {
         let (schema, statistics) = get_test_table_stats();
-        let context = AnalysisContext::from_statistics(&schema, &statistics);
+        let mut context = AnalysisContext::from_statistics(&schema, &statistics);
 
         let cases = [
             // (name, index, expected boundaries)
@@ -317,7 +317,7 @@ mod test {
 
         for (name, index, expected) in cases {
             let col = Column::new(name, index);
-            let boundaries = col.boundaries(&context);
+            let boundaries = col.boundaries(&mut context);
             assert_eq!(boundaries, expected);
         }
 

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -87,7 +87,7 @@ impl PhysicalExpr for Literal {
     #[allow(unused_variables)]
     /// Return the boundaries of this literal expression (which is the same as
     /// the value it represents).
-    fn boundaries(&self, context: &AnalysisContext) -> Option<ExprBoundaries> {
+    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
         Some(ExprBoundaries::new(
             self.value.clone(),
             self.value.clone(),
@@ -147,10 +147,10 @@ mod tests {
     #[test]
     fn literal_bounds_analysis() -> Result<()> {
         let schema = Schema::new(vec![]);
-        let context = AnalysisContext::new(&schema, vec![]);
+        let mut context = AnalysisContext::new(&schema, vec![]);
 
         let literal_expr = lit(42i32);
-        let boundaries = literal_expr.boundaries(&context).unwrap();
+        let boundaries = literal_expr.boundaries(&mut context).unwrap();
         assert_eq!(boundaries.min_value, ScalarValue::Int32(Some(42)));
         assert_eq!(boundaries.max_value, ScalarValue::Int32(Some(42)));
         assert_eq!(boundaries.distinct_count, Some(1));

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -84,15 +84,14 @@ impl PhysicalExpr for Literal {
         Ok(self)
     }
 
-    #[allow(unused_variables)]
     /// Return the boundaries of this literal expression (which is the same as
     /// the value it represents).
-    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
-        Some(ExprBoundaries::new(
+    fn analyze(&self, context: AnalysisContext) -> AnalysisContext {
+        context.with_boundaries(Some(ExprBoundaries::new(
             self.value.clone(),
             self.value.clone(),
             Some(1),
-        ))
+        )))
     }
 }
 
@@ -147,10 +146,11 @@ mod tests {
     #[test]
     fn literal_bounds_analysis() -> Result<()> {
         let schema = Schema::new(vec![]);
-        let mut context = AnalysisContext::new(&schema, vec![]);
+        let context = AnalysisContext::new(&schema, vec![]);
 
         let literal_expr = lit(42i32);
-        let boundaries = literal_expr.boundaries(&mut context).unwrap();
+        let result_ctx = literal_expr.analyze(context);
+        let boundaries = result_ctx.boundaries.unwrap();
         assert_eq!(boundaries.min_value, ScalarValue::Int32(Some(42)));
         assert_eq!(boundaries.max_value, ScalarValue::Int32(Some(42)));
         assert_eq!(boundaries.distinct_count, Some(1));

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -79,7 +79,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
     #[allow(unused_variables)]
     /// Return the boundaries of this expression. This method (and all the
     /// related APIs) are experimental and subject to change.
-    fn boundaries(&self, context: &AnalysisContext) -> Option<ExprBoundaries> {
+    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
         None
     }
 }
@@ -115,6 +115,11 @@ impl AnalysisContext {
             None => vec![None; input_schema.fields().len()],
         };
         Self::new(input_schema, column_boundaries)
+    }
+
+    /// Update the boundaries of a column.
+    pub fn update_column(&mut self, column: usize, boundaries: ExprBoundaries) {
+        self.column_boundaries[column] = Some(boundaries);
     }
 }
 

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -76,11 +76,10 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>>;
 
-    #[allow(unused_variables)]
     /// Return the boundaries of this expression. This method (and all the
     /// related APIs) are experimental and subject to change.
-    fn boundaries(&self, context: &mut AnalysisContext) -> Option<ExprBoundaries> {
-        None
+    fn analyze(&self, context: AnalysisContext) -> AnalysisContext {
+        context
     }
 }
 
@@ -91,6 +90,8 @@ pub struct AnalysisContext {
     /// A list of known column boundaries, ordered by the index
     /// of the column in the current schema.
     pub column_boundaries: Vec<Option<ExprBoundaries>>,
+    // Result of the current analysis.
+    pub boundaries: Option<ExprBoundaries>,
 }
 
 impl AnalysisContext {
@@ -99,7 +100,10 @@ impl AnalysisContext {
         column_boundaries: Vec<Option<ExprBoundaries>>,
     ) -> Self {
         assert_eq!(input_schema.fields().len(), column_boundaries.len());
-        Self { column_boundaries }
+        Self {
+            column_boundaries,
+            boundaries: None,
+        }
     }
 
     /// Create a new analysis context from column statistics.
@@ -117,9 +121,24 @@ impl AnalysisContext {
         Self::new(input_schema, column_boundaries)
     }
 
+    pub fn boundaries(&self) -> Option<&ExprBoundaries> {
+        self.boundaries.as_ref()
+    }
+
+    /// Set the result of the current analysis.
+    pub fn with_boundaries(mut self, result: Option<ExprBoundaries>) -> Self {
+        self.boundaries = result;
+        self
+    }
+
     /// Update the boundaries of a column.
-    pub fn update_column(&mut self, column: usize, boundaries: ExprBoundaries) {
+    pub fn with_column_update(
+        mut self,
+        column: usize,
+        boundaries: ExprBoundaries,
+    ) -> Self {
         self.column_boundaries[column] = Some(boundaries);
+        self
     }
 }
 
@@ -270,6 +289,18 @@ fn scatter(mask: &BooleanArray, truthy: &dyn Array) -> Result<ArrayRef> {
 
     let data = mutable.freeze();
     Ok(make_array(data))
+}
+
+#[macro_export]
+// If the given expression is None, return the given context
+// without setting the boundaries.
+macro_rules! analysis_expect {
+    ($context: ident, $expr: expr) => {
+        match $expr {
+            Some(expr) => expr,
+            None => return $context.with_boundaries(None),
+        }
+    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4518.

# Rationale for this change

Allowing the propagation of column statistics in filter estimations theoretically unlocks all the parent estimations which in turn should benefit us greatly when dealing with nested joins.

# What changes are included in this PR?

The major change here is the new analysis context API which allows it to be attached with an expression boundaries alongside the information it already holds (column boundaries). With this in our hand, we can derive the column statistics for filter's result and all other use cases where the expression analysis used. 

The initial design was around sharing a single `&mut Context` around and returning `ExprBoundaries` as we do now, but thanks to @alamb's suggestion on [my fork](https://github.com/isidentical/arrow-datafusion/pull/5#discussion_r1023180238) we can achieve a similar thing (albeit a bit more verbose) while still keeping the analysis process mut-free.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No. This includes a break in the expression analysis API but it was specifically marked as experimental for stuff like this (it is currently evolving).

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->