### PR TITLE
Support using var/var_pop/stddev/stddev_pop in window expressions with custom frames

### DIFF
--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -73,6 +73,10 @@ impl AggregateExpr for Stddev {
         Ok(Box::new(StddevAccumulator::try_new(StatsType::Sample)?))
     }
 
+    fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
+        Ok(Box::new(StddevAccumulator::try_new(StatsType::Sample)?))
+    }
+
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(vec![
             Field::new(
@@ -125,6 +129,10 @@ impl AggregateExpr for StddevPop {
     }
 
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
+        Ok(Box::new(StddevAccumulator::try_new(StatsType::Population)?))
+    }
+
+    fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
         Ok(Box::new(StddevAccumulator::try_new(StatsType::Population)?))
     }
 
@@ -182,6 +190,10 @@ impl Accumulator for StddevAccumulator {
 
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         self.variance.update_batch(values)
+    }
+
+    fn retract_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        self.variance.retract_batch(values)
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -79,6 +79,10 @@ impl AggregateExpr for Variance {
         Ok(Box::new(VarianceAccumulator::try_new(StatsType::Sample)?))
     }
 
+    fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
+        Ok(Box::new(VarianceAccumulator::try_new(StatsType::Sample)?))
+    }
+
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(vec![
             Field::new(
@@ -131,6 +135,12 @@ impl AggregateExpr for VariancePop {
     }
 
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
+        Ok(Box::new(VarianceAccumulator::try_new(
+            StatsType::Population,
+        )?))
+    }
+
+    fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
         Ok(Box::new(VarianceAccumulator::try_new(
             StatsType::Population,
         )?))


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/4846 for `var`, `var_pop`, `stddev`, and `stddev_pop`. 

The actual `retract_batch` function was already implemented, but it looks like the `create_sliding_accumulator` implementations weren't added previously so it wasn't possible to use these aggregate functions in window expressions that use custom frames.

# Are these changes tested?
The test added in effc4728912684f63b2e4ce837ae1b1816796480 will fail until https://github.com/apache/arrow-datafusion/pull/4847 is merged and this branch is updated.

I'll mark this is draft until then.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
`var`, `var_pop`, `stddev`, and `stddev_pop` will now work in window expressions that use custom frames rather than raising an error.
