### PR TITLE
refactor: parallelize `parquet_exec` test case `single_file`

### DIFF
--- a/datafusion/core/tests/parquet/filter_pushdown.rs
+++ b/datafusion/core/tests/parquet/filter_pushdown.rs
@@ -52,6 +52,7 @@ fn init() {
 }
 
 #[cfg(not(target_family = "windows"))]
+// Use multi-threaded executor as this test consumes CPU
 #[tokio::test(flavor = "multi_thread")]
 async fn single_file() {
     // Only create the parquet file once as it is fairly large
@@ -223,7 +224,9 @@ async fn single_file() {
     set.spawn(async move { case.run().await });
 
     // Join all the cases.
-    while let Some(_) = set.join_next().await {}
+    while let Some(result) = set.join_next().await {
+      result.unwrap()
+    }
 }
 
 #[cfg(not(target_family = "windows"))]

--- a/datafusion/core/tests/parquet/filter_pushdown.rs
+++ b/datafusion/core/tests/parquet/filter_pushdown.rs
@@ -225,7 +225,7 @@ async fn single_file() {
 
     // Join all the cases.
     while let Some(result) = set.join_next().await {
-      result.unwrap()
+        result.unwrap()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

I found this test is very slow (the last one `datafusion::parquet_exec parquet::filter_pushdown::single_file`):
```
        PASS [   0.061s]        datafusion-benchmarks::bin/tpch tests::run_q5
        PASS [   0.091s]        datafusion-benchmarks::bin/tpch tests::run_q21
        PASS [   0.082s]        datafusion-benchmarks::bin/tpch tests::run_q9
        PASS [   0.056s]          datafusion::user_defined_plan normal_query_without_schemas
        PASS [   0.047s]          datafusion::user_defined_plan topk_plan
        PASS [   0.081s]          datafusion::user_defined_plan normal_query
        PASS [   0.015s]          datafusion::user_defined_plan topk_query
        PASS [   0.120s]        datafusion-benchmarks::bin/tpch tests::run_q7
        PASS [   0.112s]    datafusion::user_defined_aggregates test_udf_returning_struct_sq
        PASS [   0.114s]    datafusion::user_defined_aggregates test_udf_returning_struct
        PASS [   0.131s]        datafusion-benchmarks::bin/tpch tests::run_q8
        PASS [   1.090s]             datafusion::tpcds_planning tpcds_physical_q88
        PASS [  23.772s]               datafusion::parquet_exec parquet::filter_pushdown::single_file
------------
     Summary [  27.234s] 2669 tests run: 2667 passed, 2 failed, 30 skipped
```
and always hold the whole test process for seconds.

# What changes are included in this PR?

This test is composed of serval little cases. I change it to run them in parallel, making the unit test faster by ~10s.
```

        PASS [   0.082s]    datafusion::user_defined_aggregates test_udf_returning_struct
        PASS [   0.023s]          datafusion::user_defined_plan topk_plan
        PASS [   0.070s]          datafusion::user_defined_plan normal_query_without_schemas
        PASS [   0.013s]          datafusion::user_defined_plan topk_query
        PASS [   0.086s]          datafusion::user_defined_plan normal_query
        PASS [   0.101s]        datafusion-benchmarks::bin/tpch tests::run_q9
        PASS [   0.116s]        datafusion-benchmarks::bin/tpch tests::run_q7
        PASS [   0.119s]        datafusion-benchmarks::bin/tpch tests::run_q8
        PASS [   0.905s]             datafusion::tpcds_planning tpcds_physical_q88
------------
     Summary [  16.256s] 2669 tests run: 2667 passed, 2 failed, 30 skipped
```

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
by it self

# Are there any user-facing changes?


no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->