### PR TITLE
fix: remove TODOs linked to arrow#3147

### DIFF
--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -416,7 +416,9 @@ impl Accumulator for ApproxPercentileAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::size_of_val(self) + self.digest.size()
+            - std::mem::size_of_val(&self.digest)
+            + self.return_type.size()
+            - std::mem::size_of_val(&self.return_type)
     }
 }

--- a/datafusion/physical-expr/src/aggregate/array_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg.rs
@@ -155,9 +155,10 @@ impl Accumulator for ArrayAggAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::size_of_val(self) + ScalarValue::size_of_vec(&self.values)
             - std::mem::size_of_val(&self.values)
+            + self.datatype.size()
+            - std::mem::size_of_val(&self.datatype)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -158,9 +158,10 @@ impl Accumulator for DistinctArrayAggAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::size_of_val(self) + ScalarValue::size_of_hashset(&self.values)
             - std::mem::size_of_val(&self.values)
+            + self.datatype.size()
+            - std::mem::size_of_val(&self.datatype)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -220,7 +220,6 @@ impl Accumulator for DistinctCountAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::size_of_val(self)
             + (std::mem::size_of::<DistinctScalarValues>() * self.values.capacity())
             + self
@@ -231,6 +230,13 @@ impl Accumulator for DistinctCountAccumulator {
                 })
                 .sum::<usize>()
             + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
+            + self
+                .state_data_types
+                .iter()
+                .map(|dt| dt.size() - std::mem::size_of_val(dt))
+                .sum::<usize>()
+            + self.count_data_type.size()
+            - std::mem::size_of_val(&self.count_data_type)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -181,7 +181,6 @@ impl Accumulator for MedianAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::align_of_val(self)
             + (std::mem::size_of::<ArrayRef>() * self.all_values.capacity())
             + self
@@ -192,6 +191,8 @@ impl Accumulator for MedianAccumulator {
                         + array_ref.get_array_memory_size()
                 })
                 .sum::<usize>()
+            + self.data_type.size()
+            - std::mem::size_of_val(&self.data_type)
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -177,9 +177,10 @@ impl Accumulator for DistinctSumAccumulator {
     }
 
     fn size(&self) -> usize {
-        // TODO(crepererum): `DataType` is NOT fixed size, add `DataType::size` method to arrow (https://github.com/apache/arrow-rs/issues/3147)
         std::mem::size_of_val(self) + ScalarValue::size_of_hashset(&self.hash_values)
             - std::mem::size_of_val(&self.hash_values)
+            + self.data_type.size()
+            - std::mem::size_of_val(&self.data_type)
     }
 }
 


### PR DESCRIPTION
Arrow now offers `size` methods for `DataType` and `Field`, so these TODOs can be fixed.

# Which issue does this PR close?
\-

# Rationale for this change
Improve `size`/memory usage calculations within DF.

# What changes are included in this PR?
Include `Field` and `DataType` into size calcuations.

# Are these changes tested?
\-

# Are there any user-facing changes?
Size calculations are more accurate.