### PR TITLE
Support gs:// as GCS schema

### DIFF
--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -34,7 +34,7 @@ impl FromStr for ObjectStoreScheme {
     fn from_str(input: &str) -> Result<Self> {
         match input {
             "s3" => Ok(ObjectStoreScheme::S3),
-            "gcs" => Ok(ObjectStoreScheme::GCS),
+            "gs" | "gcs" => Ok(ObjectStoreScheme::GCS),
             _ => Err(DataFusionError::Execution(format!(
                 "Unsupported object store scheme {}",
                 input
@@ -98,6 +98,18 @@ mod tests {
     #[test]
     fn s3_provider_no_host() {
         let no_host_url = "s3:///";
+        let provider = DatafusionCliObjectStoreProvider {};
+        let err = provider
+            .get_by_url(&Url::from_str(no_host_url).unwrap())
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Not able to parse hostname from url"))
+    }
+
+    #[test]
+    fn gs_provider_no_host() {
+        let no_host_url = "gs:///";
         let provider = DatafusionCliObjectStoreProvider {};
         let err = provider
             .get_by_url(&Url::from_str(no_host_url).unwrap())


### PR DESCRIPTION
# Which issue does this PR close?

NA

# Rationale for this change

It is a minor improvement. From Google Cloud Console, the schema for GCS is `gs://`
https://cloud.google.com/storage/docs/gsutil#syntax

# What changes are included in this PR?

support `gs://` same as `gcs://`

# Are these changes tested?

yes, unit test

# Are there any user-facing changes?

No