### PR TITLE
Covariance single row input & null skipping

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
@@ -36,11 +36,93 @@ SELECT covar(c2, c12) FROM aggregate_test_100
 ----
 -0.07996901247859442
 
+# single_row_query_covar_1
+query R
+select covar_samp(sq.column1, sq.column2) from (values (1.1, 2.2)) as sq
+----
+NULL
+
+# single_row_query_covar_2
+query R
+select covar_pop(sq.column1, sq.column2) from (values (1.1, 2.2)) as sq
+----
+0
+
+# all_nulls_query_covar
+query R
+with data as (
+  select null::int as f, null::int as b
+  union all
+  select null::int as f, null::int as b
+)
+select covar_samp(f, b), covar_pop(f, b)
+from data
+----
+NULL NULL
+
+# covar_query_with_nulls
+query R
+with data as (
+  select 1 as f,       4 as b
+  union all
+  select null as f,   99 as b
+  union all
+  select 2 as f,       5 as b
+  union all
+  select 98 as f,   null as b
+  union all
+  select 3 as f,       6 as b
+  union all
+  select null as f, null as b
+)
+select covar_samp(f, b), covar_pop(f, b)
+from data
+----
+1 0.6666666666666666
+
 # csv_query_correlation
 query R
 SELECT corr(c2, c12) FROM aggregate_test_100
 ----
 -0.19064544190576607
+
+# single_row_query_correlation
+query R
+select corr(sq.column1, sq.column2) from (values (1.1, 2.2)) as sq
+----
+0
+
+# all_nulls_query_correlation
+query R
+with data as (
+  select null::int as f, null::int as b
+  union all
+  select null::int as f, null::int as b
+)
+select corr(f, b)
+from data
+----
+NULL
+
+# correlation_query_with_nulls
+query R
+with data as (
+  select 1 as f,       4 as b
+  union all
+  select null as f,   99 as b
+  union all
+  select 2 as f,       5 as b
+  union all
+  select 98 as f,   null as b
+  union all
+  select 3 as f,       6 as b
+  union all
+  select null as f, null as b
+)
+select corr(f, b)
+from data
+----
+1
 
 # csv_query_variance_1
 query R

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -149,6 +149,11 @@ impl Accumulator for CorrelationAccumulator {
     }
 
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        // TODO: null input skipping logic duplicated across Correlation
+        // and its children accumulators.
+        // This could be simplified by splitting up input filtering and
+        // calculation logic in children accumulators, and calling only
+        // calculation part from Correlation
         let values = if values[0].null_count() != 0 || values[1].null_count() != 0 {
             let mask = and(&is_not_null(&values[0])?, &is_not_null(&values[1])?)?;
             let values1 = filter(&values[0], &mask)?;

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -254,13 +254,15 @@ impl Accumulator for CovarianceAccumulator {
         let mut arr2 = downcast_value!(values2, Float64Array).iter().flatten();
 
         for i in 0..values1.len() {
-            let value1 = match values1.is_valid(i) {
-                true => arr1.next(),
-                false => None,
+            let value1 = if values1.is_valid(i) {
+                arr1.next()
+            } else {
+                None
             };
-            let value2 = match values2.is_valid(i) {
-                true => arr2.next(),
-                false => None,
+            let value2 = if values2.is_valid(i) {
+                arr2.next()
+            } else {
+                None
             };
 
             if value1.is_none() || value2.is_none() {
@@ -292,13 +294,15 @@ impl Accumulator for CovarianceAccumulator {
         let mut arr2 = downcast_value!(values2, Float64Array).iter().flatten();
 
         for i in 0..values1.len() {
-            let value1 = match values1.is_valid(i) {
-                true => arr1.next(),
-                false => None,
+            let value1 = if values1.is_valid(i) {
+                arr1.next()
+            } else {
+                None
             };
-            let value2 = match values2.is_valid(i) {
-                true => arr2.next(),
-                false => None,
+            let value2 = if values2.is_valid(i) {
+                arr2.next()
+            } else {
+                None
             };
 
             if value1.is_none() || value2.is_none() {

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -253,33 +253,33 @@ impl Accumulator for CovarianceAccumulator {
         let mut arr1 = downcast_value!(values1, Float64Array).iter().flatten();
         let mut arr2 = downcast_value!(values2, Float64Array).iter().flatten();
 
-        for _i in 0..values1.len() {
-            let value1 = arr1.next();
-            let value2 = arr2.next();
+        for i in 0..values1.len() {
+            let value1 = match values1.is_valid(i) {
+                true => arr1.next(),
+                false => None,
+            };
+            let value2 = match values2.is_valid(i) {
+                true => arr2.next(),
+                false => None,
+            };
 
             if value1.is_none() || value2.is_none() {
-                if value1.is_none() && value2.is_none() {
-                    continue;
-                } else {
-                    return Err(DataFusionError::Internal(
-                        "The two columns are not aligned".to_string(),
-                    ));
-                }
-            } else {
-                let value1 = unwrap_or_internal_err!(value1);
-                let value2 = unwrap_or_internal_err!(value2);
-                let new_count = self.count + 1;
-                let delta1 = value1 - self.mean1;
-                let new_mean1 = delta1 / new_count as f64 + self.mean1;
-                let delta2 = value2 - self.mean2;
-                let new_mean2 = delta2 / new_count as f64 + self.mean2;
-                let new_c = delta1 * (value2 - new_mean2) + self.algo_const;
-
-                self.count += 1;
-                self.mean1 = new_mean1;
-                self.mean2 = new_mean2;
-                self.algo_const = new_c;
+                continue;
             }
+
+            let value1 = unwrap_or_internal_err!(value1);
+            let value2 = unwrap_or_internal_err!(value2);
+            let new_count = self.count + 1;
+            let delta1 = value1 - self.mean1;
+            let new_mean1 = delta1 / new_count as f64 + self.mean1;
+            let delta2 = value2 - self.mean2;
+            let new_mean2 = delta2 / new_count as f64 + self.mean2;
+            let new_c = delta1 * (value2 - new_mean2) + self.algo_const;
+
+            self.count += 1;
+            self.mean1 = new_mean1;
+            self.mean2 = new_mean2;
+            self.algo_const = new_c;
         }
 
         Ok(())
@@ -291,19 +291,20 @@ impl Accumulator for CovarianceAccumulator {
         let mut arr1 = downcast_value!(values1, Float64Array).iter().flatten();
         let mut arr2 = downcast_value!(values2, Float64Array).iter().flatten();
 
-        for _i in 0..values1.len() {
-            let value1 = arr1.next();
-            let value2 = arr2.next();
+        for i in 0..values1.len() {
+            let value1 = match values1.is_valid(i) {
+                true => arr1.next(),
+                false => None,
+            };
+            let value2 = match values2.is_valid(i) {
+                true => arr2.next(),
+                false => None,
+            };
 
             if value1.is_none() || value2.is_none() {
-                if value1.is_none() && value2.is_none() {
-                    continue;
-                } else {
-                    return Err(DataFusionError::Internal(
-                        "The two columns are not aligned".to_string(),
-                    ));
-                }
+                continue;
             }
+
             let new_count = self.count - 1;
             let delta1 = self.mean1 - value1.unwrap();
             let new_mean1 = delta1 / new_count as f64 + self.mean1;
@@ -316,6 +317,7 @@ impl Accumulator for CovarianceAccumulator {
             self.mean2 = new_mean2;
             self.algo_const = new_c;
         }
+
         Ok(())
     }
 
@@ -361,13 +363,7 @@ impl Accumulator for CovarianceAccumulator {
             }
         };
 
-        if count <= 1 {
-            return Err(DataFusionError::Internal(
-                "At least two values are needed to calculate covariance".to_string(),
-            ));
-        }
-
-        if self.count == 0 {
+        if count == 0 {
             Ok(ScalarValue::Float64(None))
         } else {
             Ok(ScalarValue::Float64(Some(self.algo_const / count as f64)))
@@ -529,25 +525,60 @@ mod tests {
 
     #[test]
     fn covariance_i32_with_nulls_2() -> Result<()> {
-        let a: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]));
-        let b: ArrayRef = Arc::new(Int32Array::from(vec![Some(4), Some(5), Some(6)]));
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(2),
+            None,
+            Some(3),
+            None,
+        ]));
+        let b: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(4),
+            Some(9),
+            Some(5),
+            Some(8),
+            Some(6),
+            None,
+        ]));
 
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, true),
-            Field::new("b", DataType::Int32, true),
-        ]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
+        generic_test_op2!(
+            a,
+            b,
+            DataType::Int32,
+            DataType::Int32,
+            CovariancePop,
+            ScalarValue::from(0.6666666666666666_f64)
+        )
+    }
 
-        let agg = Arc::new(Covariance::new(
-            col("a", &schema)?,
-            col("b", &schema)?,
-            "bla".to_string(),
-            DataType::Float64,
-        ));
-        let actual = aggregate(&batch, agg);
-        assert!(actual.is_err());
+    #[test]
+    fn covariance_i32_with_nulls_3() -> Result<()> {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(2),
+            None,
+            Some(3),
+            None,
+        ]));
+        let b: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(4),
+            Some(9),
+            Some(5),
+            Some(8),
+            Some(6),
+            None,
+        ]));
 
-        Ok(())
+        generic_test_op2!(
+            a,
+            b,
+            DataType::Int32,
+            DataType::Int32,
+            Covariance,
+            ScalarValue::from(1_f64)
+        )
     }
 
     #[test]
@@ -555,22 +586,59 @@ mod tests {
         let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
         let b: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
 
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, true),
-            Field::new("b", DataType::Int32, true),
-        ]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![a, b])?;
+        generic_test_op2!(
+            a,
+            b,
+            DataType::Int32,
+            DataType::Int32,
+            Covariance,
+            ScalarValue::Float64(None)
+        )
+    }
 
-        let agg = Arc::new(Covariance::new(
-            col("a", &schema)?,
-            col("b", &schema)?,
-            "bla".to_string(),
+    #[test]
+    fn covariance_pop_i32_all_nulls() -> Result<()> {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
+        let b: ArrayRef = Arc::new(Int32Array::from(vec![None, None]));
+
+        generic_test_op2!(
+            a,
+            b,
+            DataType::Int32,
+            DataType::Int32,
+            CovariancePop,
+            ScalarValue::Float64(None)
+        )
+    }
+
+    #[test]
+    fn covariance_1_input() -> Result<()> {
+        let a: ArrayRef = Arc::new(Float64Array::from(vec![1_f64]));
+        let b: ArrayRef = Arc::new(Float64Array::from(vec![2_f64]));
+
+        generic_test_op2!(
+            a,
+            b,
             DataType::Float64,
-        ));
-        let actual = aggregate(&batch, agg);
-        assert!(actual.is_err());
+            DataType::Float64,
+            Covariance,
+            ScalarValue::Float64(None)
+        )
+    }
 
-        Ok(())
+    #[test]
+    fn covariance_pop_1_input() -> Result<()> {
+        let a: ArrayRef = Arc::new(Float64Array::from(vec![1_f64]));
+        let b: ArrayRef = Arc::new(Float64Array::from(vec![2_f64]));
+
+        generic_test_op2!(
+            a,
+            b,
+            DataType::Float64,
+            DataType::Float64,
+            CovariancePop,
+            ScalarValue::from(0_f64)
+        )
     }
 
     #[test]

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -309,12 +309,15 @@ impl Accumulator for CovarianceAccumulator {
                 continue;
             }
 
+            let value1 = unwrap_or_internal_err!(value1);
+            let value2 = unwrap_or_internal_err!(value2);
+
             let new_count = self.count - 1;
-            let delta1 = self.mean1 - value1.unwrap();
+            let delta1 = self.mean1 - value1;
             let new_mean1 = delta1 / new_count as f64 + self.mean1;
-            let delta2 = self.mean2 - value2.unwrap();
+            let delta2 = self.mean2 - value2;
             let new_mean2 = delta2 / new_count as f64 + self.mean2;
-            let new_c = self.algo_const - delta1 * (new_mean2 - value2.unwrap());
+            let new_c = self.algo_const - delta1 * (new_mean2 - value2);
 
             self.count -= 1;
             self.mean1 = new_mean1;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up on #4843 (or #4314)

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Covariance function also has an issue with single row inputs processing and cases when inputs contain NULL values

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Covariance function now able to process single row and pairs of (NULL, NOT NULL) arguments. As a consequence of proper handling NULLs in Variance, Correlation function now requires additional input filtering - in case one input field is NULL, we should filter out whole record (second field actually) to keep Sttdev (as part of correlation) calculation relevant.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Fixed/added tests for corresponding accumulators and sqllogictests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

covar_samp/covar_pop/corr functions don't return Errors in case of single row input or (null, not null) argument values

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->