### PR TITLE
Upgrade to Substrait 0.4.0

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -26,7 +26,7 @@ async-recursion = "1.0"
 datafusion = { version = "16.0.0", path = "../core" }
 prost = "0.11"
 prost-types = "0.11"
-substrait = "0.3"
+substrait = "0.4"
 tokio = "1.17"
 
 [build-dependencies]

--- a/datafusion/substrait/src/consumer.rs
+++ b/datafusion/substrait/src/consumer.rs
@@ -30,7 +30,7 @@ use datafusion::{
     prelude::{Column, SessionContext},
     scalar::ScalarValue,
 };
-use substrait::protobuf::{
+use substrait::proto::{
     aggregate_function::AggregationInvocation,
     expression::{
         field_reference::ReferenceType::DirectReference, literal::LiteralType,
@@ -38,6 +38,7 @@ use substrait::protobuf::{
     },
     extensions::simple_extension_declaration::MappingType,
     function_argument::ArgType,
+    plan_rel,
     read_rel::ReadType,
     rel::RelType,
     sort_field::{SortDirection, SortKind::*},
@@ -112,10 +113,10 @@ pub async fn from_substrait_plan(
         1 => {
             match plan.relations[0].rel_type.as_ref() {
                 Some(rt) => match rt {
-                    substrait::protobuf::plan_rel::RelType::Rel(rel) => {
+                    plan_rel::RelType::Rel(rel) => {
                         Ok(from_substrait_rel(ctx, rel, &function_extension).await?)
                     },
-                    substrait::protobuf::plan_rel::RelType::Root(root) => {
+                    plan_rel::RelType::Root(root) => {
                         Ok(from_substrait_rel(ctx, root.input.as_ref().unwrap(), &function_extension).await?)
                     }
                 },

--- a/datafusion/substrait/src/producer.rs
+++ b/datafusion/substrait/src/producer.rs
@@ -29,7 +29,7 @@ use datafusion::logical_expr::aggregate_function;
 use datafusion::logical_expr::expr::{BinaryExpr, Case, Sort};
 use datafusion::logical_expr::{expr, Between, JoinConstraint, LogicalPlan, Operator};
 use datafusion::prelude::{binary_expr, Expr};
-use substrait::protobuf::{
+use substrait::proto::{
     aggregate_function::AggregationInvocation,
     aggregate_rel::{Grouping, Measure},
     expression::{
@@ -49,9 +49,9 @@ use substrait::protobuf::{
     read_rel::{NamedTable, ReadType},
     rel::RelType,
     sort_field::{SortDirection, SortKind},
-    AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, FunctionArgument,
-    JoinRel, NamedStruct, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot, SortField,
-    SortRel,
+    AggregateFunction, AggregateRel, AggregationPhase, Expression, FetchRel, FilterRel,
+    FunctionArgument, JoinRel, NamedStruct, Plan, PlanRel, ProjectRel, ReadRel, Rel,
+    RelRoot, SortField, SortRel,
 };
 
 /// Convert DataFusion LogicalPlan to Substrait Plan
@@ -367,7 +367,7 @@ pub fn to_substrait_agg_measure(
                         true => AggregationInvocation::Distinct as i32,
                         false => AggregationInvocation::All as i32,
                     },
-                    phase: substrait::protobuf::AggregationPhase::Unspecified as i32,
+                    phase: AggregationPhase::Unspecified as i32,
                     args: vec![],
                     options: vec![],
                 }),

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -21,7 +21,7 @@ use datafusion::error::Result;
 use datafusion::prelude::*;
 
 use prost::Message;
-use substrait::protobuf::Plan;
+use substrait::proto::Plan;
 
 use std::fs::OpenOptions;
 use std::io::{Read, Write};

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -24,7 +24,7 @@ mod tests {
     use crate::{consumer::from_substrait_plan, producer::to_substrait_plan};
     use datafusion::error::Result;
     use datafusion::prelude::*;
-    use substrait::protobuf::extensions::simple_extension_declaration::MappingType;
+    use substrait::proto::extensions::simple_extension_declaration::MappingType;
 
     #[tokio::test]
     async fn simple_select() -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4950.

# Rationale for this change

Bump to latest `substrait` crate release.

# What changes are included in this PR?

Dependabot's bump commit (#4961) and a commit that handles the rename of the `protobuf` module to `proto`.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.