### PR TITLE
Minor: Fix logical conflict

### DIFF
--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -557,7 +557,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     runtime,
                     extension_codec
                 )?;
-                Ok(Arc::new(CrossJoinExec::try_new(left, right)?))
+                Ok(Arc::new(CrossJoinExec::new(left, right)))
             }
             PhysicalPlanType::Empty(empty) => {
                 let schema = Arc::new(convert_required!(empty.schema)?);


### PR DESCRIPTION
# Which issue does this PR close?

N/a

# Rationale for this change

https://github.com/apache/arrow-datafusion/pull/4432 had a logical conflict (and I didn't recheck it)

First master CI faillure: https://github.com/apache/arrow-datafusion/actions/runs/3657087583/jobs/6180276339

```

    Checking datafusion-benchmarks v15.0.0 (/__w/arrow-datafusion/arrow-datafusion/benchmarks)
error[E0599]: no function or associated item named `try_new` found for struct `CrossJoinExec` in the current scope
   --> datafusion/proto/src/physical_plan/mod.rs:560:44
    |
560 |                 Ok(Arc::new(CrossJoinExec::try_new(left, right)?))
    |                                            ^^^^^^^ function or associated item not found in `CrossJoinExec`

```


# What changes are included in this PR?

Fix compilation of datafusion-proto

# Are these changes tested?
yes