### PR TITLE
Move subquery alias assignment onto rules

### DIFF
--- a/benchmarks/expected-plans/q11.txt
+++ b/benchmarks/expected-plans/q11.txt
@@ -1,6 +1,6 @@
 Sort: value DESC NULLS FIRST
   Projection: partsupp.ps_partkey, SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS value
-    Filter: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Decimal128(38, 15)) > CAST(__sq_1.__value AS Decimal128(38, 15))
+    Filter: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Decimal128(38, 15)) > CAST(__scalar_sq_1.__value AS Decimal128(38, 15))
       CrossJoin:
         Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]
           Inner Join: supplier.s_nationkey = nation.n_nationkey
@@ -9,7 +9,7 @@ Sort: value DESC NULLS FIRST
               TableScan: supplier projection=[s_suppkey, s_nationkey]
             Filter: nation.n_name = Utf8("GERMANY")
               TableScan: nation projection=[n_nationkey, n_name]
-        SubqueryAlias: __sq_1
+        SubqueryAlias: __scalar_sq_1
           Projection: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Float64) * Float64(0.0001) AS __value
             Aggregate: groupBy=[[]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]
               Inner Join: supplier.s_nationkey = nation.n_nationkey

--- a/benchmarks/expected-plans/q15.txt
+++ b/benchmarks/expected-plans/q15.txt
@@ -1,7 +1,7 @@
 EmptyRelation
 Sort: supplier.s_suppkey ASC NULLS LAST
   Projection: supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, revenue0.total_revenue
-    Inner Join: revenue0.total_revenue = __sq_1.__value
+    Inner Join: revenue0.total_revenue = __scalar_sq_1.__value
       Inner Join: supplier.s_suppkey = revenue0.supplier_no
         TableScan: supplier projection=[s_suppkey, s_name, s_address, s_phone]
         SubqueryAlias: revenue0
@@ -10,7 +10,7 @@ Sort: supplier.s_suppkey ASC NULLS LAST
               Aggregate: groupBy=[[lineitem.l_suppkey]], aggr=[[SUM(CAST(lineitem.l_extendedprice AS Decimal128(38, 4)) * CAST(Decimal128(Some(100),23,2) - CAST(lineitem.l_discount AS Decimal128(23, 2)) AS Decimal128(38, 4))) AS SUM(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]]
                 Filter: lineitem.l_shipdate >= Date32("9496") AND lineitem.l_shipdate < Date32("9587")
                   TableScan: lineitem projection=[l_suppkey, l_extendedprice, l_discount, l_shipdate]
-      SubqueryAlias: __sq_1
+      SubqueryAlias: __scalar_sq_1
         Projection: MAX(revenue0.total_revenue) AS __value
           Aggregate: groupBy=[[]], aggr=[[MAX(revenue0.total_revenue)]]
             SubqueryAlias: revenue0

--- a/benchmarks/expected-plans/q16.txt
+++ b/benchmarks/expected-plans/q16.txt
@@ -3,12 +3,12 @@ Sort: supplier_cnt DESC NULLS FIRST, part.p_brand ASC NULLS LAST, part.p_type AS
     Projection: group_alias_0 AS part.p_brand, group_alias_1 AS part.p_type, group_alias_2 AS part.p_size, COUNT(alias1) AS COUNT(DISTINCT partsupp.ps_suppkey)
       Aggregate: groupBy=[[group_alias_0, group_alias_1, group_alias_2]], aggr=[[COUNT(alias1)]]
         Aggregate: groupBy=[[part.p_brand AS group_alias_0, part.p_type AS group_alias_1, part.p_size AS group_alias_2, partsupp.ps_suppkey AS alias1]], aggr=[[]]
-          LeftAnti Join: partsupp.ps_suppkey = __sq_1.s_suppkey
+          LeftAnti Join: partsupp.ps_suppkey = __correlated_sq_1.s_suppkey
             Inner Join: partsupp.ps_partkey = part.p_partkey
               TableScan: partsupp projection=[ps_partkey, ps_suppkey]
               Filter: part.p_brand != Utf8("Brand#45") AND part.p_type NOT LIKE Utf8("MEDIUM POLISHED%") AND part.p_size IN ([Int32(49), Int32(14), Int32(23), Int32(45), Int32(19), Int32(3), Int32(36), Int32(9)])
                 TableScan: part projection=[p_partkey, p_brand, p_type, p_size]
-            SubqueryAlias: __sq_1
+            SubqueryAlias: __correlated_sq_1
               Projection: supplier.s_suppkey AS s_suppkey
                 Filter: supplier.s_comment LIKE Utf8("%Customer%Complaints%")
                   TableScan: supplier projection=[s_suppkey, s_comment]

--- a/benchmarks/expected-plans/q17.txt
+++ b/benchmarks/expected-plans/q17.txt
@@ -1,11 +1,12 @@
-Projection: CAST(SUM(lineitem.l_extendedprice) AS Decimal128(38, 33)) / Decimal128(Some(7000000000000000195487369212723200),38,33) AS avg_yearly
+Projection: CAST(SUM(lineitem.l_extendedprice) AS Float64) / Float64(7) AS avg_yearly
   Aggregate: groupBy=[[]], aggr=[[SUM(lineitem.l_extendedprice)]]
-    Filter: CAST(lineitem.l_quantity AS Decimal128(38, 21)) < __sq_1.__value
-      Inner Join: part.p_partkey = __sq_1.l_partkey
+    Filter: CAST(lineitem.l_quantity AS Decimal128(30, 15)) < CAST(__scalar_sq_1.__value AS Decimal128(30, 15))
+      Inner Join: part.p_partkey = __scalar_sq_1.l_partkey, lineitem.l_partkey = __scalar_sq_1.l_partkey
         Inner Join: lineitem.l_partkey = part.p_partkey
           TableScan: lineitem projection=[l_partkey, l_quantity, l_extendedprice]
           Filter: part.p_brand = Utf8("Brand#23") AND part.p_container = Utf8("MED BOX")
             TableScan: part projection=[p_partkey, p_brand, p_container]
-        Projection: lineitem.l_partkey, Decimal128(Some(200000000000000000000),38,21) * CAST(AVG(lineitem.l_quantity) AS Decimal128(38, 21)) AS __value, alias=__sq_1
-          Aggregate: groupBy=[[lineitem.l_partkey]], aggr=[[AVG(lineitem.l_quantity)]]
-            TableScan: lineitem projection=[l_partkey, l_quantity, l_extendedprice]
+        SubqueryAlias: __scalar_sq_1
+          Projection: lineitem.l_partkey, Float64(0.2) * CAST(AVG(lineitem.l_quantity) AS Float64) AS __value
+            Aggregate: groupBy=[[lineitem.l_partkey]], aggr=[[AVG(lineitem.l_quantity)]]
+              TableScan: lineitem projection=[l_partkey, l_quantity]

--- a/benchmarks/expected-plans/q18.txt
+++ b/benchmarks/expected-plans/q18.txt
@@ -1,13 +1,13 @@
 Sort: orders.o_totalprice DESC NULLS FIRST, orders.o_orderdate ASC NULLS LAST
   Projection: customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, SUM(lineitem.l_quantity)
     Aggregate: groupBy=[[customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice]], aggr=[[SUM(lineitem.l_quantity)]]
-      LeftSemi Join: orders.o_orderkey = __sq_1.l_orderkey
+      LeftSemi Join: orders.o_orderkey = __correlated_sq_1.l_orderkey
         Inner Join: orders.o_orderkey = lineitem.l_orderkey
           Inner Join: customer.c_custkey = orders.o_custkey
             TableScan: customer projection=[c_custkey, c_name]
             TableScan: orders projection=[o_orderkey, o_custkey, o_totalprice, o_orderdate]
           TableScan: lineitem projection=[l_orderkey, l_quantity]
-        SubqueryAlias: __sq_1
+        SubqueryAlias: __correlated_sq_1
           Projection: lineitem.l_orderkey AS l_orderkey
             Filter: SUM(lineitem.l_quantity) > Decimal128(Some(30000),25,2)
               Aggregate: groupBy=[[lineitem.l_orderkey]], aggr=[[SUM(lineitem.l_quantity)]]

--- a/benchmarks/expected-plans/q2.txt
+++ b/benchmarks/expected-plans/q2.txt
@@ -1,7 +1,7 @@
 Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST
   Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment
     Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name
-      Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value
+      Inner Join: part.p_partkey = __scalar_sq_1.ps_partkey, partsupp.ps_supplycost = __scalar_sq_1.__value
         Inner Join: nation.n_regionkey = region.r_regionkey
           Inner Join: supplier.s_nationkey = nation.n_nationkey
             Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
@@ -13,7 +13,7 @@ Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplie
             TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
           Filter: region.r_name = Utf8("EUROPE")
             TableScan: region projection=[r_regionkey, r_name]
-        SubqueryAlias: __sq_1
+        SubqueryAlias: __scalar_sq_1
           Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value
             Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
               Inner Join: nation.n_regionkey = region.r_regionkey

--- a/benchmarks/expected-plans/q20.txt
+++ b/benchmarks/expected-plans/q20.txt
@@ -1,21 +1,21 @@
 Sort: supplier.s_name ASC NULLS LAST
   Projection: supplier.s_name, supplier.s_address
-    LeftSemi Join: supplier.s_suppkey = __sq_1.ps_suppkey
+    LeftSemi Join: supplier.s_suppkey = __correlated_sq_1.ps_suppkey
       Inner Join: supplier.s_nationkey = nation.n_nationkey
         TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey]
         Filter: nation.n_name = Utf8("CANADA")
           TableScan: nation projection=[n_nationkey, n_name]
-      SubqueryAlias: __sq_1
+      SubqueryAlias: __correlated_sq_1
         Projection: partsupp.ps_suppkey AS ps_suppkey
-          Filter: CAST(partsupp.ps_availqty AS Float64) > __sq_3.__value
-            Inner Join: partsupp.ps_partkey = __sq_3.l_partkey, partsupp.ps_suppkey = __sq_3.l_suppkey
-              LeftSemi Join: partsupp.ps_partkey = __sq_2.p_partkey
+          Filter: CAST(partsupp.ps_availqty AS Float64) > __scalar_sq_1.__value
+            Inner Join: partsupp.ps_partkey = __scalar_sq_1.l_partkey, partsupp.ps_suppkey = __scalar_sq_1.l_suppkey
+              LeftSemi Join: partsupp.ps_partkey = __correlated_sq_2.p_partkey
                 TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty]
-                SubqueryAlias: __sq_2
+                SubqueryAlias: __correlated_sq_2
                   Projection: part.p_partkey AS p_partkey
                     Filter: part.p_name LIKE Utf8("forest%")
                       TableScan: part projection=[p_partkey, p_name]
-              SubqueryAlias: __sq_3
+              SubqueryAlias: __scalar_sq_1
                 Projection: lineitem.l_partkey, lineitem.l_suppkey, Float64(0.5) * CAST(SUM(lineitem.l_quantity) AS Float64) AS __value
                   Aggregate: groupBy=[[lineitem.l_partkey, lineitem.l_suppkey]], aggr=[[SUM(lineitem.l_quantity)]]
                     Filter: lineitem.l_shipdate >= Date32("8766") AND lineitem.l_shipdate < Date32("9131")

--- a/benchmarks/expected-plans/q22.txt
+++ b/benchmarks/expected-plans/q22.txt
@@ -3,13 +3,13 @@ Sort: custsale.cntrycode ASC NULLS LAST
     Aggregate: groupBy=[[custsale.cntrycode]], aggr=[[COUNT(UInt8(1)), SUM(custsale.c_acctbal)]]
       SubqueryAlias: custsale
         Projection: substr(customer.c_phone, Int64(1), Int64(2)) AS cntrycode, customer.c_acctbal
-          Filter: CAST(customer.c_acctbal AS Decimal128(19, 6)) > __sq_1.__value
+          Filter: CAST(customer.c_acctbal AS Decimal128(19, 6)) > __scalar_sq_1.__value
             CrossJoin:
               LeftAnti Join: customer.c_custkey = orders.o_custkey
                 Filter: substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")])
                   TableScan: customer projection=[c_custkey, c_phone, c_acctbal]
                 TableScan: orders projection=[o_custkey]
-              SubqueryAlias: __sq_1
+              SubqueryAlias: __scalar_sq_1
                 Projection: AVG(customer.c_acctbal) AS __value
                   Aggregate: groupBy=[[]], aggr=[[AVG(customer.c_acctbal)]]
                     Filter: customer.c_acctbal > Decimal128(Some(0),15,2) AND substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")])

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -596,17 +596,7 @@ mod tests {
         expected_plan(16).await
     }
 
-    /// This query produces different plans depending on operating system. The difference is
-    /// due to re-writing the following expression:
-    ///
-    /// `sum(l_extendedprice) / 7.0 as avg_yearly`
-    ///
-    /// Linux:   Decimal128(Some(7000000000000000195487369212723200),38,33)
-    /// Windows: Decimal128(Some(6999999999999999042565864605876224),38,33)
-    ///
-    /// See https://github.com/apache/arrow-datafusion/issues/3791
     #[tokio::test]
-    #[ignore]
     async fn q17_expected_plan() -> Result<()> {
         expected_plan(17).await
     }

--- a/datafusion/core/tests/sql/subqueries.rs
+++ b/datafusion/core/tests/sql/subqueries.rs
@@ -50,21 +50,21 @@ where c_acctbal < (
 
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = "Sort: customer.c_custkey ASC NULLS LAST\
-    \n  Projection: customer.c_custkey\
-    \n    Filter: CAST(customer.c_acctbal AS Decimal128(25, 2)) < __sq_1.__value\
-    \n      Inner Join: customer.c_custkey = __sq_1.o_custkey\
-    \n        TableScan: customer projection=[c_custkey, c_acctbal]\
-    \n        SubqueryAlias: __sq_1\
-    \n          Projection: orders.o_custkey, SUM(orders.o_totalprice) AS __value\
-    \n            Aggregate: groupBy=[[orders.o_custkey]], aggr=[[SUM(orders.o_totalprice)]]\
-    \n              Filter: CAST(orders.o_totalprice AS Decimal128(25, 2)) < __sq_2.__value\
-    \n                Inner Join: orders.o_orderkey = __sq_2.l_orderkey\
-    \n                  TableScan: orders projection=[o_orderkey, o_custkey, o_totalprice]\
-    \n                  SubqueryAlias: __sq_2\
-    \n                    Projection: lineitem.l_orderkey, SUM(lineitem.l_extendedprice) AS price AS __value\
-    \n                      Aggregate: groupBy=[[lineitem.l_orderkey]], aggr=[[SUM(lineitem.l_extendedprice)]]\
-    \n                        TableScan: lineitem projection=[l_orderkey, l_extendedprice]";
+    let expected = r#"Sort: customer.c_custkey ASC NULLS LAST
+  Projection: customer.c_custkey
+    Filter: CAST(customer.c_acctbal AS Decimal128(25, 2)) < __scalar_sq_1.__value
+      Inner Join: customer.c_custkey = __scalar_sq_1.o_custkey
+        TableScan: customer projection=[c_custkey, c_acctbal]
+        SubqueryAlias: __scalar_sq_1
+          Projection: orders.o_custkey, SUM(orders.o_totalprice) AS __value
+            Aggregate: groupBy=[[orders.o_custkey]], aggr=[[SUM(orders.o_totalprice)]]
+              Filter: CAST(orders.o_totalprice AS Decimal128(25, 2)) < __scalar_sq_2.__value
+                Inner Join: orders.o_orderkey = __scalar_sq_2.l_orderkey
+                  TableScan: orders projection=[o_orderkey, o_custkey, o_totalprice]
+                  SubqueryAlias: __scalar_sq_2
+                    Projection: lineitem.l_orderkey, SUM(lineitem.l_extendedprice) AS price AS __value
+                      Aggregate: groupBy=[[lineitem.l_orderkey]], aggr=[[SUM(lineitem.l_extendedprice)]]
+                        TableScan: lineitem projection=[l_orderkey, l_extendedprice]"#;
     assert_eq!(actual, expected);
 
     Ok(())
@@ -94,12 +94,12 @@ where o_orderstatus in (
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = "Projection: orders.o_orderkey\
-    \n  LeftSemi Join: orders.o_orderstatus = __sq_1.l_linestatus, orders.o_orderkey = __sq_1.l_orderkey\
-    \n    TableScan: orders projection=[o_orderkey, o_orderstatus]\
-    \n    SubqueryAlias: __sq_1\
-    \n      Projection: lineitem.l_linestatus AS l_linestatus, lineitem.l_orderkey AS l_orderkey\
-    \n        TableScan: lineitem projection=[l_orderkey, l_linestatus]";
+    let expected = r#"Projection: orders.o_orderkey
+  LeftSemi Join: orders.o_orderstatus = __correlated_sq_1.l_linestatus, orders.o_orderkey = __correlated_sq_1.l_orderkey
+    TableScan: orders projection=[o_orderkey, o_orderstatus]
+    SubqueryAlias: __correlated_sq_1
+      Projection: lineitem.l_linestatus AS l_linestatus, lineitem.l_orderkey AS l_orderkey
+        TableScan: lineitem projection=[l_orderkey, l_linestatus]"#;
     assert_eq!(actual, expected);
 
     // assert data
@@ -140,32 +140,32 @@ order by s_acctbal desc, n_name, s_name, p_partkey;"#;
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = "Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST\
-    \n  Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment\
-    \n    Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name\
-    \n      Inner Join: part.p_partkey = __sq_1.ps_partkey, partsupp.ps_supplycost = __sq_1.__value\
-    \n        Inner Join: nation.n_regionkey = region.r_regionkey\
-    \n          Inner Join: supplier.s_nationkey = nation.n_nationkey\
-    \n            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey\
-    \n              Inner Join: part.p_partkey = partsupp.ps_partkey\
-    \n                Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8(\"%BRASS\")\
-    \n                  TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size], partial_filters=[part.p_size = Int32(15), part.p_type LIKE Utf8(\"%BRASS\")]\
-    \n                TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]\
-    \n              TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]\
-    \n            TableScan: nation projection=[n_nationkey, n_name, n_regionkey]\
-    \n          Filter: region.r_name = Utf8(\"EUROPE\")\
-    \n            TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8(\"EUROPE\")]\
-    \n        SubqueryAlias: __sq_1\
-    \n          Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value\
-    \n            Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]\
-    \n              Inner Join: nation.n_regionkey = region.r_regionkey\
-    \n                Inner Join: supplier.s_nationkey = nation.n_nationkey\
-    \n                  Inner Join: partsupp.ps_suppkey = supplier.s_suppkey\
-    \n                    TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]\
-    \n                    TableScan: supplier projection=[s_suppkey, s_nationkey]\
-    \n                  TableScan: nation projection=[n_nationkey, n_regionkey]\
-    \n                Filter: region.r_name = Utf8(\"EUROPE\")\
-    \n                  TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8(\"EUROPE\")]";
+    let expected = r#"Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST
+  Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment
+    Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name
+      Inner Join: part.p_partkey = __scalar_sq_1.ps_partkey, partsupp.ps_supplycost = __scalar_sq_1.__value
+        Inner Join: nation.n_regionkey = region.r_regionkey
+          Inner Join: supplier.s_nationkey = nation.n_nationkey
+            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+              Inner Join: part.p_partkey = partsupp.ps_partkey
+                Filter: part.p_size = Int32(15) AND part.p_type LIKE Utf8("%BRASS")
+                  TableScan: part projection=[p_partkey, p_mfgr, p_type, p_size], partial_filters=[part.p_size = Int32(15), part.p_type LIKE Utf8("%BRASS")]
+                TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
+              TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment]
+            TableScan: nation projection=[n_nationkey, n_name, n_regionkey]
+          Filter: region.r_name = Utf8("EUROPE")
+            TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]
+        SubqueryAlias: __scalar_sq_1
+          Projection: partsupp.ps_partkey, MIN(partsupp.ps_supplycost) AS __value
+            Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[MIN(partsupp.ps_supplycost)]]
+              Inner Join: nation.n_regionkey = region.r_regionkey
+                Inner Join: supplier.s_nationkey = nation.n_nationkey
+                  Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+                    TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_supplycost]
+                    TableScan: supplier projection=[s_suppkey, s_nationkey]
+                  TableScan: nation projection=[n_nationkey, n_regionkey]
+                Filter: region.r_name = Utf8("EUROPE")
+                  TableScan: region projection=[r_regionkey, r_name], partial_filters=[region.r_name = Utf8("EUROPE")]"#;
     assert_eq!(actual, expected);
 
     // assert data
@@ -230,7 +230,6 @@ async fn tpch_q4_correlated() -> Result<()> {
     Ok(())
 }
 
-#[ignore] // https://github.com/apache/arrow-datafusion/issues/3437
 #[tokio::test]
 async fn tpch_q17_correlated() -> Result<()> {
     let parts = r#"63700,goldenrod lavender spring chocolate lace,Manufacturer#1,Brand#23,PROMO BURNISHED COPPER,7,MED BOX,901.00,ly. slyly ironi
@@ -255,17 +254,18 @@ async fn tpch_q17_correlated() -> Result<()> {
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = r#"Projection: CAST(SUM(lineitem.l_extendedprice) AS Decimal128(38, 33)) / CAST(Float64(7) AS Decimal128(38, 33)) AS avg_yearly
+    let expected = r#"Projection: CAST(SUM(lineitem.l_extendedprice) AS Float64) / Float64(7) AS avg_yearly
   Aggregate: groupBy=[[]], aggr=[[SUM(lineitem.l_extendedprice)]]
-    Filter: CAST(lineitem.l_quantity AS Decimal128(38, 21)) < __sq_1.__value
-      Inner Join: part.p_partkey = __sq_1.l_partkey
+    Filter: CAST(lineitem.l_quantity AS Decimal128(30, 15)) < CAST(__scalar_sq_1.__value AS Decimal128(30, 15))
+      Inner Join: part.p_partkey = __scalar_sq_1.l_partkey, lineitem.l_partkey = __scalar_sq_1.l_partkey
         Inner Join: lineitem.l_partkey = part.p_partkey
           TableScan: lineitem projection=[l_partkey, l_quantity, l_extendedprice]
           Filter: part.p_brand = Utf8("Brand#23") AND part.p_container = Utf8("MED BOX")
             TableScan: part projection=[p_partkey, p_brand, p_container]
-        Projection: lineitem.l_partkey, CAST(Float64(0.2) AS Decimal128(38, 21)) * CAST(AVG(lineitem.l_quantity) AS Decimal128(38, 21)) AS __value, alias=__sq_1
-          Aggregate: groupBy=[[lineitem.l_partkey]], aggr=[[AVG(lineitem.l_quantity)]]
-            TableScan: lineitem projection=[l_partkey, l_quantity, l_extendedprice]"#
+        SubqueryAlias: __scalar_sq_1
+          Projection: lineitem.l_partkey, Float64(0.2) * CAST(AVG(lineitem.l_quantity) AS Float64) AS __value
+            Aggregate: groupBy=[[lineitem.l_partkey]], aggr=[[AVG(lineitem.l_quantity)]]
+              TableScan: lineitem projection=[l_partkey, l_quantity]"#
         .to_string();
     assert_eq!(actual, expected);
 
@@ -275,7 +275,7 @@ async fn tpch_q17_correlated() -> Result<()> {
         "+--------------------+",
         "| avg_yearly         |",
         "+--------------------+",
-        "| 1901.3714285714286 |",
+        "| 190.13714285714286 |",
         "+--------------------+",
     ];
     assert_batches_eq!(expected, &results);
@@ -309,28 +309,28 @@ order by s_name;
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = "Sort: supplier.s_name ASC NULLS LAST\
-    \n  Projection: supplier.s_name, supplier.s_address\
-    \n    LeftSemi Join: supplier.s_suppkey = __sq_1.ps_suppkey\
-    \n      Inner Join: supplier.s_nationkey = nation.n_nationkey\
-    \n        TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey]\
-    \n        Filter: nation.n_name = Utf8(\"CANADA\")\
-    \n          TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8(\"CANADA\")]\
-    \n      SubqueryAlias: __sq_1\
-    \n        Projection: partsupp.ps_suppkey AS ps_suppkey\
-    \n          Filter: CAST(partsupp.ps_availqty AS Float64) > __sq_3.__value\
-    \n            Inner Join: partsupp.ps_partkey = __sq_3.l_partkey, partsupp.ps_suppkey = __sq_3.l_suppkey\
-    \n              LeftSemi Join: partsupp.ps_partkey = __sq_2.p_partkey\
-    \n                TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty]\
-    \n                SubqueryAlias: __sq_2\
-    \n                  Projection: part.p_partkey AS p_partkey\
-    \n                    Filter: part.p_name LIKE Utf8(\"forest%\")\
-    \n                      TableScan: part projection=[p_partkey, p_name], partial_filters=[part.p_name LIKE Utf8(\"forest%\")]\
-    \n              SubqueryAlias: __sq_3\
-    \n                Projection: lineitem.l_partkey, lineitem.l_suppkey, Float64(0.5) * CAST(SUM(lineitem.l_quantity) AS Float64) AS __value\
-    \n                  Aggregate: groupBy=[[lineitem.l_partkey, lineitem.l_suppkey]], aggr=[[SUM(lineitem.l_quantity)]]\
-    \n                    Filter: lineitem.l_shipdate >= Date32(\"8766\")\
-    \n                      TableScan: lineitem projection=[l_partkey, l_suppkey, l_quantity, l_shipdate], partial_filters=[lineitem.l_shipdate >= Date32(\"8766\")]";
+    let expected = r#"Sort: supplier.s_name ASC NULLS LAST
+  Projection: supplier.s_name, supplier.s_address
+    LeftSemi Join: supplier.s_suppkey = __correlated_sq_1.ps_suppkey
+      Inner Join: supplier.s_nationkey = nation.n_nationkey
+        TableScan: supplier projection=[s_suppkey, s_name, s_address, s_nationkey]
+        Filter: nation.n_name = Utf8("CANADA")
+          TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8("CANADA")]
+      SubqueryAlias: __correlated_sq_1
+        Projection: partsupp.ps_suppkey AS ps_suppkey
+          Filter: CAST(partsupp.ps_availqty AS Float64) > __scalar_sq_1.__value
+            Inner Join: partsupp.ps_partkey = __scalar_sq_1.l_partkey, partsupp.ps_suppkey = __scalar_sq_1.l_suppkey
+              LeftSemi Join: partsupp.ps_partkey = __correlated_sq_2.p_partkey
+                TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty]
+                SubqueryAlias: __correlated_sq_2
+                  Projection: part.p_partkey AS p_partkey
+                    Filter: part.p_name LIKE Utf8("forest%")
+                      TableScan: part projection=[p_partkey, p_name], partial_filters=[part.p_name LIKE Utf8("forest%")]
+              SubqueryAlias: __scalar_sq_1
+                Projection: lineitem.l_partkey, lineitem.l_suppkey, Float64(0.5) * CAST(SUM(lineitem.l_quantity) AS Float64) AS __value
+                  Aggregate: groupBy=[[lineitem.l_partkey, lineitem.l_suppkey]], aggr=[[SUM(lineitem.l_quantity)]]
+                    Filter: lineitem.l_shipdate >= Date32("8766")
+                      TableScan: lineitem projection=[l_partkey, l_suppkey, l_quantity, l_shipdate], partial_filters=[lineitem.l_shipdate >= Date32("8766")]"#;
     assert_eq!(actual, expected);
 
     // assert data
@@ -364,22 +364,22 @@ order by cntrycode;"#;
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected = "Sort: custsale.cntrycode ASC NULLS LAST\
-    \n  Projection: custsale.cntrycode, COUNT(UInt8(1)) AS numcust, SUM(custsale.c_acctbal) AS totacctbal\
-    \n    Aggregate: groupBy=[[custsale.cntrycode]], aggr=[[COUNT(UInt8(1)), SUM(custsale.c_acctbal)]]\
-    \n      SubqueryAlias: custsale\
-    \n        Projection: substr(customer.c_phone, Int64(1), Int64(2)) AS cntrycode, customer.c_acctbal\
-    \n          Filter: CAST(customer.c_acctbal AS Decimal128(19, 6)) > __sq_1.__value\
-    \n            CrossJoin:\
-    \n              LeftAnti Join: customer.c_custkey = orders.o_custkey\
-    \n                Filter: substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8(\"13\"), Utf8(\"31\"), Utf8(\"23\"), Utf8(\"29\"), Utf8(\"30\"), Utf8(\"18\"), Utf8(\"17\")])\
-    \n                  TableScan: customer projection=[c_custkey, c_phone, c_acctbal], partial_filters=[substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8(\"13\"), Utf8(\"31\"), Utf8(\"23\"), Utf8(\"29\"), Utf8(\"30\"), Utf8(\"18\"), Utf8(\"17\")])]\
-    \n                TableScan: orders projection=[o_custkey]\
-    \n              SubqueryAlias: __sq_1\
-    \n                Projection: AVG(customer.c_acctbal) AS __value\
-    \n                  Aggregate: groupBy=[[]], aggr=[[AVG(customer.c_acctbal)]]\
-    \n                    Filter: customer.c_acctbal > Decimal128(Some(0),15,2) AND substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8(\"13\"), Utf8(\"31\"), Utf8(\"23\"), Utf8(\"29\"), Utf8(\"30\"), Utf8(\"18\"), Utf8(\"17\")])\
-    \n                      TableScan: customer projection=[c_phone, c_acctbal], partial_filters=[customer.c_acctbal > Decimal128(Some(0),15,2) AS customer.c_acctbal > Decimal128(Some(0),30,15), substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8(\"13\"), Utf8(\"31\"), Utf8(\"23\"), Utf8(\"29\"), Utf8(\"30\"), Utf8(\"18\"), Utf8(\"17\")]), customer.c_acctbal > Decimal128(Some(0),15,2)]";
+    let expected = r#"Sort: custsale.cntrycode ASC NULLS LAST
+  Projection: custsale.cntrycode, COUNT(UInt8(1)) AS numcust, SUM(custsale.c_acctbal) AS totacctbal
+    Aggregate: groupBy=[[custsale.cntrycode]], aggr=[[COUNT(UInt8(1)), SUM(custsale.c_acctbal)]]
+      SubqueryAlias: custsale
+        Projection: substr(customer.c_phone, Int64(1), Int64(2)) AS cntrycode, customer.c_acctbal
+          Filter: CAST(customer.c_acctbal AS Decimal128(19, 6)) > __scalar_sq_1.__value
+            CrossJoin:
+              LeftAnti Join: customer.c_custkey = orders.o_custkey
+                Filter: substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")])
+                  TableScan: customer projection=[c_custkey, c_phone, c_acctbal], partial_filters=[substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")])]
+                TableScan: orders projection=[o_custkey]
+              SubqueryAlias: __scalar_sq_1
+                Projection: AVG(customer.c_acctbal) AS __value
+                  Aggregate: groupBy=[[]], aggr=[[AVG(customer.c_acctbal)]]
+                    Filter: customer.c_acctbal > Decimal128(Some(0),15,2) AND substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")])
+                      TableScan: customer projection=[c_phone, c_acctbal], partial_filters=[customer.c_acctbal > Decimal128(Some(0),15,2) AS customer.c_acctbal > Decimal128(Some(0),30,15), substr(customer.c_phone, Int64(1), Int64(2)) IN ([Utf8("13"), Utf8("31"), Utf8("23"), Utf8("29"), Utf8("30"), Utf8("18"), Utf8("17")]), customer.c_acctbal > Decimal128(Some(0),15,2)]"#;
     assert_eq!(expected, actual);
 
     // assert data
@@ -420,26 +420,26 @@ order by value desc;
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
     let actual = format!("{}", plan.display_indent());
-    let expected =  "Sort: value DESC NULLS FIRST\
-    \n  Projection: partsupp.ps_partkey, SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS value\
-    \n    Filter: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Decimal128(38, 15)) > CAST(__sq_1.__value AS Decimal128(38, 15))\
-    \n      CrossJoin:\
-    \n        Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]\
-    \n          Inner Join: supplier.s_nationkey = nation.n_nationkey\
-    \n            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey\
-    \n              TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty, ps_supplycost]\
-    \n              TableScan: supplier projection=[s_suppkey, s_nationkey]\
-    \n            Filter: nation.n_name = Utf8(\"GERMANY\")\
-    \n              TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8(\"GERMANY\")]\
-    \n        SubqueryAlias: __sq_1\
-    \n          Projection: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Float64) * Float64(0.0001) AS __value\
-    \n            Aggregate: groupBy=[[]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]\
-    \n              Inner Join: supplier.s_nationkey = nation.n_nationkey\
-    \n                Inner Join: partsupp.ps_suppkey = supplier.s_suppkey\
-    \n                  TableScan: partsupp projection=[ps_suppkey, ps_availqty, ps_supplycost]\
-    \n                  TableScan: supplier projection=[s_suppkey, s_nationkey]\
-    \n                Filter: nation.n_name = Utf8(\"GERMANY\")\
-    \n                  TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8(\"GERMANY\")]";
+    let expected = r#"Sort: value DESC NULLS FIRST
+  Projection: partsupp.ps_partkey, SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS value
+    Filter: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Decimal128(38, 15)) > CAST(__scalar_sq_1.__value AS Decimal128(38, 15))
+      CrossJoin:
+        Aggregate: groupBy=[[partsupp.ps_partkey]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]
+          Inner Join: supplier.s_nationkey = nation.n_nationkey
+            Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+              TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty, ps_supplycost]
+              TableScan: supplier projection=[s_suppkey, s_nationkey]
+            Filter: nation.n_name = Utf8("GERMANY")
+              TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8("GERMANY")]
+        SubqueryAlias: __scalar_sq_1
+          Projection: CAST(SUM(partsupp.ps_supplycost * partsupp.ps_availqty) AS Float64) * Float64(0.0001) AS __value
+            Aggregate: groupBy=[[]], aggr=[[SUM(CAST(partsupp.ps_supplycost AS Decimal128(26, 2)) * CAST(partsupp.ps_availqty AS Decimal128(26, 2)))]]
+              Inner Join: supplier.s_nationkey = nation.n_nationkey
+                Inner Join: partsupp.ps_suppkey = supplier.s_suppkey
+                  TableScan: partsupp projection=[ps_suppkey, ps_availqty, ps_supplycost]
+                  TableScan: supplier projection=[s_suppkey, s_nationkey]
+                Filter: nation.n_name = Utf8("GERMANY")
+                  TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8("GERMANY")]"#;
     assert_eq!(actual, expected);
 
     // assert data

--- a/datafusion/optimizer/src/alias.rs
+++ b/datafusion/optimizer/src/alias.rs
@@ -15,32 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod alias;
-pub mod common_subexpr_eliminate;
-pub mod decorrelate_where_exists;
-pub mod decorrelate_where_in;
-pub mod eliminate_cross_join;
-pub mod eliminate_filter;
-pub mod eliminate_limit;
-pub mod eliminate_outer_join;
-pub mod extract_equijoin_predicate;
-pub mod filter_null_join_keys;
-pub mod inline_table_scan;
-pub mod optimizer;
-pub mod propagate_empty_relation;
-pub mod push_down_filter;
-pub mod push_down_limit;
-pub mod push_down_projection;
-pub mod scalar_subquery_to_join;
-pub mod simplify_expressions;
-pub mod single_distinct_to_groupby;
-pub mod type_coercion;
-pub mod utils;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub mod rewrite_disjunctive_predicate;
-#[cfg(test)]
-pub mod test;
-pub mod unwrap_cast_in_comparison;
+/// A utility struct that can be used to generate unique aliases when optimizing queries
+pub struct AliasGenerator {
+    next_id: AtomicUsize,
+}
 
-pub use optimizer::{OptimizerConfig, OptimizerContext, OptimizerRule};
-pub use utils::optimize_children;
+impl Default for AliasGenerator {
+    fn default() -> Self {
+        Self {
+            next_id: AtomicUsize::new(1),
+        }
+    }
+}
+
+impl AliasGenerator {
+    /// Create a new [`AliasGenerator`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a unique alias with the provided prefix
+    pub fn next(&self, prefix: &str) -> String {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        format!("{}_{}", prefix, id)
+    }
+}

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -64,10 +64,10 @@ fn subquery_filter_with_cast() -> Result<()> {
     )";
     let plan = test_sql(sql)?;
     let expected = "Projection: test.col_int32\
-    \n  Filter: CAST(test.col_int32 AS Float64) > __sq_1.__value\
+    \n  Filter: CAST(test.col_int32 AS Float64) > __scalar_sq_1.__value\
     \n    CrossJoin:\
     \n      TableScan: test projection=[col_int32]\
-    \n      SubqueryAlias: __sq_1\
+    \n      SubqueryAlias: __scalar_sq_1\
     \n        Projection: AVG(test.col_int32) AS __value\
     \n          Aggregate: groupBy=[[]], aggr=[[AVG(test.col_int32)]]\
     \n            Filter: test.col_utf8 >= Utf8(\"2002-05-08\") AND test.col_utf8 <= Utf8(\"2002-05-13\")\


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3437
Closes #3791

(although these were actually fixed by https://github.com/apache/arrow-datafusion/pull/4038)

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Having mutable state associated with `OptimizerConfig` complicates implementing it for `SessionState`. I originally hoped to implement `OptimizerConfig` for `DataFrame`, but this would have required churning all the planning machinery and so I decided against this.  

There is one implication potentially worth highlighting with this change, as the state is now associated with the `OptimizerRule` and not an `OptimizerContext` created for the call to `SessionState::optimize`, state will now bleed across calls whereas it previously wouldn't. In some ways this is better, as previously calling `optimize` twice could theoretically result in an alias collision, but I thought it worth highlighting.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Move alias state from `OptimizerConfig` onto the individual rules

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

Yes, queries will get potentially different aliases assigned to them by the optimizer.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->