### PR TITLE
MINOR: add some comments about intended use of ChunkedStore

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/chunked_store.rs
+++ b/datafusion/core/src/physical_plan/file_format/chunked_store.rs
@@ -28,6 +28,13 @@ use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWrite, BufReader};
 
 /// Wraps a [`ObjectStore`] and makes its get response return chunks
+/// in a controllable manner.
+///
+/// A `ChunkedStore` makes the memory consumption and performance of
+/// the wrapped [`ObjectStore`] worse. It is intended for use within
+/// tests, to control the chunks in the produced output streams. For
+/// example, it is used to verify the delimiting logic in
+/// newline_delimited_stream.
 ///
 /// TODO: Upstream into object_store_rs
 #[derive(Debug)]


### PR DESCRIPTION
# Which issue does this PR close?

N/A
# Rationale for this change

There appeared to be confusion (maybe meta confusion) about the usecase for `ChunkedStream` on https://github.com/apache/arrow-datafusion/pull/4525


# What changes are included in this PR?

Add some docstrings (adapted from @tustvold  and @metesynnada 's comments on https://github.com/apache/arrow-datafusion/pull/4525) to `ChunkedStore`

# Are these changes tested?
Docstring only tests

# Are there any user-facing changes?
No