### PR TITLE
Add test cases: row group filter with missing statistics for decimal data type

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet/row_groups.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet/row_groups.rs
@@ -475,10 +475,21 @@ mod tests {
             // c1 > 5, this row group will not be included in the results.
             vec![ParquetStatistics::int32(Some(10), Some(20), None, 0, false)],
         );
+        let rgm3 = get_row_group_meta_data(
+            &schema_descr,
+            // [1, None]
+            // c1 > 5, this row group will not be included in the results.
+            vec![ParquetStatistics::int32(Some(100), None, None, 0, false)],
+        );
         let metrics = parquet_file_metrics();
         assert_eq!(
-            prune_row_groups(&[rgm1, rgm2], None, Some(&pruning_predicate), &metrics),
-            vec![0]
+            prune_row_groups(
+                &[rgm1, rgm2, rgm3],
+                None,
+                Some(&pruning_predicate),
+                &metrics
+            ),
+            vec![0, 2]
         );
 
         // INT32: c1 > 5, but parquet decimal type has different precision or scale to arrow decimal
@@ -528,15 +539,21 @@ mod tests {
             // c1 > 5, this row group will not be included in the results.
             vec![ParquetStatistics::int32(Some(0), Some(2), None, 0, false)],
         );
+        let rgm4 = get_row_group_meta_data(
+            &schema_descr,
+            // [None, 2]
+            // c1 > 5, this row group will not be included in the results.
+            vec![ParquetStatistics::int32(None, Some(2), None, 0, false)],
+        );
         let metrics = parquet_file_metrics();
         assert_eq!(
             prune_row_groups(
-                &[rgm1, rgm2, rgm3],
+                &[rgm1, rgm2, rgm3, rgm4],
                 None,
                 Some(&pruning_predicate),
                 &metrics
             ),
-            vec![0, 1]
+            vec![0, 1, 3]
         );
 
         // INT64: c1 < 5, the c1 is decimal(18,2)
@@ -572,10 +589,20 @@ mod tests {
             // [0.1, 0.2]
             vec![ParquetStatistics::int64(Some(10), Some(20), None, 0, false)],
         );
+        let rgm3 = get_row_group_meta_data(
+            &schema_descr,
+            // [0.1, 0.2]
+            vec![ParquetStatistics::int64(None, None, None, 0, false)],
+        );
         let metrics = parquet_file_metrics();
         assert_eq!(
-            prune_row_groups(&[rgm1, rgm2], None, Some(&pruning_predicate), &metrics),
-            vec![1]
+            prune_row_groups(
+                &[rgm1, rgm2, rgm3],
+                None,
+                Some(&pruning_predicate),
+                &metrics
+            ),
+            vec![1, 2]
         );
 
         // FIXED_LENGTH_BYTE_ARRAY: c1 = decimal128(100000, 28, 3), the c1 is decimal(18,2)
@@ -631,13 +658,24 @@ mod tests {
                 false,
             )],
         );
+
+        let rgm3 = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::fixed_len_byte_array(
+                None, None, None, 0, false,
+            )],
+        );
         let metrics = parquet_file_metrics();
         assert_eq!(
-            prune_row_groups(&[rgm1, rgm2], None, Some(&pruning_predicate), &metrics),
-            vec![1]
+            prune_row_groups(
+                &[rgm1, rgm2, rgm3],
+                None,
+                Some(&pruning_predicate),
+                &metrics
+            ),
+            vec![1, 2]
         );
 
-        // TODO: BYTE_ARRAY support read decimal from parquet, after the 20.0.0 arrow-rs release
         // BYTE_ARRAY: c1 = decimal128(100000, 28, 3), the c1 is decimal(18,2)
         // the type of parquet is decimal(18,2)
         let schema =
@@ -683,10 +721,19 @@ mod tests {
                 false,
             )],
         );
+        let rgm3 = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::byte_array(None, None, None, 0, false)],
+        );
         let metrics = parquet_file_metrics();
         assert_eq!(
-            prune_row_groups(&[rgm1, rgm2], None, Some(&pruning_predicate), &metrics),
-            vec![1]
+            prune_row_groups(
+                &[rgm1, rgm2, rgm3],
+                None,
+                Some(&pruning_predicate),
+                &metrics
+            ),
+            vec![1, 2]
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

From the comments @alamb  https://github.com/apache/arrow-datafusion/pull/4742#discussion_r1059755347

If the min or max is None which indicate the statistics is missing, the row group should not be filtered.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->