### PR TITLE
minor: Update data type support documentation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -42,8 +42,7 @@ jobs:
           node-version: "14"
       - name: Prettier check
         run: |
-          # if you encounter error, try rerun the command below with --write instead of --check
-          # and commit the changes
+          # if you encounter error, rerun the command below and commit the changes
           #
           # ignore subproject CHANGELOG.md because they are machine generated
           npx prettier@2.7.1 --write \

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -25,6 +25,18 @@ execution. The SQL types from
 are mapped to [Arrow data types](https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html) according to the following table.
 This mapping occurs when defining the schema in a `CREATE EXTERNAL TABLE` command or when performing a SQL `CAST` operation.
 
+You can see the corresponding Arrow type for any SQL expression using
+the `arrow_typeof` function. For example:
+
+```sql
+❯ select arrow_typeof(interval '1 month');
++-------------------------------------+
+| arrowtypeof(IntervalYearMonth("1")) |
++-------------------------------------+
+| Interval(YearMonth)                 |
++-------------------------------------+
+```
+
 ## Character Types
 
 | SQL DataType | Arrow DataType |
@@ -32,6 +44,7 @@ This mapping occurs when defining the schema in a `CREATE EXTERNAL TABLE` comman
 | `CHAR`       | `Utf8`         |
 | `VARCHAR`    | `Utf8`         |
 | `TEXT`       | `Utf8`         |
+| `STRING`     | `Utf8`         |
 
 ## Numeric Types
 
@@ -52,11 +65,12 @@ This mapping occurs when defining the schema in a `CREATE EXTERNAL TABLE` comman
 
 ## Date/Time Types
 
-| SQL DataType | Arrow DataType                          |
-| ------------ | :-------------------------------------- |
-| `DATE`       | `Date32`                                |
-| `TIME`       | `Time64(TimeUnit::Nanosecond)`          |
-| `TIMESTAMP`  | `Timestamp(TimeUnit::Nanosecond, None)` |
+| SQL DataType | Arrow DataType                                                           |
+| ------------ | :----------------------------------------------------------------------- |
+| `DATE`       | `Date32`                                                                 |
+| `TIME`       | `Time64(TimeUnit::Nanosecond)`                                           |
+| `TIMESTAMP`  | `Timestamp(TimeUnit::Nanosecond, None)`                                  |
+| `INTERVAL`   | `Interval(IntervalUnit::YearMonth)` or `Interval(IntervalUnit::DayTime)` |
 
 ## Boolean Types
 
@@ -81,10 +95,8 @@ This mapping occurs when defining the schema in a `CREATE EXTERNAL TABLE` comman
 | `VARBINARY`   | _Not yet supported_ |
 | `REGCLASS`    | _Not yet supported_ |
 | `NVARCHAR`    | _Not yet supported_ |
-| `STRING`      | _Not yet supported_ |
 | `CUSTOM`      | _Not yet supported_ |
 | `ARRAY`       | _Not yet supported_ |
 | `ENUM`        | _Not yet supported_ |
 | `SET`         | _Not yet supported_ |
-| `INTERVAL`    | _Not yet supported_ |
 | `DATETIME`    | _Not yet supported_ |

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -280,6 +280,19 @@ wherever it appears in the statement, using a value chosen at planning time.
 
 ### `array`
 
+### `arrow_typeof`
+
+Returns the underlying Arrow type of the the expression:
+
+```sql
+❯ select arrow_typeof(4 + 4.3);
++--------------------------------------+
+| arrowtypeof(Int64(4) + Float64(4.3)) |
++--------------------------------------+
+| Float64                              |
++--------------------------------------+
+```
+
 ### `in_list`
 
 ### `random`


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

https://arrow.apache.org/datafusion/user-guide/sql/data_types.html is out of date, as we discovered while working on docs for IOx: https://github.com/influxdata/docs-v2/pull/4700

# What changes are included in this PR?
1. Update supported type
2. Add note about `arrow_typeof` function

# Are these changes tested?

N/A (they are docs)

# Are there any user-facing changes?

Yes, docs