### PR TITLE
Typo of greptimedb

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here are some of the projects known to use DataFusion:
 - [datafusion-tui](https://github.com/datafusion-contrib/datafusion-tui) Text UI for DataFusion
 - [delta-rs](https://github.com/delta-io/delta-rs) Native Rust implementation of Delta Lake
 - [Flock](https://github.com/flock-lab/flock)
-- [Greptime DB](https://github.com/GreptimeTeam/greptimedb) Open Source & Cloud Native Distributed Time Series Database
+- [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) Open Source & Cloud Native Distributed Time Series Database
 - [InfluxDB IOx](https://github.com/influxdata/influxdb_iox) Time Series Database
 - [Kamu](https://github.com/kamu-data/kamu-cli/) Planet-scale streaming data pipeline
 - [Parseable](https://github.com/parseablehq/parseable) Log storage and observability platform


### PR DESCRIPTION
Thanks a ton to @francis-du  for adding the info about [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) in #4768 . We noticed that the name was written as Greptime DB, but the correct name is actually GreptimeDB. 