### PR TITLE
Avoid boxing config keys

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -35,6 +35,7 @@ use crate::{
 pub use datafusion_physical_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::var_provider::is_system_variables;
 use parking_lot::RwLock;
+use std::borrow::Cow;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{
@@ -391,7 +392,7 @@ impl SessionContext {
                                 value,
                             ))
                         })?;
-                        config_options.set_bool(&variable, new_value);
+                        config_options.set_bool(variable, new_value);
                     }
 
                     ScalarValue::UInt64(_) => {
@@ -401,7 +402,7 @@ impl SessionContext {
                                 value,
                             ))
                         })?;
-                        config_options.set_u64(&variable, new_value);
+                        config_options.set_u64(variable, new_value);
                     }
 
                     ScalarValue::Utf8(_) => {
@@ -411,7 +412,7 @@ impl SessionContext {
                                 value,
                             ))
                         })?;
-                        config_options.set_string(&variable, new_value);
+                        config_options.set_string(variable, new_value);
                     }
 
                     _ => {
@@ -1192,29 +1193,29 @@ impl SessionConfig {
     }
 
     /// Set a configuration option
-    pub fn set(mut self, key: &str, value: ScalarValue) -> Self {
+    pub fn set(mut self, key: impl Into<Cow<'static, str>>, value: ScalarValue) -> Self {
         self.config_options.set(key, value);
         self
     }
 
     /// Set a boolean configuration option
-    pub fn set_bool(self, key: &str, value: bool) -> Self {
+    pub fn set_bool(self, key: impl Into<Cow<'static, str>>, value: bool) -> Self {
         self.set(key, ScalarValue::Boolean(Some(value)))
     }
 
     /// Set a generic `u64` configuration option
-    pub fn set_u64(self, key: &str, value: u64) -> Self {
+    pub fn set_u64(self, key: impl Into<Cow<'static, str>>, value: u64) -> Self {
         self.set(key, ScalarValue::UInt64(Some(value)))
     }
 
     /// Set a generic `usize` configuration option
-    pub fn set_usize(self, key: &str, value: usize) -> Self {
+    pub fn set_usize(self, key: impl Into<Cow<'static, str>>, value: usize) -> Self {
         let value: u64 = value.try_into().expect("convert usize to u64");
         self.set(key, ScalarValue::UInt64(Some(value)))
     }
 
     /// Set a generic `str` configuration option
-    pub fn set_str(self, key: &str, value: &str) -> Self {
+    pub fn set_str(self, key: impl Into<Cow<'static, str>>, value: &str) -> Self {
         self.set(key, ScalarValue::Utf8(Some(value.to_string())))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #4517 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Config keys are almost always static strings, currently we allocate a `String` for each of these, and clone these allocations when we clone `SessionConfig`, which is done multiple times per query. Switching to use `Cow<'static, str>` avoids this.

I prevaricated about this change as we may eventually change `ConfigOptions` into a struct, but thought I'd propose it anyway and see what people thought

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This changes the definition of `ConfigOptions` to avoid boxing static strings.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->