### PR TITLE
Take the top level `schema` into account when creating `UnionExec`

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -773,12 +773,19 @@ impl DefaultPhysicalPlanner {
                     )?;
                     Ok(Arc::new(FilterExec::try_new(runtime_expr, physical_input)?))
                 }
-                LogicalPlan::Union(Union { inputs, .. }) => {
+                LogicalPlan::Union(Union { inputs, schema }) => {
                     let physical_plans = futures::stream::iter(inputs)
                         .then(|lp| self.create_initial_plan(lp, session_state))
                         .try_collect::<Vec<_>>()
                         .await?;
-                    Ok(Arc::new(UnionExec::new(physical_plans)))
+                    if schema.fields().len() < physical_plans[0].schema().fields().len() {
+                        // `schema` could be a subset of the child schema. For example
+                        // for query "select count(*) from (select a from t union all select a from t)"
+                        // `schema` is empty but child schema contains one field `a`.
+                        Ok(Arc::new(UnionExec::try_new_with_schema(physical_plans, schema.clone())?))
+                    } else {
+                        Ok(Arc::new(UnionExec::new(physical_plans)))
+                    }
                 }
                 LogicalPlan::Repartition(Repartition {
                     input,

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -83,8 +83,9 @@ async fn union_all_with_aggregate() -> Result<()> {
 #[tokio::test]
 async fn union_all_with_count() -> Result<()> {
     let ctx = SessionContext::new();
+    execute_to_batches(&ctx, "CREATE table t as SELECT 1 as a").await;
     let sql =
-        "SELECT COUNT(*) FROM (SELECT 1 as c, 2 as d UNION ALL SELECT 1 as c, 3 AS d)";
+        "SELECT COUNT(*) FROM (SELECT a from t UNION ALL SELECT a from t)";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -84,8 +84,7 @@ async fn union_all_with_aggregate() -> Result<()> {
 async fn union_all_with_count() -> Result<()> {
     let ctx = SessionContext::new();
     execute_to_batches(&ctx, "CREATE table t as SELECT 1 as a").await;
-    let sql =
-        "SELECT COUNT(*) FROM (SELECT a from t UNION ALL SELECT a from t)";
+    let sql = "SELECT COUNT(*) FROM (SELECT a from t UNION ALL SELECT a from t)";
     let actual = execute_to_batches(&ctx, sql).await;
     let expected = vec![
         "+-----------------+",

--- a/datafusion/core/tests/sql/union.rs
+++ b/datafusion/core/tests/sql/union.rs
@@ -81,6 +81,23 @@ async fn union_all_with_aggregate() -> Result<()> {
 }
 
 #[tokio::test]
+async fn union_all_with_count() -> Result<()> {
+    let ctx = SessionContext::new();
+    let sql =
+        "SELECT COUNT(*) FROM (SELECT 1 as c, 2 as d UNION ALL SELECT 1 as c, 3 AS d)";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+-----------------+",
+        "| COUNT(UInt8(1)) |",
+        "+-----------------+",
+        "| 2               |",
+        "+-----------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn union_schemas() -> Result<()> {
     let ctx =
         SessionContext::with_config(SessionConfig::new().with_information_schema(true));


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4677.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When creating `UnionExec` from `LogicalPlan::Union`, the schema of the top plan is ignored. This could cause errors when the top level schema doesn't match the child schema. (see the example in #4677)

## Before
```sql
❯ create table t as select 1 as a;
0 rows in set. Query took 0.014 seconds.
❯ select count(*) from (select a from t union all select a from t);
Internal("create_physical_expr expected same number of fields, got got Arrow schema with 1  and DataFusion schema with 0")
```

## After
```sql
❯ create table t as select 1 as a;
0 rows in set. Query took 0.014 seconds.
❯ select count(*) from (select a from t union all select a from t);
+-----------------+
| COUNT(UInt8(1)) |
+-----------------+
| 2               |
+-----------------+
1 row in set. Query took 0.010 seconds.
```

# What changes are included in this PR?
1.  a new function `try_new_with_schema` for creating `UnionExec`
2. When building physical plans, if the top level schema is a subset of the child schema, then use `try_new_schema`, else use `new`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->