### PR TITLE
[Substrait] ReadRel. Get column names from TableScan source

### DIFF
--- a/datafusion/substrait/src/producer.rs
+++ b/datafusion/substrait/src/producer.rs
@@ -108,7 +108,8 @@ pub fn to_substrait_rel(
                         common: None,
                         base_schema: Some(NamedStruct {
                             names: scan
-                                .projected_schema
+                                .source
+                                .schema()
                                 .fields()
                                 .iter()
                                 .map(|f| f.name().to_owned())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/4897

Original PR in datafusion-substrait repo: https://github.com/datafusion-contrib/datafusion-substrait/pull/37

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Quick fix to list ALL columns from source table in ReadRel base_schema.

According to Substrait [documentation](https://substrait.io/relations/logical_relations/#read-properties), the base_schema (Direct Schema) property should contain all columns BEFORE projection or emit/hiding is applied.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No .. this is applying a PR that was already merged in the original repo prior to us accepting the code donation here, so I am just trying to get those changes re-applied

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->