### PR TITLE
[window function] support min max with self define sliding window and optimize segment tree .

### DIFF
--- a/datafusion/core/benches/window_query_sql.rs
+++ b/datafusion/core/benches/window_query_sql.rs
@@ -222,20 +222,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             })
         },
     );
-
-    c.bench_function(
-        "window order by, u64_narrow, sum functions",
-        |b| {
-            b.iter(|| {
-                query(
-                    ctx.clone(),
-                    "SELECT \
-                        SUM(u64_narrow) OVER (ORDER by u64_narrow desc ROWS BETWEEN 50 PRECEDING AND 50 FOLLOWING) \
-                    FROM t",
-                )
-            })
-        },
-    );
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/datafusion/core/benches/window_query_sql.rs
+++ b/datafusion/core/benches/window_query_sql.rs
@@ -222,6 +222,20 @@ fn criterion_benchmark(c: &mut Criterion) {
             })
         },
     );
+
+    c.bench_function(
+        "window order by, u64_narrow, sum functions",
+        |b| {
+            b.iter(|| {
+                query(
+                    ctx.clone(),
+                    "SELECT \
+                        SUM(u64_narrow) OVER (ORDER by u64_narrow desc ROWS BETWEEN 50 PRECEDING AND 50 FOLLOWING) \
+                    FROM t",
+                )
+            })
+        },
+    );
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -147,6 +147,17 @@ pub enum WindowFrameBound {
     Following(ScalarValue),
 }
 
+impl WindowFrameBound {
+    /// check the frame is UNBOUNDED or not
+    pub fn is_unbounded(&self) -> bool {
+        match self {
+            WindowFrameBound::Preceding(x) => x.eq(&ScalarValue::Null),
+            WindowFrameBound::CurrentRow => false,
+            WindowFrameBound::Following(x) => x.eq(&ScalarValue::Null),
+        }
+    }
+}
+
 impl TryFrom<ast::WindowFrameBound> for WindowFrameBound {
     type Error = DataFusionError;
 

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -185,7 +185,7 @@ enum WindowAccumulator {
     SegTree(SegmentTree),
 }
 
-// Only using segment tree in Min, Max, Sum with sliding window(Both left side and right side need to move)
+// Only using segment tree in Min, Max with sliding window(Both left side and right side need to move)
 fn need_use_segment_tree(
     frame: &Arc<WindowFrame>,
     agg: &Arc<dyn AggregateExpr>,

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -192,12 +192,10 @@ fn need_use_segment_tree(
 ) -> Option<Operator> {
     if !frame.start_bound.is_unbounded() && !frame.end_bound.is_unbounded() {
         let agg_any = agg.as_any();
-        if agg_any.downcast_ref::<expressions::Sum>().is_some() {
-            Some(Operator::Add)
+        if agg_any.downcast_ref::<expressions::Max>().is_some() {
+            Some(Operator::Max)
         } else if agg_any.downcast_ref::<expressions::Min>().is_some() {
             Some(Operator::Min)
-        } else if agg_any.downcast_ref::<expressions::Max>().is_some() {
-            Some(Operator::Max)
         } else {
             None
         }

--- a/datafusion/physical-expr/src/window/mod.rs
+++ b/datafusion/physical-expr/src/window/mod.rs
@@ -24,9 +24,9 @@ pub(crate) mod nth_value;
 pub(crate) mod partition_evaluator;
 pub(crate) mod rank;
 pub(crate) mod row_number;
+pub(crate) mod segment_tree;
 mod window_expr;
 mod window_frame_state;
-pub(crate) mod segment_tree;
 
 pub use aggregate::AggregateWindowExpr;
 pub use built_in::BuiltInWindowExpr;

--- a/datafusion/physical-expr/src/window/mod.rs
+++ b/datafusion/physical-expr/src/window/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod rank;
 pub(crate) mod row_number;
 mod window_expr;
 mod window_frame_state;
+pub(crate) mod segment_tree;
 
 pub use aggregate::AggregateWindowExpr;
 pub use built_in::BuiltInWindowExpr;

--- a/datafusion/physical-expr/src/window/segment_tree.rs
+++ b/datafusion/physical-expr/src/window/segment_tree.rs
@@ -128,10 +128,8 @@ mod tests {
         let rand_vals: Vec<i32> = (0..test_size)
             .map(|_| rng.gen_range(0..val_range))
             .collect();
-        let rand_scalar: Vec<ScalarValue> = rand_vals
-            .iter()
-            .map(|v| ScalarValue::from(v.clone()))
-            .collect();
+        let rand_scalar: Vec<ScalarValue> =
+            rand_vals.iter().map(|v| ScalarValue::from(*v)).collect();
 
         let segment_tree_min =
             SegmentTree::build(rand_scalar.clone(), Operator::Min, DataType::Int32)
@@ -148,11 +146,11 @@ mod tests {
 
             assert_eq!(
                 min_result,
-                ScalarValue::from(rand_vals[start..end].iter().min().unwrap().clone())
+                ScalarValue::from(*rand_vals[start..end].iter().min().unwrap())
             );
             assert_eq!(
                 max_result,
-                ScalarValue::from(rand_vals[start..end].iter().max().unwrap().clone())
+                ScalarValue::from(*rand_vals[start..end].iter().max().unwrap())
             );
         }
     }

--- a/datafusion/physical-expr/src/window/segment_tree.rs
+++ b/datafusion/physical-expr/src/window/segment_tree.rs
@@ -21,9 +21,9 @@ use datafusion_common::{DataFusionError, Result, ScalarValue};
 
 // A Enum that specifies which operator could use in segment tree.
 pub enum Operator {
-    ADD,
-    MIN,
-    MAX,
+    Add,
+    Min,
+    Max,
 }
 
 impl Operator {
@@ -33,9 +33,9 @@ impl Operator {
     // combine(a, combine(b, c))`.
     pub fn combine(&self, a: &ScalarValue, b: &ScalarValue) -> Result<ScalarValue> {
         match self {
-            Operator::ADD => a.add(b),
-            Operator::MIN => min(a, b),
-            Operator::MAX => max(a, b),
+            Operator::Add => a.add(b),
+            Operator::Min => min(a, b),
+            Operator::Max => max(a, b),
         }
     }
 }
@@ -88,9 +88,10 @@ impl SegmentTree {
 
     // Computes `a[l] op a[l+1] op ... op a[r-1]`.
     // Uses `O(log(len))` time.
-    // If `l >= r`, this method returns error.
+    // If `l > r`, this method returns error.
+    // If `l == r`, this method returns Null.
     pub fn query(&self, mut l: usize, mut r: usize) -> Result<ScalarValue> {
-        if l >= r {
+        if l >r {
             return Err(DataFusionError::Internal(
                 "Query SegmentTree l must <= r".to_string(),
             ));
@@ -135,14 +136,14 @@ mod tests {
             .collect();
 
         let segment_tree_add =
-            SegmentTree::build(rand_scalar.clone(), Operator::ADD, DataType::Int32)
+            SegmentTree::build(rand_scalar.clone(), Operator::Add, DataType::Int32)
                 .unwrap();
 
         let segment_tree_min =
-            SegmentTree::build(rand_scalar.clone(), Operator::MIN, DataType::Int32)
+            SegmentTree::build(rand_scalar.clone(), Operator::Min, DataType::Int32)
                 .unwrap();
         let segment_tree_max =
-            SegmentTree::build(rand_scalar, Operator::MAX, DataType::Int32).unwrap();
+            SegmentTree::build(rand_scalar, Operator::Max, DataType::Int32).unwrap();
 
         for _i in 0..1000 {
             let start: usize = rng.gen_range(0..test_size - 1);

--- a/datafusion/physical-expr/src/window/segment_tree.rs
+++ b/datafusion/physical-expr/src/window/segment_tree.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::aggregate::min_max::{max, min};
+use arrow_schema::DataType;
+use datafusion_common::{DataFusionError, Result, ScalarValue};
+
+// A Enum that specifies which operator could use in segment tree.
+pub enum Operator {
+    ADD,
+    MIN,
+    MAX,
+}
+
+impl Operator {
+    // The operation that is performed to combine two intervals in the segment tree.
+    //
+    // This function must be associative, that is `combine(combine(a, b), c) =
+    // combine(a, combine(b, c))`.
+    pub fn combine(&self, a: &ScalarValue, b: &ScalarValue) -> Result<ScalarValue> {
+        match self {
+            Operator::ADD => a.add(b),
+            Operator::MIN => min(a, b),
+            Operator::MAX => max(a, b),
+        }
+    }
+}
+// A segment tree is a binary tree where each node contains the combination of the
+// children under the operation.
+pub struct SegmentTree {
+    buf: Vec<ScalarValue>,
+    count: usize,
+    op: Operator,
+    data_type: DataType,
+}
+
+impl SegmentTree {
+    // Builds a tree using the given buffer with ScalarValues.
+    pub fn build(
+        mut buf: Vec<ScalarValue>,
+        op: Operator,
+        data_type: DataType,
+    ) -> Result<Self> {
+        let len = buf.len();
+        buf.reserve_exact(len);
+        for i in 0..len {
+            let clone = unsafe { buf.get_unchecked(i).clone() }; // SAFETY: will never out of bound.
+            buf.push(clone);
+        }
+        SegmentTree::build_inner(buf, op, data_type)
+    }
+
+    fn build_inner(
+        mut buf: Vec<ScalarValue>,
+        op: Operator,
+        data_type: DataType,
+    ) -> Result<Self> {
+        let len = buf.len();
+        let count = len >> 1;
+        if len & 1 == 1 {
+            panic!("SegmentTree::build_inner: odd size");
+        }
+        for i in (1..count).rev() {
+            let res = op.combine(&buf[i << 1], &buf[i << 1 | 1])?;
+            buf[i] = res;
+        }
+        Ok(SegmentTree {
+            buf,
+            count,
+            op,
+            data_type,
+        })
+    }
+
+    // Computes `a[l] op a[l+1] op ... op a[r-1]`.
+    // Uses `O(log(len))` time.
+    // If `l >= r`, this method returns error.
+    pub fn query(&self, mut l: usize, mut r: usize) -> Result<ScalarValue> {
+        if l >= r {
+            return Err(DataFusionError::Internal(
+                "Query SegmentTree l must <= r".to_string(),
+            ));
+        }
+        let mut res = ScalarValue::try_from(&self.data_type)?;
+        l += self.count;
+        r += self.count;
+        while l < r {
+            if l & 1 == 1 {
+                res = self.op.combine(&res, &self.buf[l])?;
+                l += 1;
+            }
+            if r & 1 == 1 {
+                r -= 1;
+                res = self.op.combine(&res, &self.buf[r])?;
+            }
+            l >>= 1;
+            r >>= 1;
+        }
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::window::segment_tree::{Operator, SegmentTree};
+    use arrow_schema::DataType;
+    use datafusion_common::ScalarValue;
+    use rand::Rng;
+
+    #[test]
+    fn test_query_segment_tree() {
+        let test_size = 1000;
+        let val_range = 10000;
+        let mut rng = rand::thread_rng();
+        let rand_vals: Vec<i32> = (0..test_size)
+            .map(|_| rng.gen_range(0..val_range))
+            .collect();
+        let rand_scalar: Vec<ScalarValue> = rand_vals
+            .iter()
+            .map(|v| ScalarValue::from(v.clone()))
+            .collect();
+
+        let segment_tree_add =
+            SegmentTree::build(rand_scalar.clone(), Operator::ADD, DataType::Int32)
+                .unwrap();
+
+        let segment_tree_min =
+            SegmentTree::build(rand_scalar.clone(), Operator::MIN, DataType::Int32)
+                .unwrap();
+        let segment_tree_max =
+            SegmentTree::build(rand_scalar, Operator::MAX, DataType::Int32).unwrap();
+
+        for _i in 0..1000 {
+            let start: usize = rng.gen_range(0..test_size - 1);
+            let end: usize = rng.gen_range(start + 1..test_size);
+
+            let add_result = segment_tree_add.query(start, end).unwrap();
+            let min_result = segment_tree_min.query(start, end).unwrap();
+            let max_result = segment_tree_max.query(start, end).unwrap();
+
+            assert_eq!(
+                add_result,
+                ScalarValue::from(rand_vals[start..end].iter().sum::<i32>())
+            );
+            assert_eq!(
+                min_result,
+                ScalarValue::from(rand_vals[start..end].iter().min().unwrap().clone())
+            );
+            assert_eq!(
+                max_result,
+                ScalarValue::from(rand_vals[start..end].iter().max().unwrap().clone())
+            );
+        }
+    }
+}

--- a/datafusion/physical-expr/src/window/segment_tree.rs
+++ b/datafusion/physical-expr/src/window/segment_tree.rs
@@ -21,7 +21,6 @@ use datafusion_common::{DataFusionError, Result, ScalarValue};
 
 // A Enum that specifies which operator could use in segment tree.
 pub enum Operator {
-    Add,
     Min,
     Max,
 }
@@ -33,7 +32,6 @@ impl Operator {
     // combine(a, combine(b, c))`.
     pub fn combine(&self, a: &ScalarValue, b: &ScalarValue) -> Result<ScalarValue> {
         match self {
-            Operator::Add => a.add(b),
             Operator::Min => min(a, b),
             Operator::Max => max(a, b),
         }
@@ -135,10 +133,6 @@ mod tests {
             .map(|v| ScalarValue::from(v.clone()))
             .collect();
 
-        let segment_tree_add =
-            SegmentTree::build(rand_scalar.clone(), Operator::Add, DataType::Int32)
-                .unwrap();
-
         let segment_tree_min =
             SegmentTree::build(rand_scalar.clone(), Operator::Min, DataType::Int32)
                 .unwrap();
@@ -149,14 +143,9 @@ mod tests {
             let start: usize = rng.gen_range(0..test_size - 1);
             let end: usize = rng.gen_range(start + 1..test_size);
 
-            let add_result = segment_tree_add.query(start, end).unwrap();
             let min_result = segment_tree_min.query(start, end).unwrap();
             let max_result = segment_tree_max.query(start, end).unwrap();
 
-            assert_eq!(
-                add_result,
-                ScalarValue::from(rand_vals[start..end].iter().sum::<i32>())
-            );
             assert_eq!(
                 min_result,
                 ScalarValue::from(rand_vals[start..end].iter().min().unwrap().clone())

--- a/datafusion/physical-expr/src/window/segment_tree.rs
+++ b/datafusion/physical-expr/src/window/segment_tree.rs
@@ -91,7 +91,7 @@ impl SegmentTree {
     // If `l > r`, this method returns error.
     // If `l == r`, this method returns Null.
     pub fn query(&self, mut l: usize, mut r: usize) -> Result<ScalarValue> {
-        if l >r {
+        if l > r {
             return Err(DataFusionError::Internal(
                 "Query SegmentTree l must <= r".to_string(),
             ));


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4603.

# Rationale for this change
There are three kind of window:

1. `RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`: compute once.
2. `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`:  use Aggregator  compute cumulative state
3. `ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING`:  need Aggregator support remove sub-state, for now `min_max` agg func not support this `remove` operator

From [paper](http://www.vldb.org/pvldb/vol8/p1058-leis.pdf) `For aggregate functions like min, max, count, and sum, the Segment Tree uses the obvious corresponding aggregate function`.

So i try to use `segment-tree` to support this.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes, also test result with spark-sql

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->