### PR TITLE
Add line that prevents display_name from being called on Wildcard

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1253,9 +1253,7 @@ fn create_name(e: &Expr) -> Result<String> {
         Expr::Sort { .. } => Err(DataFusionError::Internal(
             "Create name does not support sort expression".to_string(),
         )),
-        Expr::Wildcard => Err(DataFusionError::Internal(
-            "Create name does not support wildcard".to_string(),
-        )),
+        Expr::Wildcard => Ok("*".to_string()),
         Expr::QualifiedWildcard { .. } => Err(DataFusionError::Internal(
             "Create name does not support qualified wildcard".to_string(),
         )),

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -583,7 +583,6 @@ where
 fn name_for_alias(expr: &Expr) -> Result<String> {
     match expr {
         Expr::Sort { expr, .. } => name_for_alias(expr),
-        Expr::Wildcard => Ok("*".to_string()),
         expr => expr.display_name(),
     }
 }

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -583,6 +583,7 @@ where
 fn name_for_alias(expr: &Expr) -> Result<String> {
     match expr {
         Expr::Sort { expr, .. } => name_for_alias(expr),
+        Expr::Wildcard => Ok("*".to_string()),
         expr => expr.display_name(),
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4681.

# Rationale for this change

As detailed in the issue, there was a problem with `create_name()` being called on `Expr::Wildcard` in the `type_coercion` and `unwrap_cast_in_comparison` optimization rules, which eventually led to these optimization rules not being applied.

# What changes are included in this PR?

In the issue description, two different solutions were suggested. Here, I chose the first one, i.e. to add one line to the `name_for_alias` function, ensuring that we individualize the `Expr::Wildcard` case, and naming the expression in a reasonable way (e.g. "*") instead of calling `display_name()`.

# Are these changes tested?

No tests were added in this PR, but we tested the code with the suggested change on our own and the bug is solved, since the warnings are gone and the optimization rules are applied as intended.

# If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

We still want to hear what you think about the best way to solve the issue.

# If there are user-facing changes then we may require documentation to be updated before approving the PR.

No.

# If there are any breaking changes to public APIs, please add the `api change` label.

No.