### PR TITLE
Fix date_part/extract functions to support now()

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1296,6 +1296,7 @@ async fn test_extract_date_part() -> Result<()> {
         "EXTRACT(microsecond FROM to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
         "12123456.78"
     );
+    // Depends on https://github.com/apache/arrow-datafusion/issues/4528
     // test_expression!(
     //     "EXTRACT(nanosecond FROM to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
     //     "1212345678"
@@ -1316,6 +1317,81 @@ async fn test_extract_date_part() -> Result<()> {
         "date_part('nanosecond', to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
         "12123456780"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_extract_date_part_func() -> Result<()> {
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "year"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "quarter"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "month"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "week"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!("(date_part('{0}', now()) = EXTRACT({0} FROM now()))", "day"),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "hour"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "minute"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "second"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "millisecond"
+        ),
+        "true"
+    );
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "microsecond"
+        ),
+        "true"
+    );
+    // Depends on https://github.com/apache/arrow-datafusion/issues/4528
+    //test_expression!(format!("(date_part('{0}', now()) = EXTRACT({0} FROM now()))", "nanosecond"), "true");
+
     Ok(())
 }
 

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -474,6 +474,10 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
                 ]),
+                TypeSignature::Exact(vec![
+                    DataType::Utf8,
+                    DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".to_owned())),
+                ]),
             ],
             fun.volatility(),
         ),

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -413,7 +413,7 @@ macro_rules! extract_date_part {
                 Ok($FN(array)
                     .map(|v| cast(&(Arc::new(v) as ArrayRef), &DataType::Float64))?)
             }
-            DataType::Timestamp(time_unit, None) => match time_unit {
+            DataType::Timestamp(time_unit, _) => match time_unit {
                 TimeUnit::Second => {
                     let array = as_timestamp_second_array($ARRAY)?;
                     Ok($FN(array)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3096.

# Rationale for this change

See #3096 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Bugfix for extract/date_part to work with functions  

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->