### PR TITLE
Preserve the TryCast expression in columnize_expr

### DIFF
--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -688,6 +688,10 @@ pub fn columnize_expr(e: Expr, input_schema: &DFSchema) -> Expr {
             expr: Box::new(columnize_expr(*expr, input_schema)),
             data_type,
         }),
+        Expr::TryCast { expr, data_type } => Expr::TryCast {
+            expr: Box::new(columnize_expr(*expr, input_schema)),
+            data_type,
+        },
         Expr::ScalarSubquery(_) => e.clone(),
         _ => match e.display_name() {
             Ok(name) => match input_schema.field_with_unqualified_name(&name) {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3367,6 +3367,16 @@ mod tests {
     }
 
     #[test]
+    fn try_cast_from_aggregation() {
+        quick_test(
+            "SELECT TRY_CAST(SUM(age) AS FLOAT) FROM person",
+            "Projection: TRY_CAST(SUM(person.age) AS Float32)\
+            \n  Aggregate: groupBy=[[]], aggr=[[SUM(person.age)]]\
+            \n    TableScan: person",
+        );
+    }
+
+    #[test]
     fn cast_to_invalid_decimal_type() {
         // precision == 0
         {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None
Related to pr #4137


# Rationale for this change
Generate a  logical plan for query :
  `SELECT TRY_CAST(SUM(age) AS FLOAT) FROM person`

    
**Expected plan:**
```
Projection: TRY_CAST(SUM(person.age) AS Float32)
     Aggregate: groupBy=[[]], aggr=[[SUM(person.age)]]
          TableScan: person
```

**Actual plan:**
```
Projection: SUM(person.age)
     Aggregate: groupBy=[[]], aggr=[[SUM(person.age)]]
          TableScan: person
```
The try_cast expression is dropped.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->