### PR TITLE
rewrite the function `ensure_any_column_reference_is_unambiguous`

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -3251,43 +3251,44 @@ fn ensure_any_column_reference_is_unambiguous(
     if schemas.len() == 1 {
         return Ok(());
     }
-
-    // extract columns both in one more schemas.
-    let mut column_count_map: HashMap<&str, usize> = HashMap::new();
-    schemas
+    // all referenced columns in the expression that don't have relation
+    let referenced_cols = expr.to_columns()?;
+    let mut no_relation_cols = referenced_cols
+        .iter()
+        .filter_map(|col| {
+            if col.relation.is_none() {
+                Some((col.name.as_str(), 0))
+            } else {
+                None
+            }
+        })
+        .collect::<HashMap<&str, u8>>();
+    // find the name of the column existing in multi schemas.
+    let ambiguous_col_name = schemas
         .iter()
         .flat_map(|schema| schema.fields())
-        .for_each(|field| {
-            column_count_map
-                .entry(field.name())
-                .and_modify(|v| *v += 1)
-                .or_insert(1usize);
+        .map(|field| field.name())
+        .find(|col_name| {
+            no_relation_cols.entry(col_name).and_modify(|v| *v += 1);
+            matches!(
+                no_relation_cols.get_key_value(col_name.as_str()),
+                Some((_, 2..))
+            )
         });
 
-    let duplicated_column_set = column_count_map
-        .into_iter()
-        .filter_map(|(column, count)| if count > 1 { Some(column) } else { None })
-        .collect::<HashSet<&str>>();
-
-    // check if there is ambiguous column.
-    let using_columns = expr.to_columns()?;
-    let ambiguous_column = using_columns.iter().find(|column| {
-        column.relation.is_none() && duplicated_column_set.contains(column.name.as_str())
-    });
-
-    if let Some(column) = ambiguous_column {
+    if let Some(col_name) = ambiguous_col_name {
         let maybe_field = schemas
             .iter()
             .flat_map(|schema| {
                 schema
-                    .field_with_unqualified_name(&column.name)
+                    .field_with_unqualified_name(col_name)
                     .map(|f| f.qualified_name())
                     .ok()
             })
             .collect::<Vec<_>>();
         Err(DataFusionError::Plan(format!(
             "reference \'{}\' is ambiguous, could be {};",
-            column.name,
+            col_name,
             maybe_field.join(","),
         )))
     } else {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As the columns referenced in `expr` are always fewer than the columns in `schemas`, we don't need to include all the columns in our hash map.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Pass current tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->