### PR TITLE
minor: Remove more clones from the planner 

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -51,11 +51,12 @@ impl Column {
     }
 
     /// Deserialize a fully qualified name string into a column
-    pub fn from_qualified_name(flat_name: &str) -> Self {
+    pub fn from_qualified_name(flat_name: impl Into<String>) -> Self {
+        let flat_name = flat_name.into();
         use sqlparser::tokenizer::Token;
 
         let dialect = sqlparser::dialect::GenericDialect {};
-        let mut tokenizer = sqlparser::tokenizer::Tokenizer::new(&dialect, flat_name);
+        let mut tokenizer = sqlparser::tokenizer::Tokenizer::new(&dialect, &flat_name);
         if let Ok(tokens) = tokenizer.tokenize() {
             if let [Token::Word(relation), Token::Period, Token::Word(name)] =
                 tokens.as_slice()
@@ -70,7 +71,7 @@ impl Column {
         // name
         Column {
             relation: None,
-            name: String::from(flat_name),
+            name: flat_name,
         }
     }
 
@@ -141,6 +142,20 @@ impl Column {
 
 impl From<&str> for Column {
     fn from(c: &str) -> Self {
+        Self::from_qualified_name(c)
+    }
+}
+
+/// Create a column, cloning the string
+impl From<&String> for Column {
+    fn from(c: &String) -> Self {
+        Self::from_qualified_name(c)
+    }
+}
+
+/// Create a column, reusing the existing string
+impl From<String> for Column {
+    fn from(c: String) -> Self {
         Self::from_qualified_name(c)
     }
 }

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -25,11 +25,17 @@ use crate::{
     ScalarFunctionImplementation, ScalarUDF, Signature, StateTypeFunction, Volatility,
 };
 use arrow::datatypes::DataType;
-use datafusion_common::Result;
+use datafusion_common::{Column, Result};
 use std::sync::Arc;
 
 /// Create a column expression based on a qualified or unqualified column name
-pub fn col(ident: &str) -> Expr {
+///
+/// example:
+/// ```
+/// # use datafusion_expr::col;
+/// let c = col("my_column");
+/// ```
+pub fn col(ident: impl Into<Column>) -> Expr {
     Expr::Column(ident.into())
 }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -306,7 +306,7 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply an alias
-    pub fn alias(&self, alias: &str) -> Result<Self> {
+    pub fn alias(&self, alias: impl Into<String>) -> Result<Self> {
         Ok(Self::from(subquery_alias(&self.plan, alias)?))
     }
 
@@ -977,7 +977,10 @@ pub fn project(
 }
 
 /// Create a SubqueryAlias to wrap a LogicalPlan.
-pub fn subquery_alias(plan: &LogicalPlan, alias: &str) -> Result<LogicalPlan> {
+pub fn subquery_alias(
+    plan: &LogicalPlan,
+    alias: impl Into<String>,
+) -> Result<LogicalPlan> {
     Ok(LogicalPlan::SubqueryAlias(SubqueryAlias::try_new(
         plan.clone(),
         alias,

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1965,7 +1965,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             SQLExpr::MapAccess { column, keys } => {
                 if let SQLExpr::Identifier(id) = *column {
-                    plan_indexed(col(&normalize_ident(id)), keys)
+                    plan_indexed(col(normalize_ident(id)), keys)
                 } else {
                     Err(DataFusionError::NotImplemented(format!(
                         "map access requires an identifier, found column {} instead",


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/arrow-datafusion/pull/4534~

# Which issue does this PR close?

N/A
# Rationale for this change

Less cloning is better

# What changes are included in this PR?

Allow `subquery_alias` and `subquery_alias_owned` to take an existing `String` rather than always copying  it

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?
No