### PR TITLE
Support non-tuple expression for in-subquery to join

### DIFF
--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -443,7 +443,7 @@ mod tests {
         assert_optimized_plan_equal(&plan, expected)
     }
 
-    /// Test for single IN subquery filter with none equijoin
+    /// Test for single IN subquery filter with non equijoin
     #[test]
     fn in_subquery_to_non_equijoin() -> Result<()> {
         let table_scan = test_table_scan()?;
@@ -451,12 +451,12 @@ mod tests {
             .filter(in_subquery(lit(10i32), test_subquery_with_name("sq")?))?
             .project(vec![col("test.b")])?
             .build()?;
-            
+
         let expected = "Projection: test.b [b:UInt32]\
             \n  LeftSemi Join:  Filter: Int32(10) = sq.c [a:UInt32, b:UInt32, c:UInt32]\
             \n    TableScan: test [a:UInt32, b:UInt32, c:UInt32]\
             \n    Projection: sq.c [c:UInt32]\
-            \n      TableScan: sq [a:UInt32, b:UInt32, c:UInt32]";    
+            \n      TableScan: sq [a:UInt32, b:UInt32, c:UInt32]";
 
         assert_optimized_plan_equal(&plan, expected)
     }

--- a/datafusion/optimizer/src/subquery_filter_to_join.rs
+++ b/datafusion/optimizer/src/subquery_filter_to_join.rs
@@ -108,6 +108,8 @@ impl OptimizerRule for SubqueryFilterToJoin {
 
                             let right_key = right_schema.field(0).qualified_column();
                             let left_key = *expr.clone();
+                            // TODO: save the predicate to join-filter and let the other rule decide it is
+                            // a equi or non-equi predicate.
                             let (on, filter) =
                                 // When left is a constant expression, like 1, 
                                 // the join predicate will be `1 = right_key`, it is better to add it to filter.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4724.

# Rationale for this change

Currently datafusion support rewrite in-subquery to join when the expression is a column, like:
```sql
> select * from t1 where t1_id in (select t2_id from t2);
```
but following sql does not works:
```sql
> select * from t1 where t1_id + 11 in (select t2_id from t2);
NotImplemented("Physical plan does not support logical expression CAST(t1.t1_id AS Int64) + Int64(11) IN (<subquery>)")
```

We can rewrite these subquery to join also.

# What changes are included in this PR?
In `SubqueryFilterToJoin`:
1. Rewrite `where x+1 in (...)` to equi-join.
2. Rewrite `where 1 in (..)` to non equi-join.

# Are these changes tested?
Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->