### PR TITLE
Deprecate SessionContext physical plan methods (#4617)

### DIFF
--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -510,6 +510,11 @@ impl DataFrame {
         &self.plan
     }
 
+    /// Returns both the [`LogicalPlan`] and [`SessionState`] that comprise this [`DataFrame`]
+    pub fn into_parts(self) -> (SessionState, LogicalPlan) {
+        (self.session_state, self.plan)
+    }
+
     /// Return the logical plan represented by this DataFrame without running the optimizers
     ///
     /// Note: This method should not be used outside testing, as it loses the snapshot

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -991,11 +991,17 @@ impl SessionContext {
     }
 
     /// Optimizes the logical plan by applying optimizer rules.
+    #[deprecated(
+        note = "Use SessionState::optimize to ensure a consistent state for planning and execution"
+    )]
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
         self.state.read().optimize(plan)
     }
 
     /// Creates a physical plan from a logical plan.
+    #[deprecated(
+        note = "Use SessionState::create_physical_plan or DataFrame::create_physical_plan to ensure a consistent state for planning and execution"
+    )]
     pub async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -210,15 +210,15 @@ impl ContextWithParquet {
             .expect("getting input");
         let pretty_input = pretty_format_batches(&input).unwrap().to_string();
 
-        let logical_plan = self.ctx.optimize(&logical_plan).expect("optimizing plan");
+        let state = self.ctx.state();
+        let logical_plan = state.optimize(&logical_plan).expect("optimizing plan");
 
-        let physical_plan = self
-            .ctx
+        let physical_plan = state
             .create_physical_plan(&logical_plan)
             .await
             .expect("creating physical plan");
 
-        let task_ctx = self.ctx.task_ctx();
+        let task_ctx = state.task_ctx();
         let results = datafusion::physical_plan::collect(physical_plan.clone(), task_ctx)
             .await
             .expect("Running");

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -1109,6 +1109,7 @@ async fn count_distinct_integers_aggregated_multiple_partitions() -> Result<()> 
 #[tokio::test]
 async fn aggregate_with_alias() -> Result<()> {
     let ctx = SessionContext::new();
+    let state = ctx.state();
 
     let schema = Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),
@@ -1120,9 +1121,8 @@ async fn aggregate_with_alias() -> Result<()> {
         .project(vec![col("c1"), sum(col("c2")).alias("total_salary")])?
         .build()?;
 
-    let plan = ctx.optimize(&plan)?;
-
-    let physical_plan = ctx.create_physical_plan(&Arc::new(plan)).await?;
+    let plan = state.optimize(&plan)?;
+    let physical_plan = state.create_physical_plan(&Arc::new(plan)).await?;
     assert_eq!("c1", physical_plan.schema().field(0).name().as_str());
     assert_eq!(
         "total_salary",

--- a/datafusion/core/tests/sql/explain.rs
+++ b/datafusion/core/tests/sql/explain.rs
@@ -37,8 +37,11 @@ fn optimize_explain() {
         panic!("plan was not an explain: {:?}", plan);
     }
 
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+
     // now optimize the plan and expect to see more plans
-    let optimized_plan = SessionContext::new().optimize(&plan).unwrap();
+    let optimized_plan = state.optimize(&plan).unwrap();
     if let LogicalPlan::Explain(e) = &optimized_plan {
         // should have more than one plan
         assert!(

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -1022,13 +1022,11 @@ async fn try_execute_to_batches(
 ) -> Result<Vec<RecordBatch>> {
     let dataframe = ctx.sql(sql).await?;
     let logical_schema = dataframe.schema().clone();
+    let (state, plan) = dataframe.into_parts();
 
-    let optimized = ctx.optimize(dataframe.logical_plan())?;
-    let optimized_logical_schema = optimized.schema();
-    let results = dataframe.collect().await?;
-
-    assert_eq!(&logical_schema, optimized_logical_schema.as_ref());
-    Ok(results)
+    let optimized = state.optimize(&plan)?;
+    assert_eq!(&logical_schema, optimized.schema().as_ref());
+    DataFrame::new(state, optimized).collect().await
 }
 
 /// Execute query and return results as a Vec of RecordBatches

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -172,7 +172,8 @@ async fn projection_on_table_scan() -> Result<()> {
         .project(vec![col("c2")])?
         .build()?;
 
-    let optimized_plan = ctx.optimize(&logical_plan)?;
+    let state = ctx.state();
+    let optimized_plan = state.optimize(&logical_plan)?;
     match &optimized_plan {
         LogicalPlan::Projection(Projection { input, .. }) => match &**input {
             LogicalPlan::TableScan(TableScan {
@@ -192,12 +193,11 @@ async fn projection_on_table_scan() -> Result<()> {
                     \n  TableScan: test projection=[c2]";
     assert_eq!(format!("{:?}", optimized_plan), expected);
 
-    let physical_plan = ctx.create_physical_plan(&optimized_plan).await?;
+    let physical_plan = state.create_physical_plan(&optimized_plan).await?;
 
     assert_eq!(1, physical_plan.schema().fields().len());
     assert_eq!("c2", physical_plan.schema().field(0).name().as_str());
-    let task_ctx = ctx.task_ctx();
-    let batches = collect(physical_plan, task_ctx).await?;
+    let batches = collect(physical_plan, state.task_ctx()).await?;
     assert_eq!(40, batches.iter().map(|x| x.num_rows()).sum::<usize>());
 
     Ok(())
@@ -215,8 +215,8 @@ async fn preserve_nullability_on_projection() -> Result<()> {
         .project(vec![col("c1")])?
         .build()?;
 
-    let plan = ctx.optimize(&plan)?;
-    let physical_plan = ctx.create_physical_plan(&Arc::new(plan)).await?;
+    let dataframe = DataFrame::new(ctx.state(), plan);
+    let physical_plan = dataframe.create_physical_plan().await?;
     assert!(!physical_plan.schema().field_with_name("c1")?.is_nullable());
     Ok(())
 }
@@ -247,9 +247,8 @@ async fn project_cast_dictionary() {
     .unwrap();
 
     let logical_plan = builder.project(vec![expr]).unwrap().build().unwrap();
-
-    let physical_plan = ctx.create_physical_plan(&logical_plan).await.unwrap();
-    let actual = collect(physical_plan, ctx.task_ctx()).await.unwrap();
+    let df = DataFrame::new(ctx.state(), logical_plan);
+    let actual = df.collect().await.unwrap();
 
     let expected = vec![
         "+----------------------------------------------------------------------------------+",
@@ -289,7 +288,8 @@ async fn projection_on_memory_scan() -> Result<()> {
     assert_fields_eq(&plan, vec!["b"]);
 
     let ctx = SessionContext::new();
-    let optimized_plan = ctx.optimize(&plan)?;
+    let state = ctx.state();
+    let optimized_plan = state.optimize(&plan)?;
     match &optimized_plan {
         LogicalPlan::Projection(Projection { input, .. }) => match &**input {
             LogicalPlan::TableScan(TableScan {
@@ -312,13 +312,12 @@ async fn projection_on_memory_scan() -> Result<()> {
     );
     assert_eq!(format!("{:?}", optimized_plan), expected);
 
-    let physical_plan = ctx.create_physical_plan(&optimized_plan).await?;
+    let physical_plan = state.create_physical_plan(&optimized_plan).await?;
 
     assert_eq!(1, physical_plan.schema().fields().len());
     assert_eq!("b", physical_plan.schema().field(0).name().as_str());
 
-    let task_ctx = ctx.task_ctx();
-    let batches = collect(physical_plan, task_ctx).await?;
+    let batches = collect(physical_plan, state.task_ctx()).await?;
     assert_eq!(1, batches.len());
     assert_eq!(1, batches[0].num_columns());
     assert_eq!(4, batches[0].num_rows());

--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -90,10 +90,7 @@ async fn scalar_udf() -> Result<()> {
         "Projection: t.a, t.b, my_add(t.a, t.b)\n  TableScan: t projection=[a, b]"
     );
 
-    let plan = ctx.optimize(&plan)?;
-    let plan = ctx.create_physical_plan(&plan).await?;
-    let task_ctx = ctx.task_ctx();
-    let result = collect(plan, task_ctx).await?;
+    let result = DataFrame::new(ctx.state(), plan).collect().await?;
 
     let expected = vec![
         "+-----+-----+-----------------+",

--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -1067,9 +1067,10 @@ async fn regression_test(query_no: u8, create_physical: bool) -> Result<()> {
 
     for sql in &sql {
         let df = ctx.sql(sql).await?;
-        let plan = df.into_optimized_plan()?;
+        let (state, plan) = df.into_parts();
+        let plan = state.optimize(&plan)?;
         if create_physical {
-            let _ = ctx.create_physical_plan(&plan).await?;
+            let _ = state.create_physical_plan(&plan).await?;
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4617

Follow on to #4679 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

These methods are very easy to accidentally misuse, and end up planning or optimizing against a different state than used for previous phases. Deprecating them will hopefully encourage correct usage of these APIs

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->