### PR TITLE
Add NULL literal support for decimal and integers

### DIFF
--- a/datafusion/substrait/src/consumer.rs
+++ b/datafusion/substrait/src/consumer.rs
@@ -38,12 +38,11 @@ use substrait::proto::{
     },
     extensions::simple_extension_declaration::MappingType,
     function_argument::ArgType,
-    join_rel, plan_rel,
-    r#type,
+    join_rel, plan_rel, r#type,
     read_rel::ReadType,
     rel::RelType,
     sort_field::{SortDirection, SortKind::*},
-    AggregateFunction, Expression, Plan, Rel, Type
+    AggregateFunction, Expression, Plan, Rel, Type,
 };
 
 use datafusion::logical_expr::expr::Sort;

--- a/datafusion/substrait/src/consumer.rs
+++ b/datafusion/substrait/src/consumer.rs
@@ -78,7 +78,7 @@ pub fn name_to_op(name: &str) -> Result<Operator> {
         "bitwise_shift_right" => Ok(Operator::BitwiseShiftRight),
         "bitwise_shift_left" => Ok(Operator::BitwiseShiftLeft),
         _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported function name: {name:?}",
+            "Unsupported function name: {name:?}"
         ))),
     }
 }
@@ -98,7 +98,7 @@ pub async fn from_substrait_plan(
                     Ok((ext_f.function_anchor, &ext_f.name))
                 }
                 _ => Err(DataFusionError::NotImplemented(format!(
-                    "Extension type not supported: {ext:?}",
+                    "Extension type not supported: {ext:?}"
                 ))),
             },
             None => Err(DataFusionError::NotImplemented(
@@ -429,13 +429,13 @@ fn from_substrait_jointype(join_type: i32) -> Result<JoinType> {
             join_rel::JoinType::Semi => Ok(JoinType::LeftSemi),
             _ => {
                 return Err(DataFusionError::Internal(format!(
-                    "unsupported join type {substrait_join_type:?}",
+                    "unsupported join type {substrait_join_type:?}"
                 )))
             }
         }
     } else {
         return Err(DataFusionError::Internal(format!(
-            "invalid join type variant {join_type:?}",
+            "invalid join type variant {join_type:?}"
         )));
     }
 }
@@ -597,7 +597,7 @@ pub async fn from_substrait_rex(
                     })))
                 }
                 (l, r) => Err(DataFusionError::NotImplemented(format!(
-                    "Invalid arguments for binary expression: {l:?} and {r:?}",
+                    "Invalid arguments for binary expression: {l:?} and {r:?}"
                 ))),
             }
         }
@@ -635,12 +635,12 @@ pub async fn from_substrait_rex(
                     ))?;
                     let p = d.precision.try_into().map_err(|e| {
                         DataFusionError::Substrait(format!(
-                            "Failed to parse decimal precision: {e}",
+                            "Failed to parse decimal precision: {e}"
                         ))
                     })?;
                     let s = d.scale.try_into().map_err(|e| {
                         DataFusionError::Substrait(format!(
-                            "Failed to parse decimal scale: {e}",
+                            "Failed to parse decimal scale: {e}"
                         ))
                     })?;
                     Ok(Arc::new(Expr::Literal(ScalarValue::Decimal128(
@@ -685,13 +685,12 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                 d.scale as i8,
             )),
             _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported null kind: {:?}",
-                kind
+                "Unsupported null kind: {kind:?}"
             ))),
         }
     } else {
-        return Err(DataFusionError::NotImplemented(
+        Err(DataFusionError::NotImplemented(
             "Null type without kind is not supported".to_string(),
-        ));
+        ))
     }
 }

--- a/datafusion/substrait/src/producer.rs
+++ b/datafusion/substrait/src/producer.rs
@@ -45,8 +45,7 @@ use substrait::proto::{
         simple_extension_declaration::{ExtensionFunction, MappingType},
     },
     function_argument::ArgType,
-    join_rel, plan_rel,
-    r#type,
+    join_rel, plan_rel, r#type,
     read_rel::{NamedTable, ReadType},
     rel::RelType,
     sort_field::{SortDirection, SortKind},
@@ -593,7 +592,7 @@ pub fn to_substrait_rex(
                         precision: *p as i32,
                         scale: *s as i32,
                     }))
-                },
+                }
                 ScalarValue::Utf8(Some(s)) => Some(LiteralType::String(s.clone())),
                 ScalarValue::LargeUtf8(Some(s)) => Some(LiteralType::String(s.clone())),
                 ScalarValue::Binary(Some(b)) => Some(LiteralType::Binary(b.clone())),
@@ -644,14 +643,16 @@ fn try_to_substrait_null(v: &ScalarValue) -> Result<LiteralType> {
                 nullability: default_nullability,
             })),
         })),
-        ScalarValue::Decimal128(None, p, s) => Ok(LiteralType::Null(substrait::proto::Type {
-            kind: Some(r#type::Kind::Decimal(r#type::Decimal {
-                scale: *s as i32,
-                precision: *p as i32,
-                type_variation_reference: default_type_ref,
-                nullability: default_nullability,
-            })),
-        })),
+        ScalarValue::Decimal128(None, p, s) => {
+            Ok(LiteralType::Null(substrait::proto::Type {
+                kind: Some(r#type::Kind::Decimal(r#type::Decimal {
+                    scale: *s as i32,
+                    precision: *p as i32,
+                    type_variation_reference: default_type_ref,
+                    nullability: default_nullability,
+                })),
+            }))
+        }
         // TODO: Extend support for remaining data types
         _ => Err(DataFusionError::NotImplemented(format!(
             "Unsupported literal: {:?}",

--- a/datafusion/substrait/src/producer.rs
+++ b/datafusion/substrait/src/producer.rs
@@ -297,7 +297,7 @@ pub fn to_substrait_rel(
             to_substrait_rel(alias.input.as_ref(), extension_info)
         }
         _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported operator: {plan:?}",
+            "Unsupported operator: {plan:?}"
         ))),
     }
 }
@@ -385,13 +385,9 @@ pub fn to_substrait_agg_measure(
             to_substrait_agg_measure(expr, schema, extension_info)
         }
         _ => Err(DataFusionError::Internal(format!(
-<<<<<<< HEAD
-            "Expression must be compatible with aggregation. Unsupported expression: {expr:?}",
-=======
             "Expression must be compatible with aggregation. Unsupported expression: {:?}. ExpressionType: {:?}",
             expr,
             expr.variant_name()
->>>>>>> Add NULL literal support for decimal and integers
         ))),
     }
 }
@@ -655,8 +651,7 @@ fn try_to_substrait_null(v: &ScalarValue) -> Result<LiteralType> {
         }
         // TODO: Extend support for remaining data types
         _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported literal: {:?}",
-            v
+            "Unsupported literal: {v:?}"
         ))),
     }
 }

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -102,6 +102,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn null_decimal_literal() -> Result<()> {
+        roundtrip("SELECT * FROM data WHERE b = NULL").await
+    }
+
+    #[tokio::test]
     async fn simple_distinct() -> Result<()> {
         test_alias(
             "SELECT * FROM (SELECT distinct a FROM data)", // `SELECT *` is used to add `projection` at the root
@@ -167,6 +172,17 @@ mod tests {
                             WHEN 1 THEN 'one'
                             ELSE 'other'
                            END) FROM data",
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn aggregate_case() -> Result<()> {
+        assert_expected_plan(
+            "SELECT SUM(CASE WHEN a > 0 THEN 1 ELSE NULL END) FROM data",
+            "Projection: SUM(CASE WHEN data.a > Int64(0) THEN Int64(1) ELSE Int64(NULL) END)\
+            \n  Aggregate: groupBy=[[]], aggr=[[SUM(CASE WHEN data.a > Int64(0) THEN Int64(1) ELSE Int64(NULL) END)]]\
+            \n    TableScan: data projection=[a]",
         )
         .await
     }
@@ -306,7 +322,7 @@ mod tests {
         explicit_options.schema = Some(&schema);
         ctx.register_csv("data", "tests/testdata/data.csv", explicit_options.clone())
             .await?;
-        ctx.register_csv("data2", "tests/testdata/data.csv", explicit_options)
+        ctx.register_csv("data2", "tests/testdata/data.csv", explicit_options.clone())
             .await?;
         Ok(ctx)
     }

--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -320,9 +320,9 @@ mod tests {
             Field::new("d", DataType::Boolean, true),
         ]);
         explicit_options.schema = Some(&schema);
-        ctx.register_csv("data", "tests/testdata/data.csv", explicit_options.clone())
+        ctx.register_csv("data", "tests/testdata/data.csv", explicit_options)
             .await?;
-        ctx.register_csv("data2", "tests/testdata/data.csv", explicit_options.clone())
+        ctx.register_csv("data2", "tests/testdata/data.csv", CsvReadOptions::new())
             .await?;
         Ok(ctx)
     }


### PR DESCRIPTION
Modified test

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-datafusion/issues/4897

Original PR: https://github.com/datafusion-contrib/datafusion-substrait/pull/40

# Rationale for this change

Applying PRs that were already merged in the original repo
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Add Substrait producer and consumer support for NULL literals of types:
  - `INT8`, `INT16`, `INT32`
  - `DECIMAL128`
- Add tests
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->