### PR TITLE
Infer prepared statement parameter types

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -218,7 +218,7 @@ pub enum Expr {
         /// The identifier of the parameter (e.g, $1 or $foo)
         id: String,
         /// The type the parameter will be filled in with
-        data_type: DataType,
+        data_type: Option<DataType>,
     },
 }
 

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -24,7 +24,7 @@ use crate::type_coercion::binary::binary_operator_data_type;
 use crate::{aggregate_function, function, window_function};
 use arrow::compute::can_cast_types;
 use arrow::datatypes::DataType;
-use datafusion_common::{DFField, DFSchema, DataFusionError, ExprSchema, Result};
+use datafusion_common::{Column, DFField, DFSchema, DataFusionError, ExprSchema, Result};
 
 /// trait to allow expr to typable with respect to a schema
 pub trait ExprSchemable {
@@ -56,9 +56,14 @@ impl ExprSchemable for Expr {
     /// (e.g. `[utf8] + [bool]`).
     fn get_type<S: ExprSchema>(&self, schema: &S) -> Result<DataType> {
         match self {
-            Expr::Alias(expr, _)
-            | Expr::Sort(Sort { expr, .. })
-            | Expr::Negative(expr) => expr.get_type(schema),
+            Expr::Alias(expr, name) => match &**expr {
+                Expr::Placeholder { data_type, .. } => match &data_type {
+                    None => schema.data_type(&Column::from_name(name)).cloned(),
+                    Some(dt) => Ok(dt.clone()),
+                },
+                _ => expr.get_type(schema),
+            },
+            Expr::Sort(Sort { expr, .. }) | Expr::Negative(expr) => expr.get_type(schema),
             Expr::Column(c) => Ok(schema.data_type(c)?.clone()),
             Expr::ScalarVariable(ty, _) => Ok(ty.clone()),
             Expr::Literal(l) => Ok(l.get_datatype()),

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -128,7 +128,9 @@ impl ExprSchemable for Expr {
             Expr::Like { .. } | Expr::ILike { .. } | Expr::SimilarTo { .. } => {
                 Ok(DataType::Boolean)
             }
-            Expr::Placeholder { data_type, .. } => Ok(data_type.clone()),
+            Expr::Placeholder { data_type, .. } => data_type.clone().ok_or_else(|| {
+                DataFusionError::Plan("Placeholder type could not be resolved".to_owned())
+            }),
             Expr::Wildcard => Err(DataFusionError::Internal(
                 "Wildcard expressions are not valid in a logical query plan".to_owned(),
             )),

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -1325,13 +1325,13 @@ pub fn parse_expr(
             )))
         }
         ExprType::Placeholder(PlaceholderNode { id, data_type }) => match data_type {
-            None => {
-                let message = format!("Protobuf deserialization error: data type must be provided for the placeholder {id}");
-                Err(proto_error(message))
-            }
+            None => Ok(Expr::Placeholder {
+                id: id.clone(),
+                data_type: None,
+            }),
             Some(data_type) => Ok(Expr::Placeholder {
                 id: id.clone(),
-                data_type: data_type.try_into()?,
+                data_type: Some(data_type.try_into()?),
             }),
         },
     }

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -892,8 +892,17 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
                         .collect::<Result<Vec<_>, Self::Error>>()?,
                 })),
             },
-            Expr::Placeholder{ id, data_type } => Self {
-                expr_type: Some(ExprType::Placeholder(PlaceholderNode { id: id.clone(), data_type: Some(data_type.try_into()?) })),
+            Expr::Placeholder{ id, data_type } => {
+                let data_type = match data_type {
+                    Some(data_type) => Some(data_type.try_into()?),
+                    None => None,
+                };
+                Self {
+                    expr_type: Some(ExprType::Placeholder(PlaceholderNode {
+                        id: id.clone(),
+                        data_type,
+                    })),
+                }
             },
 
             Expr::QualifiedWildcard { .. } | Expr::TryCast { .. } =>

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -29,6 +29,7 @@ use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use crate::utils::normalize_ident;
 use arrow_schema::DataType;
 use datafusion_common::{Column, DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter};
 use datafusion_expr::{
     col, expr, lit, AggregateFunction, Between, BinaryExpr, BuiltinScalarFunction, Cast,
     Expr, ExprSchemable, GetIndexedField, Like, Operator, TryCast,
@@ -76,6 +77,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let mut expr = self.sql_expr_to_logical_expr(sql, schema, planner_context)?;
         expr = self.rewrite_partial_qualifier(expr, schema);
         self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
+        let expr = infer_placeholder_types(expr, schema.clone())?;
         Ok(expr)
     }
 
@@ -494,6 +496,52 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             )),
         }
     }
+}
+
+/// Find all `PlaceHolder` tokens in a logical plan, and try to infer their type from context
+fn infer_placeholder_types(expr: Expr, schema: DFSchema) -> Result<Expr> {
+    struct PlaceholderReplacer {
+        schema: DFSchema,
+    }
+
+    impl ExprRewriter for PlaceholderReplacer {
+        fn mutate(&mut self, expr: Expr) -> Result<Expr> {
+            let expr = match expr {
+                Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+                    let left = (*left).clone();
+                    let right = (*right).clone();
+                    let lt = left.get_type(&self.schema);
+                    let rt = right.get_type(&self.schema);
+                    let left = match (&left, rt) {
+                        (Expr::Placeholder { id, data_type }, Ok(dt)) => {
+                            Expr::Placeholder {
+                                id: id.clone(),
+                                data_type: Some(data_type.clone().unwrap_or(dt)),
+                            }
+                        }
+                        _ => left.clone(),
+                    };
+                    let right = match (&right, lt) {
+                        (Expr::Placeholder { id, data_type }, Ok(dt)) => {
+                            Expr::Placeholder {
+                                id: id.clone(),
+                                data_type: Some(data_type.clone().unwrap_or(dt)),
+                            }
+                        }
+                        _ => right.clone(),
+                    };
+                    Expr::BinaryExpr(BinaryExpr {
+                        left: Box::new(left),
+                        op,
+                        right: Box::new(right),
+                    })
+                }
+                _ => expr.clone(),
+            };
+            Ok(expr)
+        }
+    }
+    expr.rewrite(&mut PlaceholderReplacer { schema })
 }
 
 fn plan_key(key: SQLExpr) -> Result<ScalarValue> {

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -106,13 +106,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
         };
         // Check if the placeholder is in the parameter list
-        if param_data_types.len() <= idx {
-            return Err(DataFusionError::Internal(format!(
-                "Placehoder {param} does not exist in the parameter list: {param_data_types:?}"
-            )));
-        }
+        let param_type = param_data_types.get(idx);
         // Data type of the parameter
-        let param_type = param_data_types[idx].clone();
         debug!(
             "type of param {} param_data_types[idx]: {:?}",
             param, param_type
@@ -120,7 +115,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         Ok(Expr::Placeholder {
             id: param,
-            data_type: param_type,
+            data_type: param_type.cloned(),
         })
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4683.

# Rationale for this change

Described in issue.

# What changes are included in this PR?

1. Code in sql_to_rel to infer parameter type
2. A test for a particular type of statement with parameters
3. A method to get the inferred types

# Are these changes tested?

[x]

# Are there any user-facing changes?

FlightSQL implementers can respond with types.

# Additional Info

I'm opening this as a draft PR to discuss general approach. If folks are on board with it, I'll add support for a bunch more statement types and more tests.
