### PR TITLE
Do not resort inputs to `UnionExec` if they are already sorted

### DIFF
--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -34,7 +34,6 @@ use datafusion_common::{DFSchemaRef, DataFusionError};
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use log::debug;
-use log::trace;
 use log::warn;
 
 use super::{
@@ -44,7 +43,6 @@ use super::{
     SendableRecordBatchStream, Statistics,
 };
 use crate::execution::context::TaskContext;
-use crate::physical_plan::displayable;
 use crate::{
     error::Result,
     physical_plan::{expressions, metrics::BaselineMetrics},
@@ -229,41 +227,24 @@ impl ExecutionPlan for UnionExec {
         // It might be too strict here in the case that the input ordering are compatible but not exactly the same.
         // For example one input ordering has the ordering spec SortExpr('a','b','c') and the other has the ordering
         // spec SortExpr('a'), It is safe to derive the out ordering with the spec SortExpr('a').
-        trace!("{}", displayable(self).indent());
-        let result = if !self.partition_aware
+        if !self.partition_aware
             && first_input_ordering.is_some()
             && self
                 .inputs
                 .iter()
-                .inspect(|plan| {
-                    trace!(
-                        "  considering input {}",
-                        displayable(plan.as_ref()).one_line()
-                    )
-                })
                 .map(|plan| plan.output_ordering())
                 .all(|ordering| {
-                    trace!("  ordering {ordering:?}");
-
-                    let strict_equal = ordering.is_some()
+                    ordering.is_some()
                         && sort_expr_list_eq_strict_order(
                             ordering.unwrap(),
                             first_input_ordering.unwrap(),
-                        );
-                    trace!("  strict_equal {strict_equal:?}");
-
-                    ordering.is_some() && strict_equal
-                }) {
+                        )
+                })
+        {
             first_input_ordering
         } else {
             None
-        };
-
-        trace!("self.partition_aware: {}", self.partition_aware);
-        trace!("first_input_ordering: {:?}", first_input_ordering);
-        trace!("output ordering: {:?}", result);
-
-        result
+        }
     }
 
     fn maintains_input_order(&self) -> bool {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/4943

# Rationale for this change

See https://github.com/apache/arrow-datafusion/issues/4943 -- basically the issue is that `EnforceSorting` pass is adding an unecessary sort to `UnionExec` at some times

# What changes are included in this PR?

1. Implement `UnionExec::maintains_input_order` as suggested by @mustafasrepo https://github.com/apache/arrow-datafusion/issues/4943#issuecomment-1385360298
2. Add test

# Are these changes tested?

Yes

# Are there any user-facing changes?

Bug fix (though I don't know if any SQL queries would be affected by this)