### PR TITLE
Refactor: `Add LogicalPlan::observe_expressions` to walk expressions

### DIFF
--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -396,7 +396,7 @@ fn push_down_all_join(
             .chain(once(keep_condition.into_iter().reduce(Expr::and).unwrap()))
             .collect()
     } else {
-        plan.expressions()
+        expr
     };
     let plan = from_plan(plan, &expr, &[left, right])?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Inspired by the bug in https://github.com/apache/arrow-datafusion/pull/4900 and  discussion with @avantgardnerio  on https://github.com/apache/arrow-datafusion/pull/4701#discussion_r1069131341


# Rationale for this change
I realized while reading https://github.com/apache/arrow-datafusion/pull/4900 there were likely other places in Expr that could have subqueries so there may be other bugs lurking similar to https://github.com/apache/arrow-datafusion/issues/4898

However, there was no good way to walk all expressions in a LogicalPlan other than to call `LogicalPlan::expressions()` which clones them all

# What changes are included in this PR?

1. Add LogicalPlan::inspect_expressions that calls a function on each expression
2. Rewrite subquery traversal to use this this function

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->