### PR TITLE
Make the required distribution of NestedLoopJoinExec consistent with CrossJoinExec

### DIFF
--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -3298,3 +3298,50 @@ async fn two_in_subquery_to_join_with_outer_filter() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn nested_loop_join_with_right_repartation() -> Result<()> {
+    let ctx = create_nested_loop_join_context()?;
+
+    let sql = "SELECT t1.t1_id, t2.t2_id FROM t1 INNER JOIN t2 ON t1.t1_id > t2.t2_id 
+                                               WHERE t1.t1_id > 10 AND t2.t2_int > 1";
+
+    let msg = format!("Creating logical plan for '{sql}'");
+    let dataframe = ctx.sql(sql).await.expect(&msg);
+    let physical_plan = dataframe.create_physical_plan().await?;
+
+    let expected = vec![
+        "ProjectionExec: expr=[t1_id@0 as t1_id, t2_id@1 as t2_id]",
+        "  NestedLoopJoinExec: join_type=Inner, filter=BinaryExpr { left: Column { name: \"t1_id\", index: 0 }, op: Gt, right: Column { name: \"t2_id\", index: 1 } }",
+        "    CoalescePartitionsExec",
+        "      CoalesceBatchesExec: target_batch_size=4096",
+        "        FilterExec: t1_id@0 > 10",
+        "          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1",
+        "            MemoryExec: partitions=1, partition_sizes=[1]",
+        "    CoalesceBatchesExec: target_batch_size=4096",
+        "      FilterExec: t2_int@1 > 1",
+        "        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1",
+        "          MemoryExec: partitions=1, partition_sizes=[1]",
+    ];
+    let formatted = displayable(physical_plan.as_ref()).indent().to_string();
+    let actual: Vec<&str> = formatted.trim().lines().collect();
+    assert_eq!(
+        expected, actual,
+        "\n\nexpected:\n\n{expected:#?}\nactual:\n\n{actual:#?}\n\n"
+    );
+
+    let expected = vec![
+        "+-------+-------+",
+        "| t1_id | t2_id |",
+        "+-------+-------+",
+        "| 22    | 11    |",
+        "| 33    | 11    |",
+        "| 44    | 11    |",
+        "+-------+-------+",
+    ];
+
+    let results = execute_to_batches(&ctx, sql).await;
+    assert_batches_sorted_eq!(expected, &results);
+
+    Ok(())
+}

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -3300,7 +3300,7 @@ async fn two_in_subquery_to_join_with_outer_filter() -> Result<()> {
 }
 
 #[tokio::test]
-async fn nested_loop_join_with_right_repartation() -> Result<()> {
+async fn nested_loop_join_with_right_repartition() -> Result<()> {
     let ctx = create_nested_loop_join_context()?;
 
     let sql = "SELECT t1.t1_id, t2.t2_id FROM t1 INNER JOIN t2 ON t1.t1_id > t2.t2_id 

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -692,6 +692,56 @@ fn create_sort_merge_join_datatype_context() -> Result<SessionContext> {
     Ok(ctx)
 }
 
+fn create_nested_loop_join_context() -> Result<SessionContext> {
+    let ctx = SessionContext::with_config(
+        SessionConfig::new()
+            .with_target_partitions(4)
+            .with_batch_size(4096),
+    );
+
+    let t1_schema = Arc::new(Schema::new(vec![
+        Field::new("t1_id", DataType::UInt32, true),
+        Field::new("t1_name", DataType::Utf8, true),
+        Field::new("t1_int", DataType::UInt32, true),
+    ]));
+    let t1_data = RecordBatch::try_new(
+        t1_schema,
+        vec![
+            Arc::new(UInt32Array::from_slice([11, 22, 33, 44])),
+            Arc::new(StringArray::from(vec![
+                Some("a"),
+                Some("b"),
+                Some("c"),
+                Some("d"),
+            ])),
+            Arc::new(UInt32Array::from_slice([1, 2, 3, 4])),
+        ],
+    )?;
+    ctx.register_batch("t1", t1_data)?;
+
+    let t2_schema = Arc::new(Schema::new(vec![
+        Field::new("t2_id", DataType::UInt32, true),
+        Field::new("t2_name", DataType::Utf8, true),
+        Field::new("t2_int", DataType::UInt32, true),
+    ]));
+    let t2_data = RecordBatch::try_new(
+        t2_schema,
+        vec![
+            Arc::new(UInt32Array::from_slice([11, 22, 44, 55])),
+            Arc::new(StringArray::from(vec![
+                Some("z"),
+                Some("y"),
+                Some("x"),
+                Some("w"),
+            ])),
+            Arc::new(UInt32Array::from_slice([3, 1, 3, 3])),
+        ],
+    )?;
+    ctx.register_batch("t2", t2_data)?;
+
+    Ok(ctx)
+}
+
 fn create_union_context() -> Result<SessionContext> {
     let ctx = SessionContext::new();
     let t1_schema = Arc::new(Schema::new(vec![


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5022.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
1. Currently the required distribution of `NestedLoopJoinExec` is not consistent with `CrossJoinExec`, and some optimizations(`JoinSelection`) already done for `CrossJoinExec` will not take effect for `NestedLoopJoinExec`. 
2. `NestedLoopJoinExec` will collect both left and right to a single partition for `Full` join, this may cause performance issue. 

We can always collect left for `NestedLoopJoinExec` like `CrossJoinExec` does. This will also fix #5022.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Always collect left side for `NestedLoopJoinExec` like `CrossJoinExec` does.
2. For `LEFT/LEFT-SEMI/LEFT-ANTI/FULL`, we need generate the additional data for the unmatched rows, so maintain a global state of `visited_left_side` in `NestedLoopJoinExec`.
3. Merge partition state - `visited_left_side` to global after one partition is finished.  
4. Generate the additional data for the unmatched rows based on `global state` after all partitions are finished.

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->