### PR TITLE
Add support for linear range calculation in WINDOW functions

### DIFF
--- a/datafusion/common/src/bisect.rs
+++ b/datafusion/common/src/bisect.rs
@@ -21,6 +21,7 @@ use crate::{DataFusionError, Result, ScalarValue};
 use arrow::array::ArrayRef;
 use arrow::compute::SortOptions;
 use std::cmp::Ordering;
+use std::ops::Range;
 
 /// This function compares two tuples depending on the given sort options.
 fn compare(
@@ -81,8 +82,13 @@ pub fn linear_search<const SIDE: bool>(
     item_columns: &[ArrayRef],
     target: &[ScalarValue],
     sort_options: &[SortOptions],
+    last_range: &Range<usize>,
 ) -> Result<usize> {
-    let low: usize = 0;
+    let low: usize = if SIDE {
+        last_range.start
+    } else {
+        last_range.end
+    };
     let high: usize = item_columns
         .get(0)
         .ok_or_else(|| {

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod bisect;
 pub mod cast;
 mod column;
 pub mod config;
@@ -30,6 +29,7 @@ pub mod scalar;
 pub mod stats;
 mod table_reference;
 pub mod test_util;
+pub mod utils;
 
 use arrow::compute::SortOptions;
 pub use column::Column;

--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -23,7 +23,7 @@ use arrow::compute::SortOptions;
 use std::cmp::Ordering;
 
 /// Given column vectors, returns row at `idx`.
-fn get_row_at_idx(columns: &[ArrayRef], idx: usize) -> Result<Vec<ScalarValue>> {
+pub fn get_row_at_idx(columns: &[ArrayRef], idx: usize) -> Result<Vec<ScalarValue>> {
     columns
         .iter()
         .map(|arr| ScalarValue::try_from_array(arr, idx))

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -106,8 +106,13 @@ impl WindowExpr for AggregateWindowExpr {
         // We iterate on each row to perform a running calculation.
         // First, cur_range is calculated, then it is compared with last_range.
         for i in 0..length {
-            let cur_range =
-                window_frame_ctx.calculate_range(&order_bys, &sort_options, length, i)?;
+            let cur_range = window_frame_ctx.calculate_range(
+                &order_bys,
+                &sort_options,
+                length,
+                i,
+                &last_range,
+            )?;
             let value = if cur_range.end == cur_range.start {
                 // We produce None if the window is empty.
                 ScalarValue::try_from(self.aggregate.field()?.data_type())?

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -102,13 +102,12 @@ impl WindowExpr for BuiltInWindowExpr {
                 self.order_by.iter().map(|o| o.options).collect();
             let mut row_wise_results = vec![];
 
-            let length = batch.num_rows();
             let (values, order_bys) = self.get_values_orderbys(batch)?;
             let mut window_frame_ctx = WindowFrameContext::new(&self.window_frame);
-            let mut range = Range { start: 0, end: 0 };
+            let range = Range { start: 0, end: 0 };
             // We iterate on each row to calculate window frame range and and window function result
-            for idx in 0..length {
-                range = window_frame_ctx.calculate_range(
+            for idx in 0..num_rows {
+                let range = window_frame_ctx.calculate_range(
                     &order_bys,
                     &sort_options,
                     num_rows,

--- a/datafusion/physical-expr/src/window/nth_value.rs
+++ b/datafusion/physical-expr/src/window/nth_value.rs
@@ -176,13 +176,13 @@ impl PartitionEvaluator for NthValueEvaluator {
     }
 
     fn evaluate_stateful(&mut self, values: &[ArrayRef]) -> Result<ScalarValue> {
-        self.evaluate_inside_range(values, self.state.range.clone())
+        self.evaluate_inside_range(values, &self.state.range)
     }
 
     fn evaluate_inside_range(
         &self,
         values: &[ArrayRef],
-        range: Range<usize>,
+        range: &Range<usize>,
     ) -> Result<ScalarValue> {
         // FIRST_VALUE, LAST_VALUE, NTH_VALUE window functions take single column, values will have size 1
         let arr = &values[0];
@@ -227,7 +227,7 @@ mod tests {
         let evaluator = expr.create_evaluator()?;
         let values = expr.evaluate_args(&batch)?;
         let result = ranges
-            .into_iter()
+            .iter()
             .map(|range| evaluator.evaluate_inside_range(&values, range))
             .into_iter()
             .collect::<Result<Vec<ScalarValue>>>()?;

--- a/datafusion/physical-expr/src/window/partition_evaluator.rs
+++ b/datafusion/physical-expr/src/window/partition_evaluator.rs
@@ -83,7 +83,7 @@ pub trait PartitionEvaluator: Debug + Send {
     fn evaluate_inside_range(
         &self,
         _values: &[ArrayRef],
-        _range: Range<usize>,
+        _range: &Range<usize>,
     ) -> Result<ScalarValue> {
         Err(DataFusionError::NotImplemented(
             "evaluate_inside_range is not implemented by default".into(),

--- a/datafusion/physical-expr/src/window/sliding_aggregate.rs
+++ b/datafusion/physical-expr/src/window/sliding_aggregate.rs
@@ -268,6 +268,7 @@ impl SlidingAggregateWindowExpr {
                 &sort_options,
                 length,
                 *idx,
+                last_range,
             )?;
             // Exit if range end index is length, need kind of flag to stop
             if cur_range.end == length && !is_end {

--- a/datafusion/physical-expr/src/window/window_frame_state.rs
+++ b/datafusion/physical-expr/src/window/window_frame_state.rs
@@ -186,6 +186,7 @@ impl WindowFrameStateRange {
                         idx,
                         Some(n),
                         last_range,
+                        length,
                     )?
                 }
             }
@@ -199,6 +200,7 @@ impl WindowFrameStateRange {
                         idx,
                         None,
                         last_range,
+                        length,
                     )?
                 }
             }
@@ -209,6 +211,7 @@ impl WindowFrameStateRange {
                     idx,
                     Some(n),
                     last_range,
+                    length,
                 )?,
         };
         let end = match window_frame.end_bound {
@@ -219,6 +222,7 @@ impl WindowFrameStateRange {
                     idx,
                     Some(n),
                     last_range,
+                    length,
                 )?,
             WindowFrameBound::CurrentRow => {
                 if range_columns.is_empty() {
@@ -230,6 +234,7 @@ impl WindowFrameStateRange {
                         idx,
                         None,
                         last_range,
+                        length,
                     )?
                 }
             }
@@ -244,6 +249,7 @@ impl WindowFrameStateRange {
                         idx,
                         Some(n),
                         last_range,
+                        length,
                     )?
                 }
             }
@@ -261,6 +267,7 @@ impl WindowFrameStateRange {
         idx: usize,
         delta: Option<&ScalarValue>,
         last_range: &Range<usize>,
+        length: usize,
     ) -> Result<usize> {
         let current_row_values = range_columns
             .iter()
@@ -301,8 +308,13 @@ impl WindowFrameStateRange {
             last_range.end
         };
         // `SIDE` true means from left insert, false means right insert
-        let res =
-            linear_search::<SIDE>(range_columns, &end_range, sort_options, search_start)?;
+        let res = linear_search::<SIDE>(
+            range_columns,
+            &end_range,
+            sort_options,
+            search_start,
+            length,
+        )?;
         Ok(res)
     }
 }

--- a/datafusion/physical-expr/src/window/window_frame_state.rs
+++ b/datafusion/physical-expr/src/window/window_frame_state.rs
@@ -20,7 +20,7 @@
 
 use arrow::array::ArrayRef;
 use arrow::compute::kernels::sort::SortOptions;
-use datafusion_common::bisect::{bisect, find_bisect_point};
+use datafusion_common::bisect::{bisect, find_bisect_point, linear_search};
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 use std::cmp::min;
@@ -286,7 +286,13 @@ impl WindowFrameStateRange {
             current_row_values
         };
         // `BISECT_SIDE` true means bisect_left, false means bisect_right
-        bisect::<BISECT_SIDE>(range_columns, &end_range, sort_options)
+        let linear =
+            linear_search::<BISECT_SIDE>(range_columns, &end_range, sort_options)?;
+        // `BISECT_SIDE` true means bisect_left, false means bisect_right
+        // let res = bisect::<BISECT_SIDE>(range_columns, &end_range, sort_options)?;
+        // println!("linear: {:?}", linear);
+        // println!("bisect: {:?}", res);
+        Ok(linear)
     }
 }
 

--- a/datafusion/physical-expr/src/window/window_frame_state.rs
+++ b/datafusion/physical-expr/src/window/window_frame_state.rs
@@ -20,7 +20,9 @@
 
 use arrow::array::ArrayRef;
 use arrow::compute::kernels::sort::SortOptions;
-use datafusion_common::utils::{compare_rows, find_bisect_point, search_in_slice};
+use datafusion_common::utils::{
+    compare_rows, find_bisect_point, get_row_at_idx, search_in_slice,
+};
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 use std::cmp::min;
@@ -269,10 +271,7 @@ impl WindowFrameStateRange {
         last_range: &Range<usize>,
         length: usize,
     ) -> Result<usize> {
-        let current_row_values = range_columns
-            .iter()
-            .map(|col| ScalarValue::try_from_array(col, idx))
-            .collect::<Result<Vec<ScalarValue>>>()?;
+        let current_row_values = get_row_at_idx(range_columns, idx)?;
         let end_range = if let Some(delta) = delta {
             let is_descending: bool = sort_options
                 .first()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4979. Makes progress on #4904.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
During range calculation for window frames, we can use linear search instead of bisect. Since we know that table is already sorted and we would progress only in one direction. Linear search is amortized constant (When window frame boundaries are static). Hence this version is more optimal than current bisect implementation (where search complexity is log(n)). This change decreases overall window range calculation complexity from `O(n*log(n))` to `O(n)`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Existing tests verify window range calculation correctness. Unit tests for `linear_search` is also added. We also compared time elapsed during Window result calculation for the query
```sql
SELECT SUM(a) OVER(ORDER BY a RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING) FROM t1;
```
. Time comparison between linear and bisect version for different conditions can be seen in table below. 




n_row | distinct | linear(mean) | linear(median) | bisect(mean) | bisect(median)
-- | -- | -- | -- | -- | --
100 | 10 | 1.199524ms | 772.125µs | 2.065253ms | 1.501125ms
100 | 100_000_000 | 1.614941ms | 1.599208ms | 2.30337ms | 2.346416ms
1000 | 10 | 4.521795ms | 4.417125ms | 10.986941ms | 10.994333ms
1000 | 100_000_000 | 11.82327ms | 11.8265ms | 23.83402ms | 23.641541ms
100_000 | 10 | 428.01742ms | 428.022791ms | 1.661792712s | 1.666531666s
100_000 | 100_000_000 | 1.190898003s | 1.18136925s | 3.446534628s | 3.446675916s



# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->