### PR TITLE
Avoid reading the entire file in ChunkedStore

### DIFF
--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -99,10 +99,14 @@ impl ListingTableUrl {
         };
 
         let path = std::path::Path::new(prefix).canonicalize()?;
-        let url = match path.is_file() {
-            true => Url::from_file_path(path).unwrap(),
-            false => Url::from_directory_path(path).unwrap(),
-        };
+        let url = if path.is_dir() {
+            Url::from_directory_path(path)
+        } else {
+            Url::from_file_path(path)
+        }
+        .map_err(|_| DataFusionError::Internal(format!("Can not open path: {}", s)))?;
+        // TODO: Currently we do not have an IO-related error variant that accepts ()
+        //       or a string. Once we have such a variant, change the error type above.
 
         Ok(Self::new(url, glob))
     }

--- a/datafusion/core/src/physical_plan/file_format/chunked_store.rs
+++ b/datafusion/core/src/physical_plan/file_format/chunked_store.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use object_store::path::Path;
@@ -25,7 +25,7 @@ use object_store::{MultipartId, Result};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::sync::Arc;
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncReadExt, AsyncWrite, BufReader};
 
 /// Wraps a [`ObjectStore`] and makes its get response return chunks
 ///
@@ -70,24 +70,78 @@ impl ObjectStore for ChunkedStore {
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let bytes = self.inner.get(location).await?.bytes().await?;
-        let mut offset = 0;
-        let chunk_size = self.chunk_size;
-
-        Ok(GetResult::Stream(
-            futures::stream::iter(std::iter::from_fn(move || {
-                let remaining = bytes.len() - offset;
-                if remaining == 0 {
-                    return None;
-                }
-                let to_read = remaining.min(chunk_size);
-                let next_offset = offset + to_read;
-                let slice = bytes.slice(offset..next_offset);
-                offset = next_offset;
-                Some(Ok(slice))
-            }))
-            .boxed(),
-        ))
+        match self.inner.get(location).await? {
+            GetResult::File(std_file, ..) => {
+                let file = tokio::fs::File::from_std(std_file);
+                let reader = BufReader::new(file);
+                Ok(GetResult::Stream(
+                    futures::stream::unfold(
+                        (reader, self.chunk_size),
+                        |(mut reader, chunk_size)| async move {
+                            let mut buffer = BytesMut::zeroed(chunk_size);
+                            let size = reader.read(&mut buffer).await.map_err(|e| {
+                                object_store::Error::Generic {
+                                    store: "ChunkedStore",
+                                    source: Box::new(e),
+                                }
+                            });
+                            match size {
+                                Ok(0) => None,
+                                Ok(value) => Some((
+                                    Ok(buffer.split_to(value).freeze()),
+                                    (reader, chunk_size),
+                                )),
+                                Err(e) => Some((Err(e), (reader, chunk_size))),
+                            }
+                        },
+                    )
+                    .boxed(),
+                ))
+            }
+            GetResult::Stream(stream) => {
+                let buffer = BytesMut::new();
+                Ok(GetResult::Stream(
+                    futures::stream::unfold(
+                        (stream, buffer, false, self.chunk_size),
+                        |(mut stream, mut buffer, mut exhausted, chunk_size)| async move {
+                            // Keep accumulating bytes until we reach capacity as long as
+                            // the stream can provide them:
+                            if exhausted {
+                                return None;
+                            }
+                            while buffer.len() < chunk_size {
+                                match stream.next().await {
+                                    None => {
+                                        exhausted = true;
+                                        let slice = buffer.split_off(0).freeze();
+                                        return Some((
+                                            Ok(slice),
+                                            (stream, buffer, exhausted, chunk_size),
+                                        ));
+                                    }
+                                    Some(Ok(bytes)) => {
+                                        buffer.put(bytes);
+                                    }
+                                    Some(Err(e)) => {
+                                        return Some((
+                                            Err(object_store::Error::Generic {
+                                                store: "ChunkedStore",
+                                                source: Box::new(e),
+                                            }),
+                                            (stream, buffer, exhausted, chunk_size),
+                                        ))
+                                    }
+                                };
+                            }
+                            // Return the chunked values as the next value in the stream
+                            let slice = buffer.split_to(chunk_size).freeze();
+                            Some((Ok(slice), (stream, buffer, exhausted, chunk_size)))
+                        },
+                    )
+                    .boxed(),
+                ))
+            }
+        }
     }
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
@@ -125,7 +179,9 @@ impl ObjectStore for ChunkedStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
     use object_store::memory::InMemory;
+    use object_store::path::Path;
 
     #[tokio::test]
     async fn test_chunked() {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4524.

# Rationale for this change

We would like to have low memory usage while processing queries that involve only pipeline-able operators. Obviously, the very first step of this is to read files and byte streams in a suitable manner. However, the current `ChunkedStore` implementation materializes the whole data in the memory *before* creating the `Result<Byte>` stream.  This PR fixes the implementation so that the entire file is actually read in chunks, not just outputted in chunks.

# What changes are included in this PR?

We changed the `get` method of `ChunkedStore` so that it actually reads file in chunks, without reading the whole file and splitting it into chunks.

# Are these changes tested?

Chunked byte stream conversion is tested for

- CSV
- JSON
- AVRO
- Byte array.

# Are there any user-facing changes?

Now, a user can use `ChunkedStore` for incremental reading for various types. The user can even concatenate  `ChunkedStore` with the `AmazonS3` store for increased reading performance.

# Discussion for future work

**(1)** `ChunkedStore`'s current use case seems to be mostly subsumed by [arrow_json](https://docs.rs/arrow-json/latest/arrow_json/#)] and [arrow_csv](https://docs.rs/arrow-csv/latest/arrow_csv/#)]. They can also *read and output* files in chunks if we supply `false` to `with_collect_statistics` and (`1` to `target_partition` in certain cases like reading FIFO files).

Therefore, `ChunkedStore` may not be required anymore. If we are not missing something and this is indeed the case, we can discuss deprecating it in the future.

**(2)** One has to load the entire data in memory for byte streams unless one defines a schema; i.e. `infer_schema` operates on the entire dataset.

We probably want to fix this too.