### PR TITLE
[Substrait] Change API to return LogicalPlan instead of DataFrame

### DIFF
--- a/datafusion/substrait/src/consumer.rs
+++ b/datafusion/substrait/src/consumer.rs
@@ -384,7 +384,7 @@ pub async fn from_substrait_rel(
                     },
                 };
                 let t = ctx.table(table_reference).await?;
-                let t = t.logical_plan().clone();
+                let t = t.into_optimized_plan()?;
                 match &read.projection {
                     Some(MaskExpression { select, .. }) => match &select.as_ref() {
                         Some(projection) => {
@@ -415,9 +415,9 @@ pub async fn from_substrait_rel(
                                 )),
                             }
                         }
-                        _ => Ok(t.clone()),
+                        _ => Ok(t),
                     },
-                    _ => Ok(t.clone()),
+                    _ => Ok(t),
                 }
             }
             _ => Err(DataFusionError::NotImplemented(

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -230,12 +230,14 @@ mod tests {
         Ok(())
     }
 
+    #[allow(deprecated)]
     async fn roundtrip(sql: &str) -> Result<()> {
         let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
+        let plan2 = ctx.optimize(&plan2)?;
 
         println!("{:#?}", plan);
         println!("{:#?}", plan2);

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -186,8 +186,7 @@ mod tests {
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan)?;
-        let df = from_substrait_plan(&mut ctx, &proto).await?;
-        let plan2 = df.into_optimized_plan()?;
+        let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2str = format!("{:?}", plan2);
         assert_eq!(expected_plan_str, &plan2str);
         Ok(())
@@ -198,9 +197,7 @@ mod tests {
         let df = ctx.sql(sql).await?;
         let plan1 = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan1)?;
-
-        let df = from_substrait_plan(&mut ctx, &proto).await?;
-        let plan2 = df.into_optimized_plan()?;
+        let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
 
         // Format plan string and replace all None's with 0
         let plan1str = format!("{:?}", plan1).replace("None", "0");
@@ -218,15 +215,11 @@ mod tests {
 
         let df_a = ctx.sql(sql_with_alias).await?;
         let proto_a = to_substrait_plan(&df_a.into_optimized_plan()?)?;
-        let plan_with_alias = from_substrait_plan(&mut ctx, &proto_a)
-            .await?
-            .into_optimized_plan()?;
+        let plan_with_alias = from_substrait_plan(&mut ctx, &proto_a).await?;
 
         let df = ctx.sql(sql_no_alias).await?;
-        let proto = to_substrait_plan(&df.into_optimized_plan()?)?;
-        let plan = from_substrait_plan(&mut ctx, &proto)
-            .await?
-            .into_optimized_plan()?;
+        let proto = to_substrait_plan(&df.logical_plan())?;
+        let plan = from_substrait_plan(&mut ctx, &proto).await?;
 
         println!("{:#?}", plan_with_alias);
         println!("{:#?}", plan);
@@ -242,9 +235,7 @@ mod tests {
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan)?;
-
-        let df = from_substrait_plan(&mut ctx, &proto).await?;
-        let plan2 = df.into_optimized_plan()?;
+        let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
 
         println!("{:#?}", plan);
         println!("{:#?}", plan2);

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -66,6 +66,7 @@ mod tests {
         roundtrip("SELECT * FROM data WHERE d AND a > 1").await
     }
 
+    #[ignore] // tracked in https://github.com/apache/arrow-datafusion/issues/4897
     #[tokio::test]
     async fn select_with_limit() -> Result<()> {
         roundtrip_fill_na("SELECT * FROM data LIMIT 100").await

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -218,7 +218,7 @@ mod tests {
         let plan_with_alias = from_substrait_plan(&mut ctx, &proto_a).await?;
 
         let df = ctx.sql(sql_no_alias).await?;
-        let proto = to_substrait_plan(&df.logical_plan())?;
+        let proto = to_substrait_plan(&df.into_optimized_plan()?)?;
         let plan = from_substrait_plan(&mut ctx, &proto).await?;
 
         println!("{:#?}", plan_with_alias);

--- a/datafusion/substrait/tests/serialize.rs
+++ b/datafusion/substrait/tests/serialize.rs
@@ -40,8 +40,7 @@ mod tests {
         // Read substrait plan from file
         let proto = serializer::deserialize(path).await?;
         // Check plan equality
-        let df = from_substrait_plan(&mut ctx, &proto).await?;
-        let plan = df.into_optimized_plan()?;
+        let plan = from_substrait_plan(&mut ctx, &proto).await?;
         let plan_str_ref = format!("{:?}", plan_ref);
         let plan_str = format!("{:?}", plan);
         assert_eq!(plan_str_ref, plan_str);

--- a/datafusion/substrait/tests/serialize.rs
+++ b/datafusion/substrait/tests/serialize.rs
@@ -41,6 +41,8 @@ mod tests {
         let proto = serializer::deserialize(path).await?;
         // Check plan equality
         let plan = from_substrait_plan(&mut ctx, &proto).await?;
+        // #[allow(deprecated)]
+        // let plan = ctx.optimize(&plan)?;
         let plan_str_ref = format!("{:?}", plan_ref);
         let plan_str = format!("{:?}", plan);
         assert_eq!(plan_str_ref, plan_str);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/4897

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As suggested by @nseekhao, given that to_substrait_rel() takes LogicalPlan and returns Substrait Rel, it would be better if from_subtrait_rel() takes Substrait Rel and returns LogicalPlan rather than DataFrame.

Note that this was originally https://github.com/datafusion-contrib/datafusion-substrait/pull/35 
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->