### PR TITLE
Allow overriding error type in DataFusion Result

### DIFF
--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -174,7 +174,7 @@ fn all_commands_info() -> RecordBatch {
 impl FromStr for Command {
     type Err = ();
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
             (a, Some(b))
         } else {
@@ -208,7 +208,7 @@ impl FromStr for Command {
 impl FromStr for OutputFormat {
     type Err = ();
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
             (a, Some(b))
         } else {

--- a/datafusion-cli/src/functions.rs
+++ b/datafusion-cli/src/functions.rs
@@ -155,7 +155,7 @@ DROP TABLE [ IF EXISTS ] name [, ...]
 impl FromStr for Function {
     type Err = ();
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.trim().to_uppercase().as_str() {
             "SELECT" => Self::Select,
             "EXPLAIN" => Self::Explain,

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -157,7 +157,7 @@ fn create_runtime_env() -> Result<RuntimeEnv> {
     RuntimeEnv::new(rn_config)
 }
 
-fn is_valid_file(dir: &str) -> std::result::Result<(), String> {
+fn is_valid_file(dir: &str) -> Result<(), String> {
     if Path::new(dir).is_file() {
         Ok(())
     } else {
@@ -165,7 +165,7 @@ fn is_valid_file(dir: &str) -> std::result::Result<(), String> {
     }
 }
 
-fn is_valid_data_dir(dir: &str) -> std::result::Result<(), String> {
+fn is_valid_data_dir(dir: &str) -> Result<(), String> {
     if Path::new(dir).is_dir() {
         Ok(())
     } else {
@@ -173,7 +173,7 @@ fn is_valid_data_dir(dir: &str) -> std::result::Result<(), String> {
     }
 }
 
-fn is_valid_batch_size(size: &str) -> std::result::Result<(), String> {
+fn is_valid_batch_size(size: &str) -> Result<(), String> {
     match size.parse::<usize>() {
         Ok(size) if size > 0 => Ok(()),
         _ => Err(format!("Invalid batch size '{}'", size)),

--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -36,7 +36,7 @@ pub enum PrintFormat {
 impl FromStr for PrintFormat {
     type Err = String;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         clap::ArgEnum::from_str(s, true)
     }
 }

--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -179,7 +179,7 @@ impl From<String> for Column {
 impl FromStr for Column {
     type Err = Infallible;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(s.into())
     }
 }

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -452,7 +452,7 @@ impl From<&DFSchema> for Schema {
 /// Create a `DFSchema` from an Arrow schema
 impl TryFrom<Schema> for DFSchema {
     type Error = DataFusionError;
-    fn try_from(schema: Schema) -> std::result::Result<Self, Self::Error> {
+    fn try_from(schema: Schema) -> Result<Self, Self::Error> {
         Self::new_with_metadata(
             schema
                 .fields()

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -34,7 +34,7 @@ use parquet::errors::ParquetError;
 use sqlparser::parser::ParserError;
 
 /// Result type for operations that could result in an [DataFusionError]
-pub type Result<T> = result::Result<T, DataFusionError>;
+pub type Result<T, E = DataFusionError> = result::Result<T, E>;
 
 /// Error type for generic operations that could result in DataFusionError::External
 pub type GenericError = Box<dyn error::Error + Send + Sync>;

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2431,7 +2431,7 @@ impl From<Option<&str>> for ScalarValue {
 impl FromStr for ScalarValue {
     type Err = Infallible;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(s.into())
     }
 }

--- a/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/avro_to_arrow/arrow_array_reader.rs
@@ -904,7 +904,7 @@ fn resolve_bytes(v: &Value) -> Option<Vec<u8>> {
             items
                 .iter()
                 .map(resolve_u8)
-                .collect::<std::result::Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, _>>()
                 .ok()?,
         )),
         other => Err(AvroError::GetBytes(other.into())),

--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -284,7 +284,7 @@ impl<T> AbortOnDropSingle<T> {
 }
 
 impl<T> Future for AbortOnDropSingle<T> {
-    type Output = std::result::Result<T, tokio::task::JoinError>;
+    type Output = Result<T, tokio::task::JoinError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/datafusion/core/src/physical_plan/display.rs
+++ b/datafusion/core/src/physical_plan/display.rs
@@ -156,10 +156,7 @@ struct IndentVisitor<'a, 'b> {
 
 impl<'a, 'b> ExecutionPlanVisitor for IndentVisitor<'a, 'b> {
     type Error = fmt::Error;
-    fn pre_visit(
-        &mut self,
-        plan: &dyn ExecutionPlan,
-    ) -> std::result::Result<bool, Self::Error> {
+    fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
         write!(self.f, "{:indent$}", "", indent = self.indent * 2)?;
         plan.fmt_as(self.t, self.f)?;
         match self.show_metrics {

--- a/datafusion/core/src/physical_plan/joins/utils.rs
+++ b/datafusion/core/src/physical_plan/joins/utils.rs
@@ -677,10 +677,7 @@ impl<T: 'static> OnceFut<T> {
     }
 
     /// Get the result of the computation if it is ready, without consuming it
-    pub(crate) fn get(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<std::result::Result<&T, ArrowError>> {
+    pub(crate) fn get(&mut self, cx: &mut Context<'_>) -> Poll<Result<&T, ArrowError>> {
         if let OnceFutState::Pending(fut) = &mut self.state {
             let r = ready!(fut.poll_unpin(cx));
             self.state = OnceFutState::Ready(r);

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -342,7 +342,7 @@ pub fn displayable(plan: &dyn ExecutionPlan) -> DisplayableExecutionPlan<'_> {
 pub fn accept<V: ExecutionPlanVisitor>(
     plan: &dyn ExecutionPlan,
     visitor: &mut V,
-) -> std::result::Result<(), V::Error> {
+) -> Result<(), V::Error> {
     visitor.pre_visit(plan)?;
     for child in plan.children() {
         visit_execution_plan(child.as_ref(), visitor)?;
@@ -386,19 +386,13 @@ pub trait ExecutionPlanVisitor {
     /// recursion continues. If Err(..) or Ok(false) are returned, the
     /// recursion stops immediately and the error, if any, is returned
     /// to `accept`
-    fn pre_visit(
-        &mut self,
-        plan: &dyn ExecutionPlan,
-    ) -> std::result::Result<bool, Self::Error>;
+    fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error>;
 
     /// Invoked on an `ExecutionPlan` plan *after* all of its child
     /// inputs have been visited. The return value is handled the same
     /// as the return value of `pre_visit`. The provided default
     /// implementation returns `Ok(true)`.
-    fn post_visit(
-        &mut self,
-        _plan: &dyn ExecutionPlan,
-    ) -> std::result::Result<bool, Self::Error> {
+    fn post_visit(&mut self, _plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
         Ok(true)
     }
 }
@@ -408,7 +402,7 @@ pub trait ExecutionPlanVisitor {
 pub fn visit_execution_plan<V: ExecutionPlanVisitor>(
     plan: &dyn ExecutionPlan,
     visitor: &mut V,
-) -> std::result::Result<(), V::Error> {
+) -> Result<(), V::Error> {
     visitor.pre_visit(plan)?;
     for child in plan.children() {
         visit_execution_plan(child.as_ref(), visitor)?;

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -125,10 +125,7 @@ async fn explain_analyze_baseline_metrics() {
     impl ExecutionPlanVisitor for TimeValidator {
         type Error = std::convert::Infallible;
 
-        fn pre_visit(
-            &mut self,
-            plan: &dyn ExecutionPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
             if !expected_to_have_metrics(plan) {
                 return Ok(true);
             }

--- a/datafusion/core/tests/sqllogictests/src/error.rs
+++ b/datafusion/core/tests/sqllogictests/src/error.rs
@@ -21,7 +21,7 @@ use sqllogictest::TestError;
 use sqlparser::parser::ParserError;
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, DFSqlLogicTestError>;
+pub type Result<T, E = DFSqlLogicTestError> = std::result::Result<T, E>;
 
 /// DataFusion sql-logicaltest error
 #[derive(Debug, Error)]

--- a/datafusion/core/tests/sqllogictests/src/insert/mod.rs
+++ b/datafusion/core/tests/sqllogictests/src/insert/mod.rs
@@ -72,7 +72,7 @@ pub async fn insert(ctx: &SessionContext, insert_stmt: SQLStatement) -> Result<D
                     &mut PlannerContext::new(),
                 )
             })
-            .collect::<std::result::Result<Vec<DFExpr>, DataFusionError>>()?;
+            .collect::<Result<Vec<DFExpr>, DataFusionError>>()?;
         // Directly use `select` to get `RecordBatch`
         let dataframe = ctx.read_empty()?;
         origin_batches.extend(dataframe.select(logical_exprs)?.collect().await?)

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -563,7 +563,7 @@ fn accumulate_batch(
 }
 
 impl Stream for TopKReader {
-    type Item = std::result::Result<RecordBatch, ArrowError>;
+    type Item = Result<RecordBatch, ArrowError>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,

--- a/datafusion/expr/src/expr_visitor.rs
+++ b/datafusion/expr/src/expr_visitor.rs
@@ -230,12 +230,12 @@ impl ExprVisitable for Expr {
 struct VisitorAdapter<F, E> {
     f: F,
     // Store returned error as it my not be a DataFusionError
-    err: std::result::Result<(), E>,
+    err: Result<(), E>,
 }
 
 impl<F, E> ExpressionVisitor for VisitorAdapter<F, E>
 where
-    F: FnMut(&Expr) -> std::result::Result<(), E>,
+    F: FnMut(&Expr) -> Result<(), E>,
 {
     fn pre_visit(mut self, expr: &Expr) -> Result<Recursion<Self>> {
         if let Err(e) = (self.f)(expr) {
@@ -254,9 +254,9 @@ where
 /// Performs a pre-visit traversal by recursively calling `f(expr)` on
 /// `expr`, and then on all its children. See [`ExpressionVisitor`]
 /// for more details and more options to control the walk.
-pub fn inspect_expr_pre<F, E>(expr: &Expr, f: F) -> std::result::Result<(), E>
+pub fn inspect_expr_pre<F, E>(expr: &Expr, f: F) -> Result<(), E>
 where
-    F: FnMut(&Expr) -> std::result::Result<(), E>,
+    F: FnMut(&Expr) -> Result<(), E>,
 {
     // the visit is fallable, so unwrap here
     let adapter = expr.accept(VisitorAdapter { f, err: Ok(()) }).unwrap();

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2075,10 +2075,7 @@ mod tests {
     impl PlanVisitor for OkVisitor {
         type Error = String;
 
-        fn pre_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             let s = match plan {
                 LogicalPlan::Projection { .. } => "pre_visit Projection",
                 LogicalPlan::Filter { .. } => "pre_visit Filter",
@@ -2090,10 +2087,7 @@ mod tests {
             Ok(true)
         }
 
-        fn post_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn post_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             let s = match plan {
                 LogicalPlan::Projection { .. } => "post_visit Projection",
                 LogicalPlan::Filter { .. } => "post_visit Filter",
@@ -2160,20 +2154,14 @@ mod tests {
     impl PlanVisitor for StoppingVisitor {
         type Error = String;
 
-        fn pre_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             if self.return_false_from_pre_in.dec() {
                 return Ok(false);
             }
             self.inner.pre_visit(plan)
         }
 
-        fn post_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn post_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             if self.return_false_from_post_in.dec() {
                 return Ok(false);
             }
@@ -2233,10 +2221,7 @@ mod tests {
     impl PlanVisitor for ErrorVisitor {
         type Error = String;
 
-        fn pre_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             if self.return_error_from_pre_in.dec() {
                 return Err("Error in pre_visit".into());
             }
@@ -2244,10 +2229,7 @@ mod tests {
             self.inner.pre_visit(plan)
         }
 
-        fn post_visit(
-            &mut self,
-            plan: &LogicalPlan,
-        ) -> std::result::Result<bool, Self::Error> {
+        fn post_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             if self.return_error_from_post_in.dec() {
                 return Err("Error in post_visit".into());
             }

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -19,7 +19,7 @@ use crate::alias::AliasGenerator;
 use crate::optimizer::ApplyOrder;
 use crate::utils::{conjunction, only_or_err, split_conjunction};
 use crate::{OptimizerConfig, OptimizerRule};
-use datafusion_common::{context, Column, Result};
+use datafusion_common::{context, Column, DataFusionError, Result};
 use datafusion_expr::expr_rewriter::{replace_col, unnormalize_col};
 use datafusion_expr::logical_plan::{JoinType, Projection, Subquery};
 use datafusion_expr::utils::check_all_column_from_schema;
@@ -171,7 +171,7 @@ fn optimize_where_in(
                     .collect::<_>();
 
                 cols.extend(using_cols);
-                Result::Ok(cols)
+                Result::<_, DataFusionError>::Ok(cols)
             })?;
     let join_filter = conjunction(join_filters).map_or(Ok(None), |filter| {
         replace_qualified_name(filter, &subquery_cols, &subquery_alias).map(Option::Some)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

This is technically a breaking change, as there are some rare cases where this will now result in a compile error as it cannot infer the return type.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->