### PR TITLE
Upgrade object_store from 0.5.0 to 0.5.3

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -81,7 +81,7 @@ lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
-object_store = "0.5.0"
+object_store = "0.5.3"
 parking_lot = "0.12"
 parquet = { version = "30.0.1", features = ["arrow", "async"] }
 paste = "^1.0"


### PR DESCRIPTION
# Which issue does this PR close?

NA

# Rationale for this change

object_store 0.5.3 adds support of environment variable alias for similar meaning. e.g. either `aws_endpoint` or `aws_endpoint_url`
https://github.com/apache/arrow-rs/pull/3436

It is a nice improvement to simplify downstream application config. e.g. https://github.com/roapi/roapi/pull/241/files#r1070219697

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

No