### PR TITLE
Expose `sql_to_statement` and `statement_to_plan` on `SessionState`

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1636,22 +1636,34 @@ impl SessionState {
         self
     }
 
-    /// Creates a [`LogicalPlan`] from the provided SQL string
-    ///
-    /// See [`SessionContext::sql`] for a higher-level interface that also handles DDL
-    pub async fn create_logical_plan(&self, sql: &str) -> Result<LogicalPlan> {
-        use crate::catalog::information_schema::INFORMATION_SCHEMA_TABLES;
-        use datafusion_sql::parser::Statement as DFStatement;
-        use sqlparser::ast::*;
-        use std::collections::hash_map::Entry;
-
+    /// Convert a sql string into an ast Statement
+    pub fn sql_to_statement(
+        &self,
+        sql: &str,
+    ) -> Result<datafusion_sql::parser::Statement> {
         let mut statements = DFParser::parse_sql(sql)?;
-        if statements.len() != 1 {
+        if statements.len() > 1 {
             return Err(DataFusionError::NotImplemented(
                 "The context currently only supports a single SQL statement".to_string(),
             ));
         }
-        let statement = statements.pop_front().unwrap();
+        let statement = statements.pop_front().ok_or_else(|| {
+            DataFusionError::NotImplemented(
+                "The context requires a statement!".to_string(),
+            )
+        })?;
+        Ok(statement)
+    }
+
+    /// Convert an ast Statement into a LogicalPlan
+    pub async fn statement_to_plan(
+        &self,
+        statement: datafusion_sql::parser::Statement,
+    ) -> Result<LogicalPlan> {
+        use crate::catalog::information_schema::INFORMATION_SCHEMA_TABLES;
+        use datafusion_sql::parser::Statement as DFStatement;
+        use sqlparser::ast::*;
+        use std::collections::hash_map::Entry;
 
         // Getting `TableProviders` is async but planing is not -- thus pre-fetch
         // table providers for all relations referenced in this query
@@ -1727,6 +1739,15 @@ impl SessionState {
 
         let query = SqlToRel::new(&provider);
         query.statement_to_plan(statement)
+    }
+
+    /// Creates a [`LogicalPlan`] from the provided SQL string
+    ///
+    /// See [`SessionContext::sql`] for a higher-level interface that also handles DDL
+    pub async fn create_logical_plan(&self, sql: &str) -> Result<LogicalPlan> {
+        let statement = self.sql_to_statement(sql)?;
+        let plan = self.statement_to_plan(statement).await?;
+        Ok(plan)
     }
 
     /// Optimizes the logical plan by applying optimizer rules.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4957.

# Rationale for this change

Described in issue.

# What changes are included in this PR?

Splitting planning and parsing.

# Are these changes tested?

Transitively, yes.

# Are there any user-facing changes?

New API methods, no breaking changes.