### PR TITLE
Fix limit when size of batch to poll == skip/fetch value

### DIFF
--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -585,7 +585,7 @@ mod tests {
         assert_eq!(index.value(), 0);
 
         // limit of six needs to consume the entire first record batch
-        // (5 rows) and 1 row from the second (1 row)
+        // (6 rows) and stop immediately
         let baseline_metrics = BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
         let limit_stream =
             LimitStream::new(Box::pin(input), 0, Some(6), baseline_metrics);

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -417,7 +417,7 @@ impl LimitStream {
         loop {
             let poll = input.poll_next_unpin(cx);
             let poll = poll.map_ok(|batch| {
-                if batch.num_rows() <= self.skip {
+                if batch.num_rows() < self.skip {
                     self.skip -= batch.num_rows();
                     RecordBatch::new_empty(input.schema())
                 } else {
@@ -449,7 +449,8 @@ impl LimitStream {
         if self.fetch == 0 {
             self.input = None; // clear input so it can be dropped early
             None
-        } else if batch.num_rows() <= self.fetch {
+        } else if batch.num_rows() < self.fetch {
+            //
             self.fetch -= batch.num_rows();
             Some(batch)
         } else {
@@ -542,7 +543,8 @@ mod tests {
     #[tokio::test]
     async fn limit_early_shutdown() -> Result<()> {
         let batches = vec![
-            test::make_partition(5),
+            //test::make_partition(5),
+            test::make_partition(6),
             test::make_partition(10),
             test::make_partition(15),
             test::make_partition(20),
@@ -567,6 +569,36 @@ mod tests {
 
         // Only the first two batches should be consumed
         assert_eq!(index.value(), 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn limit_equals_batch_size() -> Result<()> {
+        let batches = vec![
+            test::make_partition(6),
+            test::make_partition(6),
+            test::make_partition(6),
+        ];
+        let input = test::exec::TestStream::new(batches);
+
+        let index = input.index();
+        assert_eq!(index.value(), 0);
+
+        // limit of six needs to consume the entire first record batch
+        // (5 rows) and 1 row from the second (1 row)
+        let baseline_metrics = BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
+        let limit_stream =
+            LimitStream::new(Box::pin(input), 0, Some(6), baseline_metrics);
+        assert_eq!(index.value(), 0);
+
+        let results = collect(Box::pin(limit_stream)).await.unwrap();
+        let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
+        // Only 6 rows should have been produced
+        assert_eq!(num_rows, 6);
+
+        // Only the first batch should be consumed
+        assert_eq!(index.value(), 1);
 
         Ok(())
     }

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -544,7 +544,6 @@ mod tests {
     async fn limit_early_shutdown() -> Result<()> {
         let batches = vec![
             test::make_partition(5),
-            test::make_partition(6),
             test::make_partition(10),
             test::make_partition(15),
             test::make_partition(20),

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -543,7 +543,7 @@ mod tests {
     #[tokio::test]
     async fn limit_early_shutdown() -> Result<()> {
         let batches = vec![
-            //test::make_partition(5),
+            test::make_partition(5),
             test::make_partition(6),
             test::make_partition(10),
             test::make_partition(15),

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -417,7 +417,7 @@ impl LimitStream {
         loop {
             let poll = input.poll_next_unpin(cx);
             let poll = poll.map_ok(|batch| {
-                if batch.num_rows() < self.skip {
+                if batch.num_rows() <= self.skip {
                     self.skip -= batch.num_rows();
                     RecordBatch::new_empty(input.schema())
                 } else {


### PR DESCRIPTION
# Which issue does this PR close?


Closes #5064

# Rationale for this change
Bug fix. I found this when working with the Coralogix which pushes down limits to fully to the scan (so the batch size almost always equals the limit).

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change `<=` to `<` 🥳 

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->