### PR TITLE
Fix limited statistic collection accross files with no stats

### DIFF
--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -47,7 +47,6 @@ use futures::StreamExt;
 /// Get all files as well as the file level summary statistics (no statistic for partition columns).
 /// If the optional `limit` is provided, includes only sufficient files.
 /// Needed to read up to `limit` number of rows.
-/// TODO fix case where `num_rows` and `total_byte_size` are not defined (stat should be None instead of Some(0))
 pub async fn get_statistics_with_limit(
     all_files: impl Stream<Item = Result<(PartitionedFile, Statistics)>>,
     file_schema: SchemaRef,
@@ -55,21 +54,35 @@ pub async fn get_statistics_with_limit(
 ) -> Result<(Vec<PartitionedFile>, Statistics)> {
     let mut result_files = vec![];
 
-    let mut total_byte_size = 0;
     let mut null_counts = vec![0; file_schema.fields().len()];
     let mut has_statistics = false;
     let (mut max_values, mut min_values) = create_max_min_accs(&file_schema);
 
-    let mut num_rows = 0;
     let mut is_exact = true;
+
+    // The number of rows and the total byte size can be calculated as long as
+    // at least one file has them. If none of the files provide them, then they
+    // will be omitted from the statistics. The missing values will be counted
+    // as zero.
+    let mut num_rows = None;
+    let mut total_byte_size = None;
+
     // fusing the stream allows us to call next safely even once it is finished
     let mut all_files = Box::pin(all_files.fuse());
     while let Some(res) = all_files.next().await {
         let (file, file_stats) = res?;
         result_files.push(file);
         is_exact &= file_stats.is_exact;
-        num_rows += file_stats.num_rows.unwrap_or(0);
-        total_byte_size += file_stats.total_byte_size.unwrap_or(0);
+        num_rows = if let Some(num_rows) = num_rows {
+            Some(num_rows + file_stats.num_rows.unwrap_or(0))
+        } else {
+            file_stats.num_rows
+        };
+        total_byte_size = if let Some(total_byte_size) = total_byte_size {
+            Some(total_byte_size + file_stats.total_byte_size.unwrap_or(0))
+        } else {
+            file_stats.total_byte_size
+        };
         if let Some(vec) = &file_stats.column_statistics {
             has_statistics = true;
             for (i, cs) in vec.iter().enumerate() {
@@ -102,7 +115,12 @@ pub async fn get_statistics_with_limit(
                 }
             }
         }
-        if num_rows > limit.unwrap_or(usize::MAX) {
+
+        // If the number of rows exceeds the limit, we can stop processing
+        // files. This only applies when we know the number of rows. It also
+        // currently ignores tables that have no statistics regarding the
+        // number of rows.
+        if num_rows.unwrap_or(usize::MIN) > limit.unwrap_or(usize::MAX) {
             break;
         }
     }
@@ -125,8 +143,8 @@ pub async fn get_statistics_with_limit(
     };
 
     let statistics = Statistics {
-        num_rows: Some(num_rows),
-        total_byte_size: Some(total_byte_size),
+        num_rows,
+        total_byte_size,
         column_statistics: column_stats,
         is_exact,
     };

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -362,14 +362,24 @@ impl TryInto<Statistics> for &protobuf::Statistics {
     type Error = DataFusionError;
 
     fn try_into(self) -> Result<Statistics, Self::Error> {
+        // Keep it sync with Statistics::to_proto
+        let none_value = -1_i64;
         let column_statistics = self
             .column_stats
             .iter()
             .map(|s| s.into())
             .collect::<Vec<_>>();
         Ok(Statistics {
-            num_rows: Some(self.num_rows as usize),
-            total_byte_size: Some(self.total_byte_size as usize),
+            num_rows: if self.num_rows == none_value {
+                None
+            } else {
+                Some(self.num_rows as usize)
+            },
+            total_byte_size: if self.total_byte_size == none_value {
+                None
+            } else {
+                Some(self.total_byte_size as usize)
+            },
             // No column statistic (None) is encoded with empty array
             column_statistics: if column_statistics.is_empty() {
                 None


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4323.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Even in the cases where none of the files included stats/byte size information,  `get_statistics_with_limit` was generating statistics with the claims of zero rows / zero bytes. This PR fixes it to only include the number of rows when it is known.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
For preserving the old relaxed behavior, this PR changes the collection to include row/byte count information when any of them are present in any of the files. If it is only present in even one file, that is enough for the listing (all the others are counted towards zero rows, which is the existing behavior). 

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->