### PR TITLE
Minor: Remove datafusion-core dev dependency from datafusion-sql

### DIFF
--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -42,6 +42,3 @@ datafusion-common = { path = "../common", version = "15.0.0" }
 datafusion-expr = { path = "../expr", version = "15.0.0" }
 log = "^0.4"
 sqlparser = "0.28"
-
-[dev-dependencies]
-datafusion = { path = "../core" }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3301,14 +3301,11 @@ fn ensure_any_column_reference_is_unambiguous(
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::array::ArrayRef;
-    use datafusion::prelude::SessionContext;
     use std::any::Any;
 
     use sqlparser::dialect::{Dialect, GenericDialect, HiveDialect, MySqlDialect};
 
     use datafusion_common::assert_contains;
-    use datafusion_expr::{create_udaf, Accumulator, AggregateState, Volatility};
 
     use super::*;
 
@@ -5318,64 +5315,6 @@ mod tests {
         \n  WindowAggr: windowExpr=[[APPROXMEDIAN(orders.qty) PARTITION BY [orders.order_id] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING]]\
         \n    TableScan: orders";
         quick_test(sql, expected);
-    }
-
-    #[test]
-    fn udaf_as_window_func() -> Result<()> {
-        #[derive(Debug)]
-        struct MyAccumulator;
-
-        impl Accumulator for MyAccumulator {
-            fn state(&self) -> Result<Vec<AggregateState>> {
-                unimplemented!()
-            }
-
-            fn update_batch(&mut self, _: &[ArrayRef]) -> Result<()> {
-                unimplemented!()
-            }
-
-            fn merge_batch(&mut self, _: &[ArrayRef]) -> Result<()> {
-                unimplemented!()
-            }
-
-            fn evaluate(&self) -> Result<ScalarValue> {
-                unimplemented!()
-            }
-
-            fn size(&self) -> usize {
-                unimplemented!()
-            }
-        }
-
-        let my_acc = create_udaf(
-            "my_acc",
-            DataType::Int32,
-            Arc::new(DataType::Int32),
-            Volatility::Immutable,
-            Arc::new(|_| Ok(Box::new(MyAccumulator))),
-            Arc::new(vec![DataType::Int32]),
-        );
-
-        let mut context = SessionContext::new();
-        context.register_table(
-            TableReference::Bare { table: "my_table" },
-            Arc::new(datafusion::datasource::empty::EmptyTable::new(Arc::new(
-                Schema::new(vec![
-                    Field::new("a", DataType::UInt32, false),
-                    Field::new("b", DataType::Int32, false),
-                ]),
-            ))),
-        )?;
-        context.register_udaf(my_acc);
-
-        let sql = "SELECT a, MY_ACC(b) OVER(PARTITION BY a) FROM my_table";
-        let expected = r#"Projection: my_table.a, AggregateUDF { name: "my_acc", signature: Signature { type_signature: Exact([Int32]), volatility: Immutable }, fun: "<FUNC>" }(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-  WindowAggr: windowExpr=[[AggregateUDF { name: "my_acc", signature: Signature { type_signature: Exact([Int32]), volatility: Immutable }, fun: "<FUNC>" }(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING]]
-    TableScan: my_table"#;
-
-        let plan = context.create_logical_plan(sql)?;
-        assert_eq!(format!("{:?}", plan), expected);
-        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Draft as it builds on https://github.com/apache/arrow-datafusion/pull/4553


# Which issue does this PR close?
re https://github.com/apache/arrow-datafusion/pull/4553

# Rationale for this change

https://github.com/apache/arrow-datafusion/pull/4553 adds a dependency that will slow down `cargo test -p datafusion-sql` as now the rest of datafusion must be compiled to run the tests


# What changes are included in this PR?
1. Move the `udaf_as_window_func` from `datafusion-sql` to sql_integration (which already depends on sql core)

# Are these changes tested?
Yes

# Are there any user-facing changes?
No