### PR TITLE
Check placeholder  __timeTo and return Datafusion::Plan error

### DIFF
--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -95,6 +95,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         param: String,
         param_data_types: &[DataType],
     ) -> Result<Expr> {
+        // Parse the placeholder as a number because it is the only support from sqlparser and postgres
         let index = param[1..].parse::<usize>();
         let idx = match index {
             Ok(index) => index - 1,

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -96,13 +96,20 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         param_data_types: &[DataType],
     ) -> Result<Expr> {
         // Parse the placeholder as a number because it is the only support from sqlparser and postgres
+        // __timeTo is not supported and should return a Plan Error #5005
         let index = param[1..].parse::<usize>();
         let idx = match index {
             Ok(index) => index - 1,
             Err(_) => {
-                return Err(DataFusionError::Internal(format!(
-                    "Invalid placeholder, not a number: {param}"
-                )));
+                if &param[1..] == "__timeTo" {
+                    return Err(DataFusionError::Plan(format!(
+                        "Placeholder not supported: {param}"
+                    )));
+                } else {
+                    return Err(DataFusionError::Internal(format!(
+                        "Invalid placeholder, not a number: {param}"
+                    )));
+                }
             }
         };
         // Check if the placeholder is in the parameter list

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -95,21 +95,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         param: String,
         param_data_types: &[DataType],
     ) -> Result<Expr> {
-        // Parse the placeholder as a number because it is the only support from sqlparser and postgres
-        // __timeTo is not supported and should return a Plan Error #5005
         let index = param[1..].parse::<usize>();
         let idx = match index {
             Ok(index) => index - 1,
             Err(_) => {
-                if &param[1..] == "__timeTo" {
-                    return Err(DataFusionError::Plan(format!(
-                        "Placeholder not supported: {param}"
-                    )));
-                } else {
-                    return Err(DataFusionError::Internal(format!(
-                        "Invalid placeholder, not a number: {param}"
-                    )));
-                }
+                return Err(DataFusionError::Plan(format!(
+                    "Invalid placeholder, not a number: {param}"
+                )));
             }
         };
         // Check if the placeholder is in the parameter list

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -3113,6 +3113,15 @@ fn test_prepare_statement_to_plan_panic_param_format() {
 }
 
 #[test]
+#[should_panic(expected = "value: Plan(\"Placeholder not supported: $__timeTo\"")]
+fn test_prepare_statement_to_plan_panic_param_format_timeto() {
+    // param __timeTo is currently not supported
+    // panic due to error returned from the parser
+    let sql = "select $__timeTo";
+    logical_plan(sql).unwrap();
+}
+
+#[test]
 #[should_panic(expected = "value: SQL(ParserError(\"Expected AS, found: SELECT\"))")]
 fn test_prepare_statement_to_plan_panic_prepare_wrong_syntax() {
     // param is not number following the $ sign

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -3104,20 +3104,11 @@ fn test_ambiguous_column_references_with_in_using_join() {
 }
 
 #[test]
-#[should_panic(expected = "value: Internal(\"Invalid placeholder, not a number: $foo\"")]
+#[should_panic(expected = "value: Plan(\"Invalid placeholder, not a number: $foo\"")]
 fn test_prepare_statement_to_plan_panic_param_format() {
     // param is not number following the $ sign
     // panic due to error returned from the parser
     let sql = "PREPARE my_plan(INT) AS SELECT id, age  FROM person WHERE age = $foo";
-    logical_plan(sql).unwrap();
-}
-
-#[test]
-#[should_panic(expected = "value: Plan(\"Placeholder not supported: $__timeTo\"")]
-fn test_prepare_statement_to_plan_panic_param_format_timeto() {
-    // param __timeTo is currently not supported
-    // panic due to error returned from the parser
-    let sql = "select $__timeTo";
     logical_plan(sql).unwrap();
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5005 .

# Rationale for this change

As suggested by  @alamb in #5005, we are catching the parameter `$__timeTo` and returning `DatafusionError::Plan` error

# What changes are included in this PR?

* check the param to match `__timeTo` 
* created a test in 

# Are these changes tested?

yes

# Are there any user-facing changes?

Specific error message when this parameter is used.

----
P.S.: This is my first commit to Datafusion. I hope this is ok. Tell me, if I misunderstood the issue. Thanks for the great project!