### PR TITLE
Remove the function `consume_token` from the parser

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -391,7 +391,7 @@ impl<'a> DFParser<'a> {
     }
 
     fn parse_has_options(&mut self) -> bool {
-        self.consume_token(&Token::make_keyword("OPTIONS"))
+        self.parser.parse_keyword(Keyword::OPTIONS)
     }
 
     //
@@ -417,17 +417,6 @@ impl<'a> DFParser<'a> {
         Ok(options)
     }
 
-    fn consume_token(&mut self, expected: &Token) -> bool {
-        let token = self.parser.peek_token().to_string().to_uppercase();
-        let token = Token::make_keyword(&token);
-        if token == *expected {
-            self.parser.next_token();
-            true
-        } else {
-            false
-        }
-    }
-
     fn parse_has_file_compression_type(&mut self) -> bool {
         self.parser
             .parse_keywords(&[Keyword::COMPRESSION, Keyword::TYPE])
@@ -439,7 +428,7 @@ impl<'a> DFParser<'a> {
     }
 
     fn parse_has_delimiter(&mut self) -> bool {
-        self.consume_token(&Token::make_keyword("DELIMITER"))
+        self.parser.parse_keyword(Keyword::DELIMITER)
     }
 
     fn parse_delimiter(&mut self) -> Result<char, ParserError> {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None. This is a follow-up of #4262.
I found there were some cases in the `parser.rs` where we made the `Keyword`s which have been provided by the `sqlparser`. So I remove them and use the `Keyword` in `sqlparser` instead.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->