### PR TITLE
Add insert/update/delete to LogicalPlan and add SQL planner support

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1180,6 +1180,12 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: CreateView".to_string(),
                     ))
                 }
+                LogicalPlan::Write(_) => {
+                    // DataFusion is a read-only query engine, but also a library, so consumers may implement this
+                    Err(DataFusionError::Internal(
+                        "Unsupported logical plan: Write".to_string(),
+                    ))
+                }
                 LogicalPlan::SetVariable(_) => {
                     Err(DataFusionError::Internal(
                         "Unsupported logical plan: SetVariable must be root of the plan".to_string(),

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1180,7 +1180,7 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: CreateView".to_string(),
                     ))
                 }
-                LogicalPlan::Write(_) => {
+                LogicalPlan::Dml(_) => {
                     // DataFusion is a read-only query engine, but also a library, so consumers may implement this
                     Err(DataFusionError::Internal(
                         "Unsupported logical plan: Write".to_string(),

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -71,11 +71,11 @@ pub use logical_plan::{
         build_join_schema, union, wrap_projection_for_join_if_necessary, UNNAMED_TABLE,
     },
     Aggregate, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
-    CreateMemoryTable, CreateView, CrossJoin, Distinct, DropTable, DropView,
-    EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
-    LogicalPlan, LogicalPlanBuilder, Partitioning, PlanType, PlanVisitor, Projection,
-    Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, Union, UserDefinedLogicalNode, Values, Window, WriteOp, WriteRel,
+    CreateMemoryTable, CreateView, CrossJoin, Distinct, DmlStatement, DropTable,
+    DropView, EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType,
+    Limit, LogicalPlan, LogicalPlanBuilder, Partitioning, PlanType, PlanVisitor,
+    Projection, Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias,
+    TableScan, ToStringifiedPlan, Union, UserDefinedLogicalNode, Values, Window, WriteOp,
 };
 pub use nullif::SUPPORTED_NULLIF_TYPES;
 pub use operator::Operator;

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -75,7 +75,7 @@ pub use logical_plan::{
     EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
     LogicalPlan, LogicalPlanBuilder, Partitioning, PlanType, PlanVisitor, Projection,
     Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, Union, UserDefinedLogicalNode, Values, Window,
+    ToStringifiedPlan, Union, UserDefinedLogicalNode, Values, Window, WriteOp, WriteRel,
 };
 pub use nullif::SUPPORTED_NULLIF_TYPES;
 pub use operator::Operator;

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -27,7 +27,7 @@ pub use plan::{
     EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
     LogicalPlan, Partitioning, PlanType, PlanVisitor, Prepare, Projection, Repartition,
     SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, Union, Values, Window,
+    ToStringifiedPlan, Union, Values, Window, WriteOp, WriteRel,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -23,11 +23,11 @@ mod plan;
 pub use builder::{table_scan, LogicalPlanBuilder};
 pub use plan::{
     Aggregate, Analyze, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
-    CreateMemoryTable, CreateView, CrossJoin, Distinct, DropTable, DropView,
-    EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType, Limit,
-    LogicalPlan, Partitioning, PlanType, PlanVisitor, Prepare, Projection, Repartition,
-    SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, Union, Values, Window, WriteOp, WriteRel,
+    CreateMemoryTable, CreateView, CrossJoin, Distinct, DmlStatement, DropTable,
+    DropView, EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint, JoinType,
+    Limit, LogicalPlan, Partitioning, PlanType, PlanVisitor, Prepare, Projection,
+    Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
+    ToStringifiedPlan, Union, Values, Window, WriteOp,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -118,6 +118,8 @@ pub enum LogicalPlan {
     SetVariable(SetVariable),
     /// Prepare a statement
     Prepare(Prepare),
+    /// Insert / Update / Delete
+    Write(WriteRel),
 }
 
 impl LogicalPlan {
@@ -158,6 +160,7 @@ impl LogicalPlan {
             LogicalPlan::DropTable(DropTable { schema, .. }) => schema,
             LogicalPlan::DropView(DropView { schema, .. }) => schema,
             LogicalPlan::SetVariable(SetVariable { schema, .. }) => schema,
+            LogicalPlan::Write(WriteRel { table_schema, .. }) => table_schema,
         }
     }
 
@@ -218,6 +221,7 @@ impl LogicalPlan {
             LogicalPlan::DropTable(_)
             | LogicalPlan::DropView(_)
             | LogicalPlan::SetVariable(_) => vec![],
+            LogicalPlan::Write(WriteRel { table_schema, .. }) => vec![table_schema],
         }
     }
 
@@ -316,6 +320,7 @@ impl LogicalPlan {
             | LogicalPlan::Explain(_)
             | LogicalPlan::Union(_)
             | LogicalPlan::Distinct(_)
+            | LogicalPlan::Write(_)
             | LogicalPlan::Prepare(_) => Ok(()),
         }
     }
@@ -342,6 +347,7 @@ impl LogicalPlan {
             LogicalPlan::Distinct(Distinct { input }) => vec![input],
             LogicalPlan::Explain(explain) => vec![&explain.plan],
             LogicalPlan::Analyze(analyze) => vec![&analyze.input],
+            LogicalPlan::Write(write) => vec![&write.input],
             LogicalPlan::CreateMemoryTable(CreateMemoryTable { input, .. })
             | LogicalPlan::CreateView(CreateView { input, .. })
             | LogicalPlan::Prepare(Prepare { input, .. }) => {
@@ -544,6 +550,7 @@ impl LogicalPlan {
             }
             LogicalPlan::Explain(explain) => explain.plan.accept(visitor)?,
             LogicalPlan::Analyze(analyze) => analyze.input.accept(visitor)?,
+            LogicalPlan::Write(write) => write.input.accept(visitor)?,
             // plans without inputs
             LogicalPlan::TableScan { .. }
             | LogicalPlan::EmptyRelation(_)
@@ -928,6 +935,9 @@ impl LogicalPlan {
                             write!(f, "{expr_item:?}")?;
                         }
                         Ok(())
+                    }
+                    LogicalPlan::Write(WriteRel { table_name, op, .. }) => {
+                        write!(f, "Write: op=[{op}] table=[{table_name}]")
                     }
                     LogicalPlan::Filter(Filter {
                         predicate: ref expr,
@@ -1502,6 +1512,38 @@ pub struct CreateExternalTable {
     pub file_compression_type: CompressionTypeVariant,
     /// Table(provider) specific options
     pub options: HashMap<String, String>,
+}
+
+#[derive(Clone)]
+pub enum WriteOp {
+    Insert,
+    Delete,
+    Update,
+    Ctas,
+}
+
+impl Display for WriteOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            WriteOp::Insert => write!(f, "Insert"),
+            WriteOp::Delete => write!(f, "Delete"),
+            WriteOp::Update => write!(f, "Update"),
+            WriteOp::Ctas => write!(f, "Ctas"),
+        }
+    }
+}
+
+/// The operator that modifies the content of a database (adapted from substrait WriteRel)
+#[derive(Clone)]
+pub struct WriteRel {
+    /// The table name
+    pub table_name: OwnedTableReference,
+    /// The schema of the table (must align with Rel input)
+    pub table_schema: DFSchemaRef,
+    /// The type of operation to perform
+    pub op: WriteOp,
+    /// The relation that determines the tuples to add/remove/modify the schema must match with table_schema
+    pub input: Arc<LogicalPlan>,
 }
 
 /// Prepare a statement but do not execute it. Prepare statements can have 0 or more

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -27,8 +27,8 @@ use crate::logical_plan::{
     SubqueryAlias, Union, Values, Window,
 };
 use crate::{
-    BinaryExpr, Cast, Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator,
-    TableScan, TryCast, WriteRel,
+    BinaryExpr, Cast, DmlStatement, Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder,
+    Operator, TableScan, TryCast,
 };
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion_common::{
@@ -489,12 +489,12 @@ pub fn from_plan(
                 schema.clone(),
             )?))
         }
-        LogicalPlan::Write(WriteRel {
+        LogicalPlan::Dml(DmlStatement {
             table_name,
             table_schema,
             op,
             ..
-        }) => Ok(LogicalPlan::Write(WriteRel {
+        }) => Ok(LogicalPlan::Dml(DmlStatement {
             table_name: table_name.clone(),
             table_schema: table_schema.clone(),
             op: op.clone(),

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -28,7 +28,7 @@ use crate::logical_plan::{
 };
 use crate::{
     BinaryExpr, Cast, Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator,
-    TableScan, TryCast,
+    TableScan, TryCast, WriteRel,
 };
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion_common::{
@@ -489,6 +489,17 @@ pub fn from_plan(
                 schema.clone(),
             )?))
         }
+        LogicalPlan::Write(WriteRel {
+            table_name,
+            table_schema,
+            op,
+            ..
+        }) => Ok(LogicalPlan::Write(WriteRel {
+            table_name: table_name.clone(),
+            table_schema: table_schema.clone(),
+            op: op.clone(),
+            input: Arc::new(inputs[0].clone()),
+        })),
         LogicalPlan::Values(Values { schema, .. }) => Ok(LogicalPlan::Values(Values {
             schema: schema.clone(),
             values: expr

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -239,7 +239,7 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::SetVariable(_)
             | LogicalPlan::Distinct(_)
             | LogicalPlan::Extension(_)
-            | LogicalPlan::Write(_)
+            | LogicalPlan::Dml(_)
             | LogicalPlan::Prepare(_) => {
                 // apply the optimization to all inputs of the plan
                 utils::optimize_children(self, plan, config)?

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -239,6 +239,7 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::SetVariable(_)
             | LogicalPlan::Distinct(_)
             | LogicalPlan::Extension(_)
+            | LogicalPlan::Write(_)
             | LogicalPlan::Prepare(_) => {
                 // apply the optimization to all inputs of the plan
                 utils::optimize_children(self, plan, config)?

--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -410,6 +410,7 @@ fn optimize_plan(
         | LogicalPlan::DropView(_)
         | LogicalPlan::SetVariable(_)
         | LogicalPlan::CrossJoin(_)
+        | LogicalPlan::Write(_)
         | LogicalPlan::Extension { .. }
         | LogicalPlan::Prepare(_) => {
             let expr = plan.expressions();

--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -410,7 +410,7 @@ fn optimize_plan(
         | LogicalPlan::DropView(_)
         | LogicalPlan::SetVariable(_)
         | LogicalPlan::CrossJoin(_)
-        | LogicalPlan::Write(_)
+        | LogicalPlan::Dml(_)
         | LogicalPlan::Extension { .. }
         | LogicalPlan::Prepare(_) => {
             let expr = plan.expressions();

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1345,7 +1345,7 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::SetVariable(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DropView",
             )),
-            LogicalPlan::Write(_) => Err(proto_error(
+            LogicalPlan::Dml(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for Write",
             )),
         }

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1345,6 +1345,9 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::SetVariable(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DropView",
             )),
+            LogicalPlan::Write(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for Write",
+            )),
         }
     }
 }

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -272,7 +272,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn plan_from_tables(
+    pub(crate) fn plan_from_tables(
         &self,
         mut from: Vec<TableWithJoins>,
         planner_context: &mut PlannerContext,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -35,8 +35,8 @@ use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
     cast, col, CreateCatalog, CreateCatalogSchema,
     CreateExternalTable as PlanCreateExternalTable, CreateMemoryTable, CreateView,
-    DropTable, DropView, Explain, Filter, LogicalPlan, LogicalPlanBuilder, PlanType,
-    SetVariable, ToStringifiedPlan, WriteOp, WriteRel,
+    DmlStatement, DropTable, DropView, Explain, Filter, LogicalPlan, LogicalPlanBuilder,
+    PlanType, SetVariable, ToStringifiedPlan, WriteOp,
 };
 use sqlparser::ast;
 use sqlparser::ast::{
@@ -638,7 +638,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
         };
 
-        let plan = LogicalPlan::Write(WriteRel {
+        let plan = LogicalPlan::Dml(DmlStatement {
             table_name: table_ref,
             table_schema: schema.into(),
             op: WriteOp::Delete,
@@ -735,7 +735,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
         let source = project(source, exprs)?;
 
-        let plan = LogicalPlan::Write(WriteRel {
+        let plan = LogicalPlan::Dml(DmlStatement {
             table_name: table_ref,
             table_schema: proj_schema.into(),
             op: WriteOp::Update,
@@ -774,7 +774,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         let mut planner_context = PlannerContext::new();
         let source = self.query_to_plan(*source, &mut planner_context)?;
-        let plan = LogicalPlan::Write(WriteRel {
+        let plan = LogicalPlan::Dml(DmlStatement {
             table_name: table_ref,
             table_schema: Arc::new(schema),
             op: WriteOp::Insert,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -541,7 +541,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let table_name = match &table_factor {
             TableFactor::Table { name, .. } => name.clone(),
             _ => Err(DataFusionError::Plan(
-                "Unsupported table type for delete!".to_string(),
+                "Cannot delete from non-table relations!".to_string(),
             ))?,
         };
 

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -174,7 +174,7 @@ fn plan_update() {
     let sql = "update person set last_name='Kay' where id=1";
     let plan = r#"
 Write: op=[Update] table=[person]
-  Projection: Utf8("Kay") AS last_name, person.id AS id
+  Projection: person.age AS age, person.birth_date AS birth_date, person.first_name AS first_name, person.id AS id, Utf8("Kay") AS last_name, person.salary AS salary, person.state AS state, person.😀 AS 😀
     Filter: id = Int64(1)
       TableScan: person
       "#

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -163,7 +163,8 @@ fn plan_insert() {
         "insert into person (id, first_name, last_name) values (1, 'Alan', 'Turing')";
     let plan = r#"
 Write: op=[Insert] table=[person]
-  Values: (Int64(1), Utf8("Alan"), Utf8("Turing"))
+  Projection: column1 AS id, column2 AS first_name, column3 AS last_name
+    Values: (Int64(1), Utf8("Alan"), Utf8("Turing"))
     "#
     .trim();
     quick_test(sql, plan);

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -158,6 +158,43 @@ fn cast_to_invalid_decimal_type() {
 }
 
 #[test]
+fn plan_insert() {
+    let sql =
+        "insert into person (id, first_name, last_name) values (1, 'Alan', 'Turing')";
+    let plan = r#"
+Write: op=[Insert] table=[person]
+  Values: (Int64(1), Utf8("Alan"), Utf8("Turing"))
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_update() {
+    let sql = "update person set last_name='Kay' where id=1";
+    let plan = r#"
+Write: op=[Update] table=[person]
+  Projection: Utf8("Kay") AS last_name, person.id AS id
+    Filter: person.id = Int64(1)
+      TableScan: person
+      "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_delete() {
+    let sql = "delete from person where id=1";
+    let plan = r#"
+Write: op=[Delete] table=[person]
+  Filter: id = Int64(1)
+    TableScan: person
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
 fn select_column_does_not_exist() {
     let sql = "SELECT doesnotexist FROM person";
     let err = logical_plan(sql).expect_err("query should have failed");

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -175,7 +175,7 @@ fn plan_update() {
     let plan = r#"
 Write: op=[Update] table=[person]
   Projection: Utf8("Kay") AS last_name, person.id AS id
-    Filter: person.id = Int64(1)
+    Filter: id = Int64(1)
       TableScan: person
       "#
     .trim();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4901.

# Rationale for this change

Described in issue.

# What changes are included in this PR?

- A new `LogicalPlan` enum variant called `WriteRel` and modeled after Substrait
- Changes to the planner to allow it to generate the new plans
- Integration tests for insert/update/delete

# Are these changes tested?

Yes

# Are there any user-facing changes?

Only if the user is a programmer using DataFusion as a library, in which case more ASTs will convert to LogicalPlans.