### PR TITLE
Improve error handling for array downcasting

### DIFF
--- a/datafusion/physical-expr/src/unicode_expressions.rs
+++ b/datafusion/physical-expr/src/unicode_expressions.rs
@@ -22,27 +22,15 @@
 //! Unicode expressions
 
 use arrow::{
-    array::{ArrayRef, GenericStringArray, Int64Array, OffsetSizeTrait, PrimitiveArray},
+    array::{ArrayRef, GenericStringArray, OffsetSizeTrait, PrimitiveArray},
     datatypes::{ArrowNativeType, ArrowPrimitiveType},
 };
-use datafusion_common::{cast::as_generic_string_array, DataFusionError, Result};
+use datafusion_common::{cast::{as_int64_array, as_generic_string_array}, DataFusionError, Result};
 use hashbrown::HashMap;
 use std::cmp::Ordering;
 use std::sync::Arc;
-use std::{any::type_name, cmp::max};
+use std::{cmp::max};
 use unicode_segmentation::UnicodeSegmentation;
-
-macro_rules! downcast_arg {
-    ($ARG:expr, $NAME:expr, $ARRAY_TYPE:ident) => {{
-        $ARG.as_any().downcast_ref::<$ARRAY_TYPE>().ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "could not cast {} to {}",
-                $NAME,
-                type_name::<$ARRAY_TYPE>()
-            ))
-        })?
-    }};
-}
 
 /// Returns number of characters in the string.
 /// character_length('josé') = 4
@@ -72,7 +60,7 @@ where
 /// The implementation uses UTF-8 code points as characters
 pub fn left<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let string_array = as_generic_string_array::<T>(&args[0])?;
-    let n_array = downcast_arg!(args[1], "n", Int64Array);
+    let n_array = as_int64_array(&args[1])?;
     let result = string_array
         .iter()
         .zip(n_array.iter())
@@ -104,7 +92,7 @@ pub fn lpad<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let length_array = downcast_arg!(args[1], "length", Int64Array);
+            let length_array = as_int64_array(&args[1])?;
 
             let result = string_array
                 .iter()
@@ -140,7 +128,7 @@ pub fn lpad<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         3 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let length_array = downcast_arg!(args[1], "length", Int64Array);
+            let length_array = as_int64_array(&args[1])?;
             let fill_array = as_generic_string_array::<T>(&args[2])?;
 
             let result = string_array
@@ -216,7 +204,7 @@ pub fn reverse<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 /// The implementation uses UTF-8 code points as characters
 pub fn right<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let string_array = as_generic_string_array::<T>(&args[0])?;
-    let n_array = downcast_arg!(args[1], "n", Int64Array);
+    let n_array = as_int64_array(&args[1])?;
 
     let result = string_array
         .iter()
@@ -250,7 +238,7 @@ pub fn rpad<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let length_array = downcast_arg!(args[1], "length", Int64Array);
+            let length_array = as_int64_array(&args[1])?;
 
             let result = string_array
                 .iter()
@@ -285,7 +273,7 @@ pub fn rpad<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         3 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let length_array = downcast_arg!(args[1], "length", Int64Array);
+            let length_array = as_int64_array(&args[1])?;
             let fill_array = as_generic_string_array::<T>(&args[2])?;
 
             let result = string_array
@@ -376,7 +364,7 @@ pub fn substr<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let start_array = downcast_arg!(args[1], "start", Int64Array);
+            let start_array = as_int64_array(&args[1])?;
 
             let result = string_array
                 .iter()
@@ -397,8 +385,8 @@ pub fn substr<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         3 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
-            let start_array = downcast_arg!(args[1], "start", Int64Array);
-            let count_array = downcast_arg!(args[2], "count", Int64Array);
+            let start_array = as_int64_array(&args[1])?;
+            let count_array = as_int64_array(&args[2])?;
 
             let result = string_array
                 .iter()

--- a/datafusion/physical-expr/src/unicode_expressions.rs
+++ b/datafusion/physical-expr/src/unicode_expressions.rs
@@ -25,11 +25,13 @@ use arrow::{
     array::{ArrayRef, GenericStringArray, OffsetSizeTrait, PrimitiveArray},
     datatypes::{ArrowNativeType, ArrowPrimitiveType},
 };
-use datafusion_common::{cast::{as_int64_array, as_generic_string_array}, DataFusionError, Result};
+use datafusion_common::{
+    cast::{as_generic_string_array, as_int64_array},
+    DataFusionError, Result,
+};
 use hashbrown::HashMap;
-use std::cmp::Ordering;
+use std::cmp::{max, Ordering};
 use std::sync::Arc;
-use std::{cmp::max};
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Returns number of characters in the string.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3152 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I think this is the last PR in this series. There are still usages of `array.as_any().downcast_ref` but they are used in macros as generic downcasting. You can find them in the following screenshot. They seem OK to me. What is your opinion?

![image](https://user-images.githubusercontent.com/15185911/207149105-8508fb42-caca-4a8b-b0be-ea370d8ea98a.png)
# What changes are included in this PR?

Refactor parts where old casting schema is used.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->