### PR TITLE
Replace &Option<T> with Option<&T>

### DIFF
--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -979,48 +979,80 @@ pub fn parse_expr(
             parse_required_expr(is_not_null.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::NotExpr(not) => Ok(Expr::Not(Box::new(parse_required_expr(
-            not.expr.as_ref(), registry, "expr",
+            not.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsTrue(msg) => Ok(Expr::IsTrue(Box::new(parse_required_expr(
-            msg.expr.as_ref(), registry, "expr",
+            msg.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsFalse(msg) => Ok(Expr::IsFalse(Box::new(parse_required_expr(
-            msg.expr.as_ref(), registry, "expr",
+            msg.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsUnknown(msg) => Ok(Expr::IsUnknown(Box::new(parse_required_expr(
-            msg.expr.as_ref(), registry, "expr",
+            msg.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsNotTrue(msg) => Ok(Expr::IsNotTrue(Box::new(parse_required_expr(
-            msg.expr.as_ref(), registry, "expr",
+            msg.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsNotFalse(msg) => Ok(Expr::IsNotFalse(Box::new(parse_required_expr(
-            msg.expr.as_ref(), registry, "expr",
+            msg.expr.as_ref(),
+            registry,
+            "expr",
         )?))),
         ExprType::IsNotUnknown(msg) => Ok(Expr::IsNotUnknown(Box::new(
             parse_required_expr(msg.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::Between(between) => Ok(Expr::Between(Between::new(
-            Box::new(parse_required_expr(between.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(
+                between.expr.as_ref(),
+                registry,
+                "expr",
+            )?),
             between.negated,
             Box::new(parse_required_expr(between.low.as_ref(), registry, "expr")?),
-            Box::new(parse_required_expr(between.high.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(
+                between.high.as_ref(),
+                registry,
+                "expr",
+            )?),
         ))),
         ExprType::Like(like) => Ok(Expr::Like(Like::new(
             like.negated,
             Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
-            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
+            Box::new(parse_required_expr(
+                like.pattern.as_ref(),
+                registry,
+                "pattern",
+            )?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::Ilike(like) => Ok(Expr::ILike(Like::new(
             like.negated,
             Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
-            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
+            Box::new(parse_required_expr(
+                like.pattern.as_ref(),
+                registry,
+                "pattern",
+            )?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::SimilarTo(like) => Ok(Expr::SimilarTo(Like::new(
             like.negated,
             Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
-            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
+            Box::new(parse_required_expr(
+                like.pattern.as_ref(),
+                registry,
+                "pattern",
+            )?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::Case(case) => {
@@ -1048,12 +1080,14 @@ pub fn parse_expr(
             )))
         }
         ExprType::Cast(cast) => {
-            let expr = Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
+            let expr =
+                Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::Cast(Cast::new(expr, data_type)))
         }
         ExprType::TryCast(cast) => {
-            let expr = Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
+            let expr =
+                Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::TryCast(TryCast::new(expr, data_type)))
         }
@@ -1066,7 +1100,11 @@ pub fn parse_expr(
             parse_required_expr(negative.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::InList(in_list) => Ok(Expr::InList {
-            expr: Box::new(parse_required_expr(in_list.expr.as_ref(), registry, "expr")?),
+            expr: Box::new(parse_required_expr(
+                in_list.expr.as_ref(),
+                registry,
+                "expr",
+            )?),
             list: in_list
                 .list
                 .iter()

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -876,7 +876,7 @@ pub fn parse_expr(
                 .ok_or_else(|| Error::required("value"))?
                 .try_into()?;
 
-            let expr = parse_required_expr(&field.expr, registry, "expr")?;
+            let expr = parse_required_expr(field.expr.as_ref(), registry, "expr")?;
 
             Ok(Expr::GetIndexedField(GetIndexedField::new(
                 Box::new(expr),
@@ -926,7 +926,7 @@ pub fn parse_expr(
                         datafusion_expr::window_function::WindowFunction::AggregateFunction(
                             aggr_function,
                         ),
-                        vec![parse_required_expr(&expr.expr, registry, "expr")?],
+                        vec![parse_required_expr(expr.expr.as_ref(), registry, "expr")?],
                         partition_by,
                         order_by,
                         window_frame,
@@ -937,7 +937,7 @@ pub fn parse_expr(
                         .ok_or_else(|| Error::unknown("BuiltInWindowFunction", *i))?
                         .into();
 
-                    let args = parse_optional_expr(&expr.expr, registry)?
+                    let args = parse_optional_expr(expr.expr.as_ref(), registry)?
                         .map(|e| vec![e])
                         .unwrap_or_else(Vec::new);
 
@@ -963,64 +963,64 @@ pub fn parse_expr(
                     .map(|e| parse_expr(e, registry))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.distinct,
-                parse_optional_expr(&expr.filter, registry)?.map(Box::new),
+                parse_optional_expr(expr.filter.as_ref(), registry)?.map(Box::new),
             )))
         }
         ExprType::Alias(alias) => Ok(Expr::Alias(
-            Box::new(parse_required_expr(&alias.expr, registry, "expr")?),
+            Box::new(parse_required_expr(alias.expr.as_ref(), registry, "expr")?),
             alias.alias.clone(),
         )),
         ExprType::IsNullExpr(is_null) => Ok(Expr::IsNull(Box::new(parse_required_expr(
-            &is_null.expr,
+            is_null.expr.as_ref(),
             registry,
             "expr",
         )?))),
         ExprType::IsNotNullExpr(is_not_null) => Ok(Expr::IsNotNull(Box::new(
-            parse_required_expr(&is_not_null.expr, registry, "expr")?,
+            parse_required_expr(is_not_null.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::NotExpr(not) => Ok(Expr::Not(Box::new(parse_required_expr(
-            &not.expr, registry, "expr",
+            not.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsTrue(msg) => Ok(Expr::IsTrue(Box::new(parse_required_expr(
-            &msg.expr, registry, "expr",
+            msg.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsFalse(msg) => Ok(Expr::IsFalse(Box::new(parse_required_expr(
-            &msg.expr, registry, "expr",
+            msg.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsUnknown(msg) => Ok(Expr::IsUnknown(Box::new(parse_required_expr(
-            &msg.expr, registry, "expr",
+            msg.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsNotTrue(msg) => Ok(Expr::IsNotTrue(Box::new(parse_required_expr(
-            &msg.expr, registry, "expr",
+            msg.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsNotFalse(msg) => Ok(Expr::IsNotFalse(Box::new(parse_required_expr(
-            &msg.expr, registry, "expr",
+            msg.expr.as_ref(), registry, "expr",
         )?))),
         ExprType::IsNotUnknown(msg) => Ok(Expr::IsNotUnknown(Box::new(
-            parse_required_expr(&msg.expr, registry, "expr")?,
+            parse_required_expr(msg.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::Between(between) => Ok(Expr::Between(Between::new(
-            Box::new(parse_required_expr(&between.expr, registry, "expr")?),
+            Box::new(parse_required_expr(between.expr.as_ref(), registry, "expr")?),
             between.negated,
-            Box::new(parse_required_expr(&between.low, registry, "expr")?),
-            Box::new(parse_required_expr(&between.high, registry, "expr")?),
+            Box::new(parse_required_expr(between.low.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(between.high.as_ref(), registry, "expr")?),
         ))),
         ExprType::Like(like) => Ok(Expr::Like(Like::new(
             like.negated,
-            Box::new(parse_required_expr(&like.expr, registry, "expr")?),
-            Box::new(parse_required_expr(&like.pattern, registry, "pattern")?),
+            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::Ilike(like) => Ok(Expr::ILike(Like::new(
             like.negated,
-            Box::new(parse_required_expr(&like.expr, registry, "expr")?),
-            Box::new(parse_required_expr(&like.pattern, registry, "pattern")?),
+            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::SimilarTo(like) => Ok(Expr::SimilarTo(Like::new(
             like.negated,
-            Box::new(parse_required_expr(&like.expr, registry, "expr")?),
-            Box::new(parse_required_expr(&like.pattern, registry, "pattern")?),
+            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.pattern.as_ref(), registry, "pattern")?),
             parse_escape_char(&like.escape_char)?,
         ))),
         ExprType::Case(case) => {
@@ -1042,31 +1042,31 @@ pub fn parse_expr(
                 })
                 .collect::<Result<Vec<(Box<Expr>, Box<Expr>)>, Error>>()?;
             Ok(Expr::Case(Case::new(
-                parse_optional_expr(&case.expr, registry)?.map(Box::new),
+                parse_optional_expr(case.expr.as_ref(), registry)?.map(Box::new),
                 when_then_expr,
-                parse_optional_expr(&case.else_expr, registry)?.map(Box::new),
+                parse_optional_expr(case.else_expr.as_ref(), registry)?.map(Box::new),
             )))
         }
         ExprType::Cast(cast) => {
-            let expr = Box::new(parse_required_expr(&cast.expr, registry, "expr")?);
+            let expr = Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::Cast(Cast::new(expr, data_type)))
         }
         ExprType::TryCast(cast) => {
-            let expr = Box::new(parse_required_expr(&cast.expr, registry, "expr")?);
+            let expr = Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::TryCast(TryCast::new(expr, data_type)))
         }
         ExprType::Sort(sort) => Ok(Expr::Sort(Sort::new(
-            Box::new(parse_required_expr(&sort.expr, registry, "expr")?),
+            Box::new(parse_required_expr(sort.expr.as_ref(), registry, "expr")?),
             sort.asc,
             sort.nulls_first,
         ))),
         ExprType::Negative(negative) => Ok(Expr::Negative(Box::new(
-            parse_required_expr(&negative.expr, registry, "expr")?,
+            parse_required_expr(negative.expr.as_ref(), registry, "expr")?,
         ))),
         ExprType::InList(in_list) => Ok(Expr::InList {
-            expr: Box::new(parse_required_expr(&in_list.expr, registry, "expr")?),
+            expr: Box::new(parse_required_expr(in_list.expr.as_ref(), registry, "expr")?),
             list: in_list
                 .list
                 .iter()
@@ -1295,7 +1295,7 @@ pub fn parse_expr(
                     .iter()
                     .map(|expr| parse_expr(expr, registry))
                     .collect::<Result<Vec<_>, Error>>()?,
-                filter: parse_optional_expr(&pb.filter, registry)?.map(Box::new),
+                filter: parse_optional_expr(pb.filter.as_ref(), registry)?.map(Box::new),
             })
         }
 
@@ -1389,7 +1389,7 @@ pub fn from_proto_binary_op(op: &str) -> Result<Operator, Error> {
 }
 
 fn parse_optional_expr(
-    p: &Option<Box<protobuf::LogicalExprNode>>,
+    p: Option<&Box<protobuf::LogicalExprNode>>,
     registry: &dyn FunctionRegistry,
 ) -> Result<Option<Expr>, Error> {
     match p {
@@ -1399,7 +1399,7 @@ fn parse_optional_expr(
 }
 
 fn parse_required_expr(
-    p: &Option<Box<protobuf::LogicalExprNode>>,
+    p: Option<&Box<protobuf::LogicalExprNode>>,
     registry: &dyn FunctionRegistry,
     field: impl Into<String>,
 ) -> Result<Expr, Error> {

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -876,7 +876,7 @@ pub fn parse_expr(
                 .ok_or_else(|| Error::required("value"))?
                 .try_into()?;
 
-            let expr = parse_required_expr(field.expr.as_ref(), registry, "expr")?;
+            let expr = parse_required_expr(field.expr.clone(), registry, "expr")?;
 
             Ok(Expr::GetIndexedField(GetIndexedField::new(
                 Box::new(expr),
@@ -926,7 +926,7 @@ pub fn parse_expr(
                         datafusion_expr::window_function::WindowFunction::AggregateFunction(
                             aggr_function,
                         ),
-                        vec![parse_required_expr(expr.expr.as_ref(), registry, "expr")?],
+                        vec![parse_required_expr(expr.expr.clone(), registry, "expr")?],
                         partition_by,
                         order_by,
                         window_frame,
@@ -937,7 +937,7 @@ pub fn parse_expr(
                         .ok_or_else(|| Error::unknown("BuiltInWindowFunction", *i))?
                         .into();
 
-                    let args = parse_optional_expr(expr.expr.as_ref(), registry)?
+                    let args = parse_optional_expr(expr.expr.clone(), registry)?
                         .map(|e| vec![e])
                         .unwrap_or_else(Vec::new);
 
@@ -963,73 +963,73 @@ pub fn parse_expr(
                     .map(|e| parse_expr(e, registry))
                     .collect::<Result<Vec<_>, _>>()?,
                 expr.distinct,
-                parse_optional_expr(expr.filter.as_ref(), registry)?.map(Box::new),
+                parse_optional_expr(expr.filter.clone(), registry)?.map(Box::new),
             )))
         }
         ExprType::Alias(alias) => Ok(Expr::Alias(
-            Box::new(parse_required_expr(alias.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(alias.expr.clone(), registry, "expr")?),
             alias.alias.clone(),
         )),
         ExprType::IsNullExpr(is_null) => Ok(Expr::IsNull(Box::new(parse_required_expr(
-            is_null.expr.as_ref(),
+            is_null.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsNotNullExpr(is_not_null) => Ok(Expr::IsNotNull(Box::new(
-            parse_required_expr(is_not_null.expr.as_ref(), registry, "expr")?,
+            parse_required_expr(is_not_null.expr.clone(), registry, "expr")?,
         ))),
         ExprType::NotExpr(not) => Ok(Expr::Not(Box::new(parse_required_expr(
-            not.expr.as_ref(),
+            not.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsTrue(msg) => Ok(Expr::IsTrue(Box::new(parse_required_expr(
-            msg.expr.as_ref(),
+            msg.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsFalse(msg) => Ok(Expr::IsFalse(Box::new(parse_required_expr(
-            msg.expr.as_ref(),
+            msg.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsUnknown(msg) => Ok(Expr::IsUnknown(Box::new(parse_required_expr(
-            msg.expr.as_ref(),
+            msg.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsNotTrue(msg) => Ok(Expr::IsNotTrue(Box::new(parse_required_expr(
-            msg.expr.as_ref(),
+            msg.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsNotFalse(msg) => Ok(Expr::IsNotFalse(Box::new(parse_required_expr(
-            msg.expr.as_ref(),
+            msg.expr.clone(),
             registry,
             "expr",
         )?))),
         ExprType::IsNotUnknown(msg) => Ok(Expr::IsNotUnknown(Box::new(
-            parse_required_expr(msg.expr.as_ref(), registry, "expr")?,
+            parse_required_expr(msg.expr.clone(), registry, "expr")?,
         ))),
         ExprType::Between(between) => Ok(Expr::Between(Between::new(
             Box::new(parse_required_expr(
-                between.expr.as_ref(),
+                between.expr.clone(),
                 registry,
                 "expr",
             )?),
             between.negated,
-            Box::new(parse_required_expr(between.low.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(between.low.clone(), registry, "expr")?),
             Box::new(parse_required_expr(
-                between.high.as_ref(),
+                between.high.clone(),
                 registry,
                 "expr",
             )?),
         ))),
         ExprType::Like(like) => Ok(Expr::Like(Like::new(
             like.negated,
-            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.expr.clone(), registry, "expr")?),
             Box::new(parse_required_expr(
-                like.pattern.as_ref(),
+                like.pattern.clone(),
                 registry,
                 "pattern",
             )?),
@@ -1037,9 +1037,9 @@ pub fn parse_expr(
         ))),
         ExprType::Ilike(like) => Ok(Expr::ILike(Like::new(
             like.negated,
-            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.expr.clone(), registry, "expr")?),
             Box::new(parse_required_expr(
-                like.pattern.as_ref(),
+                like.pattern.clone(),
                 registry,
                 "pattern",
             )?),
@@ -1047,9 +1047,9 @@ pub fn parse_expr(
         ))),
         ExprType::SimilarTo(like) => Ok(Expr::SimilarTo(Like::new(
             like.negated,
-            Box::new(parse_required_expr(like.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(like.expr.clone(), registry, "expr")?),
             Box::new(parse_required_expr(
-                like.pattern.as_ref(),
+                like.pattern.clone(),
                 registry,
                 "pattern",
             )?),
@@ -1074,34 +1074,34 @@ pub fn parse_expr(
                 })
                 .collect::<Result<Vec<(Box<Expr>, Box<Expr>)>, Error>>()?;
             Ok(Expr::Case(Case::new(
-                parse_optional_expr(case.expr.as_ref(), registry)?.map(Box::new),
+                parse_optional_expr(case.expr.clone(), registry)?.map(Box::new),
                 when_then_expr,
-                parse_optional_expr(case.else_expr.as_ref(), registry)?.map(Box::new),
+                parse_optional_expr(case.else_expr.clone(), registry)?.map(Box::new),
             )))
         }
         ExprType::Cast(cast) => {
             let expr =
-                Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
+                Box::new(parse_required_expr(cast.expr.clone(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::Cast(Cast::new(expr, data_type)))
         }
         ExprType::TryCast(cast) => {
             let expr =
-                Box::new(parse_required_expr(cast.expr.as_ref(), registry, "expr")?);
+                Box::new(parse_required_expr(cast.expr.clone(), registry, "expr")?);
             let data_type = cast.arrow_type.as_ref().required("arrow_type")?;
             Ok(Expr::TryCast(TryCast::new(expr, data_type)))
         }
         ExprType::Sort(sort) => Ok(Expr::Sort(Sort::new(
-            Box::new(parse_required_expr(sort.expr.as_ref(), registry, "expr")?),
+            Box::new(parse_required_expr(sort.expr.clone(), registry, "expr")?),
             sort.asc,
             sort.nulls_first,
         ))),
         ExprType::Negative(negative) => Ok(Expr::Negative(Box::new(
-            parse_required_expr(negative.expr.as_ref(), registry, "expr")?,
+            parse_required_expr(negative.expr.clone(), registry, "expr")?,
         ))),
         ExprType::InList(in_list) => Ok(Expr::InList {
             expr: Box::new(parse_required_expr(
-                in_list.expr.as_ref(),
+                in_list.expr.clone(),
                 registry,
                 "expr",
             )?),
@@ -1333,7 +1333,7 @@ pub fn parse_expr(
                     .iter()
                     .map(|expr| parse_expr(expr, registry))
                     .collect::<Result<Vec<_>, Error>>()?,
-                filter: parse_optional_expr(pb.filter.as_ref(), registry)?.map(Box::new),
+                filter: parse_optional_expr(pb.filter.clone(), registry)?.map(Box::new),
             })
         }
 
@@ -1427,7 +1427,7 @@ pub fn from_proto_binary_op(op: &str) -> Result<Operator, Error> {
 }
 
 fn parse_optional_expr(
-    p: Option<&Box<protobuf::LogicalExprNode>>,
+    p: Option<Box<protobuf::LogicalExprNode>>,
     registry: &dyn FunctionRegistry,
 ) -> Result<Option<Expr>, Error> {
     match p {
@@ -1437,7 +1437,7 @@ fn parse_optional_expr(
 }
 
 fn parse_required_expr(
-    p: Option<&Box<protobuf::LogicalExprNode>>,
+    p: Option<Box<protobuf::LogicalExprNode>>,
     registry: &dyn FunctionRegistry,
     field: impl Into<String>,
 ) -> Result<Expr, Error> {

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -1012,18 +1012,10 @@ pub fn parse_expr(
             parse_required_expr(msg.expr.clone(), registry, "expr")?,
         ))),
         ExprType::Between(between) => Ok(Expr::Between(Between::new(
-            Box::new(parse_required_expr(
-                between.expr.clone(),
-                registry,
-                "expr",
-            )?),
+            Box::new(parse_required_expr(between.expr.clone(), registry, "expr")?),
             between.negated,
             Box::new(parse_required_expr(between.low.clone(), registry, "expr")?),
-            Box::new(parse_required_expr(
-                between.high.clone(),
-                registry,
-                "expr",
-            )?),
+            Box::new(parse_required_expr(between.high.clone(), registry, "expr")?),
         ))),
         ExprType::Like(like) => Ok(Expr::Like(Like::new(
             like.negated,
@@ -1100,11 +1092,7 @@ pub fn parse_expr(
             parse_required_expr(negative.expr.clone(), registry, "expr")?,
         ))),
         ExprType::InList(in_list) => Ok(Expr::InList {
-            expr: Box::new(parse_required_expr(
-                in_list.expr.clone(),
-                registry,
-                "expr",
-            )?),
+            expr: Box::new(parse_required_expr(in_list.expr.clone(), registry, "expr")?),
             list: in_list
                 .list
                 .iter()

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -77,14 +77,14 @@ pub(crate) fn parse_physical_expr(
         ExprType::Literal(scalar) => Arc::new(Literal::new(scalar.try_into()?)),
         ExprType::BinaryExpr(binary_expr) => Arc::new(BinaryExpr::new(
             parse_required_physical_box_expr(
-                binary_expr.l.as_ref(),
+                binary_expr.l.clone(),
                 registry,
                 "left",
                 input_schema,
             )?,
             logical_plan::from_proto::from_proto_binary_op(&binary_expr.op)?,
             parse_required_physical_box_expr(
-                binary_expr.r.as_ref(),
+                binary_expr.r.clone(),
                 registry,
                 "right",
                 input_schema,
@@ -92,14 +92,14 @@ pub(crate) fn parse_physical_expr(
         )),
         ExprType::DateTimeIntervalExpr(expr) => Arc::new(DateTimeIntervalExpr::try_new(
             parse_required_physical_box_expr(
-                expr.l.as_ref(),
+                expr.l.clone(),
                 registry,
                 "left",
                 input_schema,
             )?,
             logical_plan::from_proto::from_proto_binary_op(&expr.op)?,
             parse_required_physical_box_expr(
-                expr.r.as_ref(),
+                expr.r.clone(),
                 registry,
                 "right",
                 input_schema,
@@ -123,7 +123,7 @@ pub(crate) fn parse_physical_expr(
         }
         ExprType::IsNullExpr(e) => {
             Arc::new(IsNullExpr::new(parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
@@ -131,21 +131,21 @@ pub(crate) fn parse_physical_expr(
         }
         ExprType::IsNotNullExpr(e) => {
             Arc::new(IsNotNullExpr::new(parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
             )?))
         }
         ExprType::NotExpr(e) => Arc::new(NotExpr::new(parse_required_physical_box_expr(
-            e.expr.as_ref(),
+            e.expr.clone(),
             registry,
             "expr",
             input_schema,
         )?)),
         ExprType::Negative(e) => {
             Arc::new(NegativeExpr::new(parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
@@ -153,7 +153,7 @@ pub(crate) fn parse_physical_expr(
         }
         ExprType::InList(e) => Arc::new(InListExpr::new(
             parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
@@ -196,7 +196,7 @@ pub(crate) fn parse_physical_expr(
         )?),
         ExprType::Cast(e) => Arc::new(CastExpr::new(
             parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
@@ -206,7 +206,7 @@ pub(crate) fn parse_physical_expr(
         )),
         ExprType::TryCast(e) => Arc::new(TryCastExpr::new(
             parse_required_physical_box_expr(
-                e.expr.as_ref(),
+                e.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
@@ -262,13 +262,13 @@ pub(crate) fn parse_physical_expr(
             like_expr.negated,
             like_expr.case_insensitive,
             parse_required_physical_box_expr(
-                like_expr.expr.as_ref(),
+                like_expr.expr.clone(),
                 registry,
                 "expr",
                 input_schema,
             )?,
             parse_required_physical_box_expr(
-                like_expr.pattern.as_ref(),
+                like_expr.pattern.clone(),
                 registry,
                 "pattern",
                 input_schema,
@@ -280,7 +280,7 @@ pub(crate) fn parse_physical_expr(
 }
 
 fn parse_required_physical_box_expr(
-    expr: Option<&Box<protobuf::PhysicalExprNode>>,
+    expr: Option<Box<protobuf::PhysicalExprNode>>,
     registry: &dyn FunctionRegistry,
     field: &str,
     input_schema: &Schema,

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -91,9 +91,19 @@ pub(crate) fn parse_physical_expr(
             )?,
         )),
         ExprType::DateTimeIntervalExpr(expr) => Arc::new(DateTimeIntervalExpr::try_new(
-            parse_required_physical_box_expr(expr.l.as_ref(), registry, "left", input_schema)?,
+            parse_required_physical_box_expr(
+                expr.l.as_ref(),
+                registry,
+                "left",
+                input_schema,
+            )?,
             logical_plan::from_proto::from_proto_binary_op(&expr.op)?,
-            parse_required_physical_box_expr(expr.r.as_ref(), registry, "right", input_schema)?,
+            parse_required_physical_box_expr(
+                expr.r.as_ref(),
+                registry,
+                "right",
+                input_schema,
+            )?,
             input_schema,
         )?),
         ExprType::AggregateExpr(_) => {
@@ -111,23 +121,43 @@ pub(crate) fn parse_physical_expr(
                 "Cannot convert sort expr node to physical expression".to_owned(),
             ));
         }
-        ExprType::IsNullExpr(e) => Arc::new(IsNullExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
-        )),
-        ExprType::IsNotNullExpr(e) => Arc::new(IsNotNullExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
-        )),
+        ExprType::IsNullExpr(e) => {
+            Arc::new(IsNullExpr::new(parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?))
+        }
+        ExprType::IsNotNullExpr(e) => {
+            Arc::new(IsNotNullExpr::new(parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?))
+        }
         ExprType::NotExpr(e) => Arc::new(NotExpr::new(parse_required_physical_box_expr(
             e.expr.as_ref(),
             registry,
             "expr",
             input_schema,
         )?)),
-        ExprType::Negative(e) => Arc::new(NegativeExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
-        )),
+        ExprType::Negative(e) => {
+            Arc::new(NegativeExpr::new(parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?))
+        }
         ExprType::InList(e) => Arc::new(InListExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
+            parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?,
             e.list
                 .iter()
                 .map(|x| parse_physical_expr(x, registry, input_schema))
@@ -165,12 +195,22 @@ pub(crate) fn parse_physical_expr(
                 .transpose()?,
         )?),
         ExprType::Cast(e) => Arc::new(CastExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
+            parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?,
             convert_required!(e.arrow_type)?,
             DEFAULT_DATAFUSION_CAST_OPTIONS,
         )),
         ExprType::TryCast(e) => Arc::new(TryCastExpr::new(
-            parse_required_physical_box_expr(e.expr.as_ref(), registry, "expr", input_schema)?,
+            parse_required_physical_box_expr(
+                e.expr.as_ref(),
+                registry,
+                "expr",
+                input_schema,
+            )?,
             convert_required!(e.arrow_type)?,
         )),
         ExprType::ScalarFunction(e) => {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/4424.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This pr is following: https://github.com/apache/arrow-datafusion/pull/4446, https://github.com/apache/arrow-datafusion/pull/4458 and https://github.com/apache/arrow-datafusion/pull/5102. And I think this is the last pr for closing the issue https://github.com/apache/arrow-datafusion/issues/4424, because it clears all remaining `&Option<T>` type.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Replace `&Option<T>` with `Option<&T>`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Pass the original test.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

May change the api.