### PR TITLE
 Make datafusion-physical-expr compatible with blake3/traits-preview feature.

### DIFF
--- a/datafusion/physical-expr/src/crypto_expressions.rs
+++ b/datafusion/physical-expr/src/crypto_expressions.rs
@@ -123,7 +123,7 @@ impl DigestAlgorithm {
             Self::Blake3 => ScalarValue::Binary(value.map(|v| {
                 let mut digest = Blake3::default();
                 digest.update(v);
-                digest.finalize().as_bytes().to_vec()
+                Blake3::finalize(&digest).as_bytes().to_vec()
             })),
         })
     }
@@ -149,7 +149,7 @@ impl DigestAlgorithm {
                         opt.map(|x| {
                             let mut digest = Blake3::default();
                             digest.update(x);
-                            digest.finalize().as_bytes().to_vec()
+                            Blake3::finalize(&digest).as_bytes().to_vec()
                         })
                     })
                     .collect();
@@ -180,7 +180,7 @@ impl DigestAlgorithm {
                         opt.map(|x| {
                             let mut digest = Blake3::default();
                             digest.update(x.as_bytes());
-                            digest.finalize().as_bytes().to_vec()
+                            Blake3::finalize(&digest).as_bytes().to_vec()
                         })
                     })
                     .collect();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4781.

# What changes are included in this PR?

Makes `datafusion-physical-expr` compatible with `blake3/traits-preview` feature.

# Are there any user-facing changes?
No