### PR TITLE
Avoid to bypass `try_new/new()` to build plan directly and cleanup filter

### DIFF
--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -83,11 +83,11 @@ impl OptimizerRule for MyRule {
         match plan {
             LogicalPlan::Filter(filter) => {
                 let mut expr_rewriter = MyExprRewriter {};
-                let predicate = filter.predicate().clone();
+                let predicate = filter.predicate.clone();
                 let predicate = predicate.rewrite(&mut expr_rewriter)?;
                 Ok(Some(LogicalPlan::Filter(Filter::try_new(
                     predicate,
-                    filter.input().clone(),
+                    filter.input,
                 )?)))
             }
             _ => Ok(Some(plan.clone())),

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -761,12 +761,12 @@ impl DefaultPhysicalPlanner {
                     )?))
                 }
                 LogicalPlan::Filter(filter) => {
-                    let physical_input = self.create_initial_plan(filter.input(), session_state).await?;
+                    let physical_input = self.create_initial_plan(&filter.input, session_state).await?;
                     let input_schema = physical_input.as_ref().schema();
-                    let input_dfschema = filter.input().schema();
+                    let input_dfschema = filter.input.schema();
 
                     let runtime_expr = self.create_physical_expr(
-                        filter.predicate(),
+                        &filter.predicate,
                         input_dfschema,
                         &input_schema,
                         session_state,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1382,16 +1382,6 @@ impl Filter {
             _ => plan_err!("Could not coerce into Filter!"),
         }
     }
-
-    /// Access the filter predicate expression
-    pub fn predicate(&self) -> &Expr {
-        &self.predicate
-    }
-
-    /// Access the filter input plan
-    pub fn input(&self) -> &Arc<LogicalPlan> {
-        &self.input
-    }
 }
 
 /// Window its input based on a set of window spec and window function (e.g. SUM or RANK)

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1235,6 +1235,8 @@ pub struct Values {
 /// Evaluates an arbitrary list of expressions (essentially a
 /// SELECT with an expression list) on its input.
 #[derive(Clone)]
+// mark non_exhaustive to encourage use of try_new/new()
+#[non_exhaustive]
 pub struct Projection {
     /// The list of expressions
     pub expr: Vec<Expr>,
@@ -1298,6 +1300,8 @@ impl Projection {
 
 /// Aliased subquery
 #[derive(Clone)]
+// mark non_exhaustive to encourage use of try_new/new()
+#[non_exhaustive]
 pub struct SubqueryAlias {
     /// The incoming logical plan
     pub input: Arc<LogicalPlan>,
@@ -1561,6 +1565,8 @@ pub struct Distinct {
 /// Aggregates its input based on a set of grouping and aggregate
 /// expressions (e.g. SUM).
 #[derive(Clone)]
+// mark non_exhaustive to encourage use of try_new/new()
+#[non_exhaustive]
 pub struct Aggregate {
     /// The incoming logical plan
     pub input: Arc<LogicalPlan>,

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -122,8 +122,8 @@ impl OptimizerRule for CommonSubexprEliminate {
                 )))
             }
             LogicalPlan::Filter(filter) => {
-                let input = filter.input();
-                let predicate = filter.predicate();
+                let input = &filter.input;
+                let predicate = &filter.predicate;
                 let input_schema = Arc::clone(input.schema());
                 let mut id_array = vec![];
                 expr_to_identifier(
@@ -136,7 +136,7 @@ impl OptimizerRule for CommonSubexprEliminate {
                 let (mut new_expr, new_input) = self.rewrite_expr(
                     &[&[predicate.clone()]],
                     &[&[id_array]],
-                    filter.input(),
+                    &filter.input,
                     &mut expr_set,
                     config,
                 )?;

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -106,6 +106,7 @@ impl OptimizerRule for CommonSubexprEliminate {
                 expr,
                 input,
                 schema,
+                ..
             }) => {
                 let input_schema = Arc::clone(input.schema());
                 let arrays = to_arrays(expr, input_schema, &mut expr_set)?;
@@ -179,6 +180,7 @@ impl OptimizerRule for CommonSubexprEliminate {
                 aggr_expr,
                 input,
                 schema,
+                ..
             }) => {
                 let input_schema = Arc::clone(input.schema());
                 let group_arrays =

--- a/datafusion/optimizer/src/decorrelate_where_exists.rs
+++ b/datafusion/optimizer/src/decorrelate_where_exists.rs
@@ -83,14 +83,14 @@ impl OptimizerRule for DecorrelateWhereExists {
         match plan {
             LogicalPlan::Filter(filter) => {
                 let (subqueries, other_exprs) =
-                    self.extract_subquery_exprs(filter.predicate(), config)?;
+                    self.extract_subquery_exprs(&filter.predicate, config)?;
                 if subqueries.is_empty() {
                     // regular filter, no subquery exists clause here
                     return Ok(None);
                 }
 
                 // iterate through all exists clauses in predicate, turning each into a join
-                let mut cur_input = filter.input().as_ref().clone();
+                let mut cur_input = filter.input.as_ref().clone();
                 for subquery in subqueries {
                     if let Some(x) = optimize_exists(&subquery, &cur_input, &other_exprs)?
                     {

--- a/datafusion/optimizer/src/decorrelate_where_exists.rs
+++ b/datafusion/optimizer/src/decorrelate_where_exists.rs
@@ -153,22 +153,21 @@ fn optimize_exists(
     .map_err(|e| context!("cannot optimize non-correlated subquery", e))?;
 
     // split into filters
-    let subqry_filter_exprs = split_conjunction(subqry_filter.predicate());
+    let subqry_filter_exprs = split_conjunction(&subqry_filter.predicate);
     verify_not_disjunction(&subqry_filter_exprs)?;
 
     // Grab column names to join on
     let (col_exprs, other_subqry_exprs) =
-        find_join_exprs(subqry_filter_exprs, subqry_filter.input().schema())?;
+        find_join_exprs(subqry_filter_exprs, subqry_filter.input.schema())?;
     let (outer_cols, subqry_cols, join_filters) =
-        exprs_to_join_cols(&col_exprs, subqry_filter.input().schema(), false)?;
+        exprs_to_join_cols(&col_exprs, subqry_filter.input.schema(), false)?;
     if subqry_cols.is_empty() || outer_cols.is_empty() {
         // cannot optimize non-correlated subquery
         return Ok(None);
     }
 
     // build subquery side of join - the thing the subquery was querying
-    let mut subqry_plan =
-        LogicalPlanBuilder::from(subqry_filter.input().as_ref().clone());
+    let mut subqry_plan = LogicalPlanBuilder::from(subqry_filter.input.as_ref().clone());
     if let Some(expr) = conjunction(other_subqry_exprs) {
         subqry_plan = subqry_plan.filter(expr)? // if the subquery had additional expressions, restore them
     }

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -87,14 +87,14 @@ impl OptimizerRule for DecorrelateWhereIn {
         match plan {
             LogicalPlan::Filter(filter) => {
                 let (subqueries, other_exprs) =
-                    self.extract_subquery_exprs(filter.predicate(), config)?;
+                    self.extract_subquery_exprs(&filter.predicate, config)?;
                 if subqueries.is_empty() {
                     // regular filter, no subquery exists clause here
                     return Ok(None);
                 }
 
                 // iterate through all exists clauses in predicate, turning each into a join
-                let mut cur_input = filter.input().as_ref().clone();
+                let mut cur_input = filter.input.as_ref().clone();
                 for subquery in subqueries {
                     cur_input =
                         optimize_where_in(&subquery, &cur_input, &other_exprs, config)?;

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -140,18 +140,18 @@ fn optimize_where_in(
     let mut other_subqry_exprs = vec![];
     if let LogicalPlan::Filter(subqry_filter) = (*subqry_input).clone() {
         // split into filters
-        let subqry_filter_exprs = split_conjunction(subqry_filter.predicate());
+        let subqry_filter_exprs = split_conjunction(&subqry_filter.predicate);
         verify_not_disjunction(&subqry_filter_exprs)?;
 
         // Grab column names to join on
         let (col_exprs, other_exprs) =
-            find_join_exprs(subqry_filter_exprs, subqry_filter.input().schema())
+            find_join_exprs(subqry_filter_exprs, subqry_filter.input.schema())
                 .map_err(|e| context!("column correlation not found", e))?;
         if !col_exprs.is_empty() {
             // it's correlated
-            subqry_input = subqry_filter.input().clone();
+            subqry_input = subqry_filter.input.clone();
             (outer_cols, subqry_cols, join_filters) =
-                exprs_to_join_cols(&col_exprs, subqry_filter.input().schema(), false)
+                exprs_to_join_cols(&col_exprs, subqry_filter.input.schema(), false)
                     .map_err(|e| context!("column correlation not found", e))?;
             other_subqry_exprs = other_exprs;
         }

--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -56,7 +56,7 @@ impl OptimizerRule for EliminateCrossJoin {
     ) -> Result<Option<LogicalPlan>> {
         match plan {
             LogicalPlan::Filter(filter) => {
-                let input = (**filter.input()).clone();
+                let input = filter.input.as_ref().clone();
 
                 let mut possible_join_keys: Vec<(Expr, Expr)> = vec![];
                 let mut all_inputs: Vec<LogicalPlan> = vec![];
@@ -80,7 +80,7 @@ impl OptimizerRule for EliminateCrossJoin {
                     }
                 }
 
-                let predicate = filter.predicate();
+                let predicate = &filter.predicate;
                 // join keys are handled locally
                 let mut all_join_keys: HashSet<(Expr, Expr)> = HashSet::new();
 

--- a/datafusion/optimizer/src/eliminate_outer_join.rs
+++ b/datafusion/optimizer/src/eliminate_outer_join.rs
@@ -68,12 +68,12 @@ impl OptimizerRule for EliminateOuterJoin {
         _config: &dyn OptimizerConfig,
     ) -> Result<Option<LogicalPlan>> {
         match plan {
-            LogicalPlan::Filter(filter) => match filter.input().as_ref() {
+            LogicalPlan::Filter(filter) => match filter.input.as_ref() {
                 LogicalPlan::Join(join) => {
                     let mut non_nullable_cols: Vec<Column> = vec![];
 
                     extract_non_nullable_columns(
-                        filter.predicate(),
+                        &filter.predicate,
                         &mut non_nullable_cols,
                         join.left.schema(),
                         join.right.schema(),

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -535,14 +535,14 @@ impl OptimizerRule for PushDownFilter {
             _ => return Ok(Some(utils::optimize_children(self, plan, config)?)),
         };
 
-        let child_plan = &**filter.input();
+        let child_plan = filter.input.as_ref();
         let new_plan = match child_plan {
             LogicalPlan::Filter(child_filter) => {
                 let new_predicate =
-                    and(filter.predicate().clone(), child_filter.predicate().clone());
+                    and(filter.predicate.clone(), child_filter.predicate.clone());
                 let new_plan = LogicalPlan::Filter(Filter::try_new(
                     new_predicate,
-                    child_filter.input().clone(),
+                    child_filter.input.clone(),
                 )?);
                 return self.try_optimize(&new_plan, config);
             }
@@ -572,7 +572,7 @@ impl OptimizerRule for PushDownFilter {
                     );
                 }
                 let new_predicate =
-                    replace_cols_by_name(filter.predicate().clone(), &replace_map)?;
+                    replace_cols_by_name(filter.predicate.clone(), &replace_map)?;
                 let new_filter = LogicalPlan::Filter(Filter::try_new(
                     new_predicate,
                     subquery_alias.input.clone(),
@@ -601,7 +601,7 @@ impl OptimizerRule for PushDownFilter {
                 // re-write all filters based on this projection
                 // E.g. in `Filter: b\n  Projection: a > 1 as b`, we can swap them, but the filter must be "a > 1"
                 let new_filter = LogicalPlan::Filter(Filter::try_new(
-                    replace_cols_by_name(filter.predicate().clone(), &replace_map)?,
+                    replace_cols_by_name(filter.predicate.clone(), &replace_map)?,
                     projection.input.clone(),
                 )?);
 
@@ -619,7 +619,7 @@ impl OptimizerRule for PushDownFilter {
                     }
 
                     let push_predicate =
-                        replace_cols_by_name(filter.predicate().clone(), &replace_map)?;
+                        replace_cols_by_name(filter.predicate.clone(), &replace_map)?;
                     inputs.push(Arc::new(LogicalPlan::Filter(Filter::try_new(
                         push_predicate,
                         input.clone(),
@@ -639,7 +639,7 @@ impl OptimizerRule for PushDownFilter {
                     .collect::<Result<HashSet<_>>>()?;
 
                 let predicates = utils::split_conjunction_owned(utils::cnf_rewrite(
-                    filter.predicate().clone(),
+                    filter.predicate.clone(),
                 ));
 
                 let mut keep_predicates = vec![];
@@ -672,11 +672,8 @@ impl OptimizerRule for PushDownFilter {
                     )?),
                     None => (*agg.input).clone(),
                 };
-                let new_agg = from_plan(
-                    filter.input(),
-                    &filter.input().expressions(),
-                    &vec![child],
-                )?;
+                let new_agg =
+                    from_plan(&filter.input, &filter.input.expressions(), &vec![child])?;
                 match conjunction(keep_predicates) {
                     Some(predicate) => LogicalPlan::Filter(Filter::try_new(
                         predicate,
@@ -686,24 +683,24 @@ impl OptimizerRule for PushDownFilter {
                 }
             }
             LogicalPlan::Join(join) => {
-                match push_down_join(filter.input(), join, Some(filter.predicate()))? {
+                match push_down_join(&filter.input, join, Some(&filter.predicate))? {
                     Some(optimized_plan) => optimized_plan,
                     None => plan.clone(),
                 }
             }
             LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
                 let predicates = utils::split_conjunction_owned(utils::cnf_rewrite(
-                    filter.predicate().clone(),
+                    filter.predicate.clone(),
                 ));
 
-                push_down_all_join(predicates, filter.input(), left, right, vec![])?
+                push_down_all_join(predicates, &filter.input, left, right, vec![])?
             }
             LogicalPlan::TableScan(scan) => {
                 let mut new_scan_filters = scan.filters.clone();
                 let mut new_predicate = vec![];
 
                 let filter_predicates = utils::split_conjunction_owned(
-                    utils::cnf_rewrite(filter.predicate().clone()),
+                    utils::cnf_rewrite(filter.predicate.clone()),
                 );
 
                 for filter_expr in &filter_predicates {

--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -93,6 +93,7 @@ fn optimize_plan(
             input,
             expr,
             schema,
+            ..
         }) => {
             // projection:
             // * remove any expression that is not required

--- a/datafusion/optimizer/src/rewrite_disjunctive_predicate.rs
+++ b/datafusion/optimizer/src/rewrite_disjunctive_predicate.rs
@@ -131,7 +131,7 @@ impl OptimizerRule for RewriteDisjunctivePredicate {
     ) -> Result<Option<LogicalPlan>> {
         match plan {
             LogicalPlan::Filter(filter) => {
-                let predicate = predicate(filter.predicate())?;
+                let predicate = predicate(&filter.predicate)?;
                 let rewritten_predicate = rewrite_predicate(predicate);
                 let rewritten_expr = normalize_predicate(rewritten_predicate);
                 Ok(Some(LogicalPlan::Filter(Filter::try_new(

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -99,7 +99,7 @@ impl OptimizerRule for ScalarSubqueryToJoin {
         match plan {
             LogicalPlan::Filter(filter) => {
                 let (subqueries, other_exprs) =
-                    self.extract_subquery_exprs(filter.predicate(), config)?;
+                    self.extract_subquery_exprs(&filter.predicate, config)?;
 
                 if subqueries.is_empty() {
                     // regular filter, no subquery exists clause here
@@ -107,7 +107,7 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                 }
 
                 // iterate through all subqueries in predicate, turning each into a join
-                let mut cur_input = filter.input().as_ref().clone();
+                let mut cur_input = filter.input.as_ref().clone();
                 for subquery in subqueries {
                     if let Some(optimized_subquery) =
                         optimize_scalar(&subquery, &cur_input, &other_exprs, config)?
@@ -219,14 +219,14 @@ fn optimize_scalar(
 
     // if there were filters, we use that logical plan, otherwise the plan from the aggregate
     let input = if let Some(filter) = filter {
-        filter.input()
+        &filter.input
     } else {
         &aggr.input
     };
 
     // if there were filters, split and capture them
     let subqry_filter_exprs = if let Some(filter) = filter {
-        split_conjunction(filter.predicate())
+        split_conjunction(&filter.predicate)
     } else {
         vec![]
     };

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -99,6 +99,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 aggr_expr,
                 schema,
                 group_expr,
+                ..
             }) => {
                 if is_single_distinct_agg(plan)? && !contains_grouping_set(group_expr) {
                     // alias all original group_by exprs

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -61,7 +61,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
                 let input = filter.input().as_ref().clone();
 
                 // Splitting filter expression into components by AND
-                let filters = utils::split_conjunction(filter.predicate());
+                let filters = utils::split_conjunction(&filter.predicate);
 
                 // Searching for subquery-based filters
                 let (subquery_filters, regular_filters): (Vec<&Expr>, Vec<&Expr>) =
@@ -152,7 +152,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
                     Ok(plan) => plan,
                     Err(_) => {
                         return Ok(Some(LogicalPlan::Filter(Filter::try_new(
-                            filter.predicate().clone(),
+                            filter.predicate.clone(),
                             Arc::new(input),
                         )?)))
                     }

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -58,7 +58,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
         match plan {
             LogicalPlan::Filter(filter) => {
                 // Apply optimizer rule to current input
-                let input = filter.input().as_ref().clone();
+                let input = filter.input.as_ref().clone();
 
                 // Splitting filter expression into components by AND
                 let filters = utils::split_conjunction(&filter.predicate);
@@ -80,7 +80,7 @@ impl OptimizerRule for SubqueryFilterToJoin {
 
                 if !subqueries_in_regular.is_empty() {
                     return Ok(Some(LogicalPlan::Filter(Filter::try_new(
-                        filter.predicate().clone(),
+                        filter.predicate.clone(),
                         Arc::new(input),
                     )?)));
                 };

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -936,14 +936,14 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::Filter(filter) => {
                 let input: protobuf::LogicalPlanNode =
                     protobuf::LogicalPlanNode::try_from_logical_plan(
-                        filter.input().as_ref(),
+                        filter.input.as_ref(),
                         extension_codec,
                     )?;
                 Ok(protobuf::LogicalPlanNode {
                     logical_plan_type: Some(LogicalPlanType::Selection(Box::new(
                         protobuf::SelectionNode {
                             input: Some(Box::new(input)),
-                            expr: Some(filter.predicate().try_into()?),
+                            expr: Some((&filter.predicate).try_into()?),
                         },
                     ))),
                 })


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

# What changes are included in this PR?

- add `#[non_exhaustive]` for LogicalPlan to avoid to bypass `try_new/new()` to build plan directly and 
- cleanup filter `predicate() input()`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->