### PR TITLE
Add DataFusionError::Substrait variant to DataFusionError enum

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -86,6 +86,9 @@ pub enum DataFusionError {
     JITError(ModuleError),
     /// Error with additional context
     Context(String, Box<DataFusionError>),
+    /// Errors originating from either mapping LogicalPlans to/from Substrait plans
+    /// or serializing/deserializing protobytes to Substrait plans
+    Substrait(String),
 }
 
 #[macro_export]
@@ -319,6 +322,9 @@ impl Display for DataFusionError {
             }
             DataFusionError::Context(ref desc, ref err) => {
                 write!(f, "{}\ncaused by\n{}", desc, *err)
+            }
+            DataFusionError::Substrait(ref desc) => {
+                write!(f, "Substrait error: {desc}")
             }
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4970

# Rationale for this change

More clear error handling by providing a more specific DataFusionError enum for Substrait

# What changes are included in this PR?

Modifications to DataFusionError enum
