### PR TITLE
Avoid materializing local varaibles when creating `sortMergeJoinExec`

### DIFF
--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -113,33 +113,21 @@ impl SortMergeJoinExec {
             )));
         }
 
-        let (left_expr, right_expr): (Vec<_>, Vec<_>) = on
+        let (left_sort_exprs, right_sort_exprs): (Vec<_>, Vec<_>) = on
             .iter()
-            .map(|(l, r)| {
-                (
-                    Arc::new(l.clone()) as Arc<dyn PhysicalExpr>,
-                    Arc::new(r.clone()) as Arc<dyn PhysicalExpr>,
-                )
+            .zip(sort_options.iter())
+            .map(|((l, r), sort_op)| {
+                let left = PhysicalSortExpr {
+                    expr: Arc::new(l.clone()) as Arc<dyn PhysicalExpr>,
+                    options: *sort_op,
+                };
+                let right = PhysicalSortExpr {
+                    expr: Arc::new(r.clone()) as Arc<dyn PhysicalExpr>,
+                    options: *sort_op,
+                };        
+                (left, right)
             })
             .unzip();
-
-        let left_sort_exprs = left_expr
-            .into_iter()
-            .zip(sort_options.iter())
-            .map(|(k, sort_op)| PhysicalSortExpr {
-                expr: k,
-                options: *sort_op,
-            })
-            .collect::<Vec<_>>();
-
-        let right_sort_exprs = right_expr
-            .into_iter()
-            .zip(sort_options.iter())
-            .map(|(k, sort_op)| PhysicalSortExpr {
-                expr: k,
-                options: *sort_op,
-            })
-            .collect::<Vec<_>>();
 
         let output_ordering = match join_type {
             JoinType::Inner

--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -124,7 +124,7 @@ impl SortMergeJoinExec {
                 let right = PhysicalSortExpr {
                     expr: Arc::new(r.clone()) as Arc<dyn PhysicalExpr>,
                     options: *sort_op,
-                };        
+                };
                 (left, right)
             })
             .unzip();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Remove the local variable `left_expr` and `right_expr` to reduce memory usage and avoid iterating twice.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->