### PR TITLE
Minor: Make messages consistent for LogicalPlan::Dml

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1183,7 +1183,7 @@ impl DefaultPhysicalPlanner {
                 LogicalPlan::Dml(_) => {
                     // DataFusion is a read-only query engine, but also a library, so consumers may implement this
                     Err(DataFusionError::Internal(
-                        "Unsupported logical plan: Write".to_string(),
+                        "Unsupported logical plan: Dml".to_string(),
                     ))
                 }
                 LogicalPlan::SetVariable(_) => {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -937,7 +937,7 @@ impl LogicalPlan {
                         Ok(())
                     }
                     LogicalPlan::Dml(DmlStatement { table_name, op, .. }) => {
-                        write!(f, "Write: op=[{op}] table=[{table_name}]")
+                        write!(f, "Dml: op=[{op}] table=[{table_name}]")
                     }
                     LogicalPlan::Filter(Filter {
                         predicate: ref expr,

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1346,7 +1346,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 "LogicalPlan serde is not yet implemented for DropView",
             )),
             LogicalPlan::Dml(_) => Err(proto_error(
-                "LogicalPlan serde is not yet implemented for Write",
+                "LogicalPlan serde is not yet implemented for Dml",
             )),
         }
     }

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -162,7 +162,7 @@ fn plan_insert() {
     let sql =
         "insert into person (id, first_name, last_name) values (1, 'Alan', 'Turing')";
     let plan = r#"
-Write: op=[Insert] table=[person]
+Dml: op=[Insert] table=[person]
   Projection: column1 AS id, column2 AS first_name, column3 AS last_name
     Values: (Int64(1), Utf8("Alan"), Utf8("Turing"))
     "#
@@ -174,7 +174,7 @@ Write: op=[Insert] table=[person]
 fn plan_update() {
     let sql = "update person set last_name='Kay' where id=1";
     let plan = r#"
-Write: op=[Update] table=[person]
+Dml: op=[Update] table=[person]
   Projection: person.age AS age, person.birth_date AS birth_date, person.first_name AS first_name, person.id AS id, Utf8("Kay") AS last_name, person.salary AS salary, person.state AS state, person.😀 AS 😀
     Filter: id = Int64(1)
       TableScan: person
@@ -187,7 +187,7 @@ Write: op=[Update] table=[person]
 fn plan_delete() {
     let sql = "delete from person where id=1";
     let plan = r#"
-Write: op=[Delete] table=[person]
+Dml: op=[Delete] table=[person]
   Filter: id = Int64(1)
     TableScan: person
     "#


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/4902 from @avantgardnerio 

# Rationale for this change

There are some messages / display strings that appear to still reference an older version of the code

# What changes are included in this PR?

Update the display name to `Dml` everywhere

# Are these changes tested?

existing coverage
# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->