### PR TITLE
Implement `std::error::Error::source()` for `DataFusionError`, make `DataFusionError::find_root` more generic

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -337,7 +337,7 @@ impl Error for DataFusionError {
             #[cfg(feature = "parquet")]
             DataFusionError::ParquetError(e) => Some(e),
             #[cfg(feature = "avro")]
-            AvroError(e) => Some(e),
+            DataFusionError::AvroError(e) => Some(e),
             #[cfg(feature = "object_store")]
             DataFusionError::ObjectStore(e) => Some(e),
             DataFusionError::IoError(e) => Some(e),


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/4991

# Rationale for this change

In IOx (and in DataFusion) we often want to know what the root cause of an error is (e.g was it a bug or was it a resources exhausted). ArrowError can wrap other errors with Arrow::External (and DataFusion has something similar) but there is no easy way to get at the source of the error to walk the chain without knowing all the possible types that may be present

I want a generic way to walk up the error stack


# What changes are included in this PR?
1. Implement `std::error::Error::source()` for `DataFusionError`
2. Make `DataFusionError::find_root` less specific (uses source() rather than so much checking for arrow)

# Are these changes tested?

Yes, covered by (some quite gnarly) existing tests

# Are there any user-facing changes?
Better standard support
