### PR TITLE
WIP Stop copying Exprs so much in logical planning

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -372,7 +372,7 @@ impl LogicalPlanBuilder {
                     .collect::<Result<Vec<_>>>()?;
 
                 let expr = curr_plan.expressions();
-                from_plan(&curr_plan, &expr, &new_inputs)
+                from_plan(&curr_plan, &expr, new_inputs)
             }
         }
     }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -398,7 +398,7 @@ impl LogicalPlan {
 
     pub fn with_new_inputs(
         &self,
-        inputs: &[LogicalPlan],
+        inputs: impl IntoIterator<Item = LogicalPlan>,
     ) -> Result<LogicalPlan, DataFusionError> {
         from_plan(self, &self.expressions(), inputs)
     }
@@ -612,7 +612,7 @@ impl LogicalPlan {
             new_inputs_with_values.push(input.replace_params_with_values(param_values)?);
         }
 
-        let new_plan = utils::from_plan(self, &new_exprs, &new_inputs_with_values)?;
+        let new_plan = utils::from_plan(self, &new_exprs, new_inputs_with_values)?;
         Ok(new_plan)
     }
 

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -396,7 +396,7 @@ fn push_down_all_join(
             .chain(once(keep_condition.into_iter().reduce(Expr::and).unwrap()))
             .collect()
     } else {
-        plan.expressions()
+        expr
     };
     let plan = from_plan(plan, &expr, &[left, right])?;
 


### PR DESCRIPTION
Stop copying Exprs so much in logical planning

Draft as it builds off
https://github.com/apache/arrow-datafusion/pull/4906/

`LogicalPlan::expressions()` actually copies the expressions. Many times these expressions are then simply passed to `new_from_plan` and then copied *again*

Using the function added to https://github.com/apache/arrow-datafusion/pull/4906/ this PR avoids copying all plan expressions in several places


I ran out of time, but this direction seems promising
