### PR TITLE
refactor: make Ctes a struct to also store data types provided by prepare stmt

### DIFF
--- a/datafusion/core/tests/sqllogictests/src/insert/mod.rs
+++ b/datafusion/core/tests/sqllogictests/src/insert/mod.rs
@@ -24,9 +24,8 @@ use datafusion::datasource::MemTable;
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DFSchema, DataFusionError};
 use datafusion_expr::Expr as DFExpr;
-use datafusion_sql::planner::SqlToRel;
+use datafusion_sql::planner::{Ctes, SqlToRel};
 use sqlparser::ast::{Expr, SetExpr, Statement as SQLStatement};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 pub async fn insert(ctx: &SessionContext, insert_stmt: &SQLStatement) -> Result<String> {
@@ -65,9 +64,7 @@ pub async fn insert(ctx: &SessionContext, insert_stmt: &SQLStatement) -> Result<
     for row in insert_values.into_iter() {
         let logical_exprs = row
             .into_iter()
-            .map(|expr| {
-                sql_to_rel.sql_to_rex(expr, &DFSchema::empty(), &mut HashMap::new())
-            })
+            .map(|expr| sql_to_rel.sql_to_rex(expr, &DFSchema::empty(), &mut Ctes::new()))
             .collect::<std::result::Result<Vec<DFExpr>, DataFusionError>>()?;
         // Directly use `select` to get `RecordBatch`
         let dataframe = ctx.read_empty()?;


### PR DESCRIPTION

While working on PR #4490 that implements `PREPARE stmt`, I found that I need to pass the provided data types of the parameters/binding down to the plan's expressions  to map data types to $1, $2, ...

@alamb has suggested me to pass datatypes of the parameters  along with the CTEs. This PR is just a refactor to convert `ctes` from a hash map to a struct that store both ctes (hahhmap) and the params' data types. 


