### PR TITLE
docs: improve `Column::normalize_with_schemas` docs

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -83,7 +83,25 @@ impl Column {
         }
     }
 
-    // Internal implementation of normalize
+    /// Qualify column if not done yet.
+    ///
+    /// If this column already has a [relation](Self::relation), it will be returned as is and the given parameters are
+    /// ignored. Otherwise this will search through the given schemas to find the column. This will use the first schema
+    /// that matches.
+    ///
+    /// A schema matches if there is a single column that -- when unqualified -- matches this column. There is an
+    /// exception for `USING` statements, see below.
+    ///
+    /// # Using columns
+    /// Take the following SQL statement:
+    ///
+    /// ```sql
+    /// SELECT id FROM t1 JOIN t2 USING(id)
+    /// ```
+    ///
+    /// In this case, both `t1.id` and `t2.id` will match unqualified column `id`. To express this possibility, use
+    /// `using_columns`. Each entry in this array is a set of columns that are bound together via a `USING` clause. So
+    /// in this example this would be `[{t1.id, t2.id}]`.
     pub fn normalize_with_schemas(
         self,
         schemas: &[&Arc<DFSchema>],


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
While debugging #4854 I got a bit confused because the docs of `normalize_col_with_schemas` and `normalize_col` just state "uses `Column::normalize_with_schemas` but the latter just says "internal implementation" and I had to read throw the code to understand what "normalize" actually means.

# What changes are included in this PR?
Docs for `Column::normalize_with_schemas`.

# Are these changes tested?
\-

# Are there any user-facing changes?
Better docs.