### PR TITLE
Remove unused ExecutionPlan::relies_input_order (has been replaced with `required_input_ordering`)

### DIFF
--- a/datafusion/core/src/physical_optimizer/repartition.rs
+++ b/datafusion/core/src/physical_optimizer/repartition.rs
@@ -140,9 +140,6 @@ impl Repartition {
 ///
 /// 2. Has a direct parent that `benefits_from_input_partitioning`
 ///
-/// 3. Does not have a parent that `relies_on_input_order` unless there
-/// is an intervening node that does not `maintain_input_order`
-///
 /// if `can_reorder` is false, means that the output of this node
 /// can not be reordered as as the final output is relying on that order
 ///

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -105,10 +105,6 @@ impl ExecutionPlan for GlobalLimitExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn relies_on_input_order(&self) -> bool {
-        self.input.output_ordering().is_some()
-    }
-
     fn maintains_input_order(&self) -> bool {
         true
     }
@@ -272,10 +268,6 @@ impl ExecutionPlan for LocalLimitExec {
 
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
-    }
-
-    fn relies_on_input_order(&self) -> bool {
-        self.input.output_ordering().is_some()
     }
 
     fn benefits_from_input_partitioning(&self) -> bool {

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -141,27 +141,6 @@ pub trait ExecutionPlan: Debug + Send + Sync {
         vec![None; self.children().len()]
     }
 
-    /// Returns `true` if this operator relies on its inputs being
-    /// produced in a certain order (for example that they are sorted
-    /// a particular way) for correctness.
-    ///
-    /// If `true` is returned, DataFusion will not apply certain
-    /// optimizations which might reorder the inputs (such as
-    /// repartitioning to increase concurrency).
-    ///
-    /// The default implementation checks the input ordering requirements
-    /// and if there is non empty ordering requirements to the input, the method will
-    /// return `true`.
-    ///
-    /// WARNING: if you override this default and return `false`, your
-    /// operator can not rely on DataFusion preserving the input order
-    /// as it will likely not.
-    fn relies_on_input_order(&self) -> bool {
-        self.required_input_ordering()
-            .iter()
-            .any(|ordering| matches!(ordering, Some(_)))
-    }
-
     /// Returns `false` if this operator's implementation may reorder
     /// rows within or between partitions.
     ///

--- a/datafusion/core/src/scheduler/pipeline/execution.rs
+++ b/datafusion/core/src/scheduler/pipeline/execution.rs
@@ -239,10 +239,6 @@ impl ExecutionPlan for ProxyExecutionPlan {
         self.inner.required_input_distribution()
     }
 
-    fn relies_on_input_order(&self) -> bool {
-        self.inner.relies_on_input_order()
-    }
-
     fn maintains_input_order(&self) -> bool {
         self.inner.maintains_input_order()
     }


### PR DESCRIPTION

# Which issue does this PR close?

Related to #4686 

# Rationale for this change

https://github.com/apache/arrow-datafusion/pull/4691 from @mustafasrepo  made the `relies_on_input` redundant in favor of the more general required_input_ordering



# What changes are included in this PR?
Remove `relies_on_input`

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?
No, though it is an API change
