### PR TITLE
shouldn't add `outer_query_schema` in `sql_select_to_rex`

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -860,16 +860,16 @@ pub fn project_with_column_index(
 pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
     let left_col_num = left_plan.schema().fields().len();
 
-    // the 2 queries should have same number of columns
-    {
-        let right_col_num = right_plan.schema().fields().len();
-        if right_col_num != left_col_num {
-            return Err(DataFusionError::Plan(format!(
-                "Union queries must have the same number of columns, (left is {}, right is {})",
-                left_col_num, right_col_num)
-            ));
-        }
+    // check union plan length same.
+    let right_col_num = right_plan.schema().fields().len();
+    if right_col_num != left_col_num {
+        return Err(DataFusionError::Plan(format!(
+            "Union queries must have the same number of columns, (left is {}, right is {})",
+            left_col_num, right_col_num)
+        ));
     }
+
+    // create union schema
     let union_schema = (0..left_col_num)
         .map(|i| {
             let left_field = left_plan.schema().field(i);

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1111,7 +1111,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             &plan,
             select.projection,
             empty_from,
-            outer_query_schema,
             planner_context,
             &from_schema,
         )?;
@@ -1286,7 +1285,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         plan: &LogicalPlan,
         projection: Vec<SelectItem>,
         empty_from: bool,
-        outer_query_schema: Option<&DFSchema>,
         planner_context: &mut PlannerContext,
         from_schema: &DFSchema,
     ) -> Result<Vec<Expr>> {
@@ -1297,7 +1295,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     expr,
                     plan,
                     empty_from,
-                    outer_query_schema,
                     planner_context,
                     from_schema,
                 )
@@ -1605,28 +1602,18 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         sql: SelectItem,
         plan: &LogicalPlan,
         empty_from: bool,
-        outer_query_schema: Option<&DFSchema>,
         planner_context: &mut PlannerContext,
         from_schema: &DFSchema,
     ) -> Result<Vec<Expr>> {
-        let input_schema = match outer_query_schema {
-            Some(x) => {
-                let mut input_schema = plan.schema().as_ref().clone();
-                input_schema.merge(x);
-                input_schema
-            }
-            _ => plan.schema().as_ref().clone(),
-        };
-
         match sql {
             SelectItem::UnnamedExpr(expr) => {
-                let expr = self.sql_to_rex(expr, &input_schema, planner_context)?;
+                let expr = self.sql_to_rex(expr, plan.schema(), planner_context)?;
                 self.column_reference_ambiguous_check(from_schema, &[expr.clone()])?;
                 Ok(vec![normalize_col(expr, plan)?])
             }
             SelectItem::ExprWithAlias { expr, alias } => {
                 let select_expr =
-                    self.sql_to_rex(expr, &input_schema, planner_context)?;
+                    self.sql_to_rex(expr, plan.schema(), planner_context)?;
                 self.column_reference_ambiguous_check(
                     from_schema,
                     &[select_expr.clone()],
@@ -2150,7 +2137,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     negated,
                     Box::new(self.sql_expr_to_logical_expr(*expr, schema, planner_context)?),
                     Box::new(pattern),
-                    escape_char,
+                    escape_char
                 )))
             }
 
@@ -2376,13 +2363,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
             }
 
-            SQLExpr::Floor { expr, field: _field } => {
+            SQLExpr::Floor{expr, field: _field} => {
                 let fun = BuiltinScalarFunction::Floor;
                 let args = vec![self.sql_expr_to_logical_expr(*expr, schema, planner_context)?];
                 Ok(Expr::ScalarFunction { fun, args })
             }
 
-            SQLExpr::Ceil { expr, field: _field } => {
+            SQLExpr::Ceil{expr, field: _field} => {
                 let fun = BuiltinScalarFunction::Ceil;
                 let args = vec![self.sql_expr_to_logical_expr(*expr, schema, planner_context)?];
                 Ok(Expr::ScalarFunction { fun, args })
@@ -2673,7 +2660,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return Err(DataFusionError::Plan(format!(
                         "Unsupported Value {}",
                         value[0]
-                    )));
+                    )))
                 }
             },
             // for capture signed number e.g. +8, -8
@@ -2684,14 +2671,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return Err(DataFusionError::Plan(format!(
                         "Unsupported Value {}",
                         value[0]
-                    )));
+                    )))
                 }
             },
             _ => {
                 return Err(DataFusionError::Plan(format!(
                     "Unsupported Value {}",
                     value[0]
-                )));
+                )))
             }
         };
 
@@ -2921,7 +2908,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             return Err(DataFusionError::Internal(format!(
                                 "Incorrect data type for time_zone: {}",
                                 v.get_datatype(),
-                            )));
+                            )))
                         }
                         None => return Err(DataFusionError::Internal(
                             "Config Option datafusion.execution.time_zone doesn't exist"
@@ -2949,7 +2936,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
             }
             SQLDataType::Numeric(exact_number_info)
-            | SQLDataType::Decimal(exact_number_info) => {
+            |SQLDataType::Decimal(exact_number_info) => {
                 let (precision, scale) = match *exact_number_info {
                     ExactNumberInfo::None => (None, None),
                     ExactNumberInfo::Precision(precision) => (Some(precision), None),
@@ -2981,12 +2968,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             | SQLDataType::CharacterVarying(_)
             | SQLDataType::CharVarying(_)
             | SQLDataType::CharacterLargeObject(_)
-            | SQLDataType::CharLargeObject(_)
+                | SQLDataType::CharLargeObject(_)
             // precision is not supported
-            | SQLDataType::Timestamp(Some(_), _)
+                | SQLDataType::Timestamp(Some(_), _)
             // precision is not supported
-            | SQLDataType::Time(Some(_), _)
-            | SQLDataType::Dec(_)
+                | SQLDataType::Time(Some(_), _)
+                | SQLDataType::Dec(_)
             | SQLDataType::Clob(_) => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported SQL type {:?}",
                 sql_type


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4526

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

remove `outer_query_schema` in `sql_select_to_rex`.

selection-expr is independent, we shouldn't add outer_schema in its schema.

Selection-subquery is different from where-subquery/from-subquery.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->