### PR TITLE
Bug fix: Empty Record Batch handling

### DIFF
--- a/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
+++ b/datafusion/core/src/physical_plan/windows/window_agg_exec.rs
@@ -329,12 +329,10 @@ impl WindowAggStream {
     fn compute_aggregates(&self) -> Result<RecordBatch> {
         // record compute time on drop
         let _timer = self.baseline_metrics.elapsed_compute().timer();
-
-        if self.batches.is_empty() {
+        let batch = concat_batches(&self.input.schema(), &self.batches)?;
+        if batch.num_rows() == 0 {
             return Ok(RecordBatch::new_empty(self.schema.clone()));
         }
-
-        let batch = concat_batches(&self.input.schema(), &self.batches)?;
 
         let partition_by_sort_keys = self
             .partition_by_sort_keys

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -2387,8 +2387,7 @@ async fn test_window_agg_sort_orderby_reversed_partitionby_reversed_plan() -> Re
 
 #[tokio::test]
 async fn test_window_agg_low_cardinality() -> Result<()> {
-    let config = SessionConfig::new()
-        .with_target_partitions(32);
+    let config = SessionConfig::new().with_target_partitions(32);
     let ctx = SessionContext::with_config(config);
     register_aggregate_csv(&ctx).await?;
     let sql = "SELECT


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes [#5090](https://github.com/apache/arrow-datafusion/issues/5090).

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When cardinality of column is low, and target partition is high, we may get empty record batches in `WindowAggExec`. In these cases we receive an error as described in the [#5090](https://github.com/apache/arrow-datafusion/issues/5090). This PR adds handling for empty batches to fix the bug.

# What changes are included in this PR?

A simple change to fix the bug.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes, new tests are added.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->