### PR TITLE
Do not repartition inputs whose sort order is required

### DIFF
--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -136,7 +136,12 @@ pub trait ExecutionPlan: Debug + Send + Sync {
     }
 
     /// Specifies the ordering requirements for all of the children
-    /// For each child, it's the local ordering requirement within each partition rather than the global ordering
+    /// For each child, it's the local ordering requirement within
+    /// each partition rather than the global ordering
+    ///
+    /// NOTE that checking `!is_empty()` does **not** check for a
+    /// required input ordering. Instead, the correct check is that at
+    /// least one entry must be `Some`
     fn required_input_ordering(&self) -> Vec<Option<&[PhysicalSortExpr]>> {
         vec![None; self.children().len()]
     }

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -86,11 +86,10 @@ async fn explain_analyze_baseline_metrics() {
         "CoalesceBatchesExec: target_batch_size=4096",
         "metrics=[output_rows=5, elapsed_compute"
     );
-    // The number of output rows becomes less after changing the global sort to the local sort with limit push down
     assert_metrics!(
         &formatted,
         "CoalescePartitionsExec",
-        "metrics=[output_rows=3, elapsed_compute="
+        "metrics=[output_rows=5, elapsed_compute="
     );
     assert_metrics!(
         &formatted,


### PR DESCRIPTION
# Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/4883

the fix is small logic fix to a condition. The rest of this PR is documentation and tests 

# Rationale for this change

The repartition optimizer pass is destroying a pre-existing sort order by repartitioning the data. The plan is actually producing correct answers (which is good) because the sort is added back afterwards, but it was doing so by resorting the data :(

There is much more backstory on https://github.com/apache/arrow-datafusion/issues/4883

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


# Are these changes tested?
yes, new tests


Without this change the tests fail like (added a repartition above the parquet exec)

```

---- physical_optimizer::repartition::tests::repartition_does_not_destroy_sort_more_complex stdout ----
thread 'physical_optimizer::repartition::tests::repartition_does_not_destroy_sort_more_complex' panicked at 'assertion failed: `(left == right)`
  left: `["UnionExec", "SortRequiredExec", "ParquetExec: limit=None, partitions={1 group: [[x]]}, output_ordering=[c1@0 ASC], projection=[c1]", "FilterExec: c1@0", "RepartitionExec: partitioning=RoundRobinBatch(10)", "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[c1]"]`,
 right: `["UnionExec", "SortRequiredExec", "RepartitionExec: partitioning=RoundRobinBatch(10)", "ParquetExec: limit=None, partitions={1 group: [[x]]}, output_ordering=[c1@0 ASC], projection=[c1]", "FilterExec: c1@0", "RepartitionExec: partitioning=RoundRobinBatch(10)", "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[c1]"]`:

expected:

[
    "UnionExec",
    "SortRequiredExec",
    "ParquetExec: limit=None, partitions={1 group: [[x]]}, output_ordering=[c1@0 ASC], projection=[c1]",
    "FilterExec: c1@0",
    "RepartitionExec: partitioning=RoundRobinBatch(10)",
    "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[c1]",
]
actual:

[
    "UnionExec",
    "SortRequiredExec",
    "RepartitionExec: partitioning=RoundRobinBatch(10)",
    "ParquetExec: limit=None, partitions={1 group: [[x]]}, output_ordering=[c1@0 ASC], projection=[c1]",
    "FilterExec: c1@0",
    "RepartitionExec: partitioning=RoundRobinBatch(10)",
    "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[c1]",
]


```

# Are there any user-facing changes?

I am not sure if this bug is hittable for other users. We hit it in IOx and I think UnboundedWindowExec and MergeJoin are susceptible to the same problem, but I am not sure how widely used they are