### PR TITLE
Add null-equals-null join support

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.62"
 [dependencies]
 async-recursion = "1.0"
 datafusion = { version = "17.0.0", path = "../core" }
+itertools = "0.10.5"
 prost = "0.11"
 prost-types = "0.11"
 substrait = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/5084

# Rationale for this change
Support for `null-equals-null` joins as described in https://github.com/apache/arrow-datafusion/issues/5084.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Support `null-equals-null` joins in both producer and consumer
- Support for accepting `ScalarValue::UInt8` in the producer. (Encoded as `i32` since Substrait does not support unsigned integers)
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->