### PR TITLE
Minor: Remove invalid comments

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -231,8 +231,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    /// Generate a logic plan from selection clause, the function contain optimization for cross join to inner join
-    /// Related PR: <https://github.com/apache/arrow-datafusion/pull/1566>
     fn plan_selection(
         &self,
         selection: Option<SQLExpr>,


### PR DESCRIPTION
When I was browsing the code, I realized that the comment I wrote before is no longer useful.

Because the cross join -> inner join optimization has been moved to the optimizer.