### PR TITLE
Non-deprecated support for planning SQL without DDL, deprecate some more SessionContext methods

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -324,18 +324,17 @@ async fn execute_query(
     debug: bool,
     enable_scheduler: bool,
 ) -> Result<Vec<RecordBatch>> {
-    let plan = ctx.sql(sql).await?;
-    let plan = plan.into_unoptimized_plan();
+    let plan = ctx.sql(sql).await?.into_unoptimized_plan();
 
     if debug {
         println!("=== Logical plan ===\n{:?}\n", plan);
     }
 
-    let plan = ctx.optimize(&plan)?;
+    let plan = ctx.dataframe(plan).await?.into_optimized_plan()?;
     if debug {
         println!("=== Optimized logical plan ===\n{:?}\n", plan);
     }
-    let physical_plan = ctx.create_physical_plan(&plan).await?;
+    let physical_plan = ctx.dataframe(plan).await?.create_physical_plan().await?;
     if debug {
         println!(
             "=== Physical plan ===\n{}\n",

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1097,7 +1097,7 @@ impl DefaultPhysicalPlanner {
                     // TABLE" -- it must be handled at a higher level (so
                     // that the appropriate table can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: CreateExternalTable".to_string(),
                     ))
                 }
@@ -1105,7 +1105,7 @@ impl DefaultPhysicalPlanner {
                     // There is no default plan for "PREPARE" -- it must be
                     // handled at a higher level (so that the appropriate
                     // statement can be prepared)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: Prepare".to_string(),
                     ))
                 }
@@ -1114,7 +1114,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: CreateCatalogSchema".to_string(),
                     ))
                 }
@@ -1123,7 +1123,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: CreateCatalog".to_string(),
                     ))
                 }
@@ -1132,7 +1132,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: CreateMemoryTable".to_string(),
                     ))
                 }
@@ -1141,7 +1141,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: DropTable".to_string(),
                     ))
                 }
@@ -1150,7 +1150,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: DropView".to_string(),
                     ))
                 }
@@ -1159,16 +1159,16 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: CreateView".to_string(),
                     ))
                 }
                 LogicalPlan::SetVariable(_) => {
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::Plan(
                         "Unsupported logical plan: SetVariable must be root of the plan".to_string(),
                     ))
                 }
-                LogicalPlan::Explain(_) => Err(DataFusionError::Internal(
+                LogicalPlan::Explain(_) => Err(DataFusionError::Plan(
                     "Unsupported logical plan: Explain must be root of the plan".to_string(),
                 )),
                 LogicalPlan::Analyze(a) => {

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -210,11 +210,12 @@ impl ContextWithParquet {
             .expect("getting input");
         let pretty_input = pretty_format_batches(&input).unwrap().to_string();
 
-        let logical_plan = self.ctx.optimize(&logical_plan).expect("optimizing plan");
-
         let physical_plan = self
             .ctx
-            .create_physical_plan(&logical_plan)
+            .dataframe(logical_plan)
+            .await
+            .expect("planning")
+            .create_physical_plan()
             .await
             .expect("creating physical plan");
 

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -1120,9 +1120,8 @@ async fn aggregate_with_alias() -> Result<()> {
         .project(vec![col("c1"), sum(col("c2")).alias("total_salary")])?
         .build()?;
 
-    let plan = ctx.optimize(&plan)?;
+    let physical_plan = ctx.dataframe(plan).await?.create_physical_plan().await?;
 
-    let physical_plan = ctx.create_physical_plan(&Arc::new(plan)).await?;
     assert_eq!("c1", physical_plan.schema().field(0).name().as_str());
     assert_eq!(
         "total_salary",

--- a/datafusion/core/tests/sql/explain.rs
+++ b/datafusion/core/tests/sql/explain.rs
@@ -38,7 +38,11 @@ fn optimize_explain() {
     }
 
     // now optimize the plan and expect to see more plans
-    let optimized_plan = SessionContext::new().optimize(&plan).unwrap();
+    let optimized_plan = SessionContext::new()
+        .dataframe_without_ddl(plan.clone())
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
     if let LogicalPlan::Explain(e) = &optimized_plan {
         // should have more than one plan
         assert!(

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -1023,9 +1023,9 @@ async fn try_execute_to_batches(
     let dataframe = ctx.sql(sql).await?;
     let logical_schema = dataframe.schema().clone();
 
-    let optimized = ctx.optimize(dataframe.logical_plan())?;
-    let optimized_logical_schema = optimized.schema();
-    let results = dataframe.collect().await?;
+    let optimized = dataframe.into_optimized_plan()?;
+    let optimized_logical_schema = optimized.schema().clone();
+    let results = ctx.dataframe(optimized).await?.collect().await?;
 
     assert_eq!(&logical_schema, optimized_logical_schema.as_ref());
     Ok(results)

--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -90,10 +90,7 @@ async fn scalar_udf() -> Result<()> {
         "Projection: t.a, t.b, my_add(t.a, t.b)\n  TableScan: t projection=[a, b]"
     );
 
-    let plan = ctx.optimize(&plan)?;
-    let plan = ctx.create_physical_plan(&plan).await?;
-    let task_ctx = ctx.task_ctx();
-    let result = collect(plan, task_ctx).await?;
+    let result = ctx.dataframe(plan).await?.collect().await?;
 
     let expected = vec![
         "+-----+-----+-----------------+",

--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -1069,7 +1069,7 @@ async fn regression_test(query_no: u8, create_physical: bool) -> Result<()> {
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
         if create_physical {
-            let _ = ctx.create_physical_plan(&plan).await?;
+            let _ = ctx.dataframe(plan).await?.create_physical_plan().await?;
         }
     }
 

--- a/datafusion/proto/README.md
+++ b/datafusion/proto/README.md
@@ -58,10 +58,10 @@ use datafusion_proto::bytes::{logical_plan_from_bytes, logical_plan_to_bytes};
 #[tokio::main]
 async fn main() -> Result<()> {
     let ctx = SessionContext::new();
-    ctx.register_csv("t1", "testdata/test.csv", CsvReadOptions::default())
-        .await
-        ?;
-    let plan = ctx.table("t1")?.to_logical_plan()?;
+    let plan = ctx
+        .read_csv("testdata/test.csv", CsvReadOptions::default())
+        .await?
+        .into_optimized_plan()?;
     let bytes = logical_plan_to_bytes(&plan)?;
     let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx)?;
     assert_eq!(format!("{:?}", plan), format!("{:?}", logical_round_trip));
@@ -81,11 +81,11 @@ use datafusion_proto::bytes::{physical_plan_from_bytes,physical_plan_to_bytes};
 #[tokio::main]
 async fn main() -> Result<()> {
     let ctx = SessionContext::new();
-    ctx.register_csv("t1", "testdata/test.csv", CsvReadOptions::default())
-        .await
-        ?;
-    let logical_plan = ctx.table("t1")?.to_logical_plan()?;
-    let physical_plan = ctx.create_physical_plan(&logical_plan).await?;
+    let physical_plan = ctx
+        .read_csv("testdata/test.csv", CsvReadOptions::default())
+        .await?
+        .create_physical_plan()
+        .await?;
     let bytes = physical_plan_to_bytes(physical_plan.clone())?;
     let physical_round_trip = physical_plan_from_bytes(&bytes, &ctx)?;
     assert_eq!(format!("{:?}", physical_plan), format!("{:?}", physical_round_trip));


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/4720

Part of https://github.com/apache/arrow-datafusion/issues/4617

# Rationale for this change
More details on ticket https://github.com/apache/arrow-datafusion/issues/4720

Basically this moves the planning / execution in DataFusion to be based on DataFrame rather than some sort of mx of SessionContext / SessionState / DataFrame. Started by @tustvold  in https://github.com/apache/arrow-datafusion/pull/4679

# What changes are included in this PR?
1. Change APIs to allow query planning without DDL execution: `SessionContext::dataframe_without_ddl`
2. Add doc comments about the usecases
1. Deprecate `SessionContext::optimize` and `SessionContext::create_physical_plan`
2. Update errors in physical planner to return DataFusion::Error someone attempts to plan a DDL it is unsupported

# Are these changes tested?
Yes, existing tests 

# Are there any user-facing changes?
1. API is slightly different (different names)
1. Error messages are more precise