### PR TITLE
Uncomment nanoseconds tests after sql parser upgrade

### DIFF
--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -1296,11 +1296,10 @@ async fn test_extract_date_part() -> Result<()> {
         "EXTRACT(microsecond FROM to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
         "12123456.78"
     );
-    // Depends on https://github.com/apache/arrow-datafusion/issues/4528
-    // test_expression!(
-    //     "EXTRACT(nanosecond FROM to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
-    //     "1212345678"
-    // );
+    test_expression!(
+        "EXTRACT(nanosecond FROM to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
+        "12123456780"
+    );
     test_expression!(
         "date_part('second', to_timestamp('2020-09-08T12:00:12.12345678+00:00'))",
         "12.12345678"
@@ -1389,8 +1388,13 @@ async fn test_extract_date_part_func() -> Result<()> {
         ),
         "true"
     );
-    // Depends on https://github.com/apache/arrow-datafusion/issues/4528
-    //test_expression!(format!("(date_part('{0}', now()) = EXTRACT({0} FROM now()))", "nanosecond"), "true");
+    test_expression!(
+        format!(
+            "(date_part('{0}', now()) = EXTRACT({0} FROM now()))",
+            "nanosecond"
+        ),
+        "true"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4528.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Nanoseconds tests were disabled because of sqlparser didn't support nanoseconds. Current 29 sql parser allows tests to run

# What changes are included in this PR?
Tests for nanosecond for date_part/extract

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->