### PR TITLE
Optimize returned plan in roundtrip_fill_na function

### DIFF
--- a/datafusion/substrait/tests/roundtrip.rs
+++ b/datafusion/substrait/tests/roundtrip.rs
@@ -67,7 +67,6 @@ mod tests {
         roundtrip("SELECT * FROM data WHERE d AND a > 1").await
     }
 
-    #[ignore] // tracked in https://github.com/apache/arrow-datafusion/issues/4897
     #[tokio::test]
     async fn select_with_limit() -> Result<()> {
         roundtrip_fill_na("SELECT * FROM data LIMIT 100").await
@@ -221,6 +220,7 @@ mod tests {
         let plan1 = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan1)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
+        let plan2 = ctx.state().optimize(&plan2)?;
 
         // Format plan string and replace all None's with 0
         let plan1str = format!("{plan1:?}").replace("None", "0");
@@ -260,7 +260,7 @@ mod tests {
         let plan = df.into_optimized_plan()?;
         let proto = to_substrait_plan(&plan)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
-        let plan2 = ctx.optimize(&plan2)?;
+        let plan2 = ctx.state().optimize(&plan2)?;
 
         println!("{plan:#?}");
         println!("{plan2:#?}");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/4897

# Rationale for this change

The test that failed used a function that compared an **optimized** plan to an **unoptimized** plan.

While at it, also changed from using the deprecated `SessionContext::optimize` to the recommended `SessionState::optimize`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Modified the `roundtrip_fill_na()` function used by the failed test to compare optimized plan to optimized plan. Test now passes.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->