### PR TITLE
bugfix: just allow having use expr in `groupby` or `aggr`

### DIFF
--- a/datafusion/core/tests/sql/group_by.rs
+++ b/datafusion/core/tests/sql/group_by.rs
@@ -194,7 +194,7 @@ async fn csv_query_group_by_and_having_and_where() -> Result<()> {
 async fn csv_query_having_without_group_by() -> Result<()> {
     let ctx = SessionContext::new();
     register_aggregate_csv(&ctx).await?;
-    let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 HAVING c2 >= 4 AND c3 > 90";
+    let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 where c2 >= 4 AND c3 > 90";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+----+----+-----+",

--- a/datafusion/core/tests/sql/group_by.rs
+++ b/datafusion/core/tests/sql/group_by.rs
@@ -191,27 +191,6 @@ async fn csv_query_group_by_and_having_and_where() -> Result<()> {
 }
 
 #[tokio::test]
-async fn csv_query_having_without_group_by() -> Result<()> {
-    let ctx = SessionContext::new();
-    register_aggregate_csv(&ctx).await?;
-    let sql = "SELECT c1, c2, c3 FROM aggregate_test_100 where c2 >= 4 AND c3 > 90";
-    let actual = execute_to_batches(&ctx, sql).await;
-    let expected = vec![
-        "+----+----+-----+",
-        "| c1 | c2 | c3  |",
-        "+----+----+-----+",
-        "| c  | 4  | 123 |",
-        "| c  | 5  | 118 |",
-        "| d  | 4  | 102 |",
-        "| e  | 4  | 96  |",
-        "| e  | 4  | 97  |",
-        "+----+----+-----+",
-    ];
-    assert_batches_sorted_eq!(expected, &actual);
-    Ok(())
-}
-
-#[tokio::test]
 async fn csv_query_group_by_substr() -> Result<()> {
     let ctx = SessionContext::new();
     register_aggregate_csv(&ctx).await?;

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -1193,33 +1193,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .collect::<Result<Vec<Expr>>>()?;
 
         // process group by, aggregation or having
-        let (plan, mut select_exprs_post_aggr, having_expr_post_aggr) =
-            if !group_by_exprs.is_empty() || !aggr_exprs.is_empty() {
-                self.aggregate(
-                    plan,
-                    &select_exprs,
-                    having_expr_opt.as_ref(),
-                    group_by_exprs,
-                    aggr_exprs,
-                )?
-            } else {
-                if let Some(having_expr) = &having_expr_opt {
-                    let available_columns = select_exprs
-                        .iter()
-                        .map(|expr| expr_as_column_expr(expr, &plan))
-                        .collect::<Result<Vec<Expr>>>()?;
-
-                    // Ensure the HAVING expression is using only columns
-                    // provided by the SELECT.
-                    check_columns_satisfy_exprs(
-                        &available_columns,
-                        &[having_expr.clone()],
-                        "HAVING clause references column(s) not provided by the select",
-                    )?;
+        let (plan, mut select_exprs_post_aggr, having_expr_post_aggr) = if !group_by_exprs
+            .is_empty()
+            || !aggr_exprs.is_empty()
+        {
+            self.aggregate(
+                plan,
+                &select_exprs,
+                having_expr_opt.as_ref(),
+                group_by_exprs,
+                aggr_exprs,
+            )?
+        } else {
+            match having_expr_opt {
+                    Some(having_expr) => return Err(DataFusionError::Plan(
+                        format!("having_expr: {} must appear in the GROUP BY clause or be used in an aggregate function", having_expr))),
+                    None => (plan, select_exprs, having_expr_opt)
                 }
-
-                (plan, select_exprs, having_expr_opt)
-            };
+        };
 
         let plan = if let Some(having_expr_post_aggr) = having_expr_post_aggr {
             LogicalPlanBuilder::from(plan)
@@ -3641,10 +3632,11 @@ mod tests {
         let sql = "SELECT id, age
                    FROM person
                    HAVING age > 100 AND age < 200";
-        let expected = "Projection: person.id, person.age\
-                        \n  Filter: person.age > Int64(100) AND person.age < Int64(200)\
-                        \n    TableScan: person";
-        quick_test(sql, expected);
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert_eq!(
+            "Plan(\"having_expr: person.age > Int64(100) AND person.age < Int64(200) must appear in the GROUP BY clause or be used in an aggregate function\")",
+            format!("{:?}", err)
+        );
     }
 
     #[test]
@@ -3654,7 +3646,7 @@ mod tests {
                    HAVING first_name = 'M'";
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!(
-            "Plan(\"HAVING clause references column(s) not provided by the select: Expression person.first_name could not be resolved from available columns: person.id, person.age\")",
+            "Plan(\"having_expr: person.first_name = Utf8(\\\"M\\\") must appear in the GROUP BY clause or be used in an aggregate function\")",
             format!("{:?}", err)
         );
     }
@@ -3666,9 +3658,7 @@ mod tests {
                    HAVING age > 100";
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!(
-            "Plan(\"HAVING clause references column(s) not provided by the select: \
-            Expression person.age could not be resolved from available columns: \
-            person.id, person.age + Int64(1)\")",
+            "Plan(\"having_expr: person.age > Int64(100) must appear in the GROUP BY clause or be used in an aggregate function\")",
             format!("{:?}", err)
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4556 .

having just use expr in groupby/aggr

# Rationale for this change

```sql
pg

-- create
CREATE TABLE EMPLOYEE (
  empId INTEGER PRIMARY KEY,
  name TEXT NOT NULL,
  dept TEXT NOT NULL
);

-- insert
INSERT INTO EMPLOYEE VALUES (0001, 'Clark', 'Sales');

-- fetch 
SELECT empid FROM EMPLOYEE having empid = 0;

psql:commands.sql:15: ERROR:  column "employee.empid" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT empid FROM EMPLOYEE having empid = 0;
               ^
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->