### PR TITLE
Use DataFusionError instead of ArrowError in SendableRecordBatchStream

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -722,7 +722,6 @@ mod tests {
     use crate::{assert_batches_sorted_eq, physical_plan::common};
     use arrow::array::{Float64Array, UInt32Array};
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use arrow::error::Result as ArrowResult;
     use arrow::record_batch::RecordBatch;
     use datafusion_common::{DataFusionError, Result, ScalarValue};
     use datafusion_physical_expr::expressions::{lit, ApproxDistinct, Count, Median};
@@ -1038,7 +1037,7 @@ mod tests {
     }
 
     impl Stream for TestYieldingStream {
-        type Item = ArrowResult<RecordBatch>;
+        type Item = Result<RecordBatch>;
 
         fn poll_next(
             mut self: std::pin::Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -42,13 +42,10 @@ use crate::physical_plan::{RecordBatchStream, SendableRecordBatchStream};
 
 use crate::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use arrow::array::{new_null_array, PrimitiveArray};
+use arrow::array::{Array, UInt32Builder};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Schema, UInt32Type};
 use arrow::{array::ArrayRef, compute};
-use arrow::{
-    array::{Array, UInt32Builder},
-    error::{ArrowError, Result as ArrowResult},
-};
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::Accumulator;
@@ -226,7 +223,7 @@ impl GroupedHashAggregateStream {
 }
 
 impl Stream for GroupedHashAggregateStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -252,9 +249,7 @@ impl Stream for GroupedHashAggregateStream {
                             });
 
                             if let Err(e) = result {
-                                return Poll::Ready(Some(Err(
-                                    ArrowError::ExternalError(Box::new(e)),
-                                )));
+                                return Poll::Ready(Some(Err(e)));
                             }
                         }
                         // inner had error, return to caller
@@ -569,7 +564,7 @@ impl std::fmt::Debug for RowAggregationState {
 
 impl GroupedHashAggregateStream {
     /// Create a RecordBatch with all group keys and accumulator' states or values.
-    fn create_batch_from_map(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn create_batch_from_map(&mut self) -> Result<Option<RecordBatch>> {
         let skip_items = self.row_group_skip_position;
         if skip_items > self.row_aggr_state.group_states.len() {
             return Ok(None);
@@ -624,7 +619,6 @@ impl GroupedHashAggregateStream {
                         // the intermediate GroupByScalar type was not the same as the
                         // output
                         cast(&item, field.data_type())
-                            .map_err(DataFusionError::ArrowError)
                     }?;
                     results.push(result);
                 }

--- a/datafusion/core/src/physical_plan/analyze.rs
+++ b/datafusion/core/src/physical_plan/analyze.rs
@@ -200,7 +200,8 @@ impl ExecutionPlan for AnalyzeExec {
                     Arc::new(type_builder.finish()),
                     Arc::new(plan_builder.finish()),
                 ],
-            );
+            )
+            .map_err(Into::into);
             // again ignore error
             tx.send(maybe_batch).await.ok();
         });

--- a/datafusion/core/src/physical_plan/coalesce_batches.rs
+++ b/datafusion/core/src/physical_plan/coalesce_batches.rs
@@ -180,7 +180,7 @@ struct CoalesceBatchesStream {
 }
 
 impl Stream for CoalesceBatchesStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -200,7 +200,7 @@ impl CoalesceBatchesStream {
     fn poll_next_inner(
         self: &mut Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         // Get a clone (uses same underlying atomic) as self gets borrowed below
         let cloned_time = self.baseline_metrics.elapsed_compute().clone();
 

--- a/datafusion/core/src/physical_plan/file_format/csv.rs
+++ b/datafusion/core/src/physical_plan/file_format/csv.rs
@@ -452,7 +452,7 @@ mod tests {
         let err = it.next().await.unwrap().unwrap_err().to_string();
         assert_eq!(
             err,
-            "Csv error: incorrect number of fields for line 1, expected 14 got 13"
+            "Arrow error: Csv error: incorrect number of fields for line 1, expected 14 got 13"
         );
         Ok(())
     }

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -35,7 +35,6 @@ use arrow::{
     array::{ArrayData, ArrayRef, DictionaryArray},
     buffer::Buffer,
     datatypes::{DataType, Field, Schema, SchemaRef, UInt16Type},
-    error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
 pub use avro::AvroExec;
@@ -379,12 +378,12 @@ impl PartitionColumnProjector {
         &mut self,
         file_batch: RecordBatch,
         partition_values: &[ScalarValue],
-    ) -> ArrowResult<RecordBatch> {
+    ) -> Result<RecordBatch> {
         let expected_cols =
             self.projected_schema.fields().len() - self.projected_partition_indexes.len();
 
         if file_batch.columns().len() != expected_cols {
-            return Err(ArrowError::SchemaError(format!(
+            return Err(DataFusionError::Execution(format!(
                 "Unexpected batch schema from file, expected {} cols but got {}",
                 expected_cols,
                 file_batch.columns().len()
@@ -401,7 +400,7 @@ impl PartitionColumnProjector {
                 ),
             )
         }
-        RecordBatch::try_new(Arc::clone(&self.projected_schema), cols)
+        RecordBatch::try_new(Arc::clone(&self.projected_schema), cols).map_err(Into::into)
     }
 }
 

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -640,7 +640,11 @@ pub async fn plan_to_parquet(
                 let handle: tokio::task::JoinHandle<Result<()>> =
                     tokio::task::spawn(async move {
                         stream
-                            .map(|batch| writer.write(&batch?))
+                            .map(|batch| {
+                                writer
+                                    .write(&batch?)
+                                    .map_err(DataFusionError::ParquetError)
+                            })
                             .try_collect()
                             .await
                             .map_err(DataFusionError::from)?;
@@ -863,7 +867,7 @@ mod tests {
             .write_parquet(&out_dir, None)
             .await
             .expect_err("should fail because input file does not match inferred schema");
-        assert_eq!("Parquet error: Arrow: underlying Arrow error: Parser error: Error while parsing value d for column 0 at line 4", format!("{e}"));
+        assert_eq!("Arrow error: Parser error: Error while parsing value d for column 0 at line 4", format!("{e}"));
         Ok(())
     }
 

--- a/datafusion/core/src/physical_plan/filter.rs
+++ b/datafusion/core/src/physical_plan/filter.rs
@@ -245,9 +245,7 @@ fn batch_filter(
         .and_then(|array| {
             Ok(as_boolean_array(&array)?)
                 // apply filter array to record batch
-                .and_then(|filter_array| {
-                    filter_record_batch(batch, filter_array).map_err(Into::into)
-                })
+                .and_then(|filter_array| Ok(filter_record_batch(batch, filter_array)?))
         })
 }
 

--- a/datafusion/core/src/physical_plan/filter.rs
+++ b/datafusion/core/src/physical_plan/filter.rs
@@ -33,7 +33,6 @@ use crate::physical_plan::{
 };
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, SchemaRef};
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_boolean_array;
 use datafusion_expr::Operator;
@@ -239,20 +238,21 @@ struct FilterExecStream {
 fn batch_filter(
     batch: &RecordBatch,
     predicate: &Arc<dyn PhysicalExpr>,
-) -> ArrowResult<RecordBatch> {
+) -> Result<RecordBatch> {
     predicate
         .evaluate(batch)
         .map(|v| v.into_array(batch.num_rows()))
-        .map_err(DataFusionError::into)
         .and_then(|array| {
             Ok(as_boolean_array(&array)?)
                 // apply filter array to record batch
-                .and_then(|filter_array| filter_record_batch(batch, filter_array))
+                .and_then(|filter_array| {
+                    filter_record_batch(batch, filter_array).map_err(Into::into)
+                })
         })
 }
 
 impl Stream for FilterExecStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/joins/nested_loop_join.rs
+++ b/datafusion/core/src/physical_plan/joins/nested_loop_join.rs
@@ -34,9 +34,8 @@ use arrow::array::{
     BooleanBufferBuilder, UInt32Array, UInt32Builder, UInt64Array, UInt64Builder,
 };
 use arrow::datatypes::{Schema, SchemaRef};
-use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::Statistics;
+use datafusion_common::{DataFusionError, Statistics};
 use datafusion_expr::JoinType;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalSortExpr};
 use futures::{ready, Stream, StreamExt, TryStreamExt};
@@ -356,7 +355,7 @@ impl NestedLoopJoinStream {
     fn poll_next_impl(
         &mut self,
         cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         // all left row
         let left_data = match ready!(self.left_fut.get(cx)) {
             Ok(left_data) => left_data,
@@ -400,12 +399,9 @@ impl NestedLoopJoinStream {
                     let mut left_indices_builder = UInt64Builder::new();
                     let mut right_indices_builder = UInt32Builder::new();
                     let left_right_indices = match indices_result {
-                        Err(_) => {
-                            // TODO why the type of result stream is `Result<T, ArrowError>`, and not the `DataFusionError`
-                            Err(ArrowError::ComputeError(
-                                "Build left right indices error".to_string(),
-                            ))
-                        }
+                        Err(_) => Err(DataFusionError::Execution(
+                            "Build left right indices error".to_string(),
+                        )),
                         Ok(indices) => {
                             for (left_side, right_side) in indices {
                                 left_indices_builder.append_values(
@@ -486,7 +482,7 @@ impl NestedLoopJoinStream {
 }
 
 impl Stream for NestedLoopJoinStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -1030,8 +1030,7 @@ impl SMJStream {
                 .columns()
                 .iter()
                 .map(|column| take(column, &streamed_indices, None))
-                .collect::<Result<Vec<_>, ArrowError>>()
-                .map_err(Into::<DataFusionError>::into)?;
+                .collect::<Result<Vec<_>, ArrowError>>()?;
 
             let buffered_indices: UInt64Array = chunk.buffered_indices.finish();
 
@@ -1044,8 +1043,7 @@ impl SMJStream {
                         .columns()
                         .iter()
                         .map(|column| take(column, &buffered_indices, None))
-                        .collect::<Result<Vec<_>, ArrowError>>()
-                        .map_err(Into::<DataFusionError>::into)?
+                        .collect::<Result<Vec<_>, ArrowError>>()?
                 } else {
                     self.buffered_schema
                         .fields()

--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -32,7 +32,7 @@ use std::task::{Context, Poll};
 use arrow::array::*;
 use arrow::compute::{concat_batches, take, SortOptions};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
-use arrow::error::{ArrowError, Result as ArrowResult};
+use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
 
@@ -574,7 +574,7 @@ impl RecordBatchStream for SMJStream {
 }
 
 impl Stream for SMJStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -712,7 +712,7 @@ impl SMJStream {
     }
 
     /// Poll next streamed row
-    fn poll_streamed_row(&mut self, cx: &mut Context) -> Poll<Option<ArrowResult<()>>> {
+    fn poll_streamed_row(&mut self, cx: &mut Context) -> Poll<Option<Result<()>>> {
         loop {
             match &self.streamed_state {
                 StreamedState::Init => {
@@ -755,10 +755,7 @@ impl SMJStream {
     }
 
     /// Poll next buffered batches
-    fn poll_buffered_batches(
-        &mut self,
-        cx: &mut Context,
-    ) -> Poll<Option<ArrowResult<()>>> {
+    fn poll_buffered_batches(&mut self, cx: &mut Context) -> Poll<Option<Result<()>>> {
         loop {
             match &self.buffered_state {
                 BufferedState::Init => {
@@ -856,7 +853,7 @@ impl SMJStream {
     }
 
     /// Get comparison result of streamed row and buffered batches
-    fn compare_streamed_buffered(&self) -> ArrowResult<Ordering> {
+    fn compare_streamed_buffered(&self) -> Result<Ordering> {
         if self.streamed_state == StreamedState::Exhausted {
             return Ok(Ordering::Greater);
         }
@@ -876,7 +873,7 @@ impl SMJStream {
 
     /// Produce join and fill output buffer until reaching target batch size
     /// or the join is finished
-    fn join_partial(&mut self) -> ArrowResult<()> {
+    fn join_partial(&mut self) -> Result<()> {
         let mut join_streamed = false;
         let mut join_buffered = false;
 
@@ -960,7 +957,7 @@ impl SMJStream {
         Ok(())
     }
 
-    fn freeze_all(&mut self) -> ArrowResult<()> {
+    fn freeze_all(&mut self) -> Result<()> {
         self.freeze_streamed()?;
         self.freeze_buffered(self.buffered_data.batches.len())?;
         Ok(())
@@ -970,7 +967,7 @@ impl SMJStream {
     // no longer needed:
     //   1. freezes all indices joined to streamed side
     //   2. freezes NULLs joined to dequeued buffered batch to "release" it
-    fn freeze_dequeuing_buffered(&mut self) -> ArrowResult<()> {
+    fn freeze_dequeuing_buffered(&mut self) -> Result<()> {
         self.freeze_streamed()?;
         self.freeze_buffered(1)?;
         Ok(())
@@ -980,7 +977,7 @@ impl SMJStream {
     // NULLs on streamed side.
     //
     // Applicable only in case of Full join.
-    fn freeze_buffered(&mut self, batch_count: usize) -> ArrowResult<()> {
+    fn freeze_buffered(&mut self, batch_count: usize) -> Result<()> {
         if !matches!(self.join_type, JoinType::Full) {
             return Ok(());
         }
@@ -998,7 +995,8 @@ impl SMJStream {
                 .columns()
                 .iter()
                 .map(|column| take(column, &buffered_indices, None))
-                .collect::<ArrowResult<Vec<_>>>()?;
+                .collect::<Result<Vec<_>, ArrowError>>()
+                .map_err(Into::<DataFusionError>::into)?;
 
             let mut streamed_columns = self
                 .streamed_schema
@@ -1018,7 +1016,7 @@ impl SMJStream {
 
     // Produces and stages record batch for all output indices found
     // for current streamed batch and clears staged output indices.
-    fn freeze_streamed(&mut self) -> ArrowResult<()> {
+    fn freeze_streamed(&mut self) -> Result<()> {
         for chunk in self.streamed_batch.output_indices.iter_mut() {
             let streamed_indices = chunk.streamed_indices.finish();
 
@@ -1032,7 +1030,8 @@ impl SMJStream {
                 .columns()
                 .iter()
                 .map(|column| take(column, &streamed_indices, None))
-                .collect::<ArrowResult<Vec<_>>>()?;
+                .collect::<Result<Vec<_>, ArrowError>>()
+                .map_err(Into::<DataFusionError>::into)?;
 
             let buffered_indices: UInt64Array = chunk.buffered_indices.finish();
 
@@ -1045,7 +1044,8 @@ impl SMJStream {
                         .columns()
                         .iter()
                         .map(|column| take(column, &buffered_indices, None))
-                        .collect::<ArrowResult<Vec<_>>>()?
+                        .collect::<Result<Vec<_>, ArrowError>>()
+                        .map_err(Into::<DataFusionError>::into)?
                 } else {
                     self.buffered_schema
                         .fields()
@@ -1071,7 +1071,7 @@ impl SMJStream {
         Ok(())
     }
 
-    fn output_record_batch_and_reset(&mut self) -> ArrowResult<RecordBatch> {
+    fn output_record_batch_and_reset(&mut self) -> Result<RecordBatch> {
         let record_batch = concat_batches(&self.schema, &self.output_record_batches)?;
         self.join_metrics.output_batches.add(1);
         self.join_metrics.output_rows.add(record_batch.num_rows());
@@ -1163,7 +1163,7 @@ fn compare_join_arrays(
     right: usize,
     sort_options: &[SortOptions],
     null_equals_null: bool,
-) -> ArrowResult<Ordering> {
+) -> Result<Ordering> {
     let mut res = Ordering::Equal;
     for ((left_array, right_array), sort_options) in
         left_arrays.iter().zip(right_arrays).zip(sort_options)
@@ -1231,7 +1231,7 @@ fn compare_join_arrays(
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
             _ => {
-                return Err(ArrowError::NotYetImplemented(
+                return Err(DataFusionError::NotImplemented(
                     "Unsupported data type in sort merge join comparator".to_owned(),
                 ));
             }
@@ -1250,7 +1250,7 @@ fn is_join_arrays_equal(
     left: usize,
     right_arrays: &[ArrayRef],
     right: usize,
-) -> ArrowResult<bool> {
+) -> Result<bool> {
     let mut is_equal = true;
     for (left_array, right_array) in left_arrays.iter().zip(right_arrays) {
         macro_rules! compare_value {
@@ -1297,7 +1297,7 @@ fn is_join_arrays_equal(
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
             _ => {
-                return Err(ArrowError::NotYetImplemented(
+                return Err(DataFusionError::NotImplemented(
                     "Unsupported data type in sort merge join comparator".to_owned(),
                 ));
             }

--- a/datafusion/core/src/physical_plan/joins/utils.rs
+++ b/datafusion/core/src/physical_plan/joins/utils.rs
@@ -27,7 +27,6 @@ use arrow::array::{
 };
 use arrow::compute;
 use arrow::datatypes::{Field, Schema, UInt32Type, UInt64Type};
-use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_boolean_array;
 use datafusion_common::ScalarValue;
@@ -681,7 +680,7 @@ impl<T: 'static> OnceFut<T> {
     }
 
     /// Get the result of the computation if it is ready, without consuming it
-    pub(crate) fn get(&mut self, cx: &mut Context<'_>) -> Poll<Result<&T, ArrowError>> {
+    pub(crate) fn get(&mut self, cx: &mut Context<'_>) -> Poll<Result<&T>> {
         if let OnceFutState::Pending(fut) = &mut self.state {
             let r = ready!(fut.poll_unpin(cx));
             self.state = OnceFutState::Ready(r);
@@ -693,7 +692,7 @@ impl<T: 'static> OnceFut<T> {
             OnceFutState::Ready(r) => Poll::Ready(
                 r.as_ref()
                     .map(|r| r.as_ref())
-                    .map_err(|e| ArrowError::ExternalError(Box::new(e.clone()))),
+                    .map_err(|e| DataFusionError::External(Box::new(e.clone()))),
             ),
         }
     }
@@ -789,7 +788,7 @@ pub(crate) fn build_batch_from_indices(
     left_indices: UInt64Array,
     right_indices: UInt32Array,
     column_indices: &[ColumnIndex],
-) -> ArrowResult<RecordBatch> {
+) -> Result<RecordBatch> {
     // build the columns of the new [RecordBatch]:
     // 1. pick whether the column is from the left or right
     // 2. based on the pick, `take` items from the different RecordBatches
@@ -821,7 +820,7 @@ pub(crate) fn build_batch_from_indices(
         };
         columns.push(array);
     }
-    RecordBatch::try_new(Arc::new(schema.clone()), columns)
+    RecordBatch::try_new(Arc::new(schema.clone()), columns).map_err(Into::into)
 }
 
 /// The input is the matched indices for left and right and
@@ -938,7 +937,8 @@ pub(crate) fn get_semi_indices(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::DataType;
+    use arrow::error::Result as ArrowResult;
+    use arrow::{datatypes::DataType, error::ArrowError};
     use datafusion_common::ScalarValue;
     use std::pin::Pin;
 
@@ -991,7 +991,7 @@ mod tests {
             ) -> Poll<Self::Output> {
                 match ready!(self.0.get(cx)) {
                     Ok(()) => Poll::Ready(Ok(())),
-                    Err(e) => Poll::Ready(Err(e)),
+                    Err(e) => Poll::Ready(Err(e.into())),
                 }
             }
         }

--- a/datafusion/core/src/physical_plan/joins/utils.rs
+++ b/datafusion/core/src/physical_plan/joins/utils.rs
@@ -820,7 +820,7 @@ pub(crate) fn build_batch_from_indices(
         };
         columns.push(array);
     }
-    RecordBatch::try_new(Arc::new(schema.clone()), columns).map_err(Into::into)
+    Ok(RecordBatch::try_new(Arc::new(schema.clone()), columns)?)
 }
 
 /// The input is the matched indices for left and right and

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -31,7 +31,6 @@ use crate::physical_plan::{
 };
 use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 use super::expressions::PhysicalSortExpr;
@@ -412,7 +411,7 @@ impl LimitStream {
     fn poll_and_skip(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         let input = self.input.as_mut().unwrap();
         loop {
             let poll = input.poll_next_unpin(cx);
@@ -469,7 +468,7 @@ impl LimitStream {
 }
 
 impl Stream for LimitStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -29,7 +29,6 @@ use super::{
 };
 use crate::error::Result;
 use arrow::datatypes::SchemaRef;
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 use crate::execution::context::TaskContext;
@@ -178,7 +177,7 @@ impl MemoryStream {
 }
 
 impl Stream for MemoryStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/metrics/baseline.rs
+++ b/datafusion/core/src/physical_plan/metrics/baseline.rs
@@ -19,9 +19,10 @@
 
 use std::task::Poll;
 
-use arrow::{error::ArrowError, record_batch::RecordBatch};
+use arrow::record_batch::RecordBatch;
 
 use super::{Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, Time, Timestamp};
+use crate::error::Result;
 
 /// Helper for creating and tracking common "baseline" metrics for
 /// each operator
@@ -141,8 +142,8 @@ impl BaselineMetrics {
     /// returning the same poll result
     pub fn record_poll(
         &self,
-        poll: Poll<Option<Result<RecordBatch, ArrowError>>>,
-    ) -> Poll<Option<Result<RecordBatch, ArrowError>>> {
+        poll: Poll<Option<Result<RecordBatch>>>,
+    ) -> Poll<Option<Result<RecordBatch>>> {
         if let Poll::Ready(maybe_batch) = &poll {
             match maybe_batch {
                 Some(Ok(batch)) => {
@@ -210,7 +211,7 @@ impl RecordOutput for Option<RecordBatch> {
     }
 }
 
-impl RecordOutput for arrow::error::Result<RecordBatch> {
+impl RecordOutput for Result<RecordBatch> {
     fn record_output(self, bm: &BaselineMetrics) -> Self {
         if let Ok(record_batch) = &self {
             record_batch.record_output(bm);

--- a/datafusion/core/src/physical_plan/metrics/tracker.rs
+++ b/datafusion/core/src/physical_plan/metrics/tracker.rs
@@ -23,8 +23,9 @@ use crate::physical_plan::metrics::{
 use std::sync::Arc;
 use std::task::Poll;
 
+use crate::error::Result;
 use crate::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
-use arrow::{error::ArrowError, record_batch::RecordBatch};
+use arrow::record_batch::RecordBatch;
 
 /// Wraps a [`BaselineMetrics`] and records memory usage on a [`MemoryReservation`]
 #[derive(Debug)]
@@ -96,8 +97,8 @@ impl MemTrackingMetrics {
     /// returning the same poll result
     pub fn record_poll(
         &self,
-        poll: Poll<Option<Result<RecordBatch, ArrowError>>>,
-    ) -> Poll<Option<Result<RecordBatch, ArrowError>>> {
+        poll: Poll<Option<Result<RecordBatch>>>,
+    ) -> Poll<Option<Result<RecordBatch>>> {
         self.metrics.record_poll(poll)
     }
 }

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -27,7 +27,6 @@ use crate::error::Result;
 use crate::physical_plan::expressions::PhysicalSortExpr;
 
 use arrow::datatypes::SchemaRef;
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 pub use datafusion_expr::Accumulator;
@@ -44,7 +43,7 @@ use std::task::{Context, Poll};
 use std::{any::Any, pin::Pin};
 
 /// Trait for types that stream [arrow::record_batch::RecordBatch]
-pub trait RecordBatchStream: Stream<Item = ArrowResult<RecordBatch>> {
+pub trait RecordBatchStream: Stream<Item = Result<RecordBatch>> {
     /// Returns the schema of this `RecordBatchStream`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
@@ -76,7 +75,7 @@ impl RecordBatchStream for EmptyRecordBatchStream {
 }
 
 impl Stream for EmptyRecordBatchStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         self: Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/repartition/mod.rs
+++ b/datafusion/core/src/physical_plan/repartition/mod.rs
@@ -32,7 +32,6 @@ use crate::physical_plan::{
 };
 use arrow::array::{ArrayRef, UInt64Builder};
 use arrow::datatypes::SchemaRef;
-use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
 use log::debug;
 
@@ -53,7 +52,7 @@ use tokio::task::JoinHandle;
 
 mod distributor_channels;
 
-type MaybeBatch = Option<ArrowResult<RecordBatch>>;
+type MaybeBatch = Option<Result<RecordBatch>>;
 type SharedMemoryReservation = Arc<Mutex<MemoryReservation>>;
 
 /// Inner state of [`RepartitionExec`].
@@ -545,7 +544,7 @@ impl RepartitionExec {
     /// channels.
     async fn wait_for_task(
         input_task: AbortOnDropSingle<Result<()>>,
-        txs: HashMap<usize, DistributionSender<Option<ArrowResult<RecordBatch>>>>,
+        txs: HashMap<usize, DistributionSender<Option<Result<RecordBatch>>>>,
     ) {
         // wait for completion, and propagate error
         // note we ignore errors on send (.ok) as that means the receiver has already shutdown.
@@ -555,12 +554,10 @@ impl RepartitionExec {
                 let e = Arc::new(e);
 
                 for (_, tx) in txs {
-                    let err = Err(ArrowError::ExternalError(Box::new(
-                        DataFusionError::Context(
-                            "Join Error".to_string(),
-                            Box::new(DataFusionError::External(Box::new(Arc::clone(&e)))),
-                        ),
-                    )));
+                    let err = Err(DataFusionError::Context(
+                        "Join Error".to_string(),
+                        Box::new(DataFusionError::External(Box::new(Arc::clone(&e)))),
+                    ));
                     tx.send(Some(err)).await.ok();
                 }
             }
@@ -570,7 +567,7 @@ impl RepartitionExec {
 
                 for (_, tx) in txs {
                     // wrap it because need to send error to all output partitions
-                    let err = Err(ArrowError::ExternalError(Box::new(e.clone())));
+                    let err = Err(DataFusionError::External(Box::new(e.clone())));
                     tx.send(Some(err)).await.ok();
                 }
             }
@@ -607,7 +604,7 @@ struct RepartitionStream {
 }
 
 impl Stream for RepartitionStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -672,12 +669,9 @@ mod tests {
             },
         },
     };
+    use arrow::array::{ArrayRef, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use arrow::{
-        array::{ArrayRef, StringArray},
-        error::ArrowError,
-    };
     use datafusion_common::cast::as_string_array;
     use futures::FutureExt;
     use std::collections::HashSet;
@@ -808,9 +802,7 @@ mod tests {
                 repartition(&schema, partitions, Partitioning::RoundRobinBatch(5)).await
             });
 
-        let output_partitions = join_handle
-            .await
-            .map_err(|e| DataFusionError::Internal(e.to_string()))??;
+        let output_partitions = join_handle.await.unwrap().unwrap();
 
         assert_eq!(5, output_partitions.len());
         assert_eq!(30, output_partitions[0].len());
@@ -892,7 +884,7 @@ mod tests {
 
         // input stream returns one good batch and then one error. The
         // error should be returned.
-        let err = Err(ArrowError::ComputeError("bad data error".to_string()));
+        let err = Err(DataFusionError::Execution("bad data error".to_string()));
 
         let schema = batch.schema();
         let input = MockExec::new(vec![Ok(batch), err], schema);
@@ -1179,8 +1171,9 @@ mod tests {
         // pull partitions
         for i in 0..exec.partitioning.partition_count() {
             let mut stream = exec.execute(i, task_ctx.clone())?;
-            let err =
-                DataFusionError::ArrowError(stream.next().await.unwrap().unwrap_err());
+            let err = DataFusionError::ArrowError(
+                stream.next().await.unwrap().unwrap_err().into(),
+            );
             let err = err.find_root();
             assert!(
                 matches!(err, DataFusionError::ResourcesExhausted(_)),

--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -840,8 +840,7 @@ fn sort_batch(
                 )
             })
             .collect::<Result<Vec<ArrayRef>, ArrowError>>()?,
-    )
-    .map_err(Into::<DataFusionError>::into)?;
+    )?;
 
     let sort_arrays = sort_columns
         .into_iter()

--- a/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -23,12 +23,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::error::ArrowError;
 use arrow::row::{RowConverter, SortField};
 use arrow::{
     array::{make_array as make_arrow_array, MutableArrayData},
     datatypes::SchemaRef,
-    error::Result as ArrowResult,
     record_batch::RecordBatch,
 };
 use futures::stream::{Fuse, FusedStream};
@@ -397,7 +395,7 @@ impl SortPreservingMergeStream {
         &mut self,
         cx: &mut Context<'_>,
         idx: usize,
-    ) -> Poll<ArrowResult<()>> {
+    ) -> Poll<Result<()>> {
         if self.cursors[idx]
             .as_ref()
             .map(|cursor| !cursor.is_finished())
@@ -432,9 +430,7 @@ impl SortPreservingMergeStream {
                         let rows = match self.row_converter.convert_columns(&cols) {
                             Ok(rows) => rows,
                             Err(e) => {
-                                return Poll::Ready(Err(ArrowError::ExternalError(
-                                    Box::new(e),
-                                )));
+                                return Poll::Ready(Err(DataFusionError::ArrowError(e)));
                             }
                         };
 
@@ -462,7 +458,7 @@ impl SortPreservingMergeStream {
     /// Drains the in_progress row indexes, and builds a new RecordBatch from them
     ///
     /// Will then drop any batches for which all rows have been yielded to the output
-    fn build_record_batch(&mut self) -> ArrowResult<RecordBatch> {
+    fn build_record_batch(&mut self) -> Result<RecordBatch> {
         // Mapping from stream index to the index of the first buffer from that stream
         let mut buffer_idx = 0;
         let mut stream_to_buffer_idx = Vec::with_capacity(self.batches.len());
@@ -544,12 +540,12 @@ impl SortPreservingMergeStream {
             }
         }
 
-        RecordBatch::try_new(self.schema.clone(), columns)
+        RecordBatch::try_new(self.schema.clone(), columns).map_err(Into::into)
     }
 }
 
 impl Stream for SortPreservingMergeStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -565,7 +561,7 @@ impl SortPreservingMergeStream {
     fn poll_next_inner(
         self: &mut Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         if self.aborted {
             return Poll::Ready(None);
         }
@@ -621,7 +617,7 @@ impl SortPreservingMergeStream {
     fn init_loser_tree(
         self: &mut Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<ArrowResult<()>> {
+    ) -> Poll<Result<()>> {
         let num_streams = self.streams.num_streams();
 
         if !self.loser_tree.is_empty() {
@@ -674,7 +670,7 @@ impl SortPreservingMergeStream {
     fn update_loser_tree(
         self: &mut Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<ArrowResult<()>> {
+    ) -> Poll<Result<()>> {
         if self.loser_tree_adjusted {
             return Poll::Ready(Ok(()));
         }

--- a/datafusion/core/src/physical_plan/streaming.rs
+++ b/datafusion/core/src/physical_plan/streaming.rs
@@ -111,7 +111,9 @@ impl ExecutionPlan for StreamingTableExec {
         Ok(match self.projection.clone() {
             Some(projection) => Box::pin(RecordBatchStreamAdapter::new(
                 self.projected_schema.clone(),
-                stream.map(move |x| x.and_then(|b| b.project(projection.as_ref()))),
+                stream.map(move |x| {
+                    x.and_then(|b| b.project(projection.as_ref()).map_err(Into::into))
+                }),
             )),
             None => stream,
         })

--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -25,7 +25,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{any::Any, sync::Arc};
 
-use arrow::error::Result as ArrowResult;
 use arrow::{
     datatypes::{Field, Schema, SchemaRef},
     record_batch::RecordBatch,
@@ -358,7 +357,7 @@ impl RecordBatchStream for CombinedRecordBatchStream {
 }
 
 impl Stream for CombinedRecordBatchStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -426,7 +425,7 @@ impl RecordBatchStream for ObservedStream {
 }
 
 impl futures::Stream for ObservedStream {
-    type Item = arrow::error::Result<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,

--- a/datafusion/core/src/physical_plan/windows/bounded_window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/bounded_window_agg_exec.rs
@@ -461,7 +461,7 @@ impl SortedPartitionByBoundedWindowStream {
         if let Some(columns_to_show) = columns_to_show {
             let n_generated = columns_to_show[0].len();
             self.prune_state(n_generated)?;
-            RecordBatch::try_new(schema, columns_to_show).map_err(Into::into)
+            Ok(RecordBatch::try_new(schema, columns_to_show)?)
         } else {
             Ok(RecordBatch::new_empty(schema))
         }

--- a/datafusion/core/src/physical_plan/windows/bounded_window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/bounded_window_agg_exec.rs
@@ -35,7 +35,6 @@ use arrow::compute::{concat, lexicographical_partition_ranges, SortColumn};
 use arrow::{
     array::ArrayRef,
     datatypes::{Schema, SchemaRef},
-    error::Result as ArrowResult,
     record_batch::RecordBatch,
 };
 use datafusion_common::{DataFusionError, ScalarValue};
@@ -414,7 +413,7 @@ impl PartitionByHandler for SortedPartitionByBoundedWindowStream {
 }
 
 impl Stream for SortedPartitionByBoundedWindowStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -449,7 +448,7 @@ impl SortedPartitionByBoundedWindowStream {
         }
     }
 
-    fn compute_aggregates(&mut self) -> ArrowResult<RecordBatch> {
+    fn compute_aggregates(&mut self) -> Result<RecordBatch> {
         // calculate window cols
         for (cur_window_expr, state) in
             self.window_expr.iter().zip(&mut self.window_agg_states)
@@ -462,7 +461,7 @@ impl SortedPartitionByBoundedWindowStream {
         if let Some(columns_to_show) = columns_to_show {
             let n_generated = columns_to_show[0].len();
             self.prune_state(n_generated)?;
-            RecordBatch::try_new(schema, columns_to_show)
+            RecordBatch::try_new(schema, columns_to_show).map_err(Into::into)
         } else {
             Ok(RecordBatch::new_empty(schema))
         }
@@ -472,7 +471,7 @@ impl SortedPartitionByBoundedWindowStream {
     fn poll_next_inner(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         if self.finished {
             return Poll::Ready(None);
         }
@@ -653,9 +652,7 @@ impl SortedPartitionByBoundedWindowStream {
                 end: num_rows,
             }]
         } else {
-            lexicographical_partition_ranges(partition_columns)
-                .map_err(DataFusionError::ArrowError)?
-                .collect::<Vec<_>>()
+            lexicographical_partition_ranges(partition_columns)?.collect()
         })
     }
 }

--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -358,8 +358,7 @@ impl WindowAggStream {
             .map(|elems| concat(&elems.iter().map(|x| x.as_ref()).collect::<Vec<_>>()))
             .collect::<Vec<_>>()
             .into_iter()
-            .collect::<Result<Vec<ArrayRef>, ArrowError>>()
-            .map_err(Into::<DataFusionError>::into)?;
+            .collect::<Result<Vec<ArrayRef>, ArrowError>>()?;
 
         // combine with the original cols
         // note the setup of window aggregates is that they newly calculated window
@@ -367,7 +366,7 @@ impl WindowAggStream {
         let mut batch_columns = batch.columns().to_vec();
         // calculate window cols
         batch_columns.extend_from_slice(&columns);
-        RecordBatch::try_new(self.schema.clone(), batch_columns).map_err(Into::into)
+        Ok(RecordBatch::try_new(self.schema.clone(), batch_columns)?)
     }
 
     /// Evaluates the partition points given the sort columns. If the sort columns are

--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -32,10 +32,10 @@ use crate::physical_plan::{
 use arrow::compute::{
     concat, concat_batches, lexicographical_partition_ranges, SortColumn,
 };
+use arrow::error::ArrowError;
 use arrow::{
     array::ArrayRef,
     datatypes::{Schema, SchemaRef},
-    error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
 use datafusion_common::DataFusionError;
@@ -326,7 +326,7 @@ impl WindowAggStream {
         }
     }
 
-    fn compute_aggregates(&self) -> ArrowResult<RecordBatch> {
+    fn compute_aggregates(&self) -> Result<RecordBatch> {
         // record compute time on drop
         let _timer = self.baseline_metrics.elapsed_compute().timer();
 
@@ -348,20 +348,18 @@ impl WindowAggStream {
         // Calculate window cols
         for partition_point in partition_points {
             let length = partition_point.end - partition_point.start;
-            partition_results.push(
-                compute_window_aggregates(
-                    &self.window_expr,
-                    &batch.slice(partition_point.start, length),
-                )
-                .map_err(|e| ArrowError::ExternalError(Box::new(e)))?,
-            )
+            partition_results.push(compute_window_aggregates(
+                &self.window_expr,
+                &batch.slice(partition_point.start, length),
+            )?)
         }
         let columns = transpose(partition_results)
             .iter()
             .map(|elems| concat(&elems.iter().map(|x| x.as_ref()).collect::<Vec<_>>()))
             .collect::<Vec<_>>()
             .into_iter()
-            .collect::<ArrowResult<Vec<ArrayRef>>>()?;
+            .collect::<Result<Vec<ArrayRef>, ArrowError>>()
+            .map_err(Into::<DataFusionError>::into)?;
 
         // combine with the original cols
         // note the setup of window aggregates is that they newly calculated window
@@ -369,7 +367,7 @@ impl WindowAggStream {
         let mut batch_columns = batch.columns().to_vec();
         // calculate window cols
         batch_columns.extend_from_slice(&columns);
-        RecordBatch::try_new(self.schema.clone(), batch_columns)
+        RecordBatch::try_new(self.schema.clone(), batch_columns).map_err(Into::into)
     }
 
     /// Evaluates the partition points given the sort columns. If the sort columns are
@@ -393,7 +391,7 @@ impl WindowAggStream {
 }
 
 impl Stream for WindowAggStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -409,7 +407,7 @@ impl WindowAggStream {
     fn poll_next_inner(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ArrowResult<RecordBatch>>> {
+    ) -> Poll<Option<Result<RecordBatch>>> {
         if self.finished {
             return Poll::Ready(None);
         }

--- a/datafusion/core/src/scheduler/pipeline/execution.rs
+++ b/datafusion/core/src/scheduler/pipeline/execution.rs
@@ -26,7 +26,7 @@ use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 
 use crate::arrow::datatypes::SchemaRef;
-use crate::arrow::{error::Result as ArrowResult, record_batch::RecordBatch};
+use crate::arrow::record_batch::RecordBatch;
 use crate::error::Result;
 use crate::execution::context::TaskContext;
 use crate::physical_plan::expressions::PhysicalSortExpr;
@@ -186,7 +186,7 @@ struct InputPartitionStream {
 }
 
 impl Stream for InputPartitionStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut partition = self.partition.lock();

--- a/datafusion/core/src/scheduler/task.rs
+++ b/datafusion/core/src/scheduler/task.rs
@@ -23,7 +23,6 @@ use crate::scheduler::{
     Spawner,
 };
 use arrow::datatypes::SchemaRef;
-use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use futures::channel::mpsc;
 use futures::task::ArcWake;
@@ -261,14 +260,14 @@ struct ExecutionResultStream {
 }
 
 impl Stream for ExecutionResultStream {
-    type Item = arrow::error::Result<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let opt = ready!(self.receiver.poll_next_unpin(cx)).flatten();
-        Poll::Ready(opt.map(|r| r.map_err(|e| ArrowError::ExternalError(Box::new(e)))))
+        Poll::Ready(opt)
     }
 }
 

--- a/datafusion/core/src/test/exec.rs
+++ b/datafusion/core/src/test/exec.rs
@@ -27,7 +27,6 @@ use tokio::sync::Barrier;
 
 use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
-    error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
 use futures::Stream;
@@ -89,7 +88,7 @@ impl TestStream {
 }
 
 impl Stream for TestStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let next_batch = self.index.value();
@@ -120,7 +119,7 @@ impl RecordBatchStream for TestStream {
 #[derive(Debug)]
 pub struct MockExec {
     /// the results to send back
-    data: Vec<ArrowResult<RecordBatch>>,
+    data: Vec<Result<RecordBatch>>,
     schema: SchemaRef,
 }
 
@@ -129,7 +128,7 @@ impl MockExec {
     /// record batches in this Exec. Note the batches are not produced
     /// immediately (the caller has to actually yield and another task
     /// must run) to ensure any poll loops are correct.
-    pub fn new(data: Vec<ArrowResult<RecordBatch>>, schema: SchemaRef) -> Self {
+    pub fn new(data: Vec<Result<RecordBatch>>, schema: SchemaRef) -> Self {
         Self { data, schema }
     }
 }
@@ -216,7 +215,7 @@ impl ExecutionPlan for MockExec {
 
     // Panics if one of the batches is an error
     fn statistics(&self) -> Statistics {
-        let data: ArrowResult<Vec<_>> = self
+        let data: Result<Vec<_>> = self
             .data
             .iter()
             .map(|r| match r {
@@ -231,10 +230,10 @@ impl ExecutionPlan for MockExec {
     }
 }
 
-fn clone_error(e: &ArrowError) -> ArrowError {
-    use ArrowError::*;
+fn clone_error(e: &DataFusionError) -> DataFusionError {
+    use DataFusionError::*;
     match e {
-        ComputeError(msg) => ComputeError(msg.to_string()),
+        Execution(msg) => Execution(msg.to_string()),
         _ => unimplemented!(),
     }
 }
@@ -683,7 +682,7 @@ pub struct BlockingStream {
 }
 
 impl Stream for BlockingStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         self: Pin<&mut Self>,

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -18,7 +18,6 @@
 use arrow::array::{Int32Array, Int64Array};
 use arrow::compute::kernels::aggregate;
 use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::from_slice::FromSlice;
@@ -85,7 +84,7 @@ impl RecordBatchStream for TestCustomRecordBatchStream {
 }
 
 impl Stream for TestCustomRecordBatchStream {
-    type Item = ArrowResult<RecordBatch>;
+    type Item = Result<RecordBatch>;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -93,7 +92,7 @@ impl Stream for TestCustomRecordBatchStream {
     ) -> Poll<Option<Self::Item>> {
         if self.nb_batch > 0 {
             self.get_mut().nb_batch -= 1;
-            Poll::Ready(Some(TEST_CUSTOM_RECORD_BATCH!()))
+            Poll::Ready(Some(TEST_CUSTOM_RECORD_BATCH!().map_err(Into::into)))
         } else {
             Poll::Ready(None)
         }

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1350,7 +1350,7 @@ async fn date_bin() {
     let result = try_execute_to_batches(&ctx, sql).await;
     assert_eq!(
         result.err().unwrap().to_string(),
-        "Arrow error: External error: This feature is not implemented: DATE_BIN only supports literal values for the origin argument, not arrays"
+        "This feature is not implemented: DATE_BIN only supports literal values for the origin argument, not arrays"
     );
 }
 

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -1474,7 +1474,7 @@ async fn window_frame_creation() -> Result<()> {
     let results = df.collect().await;
     assert_contains!(
         results.err().unwrap().to_string(),
-        "Arrow error: External error: Internal error: Operator - is not implemented for types UInt32(1) and Utf8(\"1 DAY\")"
+        "External error: Internal error: Operator - is not implemented for types UInt32(1) and Utf8(\"1 DAY\"). This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
     );
 
     Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5039.

# Rationale for this change
See #5039 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Replace ArrowError with DataFusionError in DF context
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
User will get `DatafusionError::ArrowError` instead `arrow::ArrowError` for datafusion contexts
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->