### PR TITLE
revert some code for #4726 / remove unnecessary coercion in physical plans

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -575,6 +575,7 @@ fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
         },
         (Timestamp(_, tz), Utf8) => Some(Timestamp(TimeUnit::Nanosecond, tz.clone())),
         (Utf8, Timestamp(_, tz)) => Some(Timestamp(TimeUnit::Nanosecond, tz.clone())),
+        // TODO: need to investigate the result type for the comparison between timestamp and date
         (Timestamp(_, _), Date32) => Some(Date32),
         (Timestamp(_, _), Date64) => Some(Date64),
         (Timestamp(lhs_unit, lhs_tz), Timestamp(rhs_unit, rhs_tz)) => {

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -177,32 +177,9 @@ pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
         Timestamp(TimeUnit::Nanosecond, None) => {
             matches!(type_from, Null | Timestamp(_, None))
         }
-        Date32 => {
-            matches!(type_from, Null | Timestamp(_, None))
-        }
         Utf8 | LargeUtf8 => true,
         Null => can_cast_types(type_from, type_into),
         _ => false,
-    }
-}
-
-/// Returns a common coerced datatype between 2 given datatypes
-///
-/// See the module level documentation for more detail on coercion.
-pub fn get_common_coerced_type(
-    left_datatype: DataType,
-    right_datatype: DataType,
-) -> Result<DataType> {
-    if left_datatype == right_datatype || can_coerce_from(&left_datatype, &right_datatype)
-    {
-        Ok(left_datatype)
-    } else if can_coerce_from(&right_datatype, &left_datatype) {
-        Ok(right_datatype)
-    } else {
-        Err(DataFusionError::Plan(format!(
-            "Datatypes cannot be casted into common type {:?} <-> {:?}",
-            left_datatype, right_datatype
-        )))
     }
 }
 

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -28,7 +28,6 @@ use crate::{
 use arrow::datatypes::{DataType, Schema};
 use datafusion_common::{DFSchema, DataFusionError, Result, ScalarValue};
 use datafusion_expr::expr::Cast;
-use datafusion_expr::type_coercion::functions::get_common_coerced_type;
 use datafusion_expr::{
     binary_expr, Between, BinaryExpr, Expr, GetIndexedField, Like, Operator, TryCast,
 };
@@ -199,16 +198,9 @@ pub fn create_physical_expr(
                     input_schema,
                 )?)),
                 _ => {
-                    let target_datatype = get_common_coerced_type(
-                        lhs.data_type(input_schema)?,
-                        rhs.data_type(input_schema)?,
-                    )?;
-                    binary(
-                        expressions::cast(lhs, input_schema, target_datatype.clone())?,
-                        *op,
-                        expressions::cast(rhs, input_schema, target_datatype)?,
-                        input_schema,
-                    )
+                    // we have coerced both sides into a common type in the logical phase,
+                    // and then perform a binary operation
+                    binary(lhs, *op, rhs, input_schema)
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

from the https://github.com/apache/arrow-datafusion/pull/4726#issuecomment-1365869414

If we want to compare the timestamp with date, we just need to add logic in `type_coercion`, and don't need to do type coercion in the physical phase.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->