### PR TITLE
Validate assignment target column existence for UPDATE statements

### DIFF
--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -42,3 +42,6 @@ datafusion-common = { path = "../common", version = "16.0.0" }
 datafusion-expr = { path = "../expr", version = "16.0.0" }
 log = "^0.4"
 sqlparser = "0.30"
+
+[dev-dependencies]
+rstest = "*"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5068.

# Rationale for this change

Ensure that all assignment targets are actual columns of the target table, to prevent typos being silently swallowed up.

# What changes are included in this PR?

During logical planning of the `UPDATE` statement try to fetch each of the referenced assignment columns.

# Are these changes tested?

Yes, there is a new 3-case test now.

# Are there any user-facing changes?

Not really; Datafusion is read-only, so the only difference is what error is shown (`SchemaError(FieldNotFound` from the logical planning as opposed to `Internal("Unsupported logical plan: Dml")` from the physical planning phase). The real user-facing changes will be in the projects that use Datafusion as a framework and also [support writes](https://www.splitgraph.com/blog/seafowl-time-travel).