### PR TITLE
Update sqlparser requirement from 0.27 to 0.28

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -2216,9 +2216,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba319938d4bfe250a769ac88278b629701024fe16f34257f9563bc628081970"
+checksum = "249ae674b9f636b8ff64d8bfe218774cf05a26de40fd9f358669dccc4c0a9d7d"
 dependencies = [
  "log",
 ]

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -46,4 +46,4 @@ cranelift-module = { version = "0.89.0", optional = true }
 object_store = { version = "0.5.0", default-features = false, optional = true }
 parquet = { version = "28.0.0", default-features = false, optional = true }
 pyo3 = { version = "0.17.1", optional = true }
-sqlparser = "0.27"
+sqlparser = "0.28"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -90,7 +90,7 @@ pyo3 = { version = "0.17.1", optional = true }
 rand = "0.8"
 rayon = { version = "1.5", optional = true }
 smallvec = { version = "1.6", features = ["union"] }
-sqlparser = "0.27"
+sqlparser = "0.28"
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"
@@ -110,7 +110,7 @@ env_logger = "0.10"
 parquet-test-utils = { path = "../../parquet-test-utils" }
 rstest = "0.16.0"
 sqllogictest = "0.9.0"
-sqlparser = "0.27"
+sqlparser = "0.28"
 test-utils = { path = "../../test-utils" }
 
 [[bench]]

--- a/datafusion/core/tests/sqllogictests/src/insert/mod.rs
+++ b/datafusion/core/tests/sqllogictests/src/insert/mod.rs
@@ -40,9 +40,9 @@ pub async fn insert(ctx: &SessionContext, insert_stmt: SQLStatement) -> Result<D
             table_reference = object_name_to_table_reference(table_name)?;
 
             // Todo: check columns match table schema
-            match &*source.body {
+            match *source.body {
                 SetExpr::Values(values) => {
-                    insert_values = values.0.clone();
+                    insert_values = values.rows;
                 }
                 _ => {
                     // Directly panic: make it easy to find the location of the error.

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -39,4 +39,4 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 arrow = { version = "28.0.0", default-features = false }
 datafusion-common = { path = "../common", version = "15.0.0" }
 log = "^0.4"
-sqlparser = "0.27"
+sqlparser = "0.28"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -41,4 +41,4 @@ arrow-schema = "28.0.0"
 datafusion-common = { path = "../common", version = "15.0.0" }
 datafusion-expr = { path = "../expr", version = "15.0.0" }
 log = "^0.4"
-sqlparser = "0.27"
+sqlparser = "0.28"


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/pull/4523

re https://github.com/apache/arrow-datafusion/issues/3944

# Rationale for this change

Get latest sqlparser to keep up with dependencies and get fix for https://github.com/apache/arrow-datafusion/issues/3944

# What changes are included in this PR?

1. Update dependency (thanks @dependabot!) 
2. Update code for API changes

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?

maybe https://github.com/apache/arrow-datafusion/issues/3944 is fixed. I will make a subsequent PR with some tests to cover that case