### PR TITLE
Minor: comments about coercion in physical planner

### DIFF
--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -198,8 +198,13 @@ pub fn create_physical_expr(
                     input_schema,
                 )?)),
                 _ => {
-                    // we have coerced both sides into a common type in the logical phase,
-                    // and then perform a binary operation
+                    // Note that the logical planner is responsible
+                    // for type coercion on the arguments (e.g. if one
+                    // argument was originally Int32 and one was
+                    // Int64 they will both be coerced to Int64).
+                    //
+                    // There should be no coercion during physical
+                    // planning.
                     binary(lhs, *op, rhs, input_schema)
                 }
             }


### PR DESCRIPTION
# Which issue does this PR close?

As pointed out by @liukun4515  on https://github.com/apache/arrow-datafusion/pull/4726 https://github.com/apache/arrow-datafusion/pull/4726#issuecomment-1365869414 type coercion is not needed during physical planning

cc @comphead 

# Rationale for this change
~Code is uneeded~

Avoid confusion about design in the future

# What changes are included in this PR?

~Remove uneeded code~

Add comments about coercion in the physical planner

# Are these changes tested?
Yes, all existing tests pass

# Are there any user-facing changes?

No