### PR TITLE
Physical planner: Support join keys in l==r or r==l order

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -937,10 +937,21 @@ impl DefaultPhysicalPlanner {
                         .map(|(l, r)| {
                             let l = l.try_into_col()?;
                             let r = r.try_into_col()?;
-                            Ok((
-                                Column::new(&l.name, left_df_schema.index_of_column(&l)?),
-                                Column::new(&r.name, right_df_schema.index_of_column(&r)?),
-                            ))
+                            // look for l==r and r==l since join could be either way
+                            match left_df_schema.index_of_column(&l) {
+                                Ok(left_index) => {
+                                    Ok((
+                                        Column::new(&l.name, left_index),
+                                        Column::new(&r.name, right_df_schema.index_of_column(&r)?),
+                                    ))
+                                }
+                                _ => {
+                                    Ok((
+                                        Column::new(&l.name, left_df_schema.index_of_column(&r)?),
+                                        Column::new(&r.name, right_df_schema.index_of_column(&l)?),
+                                    ))
+                                }
+                            }
                         })
                         .collect::<Result<join_utils::JoinOn>>()?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/4795

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Bug fix needed for TPC-DS

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Look for join keys in either l==r or r==l order

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->