### PR TITLE
Minor: improve internal error message

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1106,7 +1106,7 @@ pub fn binary(
     let rhs_type = &rhs.data_type(input_schema)?;
     if !lhs_type.eq(rhs_type) {
         return Err(DataFusionError::Internal(format!(
-            "The type of {lhs_type} {op} {rhs_type} of binary physical should be same"
+            "The type of {lhs_type} {op:?} {rhs_type} of binary physical should be same"
         )));
     }
     Ok(Arc::new(BinaryExpr::new(lhs, op, rhs)))


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

We saw this message in our logs:

```
Error while planning query: Internal error: The type of Dictionary(Int32, Utf8) = Utf8 of binary physical should be same. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

It was not clear what operator is being used. 

# What changes are included in this PR?

Print out the debug version of Operator rather than display for a better message

# Are these changes tested?

No
# Are there any user-facing changes?
No