### PR TITLE
Simplify SortPreservingMerge using async

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -30,7 +30,7 @@ use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{
     BaselineMetrics, CompositeMetricsSet, MemTrackingMetrics, MetricsSet,
 };
-use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeStream;
+use crate::physical_plan::sorts::sort_preserving_merge::merge_streams;
 use crate::physical_plan::sorts::SortedStream;
 use crate::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
 use crate::physical_plan::{
@@ -191,13 +191,13 @@ impl ExternalSorter {
             let tracking_metrics = self
                 .metrics_set
                 .new_final_tracking(partition, self.runtime.clone());
-            Ok(Box::pin(SortPreservingMergeStream::new_from_streams(
+            Ok(merge_streams(
                 streams,
                 self.schema.clone(),
                 &self.expr,
                 tracking_metrics,
                 self.session_config.batch_size(),
-            )?))
+            )?)
         } else if in_mem_batches.len() > 0 {
             let tracking_metrics = self
                 .metrics_set

--- a/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -19,11 +19,8 @@
 
 use std::any::Any;
 use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-use arrow::error::ArrowError;
 use arrow::row::{RowConverter, SortField};
 use arrow::{
     array::{make_array as make_arrow_array, MutableArrayData},
@@ -32,7 +29,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use futures::stream::{Fuse, FusedStream};
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use log::debug;
 use tokio::sync::mpsc;
 
@@ -42,11 +39,11 @@ use crate::physical_plan::metrics::{
     ExecutionPlanMetricsSet, MemTrackingMetrics, MetricsSet,
 };
 use crate::physical_plan::sorts::{RowIndex, SortKeyCursor, SortedStream};
-use crate::physical_plan::stream::RecordBatchReceiverStream;
+use crate::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
 use crate::physical_plan::{
     common::spawn_execution, expressions::PhysicalSortExpr, DisplayFormatType,
-    Distribution, ExecutionPlan, Partitioning, PhysicalExpr, RecordBatchStream,
-    SendableRecordBatchStream, Statistics,
+    Distribution, ExecutionPlan, Partitioning, PhysicalExpr, SendableRecordBatchStream,
+    Statistics,
 };
 use datafusion_physical_expr::EquivalenceProperties;
 
@@ -224,13 +221,13 @@ impl ExecutionPlan for SortPreservingMergeExec {
 
                 debug!("Done setting up sender-receiver for SortPreservingMergeExec::execute");
 
-                let result = Box::pin(SortPreservingMergeStream::new_from_streams(
+                let result = merge_streams(
                     receivers,
                     schema,
                     &self.expr,
                     tracking_metrics,
                     context.session_config().batch_size(),
-                )?);
+                )?;
 
                 debug!("Got stream result from SortPreservingMergeStream::new_from_receivers");
 
@@ -261,41 +258,35 @@ impl ExecutionPlan for SortPreservingMergeExec {
     }
 }
 
-struct MergingStreams {
-    /// The sorted input streams to merge together
-    streams: Vec<Fuse<SendableRecordBatchStream>>,
-    /// number of streams
-    num_streams: usize,
+pub(crate) fn merge_streams(
+    streams: Vec<SortedStream>,
+    schema: SchemaRef,
+    expressions: &[PhysicalSortExpr],
+    tracking_metrics: MemTrackingMetrics,
+    batch_size: usize,
+) -> Result<SendableRecordBatchStream> {
+    let stream = SortPreservingMergeStream::new_from_streams(
+        streams,
+        Arc::clone(&schema),
+        expressions,
+        tracking_metrics,
+        batch_size,
+    )?;
+
+    let stream = futures::stream::unfold(stream, |mut stream| async move {
+        let r = stream.next().await.transpose()?;
+        Some((r, stream))
+    });
+
+    Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
 }
 
-impl std::fmt::Debug for MergingStreams {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MergingStreams")
-            .field("num_streams", &self.num_streams)
-            .finish()
-    }
-}
-
-impl MergingStreams {
-    fn new(input_streams: Vec<Fuse<SendableRecordBatchStream>>) -> Self {
-        Self {
-            num_streams: input_streams.len(),
-            streams: input_streams,
-        }
-    }
-
-    fn num_streams(&self) -> usize {
-        self.num_streams
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct SortPreservingMergeStream {
+struct SortPreservingMergeStream {
     /// The schema of the RecordBatches yielded by this stream
     schema: SchemaRef,
 
     /// The sorted input streams to merge together
-    streams: MergingStreams,
+    streams: Vec<Fuse<SendableRecordBatchStream>>,
 
     /// For each input stream maintain a dequeue of RecordBatches
     ///
@@ -312,9 +303,6 @@ pub(crate) struct SortPreservingMergeStream {
     /// used to record execution metrics
     tracking_metrics: MemTrackingMetrics,
 
-    /// If the stream has encountered an error
-    aborted: bool,
-
     /// An id to uniquely identify the input stream batch
     next_batch_id: usize,
 
@@ -327,9 +315,6 @@ pub(crate) struct SortPreservingMergeStream {
     /// the loser nodes
     loser_tree: Vec<usize>,
 
-    /// Identify whether the loser tree is adjusted
-    loser_tree_adjusted: bool,
-
     /// target batch size
     batch_size: usize,
 
@@ -338,7 +323,7 @@ pub(crate) struct SortPreservingMergeStream {
 }
 
 impl SortPreservingMergeStream {
-    pub(crate) fn new_from_streams(
+    fn new_from_streams(
         streams: Vec<SortedStream>,
         schema: SchemaRef,
         expressions: &[PhysicalSortExpr],
@@ -351,7 +336,7 @@ impl SortPreservingMergeStream {
             .map(|_| VecDeque::new())
             .collect();
         tracking_metrics.init_mem_used(streams.iter().map(|s| s.mem_used).sum());
-        let wrappers = streams.into_iter().map(|s| s.stream.fuse()).collect();
+        let streams = streams.into_iter().map(|s| s.stream.fuse()).collect();
 
         let sort_fields = expressions
             .iter()
@@ -365,93 +350,104 @@ impl SortPreservingMergeStream {
         Ok(Self {
             schema,
             batches,
-            streams: MergingStreams::new(wrappers),
+            streams,
             column_expressions: expressions.iter().map(|x| x.expr.clone()).collect(),
             tracking_metrics,
-            aborted: false,
             in_progress: vec![],
             next_batch_id: 0,
             cursors: (0..stream_count).into_iter().map(|_| None).collect(),
             loser_tree: Vec::with_capacity(stream_count),
-            loser_tree_adjusted: false,
             batch_size,
             row_converter,
         })
     }
 
+    /// Initializes the loser tree
+    async fn init_loser_tree(&mut self) -> ArrowResult<()> {
+        let num_streams = self.streams.len();
+        // Ensure all non-exhausted streams have a cursor from which
+        // rows can be pulled
+        for idx in 0..num_streams {
+            self.poll_stream(idx).await?;
+        }
+
+        // Init loser tree
+        self.loser_tree.resize(num_streams, usize::MAX);
+        for i in 0..num_streams {
+            let mut winner = i;
+            let mut cmp_node = (num_streams + i) / 2;
+            while cmp_node != 0 && self.loser_tree[cmp_node] != usize::MAX {
+                let challenger = self.loser_tree[cmp_node];
+
+                let challenger_win =
+                    match (&self.cursors[winner], &self.cursors[challenger]) {
+                        (None, _) => true,
+                        (_, None) => false,
+                        (Some(winner), Some(challenger)) => challenger < winner,
+                    };
+                if challenger_win {
+                    self.loser_tree[cmp_node] = winner;
+                    winner = challenger;
+                } else {
+                    self.loser_tree[cmp_node] = challenger;
+                }
+                cmp_node /= 2;
+            }
+            self.loser_tree[cmp_node] = winner;
+        }
+        Ok(())
+    }
+
     /// If the stream at the given index is not exhausted, and the last cursor for the
     /// stream is finished, poll the stream for the next RecordBatch and create a new
     /// cursor for the stream from the returned result
-    fn maybe_poll_stream(
-        &mut self,
-        cx: &mut Context<'_>,
-        idx: usize,
-    ) -> Poll<ArrowResult<()>> {
+    async fn poll_stream(&mut self, idx: usize) -> ArrowResult<()> {
         if self.cursors[idx]
             .as_ref()
             .map(|cursor| !cursor.is_finished())
             .unwrap_or(false)
         {
             // Cursor is not finished - don't need a new RecordBatch yet
-            return Poll::Ready(Ok(()));
+            return Ok(());
         }
-        let mut empty_batch = false;
-        {
-            let stream = &mut self.streams.streams[idx];
-            if stream.is_terminated() {
-                return Poll::Ready(Ok(()));
+
+        let stream = &mut self.streams[idx];
+        if stream.is_terminated() {
+            return Ok(());
+        }
+
+        while let Some(batch) = stream.next().await.transpose()? {
+            if batch.num_rows() == 0 {
+                continue;
             }
 
-            // Fetch a new input record and create a cursor from it
-            match futures::ready!(stream.poll_next_unpin(cx)) {
-                None => return Poll::Ready(Ok(())),
-                Some(Err(e)) => {
-                    return Poll::Ready(Err(e));
-                }
-                Some(Ok(batch)) => {
-                    if batch.num_rows() > 0 {
-                        let cols = self
-                            .column_expressions
-                            .iter()
-                            .map(|expr| {
-                                Ok(expr.evaluate(&batch)?.into_array(batch.num_rows()))
-                            })
-                            .collect::<Result<Vec<_>>>()?;
+            let cols = self
+                .column_expressions
+                .iter()
+                .map(|expr| Ok(expr.evaluate(&batch)?.into_array(batch.num_rows())))
+                .collect::<Result<Vec<_>>>()?;
 
-                        let rows = match self.row_converter.convert_columns(&cols) {
-                            Ok(rows) => rows,
-                            Err(e) => {
-                                return Poll::Ready(Err(ArrowError::ExternalError(
-                                    Box::new(e),
-                                )));
-                            }
-                        };
-
-                        self.cursors[idx] = Some(SortKeyCursor::new(
-                            idx,
-                            self.next_batch_id, // assign this batch an ID
-                            rows,
-                        ));
-                        self.next_batch_id += 1;
-                        self.batches[idx].push_back(batch)
-                    } else {
-                        empty_batch = true;
-                    }
-                }
-            }
+            let rows = self.row_converter.convert_columns(&cols)?;
+            self.cursors[idx] = Some(SortKeyCursor::new(
+                idx,
+                self.next_batch_id, // assign this batch an ID
+                rows,
+            ));
+            self.next_batch_id += 1;
+            self.batches[idx].push_back(batch);
+            break;
         }
-
-        if empty_batch {
-            self.maybe_poll_stream(cx, idx)
-        } else {
-            Poll::Ready(Ok(()))
-        }
+        Ok(())
     }
 
     /// Drains the in_progress row indexes, and builds a new RecordBatch from them
     ///
     /// Will then drop any batches for which all rows have been yielded to the output
-    fn build_record_batch(&mut self) -> ArrowResult<RecordBatch> {
+    fn build_record_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+        if self.in_progress.is_empty() {
+            return Ok(None);
+        }
+
         // Mapping from stream index to the index of the first buffer from that stream
         let mut buffer_idx = 0;
         let mut stream_to_buffer_idx = Vec::with_capacity(self.batches.len());
@@ -533,138 +529,59 @@ impl SortPreservingMergeStream {
             }
         }
 
-        RecordBatch::try_new(self.schema.clone(), columns)
+        let batch = RecordBatch::try_new(self.schema.clone(), columns)?;
+        self.tracking_metrics.record_output(batch.num_rows());
+        Ok(Some(batch))
     }
-}
 
-impl Stream for SortPreservingMergeStream {
-    type Item = ArrowResult<RecordBatch>;
+    /// Pops the next [`RowIndex`]
+    async fn pop_next_row(&mut self) -> ArrowResult<Option<RowIndex>> {
+        let mut winner = self.loser_tree[0];
+        let next = match self.cursors[winner].as_mut() {
+            Some(cursor) if !cursor.is_finished() => RowIndex {
+                stream_idx: cursor.stream_idx(),
+                batch_idx: self.batches[cursor.stream_idx()].len() - 1,
+                row_idx: cursor.advance(),
+            },
+            _ => return Ok(None),
+        };
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let poll = self.poll_next_inner(cx);
-        self.tracking_metrics.record_poll(poll)
-    }
-}
+        self.poll_stream(winner).await?;
 
-impl SortPreservingMergeStream {
-    #[inline]
-    fn poll_next_inner(
-        self: &mut Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
-        if self.aborted {
-            return Poll::Ready(None);
+        let mut cmp_node = (self.streams.len() + winner) / 2;
+        while cmp_node != 0 {
+            let challenger = self.loser_tree[cmp_node];
+            let challenger_win = match (&self.cursors[winner], &self.cursors[challenger])
+            {
+                (None, _) => true,
+                (_, None) => false,
+                (Some(winner), Some(challenger)) => challenger < winner,
+            };
+            if challenger_win {
+                self.loser_tree[cmp_node] = winner;
+                winner = challenger;
+            }
+            cmp_node /= 2;
         }
-        let num_streams = self.streams.num_streams();
+        self.loser_tree[0] = winner;
 
+        Ok(Some(next))
+    }
+
+    /// Builds the next batch from the in progress state
+    async fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
         // Init all cursors and the loser tree in the first poll
         if self.loser_tree.is_empty() {
-            // Ensure all non-exhausted streams have a cursor from which
-            // rows can be pulled
-            for i in 0..num_streams {
-                match futures::ready!(self.maybe_poll_stream(cx, i)) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        self.aborted = true;
-                        return Poll::Ready(Some(Err(e)));
-                    }
-                }
-            }
-
-            // Init loser tree
-            self.loser_tree.resize(num_streams, usize::MAX);
-            for i in 0..num_streams {
-                let mut winner = i;
-                let mut cmp_node = (num_streams + i) / 2;
-                while cmp_node != 0 && self.loser_tree[cmp_node] != usize::MAX {
-                    let challenger = self.loser_tree[cmp_node];
-                    let challenger_win =
-                        match (&self.cursors[winner], &self.cursors[challenger]) {
-                            (None, _) => true,
-                            (_, None) => false,
-                            (Some(winner), Some(challenger)) => challenger < winner,
-                        };
-                    if challenger_win {
-                        self.loser_tree[cmp_node] = winner;
-                        winner = challenger;
-                    } else {
-                        self.loser_tree[cmp_node] = challenger;
-                    }
-                    cmp_node /= 2;
-                }
-                self.loser_tree[cmp_node] = winner;
-            }
-            self.loser_tree_adjusted = true;
+            self.init_loser_tree().await?
         }
 
-        // NB timer records time taken on drop, so there are no
-        // calls to `timer.done()` below.
-        let elapsed_compute = self.tracking_metrics.elapsed_compute().clone();
-        let _timer = elapsed_compute.timer();
-
-        loop {
-            // Adjust the loser tree if necessary
-            if !self.loser_tree_adjusted {
-                let mut winner = self.loser_tree[0];
-                match futures::ready!(self.maybe_poll_stream(cx, winner)) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        self.aborted = true;
-                        return Poll::Ready(Some(Err(e)));
-                    }
-                }
-
-                let mut cmp_node = (num_streams + winner) / 2;
-                while cmp_node != 0 {
-                    let challenger = self.loser_tree[cmp_node];
-                    let challenger_win =
-                        match (&self.cursors[winner], &self.cursors[challenger]) {
-                            (None, _) => true,
-                            (_, None) => false,
-                            (Some(winner), Some(challenger)) => challenger < winner,
-                        };
-                    if challenger_win {
-                        self.loser_tree[cmp_node] = winner;
-                        winner = challenger;
-                    }
-                    cmp_node /= 2;
-                }
-                self.loser_tree[0] = winner;
-                self.loser_tree_adjusted = true;
-            }
-
-            let min_cursor_idx = self.loser_tree[0];
-            let next = self.cursors[min_cursor_idx]
-                .as_mut()
-                .filter(|cursor| !cursor.is_finished())
-                .map(|cursor| (cursor.stream_idx(), cursor.advance()));
-
-            if let Some((stream_idx, row_idx)) = next {
-                self.loser_tree_adjusted = false;
-                let batch_idx = self.batches[stream_idx].len() - 1;
-                self.in_progress.push(RowIndex {
-                    stream_idx,
-                    batch_idx,
-                    row_idx,
-                });
-                if self.in_progress.len() == self.batch_size {
-                    return Poll::Ready(Some(self.build_record_batch()));
-                }
-            } else if !self.in_progress.is_empty() {
-                return Poll::Ready(Some(self.build_record_batch()));
-            } else {
-                return Poll::Ready(None);
+        while let Some(next) = self.pop_next_row().await? {
+            self.in_progress.push(next);
+            if self.in_progress.len() == self.batch_size {
+                break;
             }
         }
-    }
-}
-
-impl RecordBatchStream for SortPreservingMergeStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        self.build_record_batch()
     }
 }
 
@@ -1260,7 +1177,7 @@ mod tests {
         let metrics = ExecutionPlanMetricsSet::new();
         let tracking_metrics = MemTrackingMetrics::new(&metrics, 0);
 
-        let merge_stream = SortPreservingMergeStream::new_from_streams(
+        let merge_stream = merge_streams(
             streams,
             batches.schema(),
             sort.as_slice(),
@@ -1269,7 +1186,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut merged = common::collect(Box::pin(merge_stream)).await.unwrap();
+        let mut merged = common::collect(merge_stream).await.unwrap();
 
         assert_eq!(merged.len(), 1);
         let merged = merged.remove(0);


### PR DESCRIPTION
_Draft as currently represents a non-trivial performance regression_

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Reworks SortPreservingMerge to use async instead of manual poll. This will make it easier to iterate on as I look to integrate the row format more comprehensively with it.


```
merge i64               time:   [8.3403 ms 8.3477 ms 8.3553 ms]
                        change: [+9.8691% +9.9888% +10.105%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

merge f64               time:   [8.4809 ms 8.4867 ms 8.4930 ms]
                        change: [+8.4317% +8.5771% +8.7138%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

merge utf8 low cardinality
                        time:   [5.3511 ms 5.3562 ms 5.3613 ms]
                        change: [+7.6734% +7.8124% +7.9371%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

merge utf8 high cardinality
                        time:   [9.0445 ms 9.0712 ms 9.0983 ms]
                        change: [+6.5674% +7.0497% +7.4911%] (p = 0.00 < 0.05)
                        Performance has regressed.

merge utf8 tuple        time:   [15.445 ms 15.508 ms 15.573 ms]
                        change: [+1.0406% +1.7112% +2.4312%] (p = 0.00 < 0.05)
                        Performance has regressed.

merge utf8 dictionary   time:   [5.2034 ms 5.2068 ms 5.2104 ms]
                        change: [+9.7946% +9.8948% +9.9914%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

merge utf8 dictionary tuple
                        time:   [7.6790 ms 7.6834 ms 7.6882 ms]
                        change: [+4.3158% +4.4152% +4.5234%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

merge mixed utf8 dictionary tuple
                        time:   [13.357 ms 13.366 ms 13.376 ms]
                        change: [+1.9315% +2.1712% +2.4107%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

merge mixed tuple       time:   [15.166 ms 15.226 ms 15.287 ms]
                        change: [+1.9570% +2.5373% +3.1653%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->