### PR TITLE
Remove ObjectStore from FileStream (#4533)

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/avro.rs
+++ b/datafusion/core/src/physical_plan/file_format/avro.rs
@@ -107,7 +107,7 @@ impl ExecutionPlan for AvroExec {
         use super::file_stream::FileStream;
         let object_store = context
             .runtime_env()
-            .object_store(&config.object_store_url)?;
+            .object_store(&self.base_config.object_store_url)?;
 
         let config = Arc::new(private::AvroConfig {
             schema: Arc::clone(&self.base_config.file_schema),

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -23,22 +23,18 @@
 
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
 use arrow::datatypes::SchemaRef;
 use arrow::{error::Result as ArrowResult, record_batch::RecordBatch};
+use datafusion_common::ScalarValue;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{ready, FutureExt, Stream, StreamExt};
-use object_store::ObjectStore;
-
-use datafusion_common::ScalarValue;
 
 use crate::datasource::listing::PartitionedFile;
 use crate::error::Result;
-use crate::execution::context::TaskContext;
 use crate::physical_plan::file_format::{
     FileMeta, FileScanConfig, PartitionColumnProjector,
 };
@@ -56,11 +52,7 @@ pub type FileOpenFuture =
 pub trait FileOpener: Unpin {
     /// Asynchronously open the specified file and return a stream
     /// of [`RecordBatch`]
-    fn open(
-        &self,
-        store: Arc<dyn ObjectStore>,
-        file_meta: FileMeta,
-    ) -> Result<FileOpenFuture>;
+    fn open(&self, file_meta: FileMeta) -> Result<FileOpenFuture>;
 }
 
 /// A stream that iterates record batch by record batch, file over file.
@@ -79,8 +71,6 @@ pub struct FileStream<F: FileOpener> {
     file_reader: F,
     /// The partition column projector
     pc_projector: PartitionColumnProjector,
-    /// the store from which to source the files.
-    object_store: Arc<dyn ObjectStore>,
     /// The stream state
     state: FileStreamState,
     /// File stream specific metrics
@@ -175,7 +165,6 @@ impl<F: FileOpener> FileStream<F> {
     pub fn new(
         config: &FileScanConfig,
         partition: usize,
-        context: Arc<TaskContext>,
         file_reader: F,
         metrics: ExecutionPlanMetricsSet,
     ) -> Result<Self> {
@@ -191,17 +180,12 @@ impl<F: FileOpener> FileStream<F> {
 
         let files = config.file_groups[partition].clone();
 
-        let object_store = context
-            .runtime_env()
-            .object_store(&config.object_store_url)?;
-
         Ok(Self {
             file_iter: files.into(),
             projected_schema,
             remain: config.limit,
             file_reader,
             pc_projector,
-            object_store,
             state: FileStreamState::Idle,
             file_stream_metrics: FileStreamMetrics::new(&metrics, partition),
             baseline_metrics: BaselineMetrics::new(&metrics, partition),
@@ -228,7 +212,7 @@ impl<F: FileOpener> FileStream<F> {
 
                     self.file_stream_metrics.time_opening.start();
 
-                    match self.file_reader.open(self.object_store.clone(), file_meta) {
+                    match self.file_reader.open(file_meta) {
                         Ok(future) => {
                             self.state = FileStreamState::Open {
                                 future,
@@ -339,11 +323,7 @@ mod tests {
     }
 
     impl FileOpener for TestOpener {
-        fn open(
-            &self,
-            _store: Arc<dyn ObjectStore>,
-            _file_meta: FileMeta,
-        ) -> Result<FileOpenFuture> {
+        fn open(&self, _file_meta: FileMeta) -> Result<FileOpenFuture> {
             let iterator = self.records.clone().into_iter().map(Ok);
             let stream = futures::stream::iter(iterator).boxed();
             Ok(futures::future::ready(Ok(stream)).boxed())
@@ -375,14 +355,8 @@ mod tests {
             output_ordering: None,
         };
 
-        let file_stream = FileStream::new(
-            &config,
-            0,
-            ctx.task_ctx(),
-            reader,
-            ExecutionPlanMetricsSet::new(),
-        )
-        .unwrap();
+        let file_stream =
+            FileStream::new(&config, 0, reader, ExecutionPlanMetricsSet::new()).unwrap();
 
         file_stream
             .map(|b| b.expect("No error expected in stream"))

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -320,7 +320,6 @@ impl ExecutionPlan for ParquetExec {
         let stream = FileStream::new(
             &self.base_config,
             partition_index,
-            ctx,
             opener,
             self.metrics.clone(),
         )?;
@@ -406,11 +405,7 @@ struct ParquetOpener {
 }
 
 impl FileOpener for ParquetOpener {
-    fn open(
-        &self,
-        _: Arc<dyn ObjectStore>,
-        file_meta: FileMeta,
-    ) -> Result<FileOpenFuture> {
+    fn open(&self, file_meta: FileMeta) -> Result<FileOpenFuture> {
         let file_range = file_meta.range.clone();
 
         let file_metrics = ParquetFileMetrics::new(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4533

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Reduces the coupling between ParquetExec and ObjectStore

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->