### PR TITLE
Implemented a ReadOptions trait for cleaner code.

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -781,6 +781,7 @@ mod tests {
     use crate::prelude::*;
     use crate::{
         datasource::file_format::{avro::AvroFormat, parquet::ParquetFormat},
+        execution::options::ReadOptions,
         logical_expr::{col, lit},
         test::{columns, object_store::register_test_store},
     };

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1098,7 +1098,8 @@ mod tests {
         #[values(true, false)] infinite_data: bool,
     ) -> Result<()> {
         let config = CsvReadOptions::new().mark_infinite(infinite_data);
-        let listing_options = config.to_listing_options(1);
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let listing_options = config.to_listing_options(&session_config);
         unbounded_table_helper(FileType::CSV, listing_options, infinite_data).await
     }
 
@@ -1108,7 +1109,8 @@ mod tests {
         #[values(true, false)] infinite_data: bool,
     ) -> Result<()> {
         let config = NdJsonReadOptions::default().mark_infinite(infinite_data);
-        let listing_options = config.to_listing_options(1);
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let listing_options = config.to_listing_options(&session_config);
         unbounded_table_helper(FileType::JSON, listing_options, infinite_data).await
     }
 
@@ -1118,7 +1120,8 @@ mod tests {
         #[values(true, false)] infinite_data: bool,
     ) -> Result<()> {
         let config = AvroReadOptions::default().mark_infinite(infinite_data);
-        let listing_options = config.to_listing_options(1);
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let listing_options = config.to_listing_options(&session_config);
         unbounded_table_helper(FileType::AVRO, listing_options, infinite_data).await
     }
 

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -99,7 +99,7 @@ use datafusion_sql::planner::object_name_to_table_reference;
 use uuid::Uuid;
 
 use super::options::{
-    AvroReadOptions, CsvReadOptions, NdJsonReadOptions, ParquetReadOptions,
+    AvroReadOptions, CsvReadOptions, NdJsonReadOptions, ParquetReadOptions, ReadOptions,
 };
 
 /// SessionContext is the main interface for executing queries with DataFusion. It stands for
@@ -550,6 +550,32 @@ impl SessionContext {
             .insert(f.name.clone(), Arc::new(f));
     }
 
+    /// Creates a [`DataFrame`] for reading a CSV data source.
+    ///
+    /// For more control such as reading multiple files, you can use
+    /// [`read_table`](Self::read_table) with a [`ListingTable`].
+    async fn _read_type<'a>(
+        &self,
+        table_path: impl AsRef<str>,
+        options: impl ReadOptions<'a>,
+    ) -> Result<DataFrame> {
+        let table_path = ListingTableUrl::parse(table_path)?;
+        let target_partitions = self.copied_config().target_partitions();
+        let listing_options = options.to_listing_options(target_partitions);
+        let resolved_schema = match options
+            .get_resolved_schema(target_partitions, self.state(), table_path.clone())
+            .await
+        {
+            Ok(resolved_schema) => resolved_schema,
+            Err(e) => return Err(e),
+        };
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(listing_options)
+            .with_schema(resolved_schema);
+        let provider = ListingTable::try_new(config)?;
+        self.read_table(Arc::new(provider))
+    }
+
     /// Creates a [`DataFrame`] for reading an Avro data source.
     ///
     /// For more control such as reading multiple files, you can use
@@ -559,31 +585,7 @@ impl SessionContext {
         table_path: impl AsRef<str>,
         options: AvroReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let table_path = ListingTableUrl::parse(table_path)?;
-        let target_partitions = self.copied_config().target_partitions();
-
-        let listing_options = options.to_listing_options(target_partitions);
-
-        let resolved_schema = match (options.schema, options.infinite) {
-            (Some(s), _) => Arc::new(s.to_owned()),
-            (None, false) => {
-                listing_options
-                    .infer_schema(&self.state(), &table_path)
-                    .await?
-            }
-            (None, true) => {
-                return Err(DataFusionError::Plan(
-                    "Schema inference for infinite data sources is not supported."
-                        .to_string(),
-                ))
-            }
-        };
-
-        let config = ListingTableConfig::new(table_path)
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-        let provider = ListingTable::try_new(config)?;
-        self.read_table(Arc::new(provider))
+        self._read_type(table_path, options).await
     }
 
     /// Creates a [`DataFrame`] for reading an Json data source.
@@ -595,31 +597,7 @@ impl SessionContext {
         table_path: impl AsRef<str>,
         options: NdJsonReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let table_path = ListingTableUrl::parse(table_path)?;
-        let target_partitions = self.copied_config().target_partitions();
-
-        let listing_options = options.to_listing_options(target_partitions);
-
-        let resolved_schema = match (options.schema, options.infinite) {
-            (Some(s), _) => Arc::new(s.to_owned()),
-            (None, false) => {
-                listing_options
-                    .infer_schema(&self.state(), &table_path)
-                    .await?
-            }
-            (None, true) => {
-                return Err(DataFusionError::Plan(
-                    "Schema inference for infinite data sources is not supported."
-                        .to_string(),
-                ))
-            }
-        };
-        let config = ListingTableConfig::new(table_path)
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-        let provider = ListingTable::try_new(config)?;
-
-        self.read_table(Arc::new(provider))
+        self._read_type(table_path, options).await
     }
 
     /// Creates an empty DataFrame.
@@ -639,29 +617,7 @@ impl SessionContext {
         table_path: impl AsRef<str>,
         options: CsvReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let table_path = ListingTableUrl::parse(table_path)?;
-        let target_partitions = self.copied_config().target_partitions();
-        let listing_options = options.to_listing_options(target_partitions);
-        let resolved_schema = match (options.schema, options.infinite) {
-            (Some(s), _) => Arc::new(s.to_owned()),
-            (None, false) => {
-                listing_options
-                    .infer_schema(&self.state(), &table_path)
-                    .await?
-            }
-            (None, true) => {
-                return Err(DataFusionError::Plan(
-                    "Schema inference for infinite data sources is not supported."
-                        .to_string(),
-                ))
-            }
-        };
-        let config = ListingTableConfig::new(table_path.clone())
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-
-        let provider = ListingTable::try_new(config)?;
-        self.read_table(Arc::new(provider))
+        self._read_type(table_path, options).await
     }
 
     /// Creates a [`DataFrame`] for reading a Parquet data source.
@@ -673,20 +629,7 @@ impl SessionContext {
         table_path: impl AsRef<str>,
         options: ParquetReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let table_path = ListingTableUrl::parse(table_path)?;
-        let listing_options = options.to_listing_options(&self.state.read().config);
-
-        // with parquet we resolve the schema in all cases
-        let resolved_schema = listing_options
-            .infer_schema(&self.state(), &table_path)
-            .await?;
-
-        let config = ListingTableConfig::new(table_path)
-            .with_listing_options(listing_options)
-            .with_schema(resolved_schema);
-
-        let provider = ListingTable::try_new(config)?;
-        self.read_table(Arc::new(provider))
+        self._read_type(table_path, options).await
     }
 
     /// Creates a [`DataFrame`] for a [`TableProvider`] such as a
@@ -800,7 +743,8 @@ impl SessionContext {
         table_path: &str,
         options: ParquetReadOptions<'_>,
     ) -> Result<()> {
-        let listing_options = options.to_listing_options(&self.state.read().config);
+        let listing_options =
+            options.to_listing_options(self.state.read().config.target_partitions());
 
         self.register_listing_table(name, table_path, listing_options, None, None)
             .await?;

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -550,7 +550,7 @@ impl SessionContext {
             .insert(f.name.clone(), Arc::new(f));
     }
 
-    /// Creates a [`DataFrame`] for reading a CSV data source.
+    /// Creates a [`DataFrame`] for reading a data source.
     ///
     /// For more control such as reading multiple files, you can use
     /// [`read_table`](Self::read_table) with a [`ListingTable`].

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -560,10 +560,10 @@ impl SessionContext {
         options: impl ReadOptions<'a>,
     ) -> Result<DataFrame> {
         let table_path = ListingTableUrl::parse(table_path)?;
-        let target_partitions = self.copied_config().target_partitions();
-        let listing_options = options.to_listing_options(target_partitions);
+        let session_config = self.copied_config();
+        let listing_options = options.to_listing_options(&session_config);
         let resolved_schema = match options
-            .get_resolved_schema(target_partitions, self.state(), table_path.clone())
+            .get_resolved_schema(&session_config, self.state(), table_path.clone())
             .await
         {
             Ok(resolved_schema) => resolved_schema,
@@ -698,8 +698,7 @@ impl SessionContext {
         table_path: &str,
         options: CsvReadOptions<'_>,
     ) -> Result<()> {
-        let listing_options =
-            options.to_listing_options(self.copied_config().target_partitions());
+        let listing_options = options.to_listing_options(&self.copied_config());
 
         self.register_listing_table(
             name,
@@ -721,8 +720,7 @@ impl SessionContext {
         table_path: &str,
         options: NdJsonReadOptions<'_>,
     ) -> Result<()> {
-        let listing_options =
-            options.to_listing_options(self.copied_config().target_partitions());
+        let listing_options = options.to_listing_options(&self.copied_config());
 
         self.register_listing_table(
             name,
@@ -743,8 +741,7 @@ impl SessionContext {
         table_path: &str,
         options: ParquetReadOptions<'_>,
     ) -> Result<()> {
-        let listing_options =
-            options.to_listing_options(self.state.read().config.target_partitions());
+        let listing_options = options.to_listing_options(&self.state.read().config);
 
         self.register_listing_table(name, table_path, listing_options, None, None)
             .await?;
@@ -759,8 +756,7 @@ impl SessionContext {
         table_path: &str,
         options: AvroReadOptions<'_>,
     ) -> Result<()> {
-        let listing_options =
-            options.to_listing_options(self.copied_config().target_partitions());
+        let listing_options = options.to_listing_options(&self.copied_config());
 
         self.register_listing_table(
             name,

--- a/datafusion/core/src/execution/options.rs
+++ b/datafusion/core/src/execution/options.rs
@@ -343,11 +343,12 @@ impl<'a> NdJsonReadOptions<'a> {
 }
 
 #[async_trait]
-///
+/// ['ReadOptions'] is implemented by Options like ['CsvReadOptions'] that control the reading of respective files/sources.
 pub trait ReadOptions<'a> {
     /// Helper to convert these user facing options to `ListingTable` options
     fn to_listing_options(&self, target_partitions: usize) -> ListingOptions;
-    ///
+
+    /// Infer and resolve the schema from the files/sources provided.
     async fn get_resolved_schema(
         &self,
         target_partitions: usize,
@@ -355,7 +356,7 @@ pub trait ReadOptions<'a> {
         table_path: ListingTableUrl,
     ) -> Result<SchemaRef>;
 
-    ///
+    /// helper function to reduce repetitive code. Infers the schema from sources if not provided. Infinite data sources not supported through this function.
     async fn _get_resolved_schema(
         &'a self,
         target_partitions: usize,

--- a/datafusion/core/src/execution/options.rs
+++ b/datafusion/core/src/execution/options.rs
@@ -432,7 +432,7 @@ impl ReadOptions<'_> for ParquetReadOptions<'_> {
     ) -> Result<SchemaRef> {
         // with parquet we resolve the schema in all cases
         Ok(self
-            .to_listing_options(&config)
+            .to_listing_options(config)
             .infer_schema(&state, &table_path)
             .await?)
     }

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -18,7 +18,7 @@
 use std::{fs, path::Path};
 
 use ::parquet::arrow::ArrowWriter;
-use datafusion::datasource::listing::ListingOptions;
+use datafusion::{datasource::listing::ListingOptions, execution::options::ReadOptions};
 use datafusion_common::cast::{as_list_array, as_primitive_array, as_string_array};
 use tempfile::TempDir;
 
@@ -59,7 +59,7 @@ async fn parquet_with_sort_order_specified() {
 
     // The sort order is not specified
     let options_no_sort = parquet_read_options
-        .to_listing_options(&session_config)
+        .to_listing_options(session_config.target_partitions())
         .with_file_sort_order(None);
 
     // The sort order is specified (not actually correct in this case)
@@ -73,7 +73,7 @@ async fn parquet_with_sort_order_specified() {
         .collect::<Vec<_>>();
 
     let options_sort = parquet_read_options
-        .to_listing_options(&session_config)
+        .to_listing_options(session_config.target_partitions())
         .with_file_sort_order(Some(file_sort_order));
 
     // This string appears in ParquetExec if the output ordering is

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -59,7 +59,7 @@ async fn parquet_with_sort_order_specified() {
 
     // The sort order is not specified
     let options_no_sort = parquet_read_options
-        .to_listing_options(session_config.target_partitions())
+        .to_listing_options(&session_config)
         .with_file_sort_order(None);
 
     // The sort order is specified (not actually correct in this case)
@@ -73,7 +73,7 @@ async fn parquet_with_sort_order_specified() {
         .collect::<Vec<_>>();
 
     let options_sort = parquet_read_options
-        .to_listing_options(session_config.target_partitions())
+        .to_listing_options(&session_config)
         .with_file_sort_order(Some(file_sort_order));
 
     // This string appears in ParquetExec if the output ordering is

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -18,6 +18,7 @@
 use super::*;
 use ::parquet::arrow::arrow_writer::ArrowWriter;
 use ::parquet::file::properties::WriterProperties;
+use datafusion::execution::options::ReadOptions;
 
 /// for window functions without order by the first, last, and nth function call does not make sense
 #[tokio::test]
@@ -2459,7 +2460,7 @@ async fn get_test_context(tmpdir: &TempDir) -> Result<SessionContext> {
         .collect::<Vec<_>>();
 
     let options_sort = parquet_read_options
-        .to_listing_options(&ctx.copied_config())
+        .to_listing_options(ctx.copied_config().target_partitions())
         .with_file_sort_order(Some(file_sort_order));
 
     write_test_data_to_parquet(tmpdir, 1)?;

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -2460,7 +2460,7 @@ async fn get_test_context(tmpdir: &TempDir) -> Result<SessionContext> {
         .collect::<Vec<_>>();
 
     let options_sort = parquet_read_options
-        .to_listing_options(ctx.copied_config().target_partitions())
+        .to_listing_options(&ctx.copied_config())
         .with_file_sort_order(Some(file_sort_order));
 
     write_test_data_to_parquet(tmpdir, 1)?;


### PR DESCRIPTION
The `read_csv`, `read_parquet`, `read_json` and `read_avro` methods can not use a single method to read the locations.

# Which issue does this PR close?
Closes #5024.

# Rationale for this change
This will make for a simpler code in #4908.

# What changes are included in this PR?
Implemented a new trait `ReadOptions`. The code for method `to_listing_options` has been moved from the respective structs into this trait. Also the code from `read_csv/json/avro/parquet` to get the resolved schema has been moved here in `get_resolved_schema`.
Once this trait is implemented, the remaining code in the methods `read_csv/json/avro/parquet` is the same and has been moved to a private method.

# Are these changes tested?
This is only a refactor and the existing tests should cover the refactored code.

# Are there any user-facing changes?
No