### PR TITLE
[sqllogictest] Support `pg_typeof`

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -113,6 +113,7 @@ doc-comment = "0.3"
 env_logger = "0.10"
 half = "2.2.1"
 parquet-test-utils = { path = "../../parquet-test-utils" }
+postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["derive", "with-chrono-0_4"] }
 rstest = "0.16.0"
 rust_decimal = { version = "1.27.0", features = ["tokio-pg"] }

--- a/datafusion/core/tests/sqllogictests/src/engines/postgres/mod.rs
+++ b/datafusion/core/tests/sqllogictests/src/engines/postgres/mod.rs
@@ -30,6 +30,9 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use postgres_types::Type;
 use rust_decimal::Decimal;
 use tokio_postgres::{Column, Row};
+use types::PgRegtype;
+
+mod types;
 
 // default connect string, can be overridden by the `PG_URL` environment variable
 const PG_URI: &str = "postgresql://postgres@127.0.0.1/test";
@@ -245,6 +248,7 @@ fn cell_to_string(row: &Row, column: &Column, idx: usize) -> String {
         }
         Type::FLOAT4 => make_string!(row, idx, f32, f32_to_str),
         Type::FLOAT8 => make_string!(row, idx, f64, f64_to_str),
+        Type::REGTYPE => make_string!(row, idx, PgRegtype),
         _ => unimplemented!("Unsupported type: {}", column.type_().name()),
     }
 }

--- a/datafusion/core/tests/sqllogictests/src/engines/postgres/types.rs
+++ b/datafusion/core/tests/sqllogictests/src/engines/postgres/types.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use postgres_types::Type;
 use tokio_postgres::types::FromSql;
 

--- a/datafusion/core/tests/sqllogictests/src/engines/postgres/types.rs
+++ b/datafusion/core/tests/sqllogictests/src/engines/postgres/types.rs
@@ -1,0 +1,27 @@
+use postgres_types::Type;
+use tokio_postgres::types::FromSql;
+
+pub struct PgRegtype {
+    value: String,
+}
+
+impl<'a> FromSql<'a> for PgRegtype {
+    fn from_sql(
+        _: &Type,
+        buf: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        let oid = postgres_protocol::types::oid_from_sql(buf)?;
+        let value = Type::from_oid(oid).ok_or("bad type")?.to_string();
+        Ok(PgRegtype { value })
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(*ty, Type::REGTYPE)
+    }
+}
+
+impl ToString for PgRegtype {
+    fn to_string(&self) -> String {
+        self.value.clone()
+    }
+}

--- a/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
@@ -1,0 +1,177 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+query ??
+select true and true, false and false;
+----
+true false
+
+
+onlyif DataFusion
+query ??
+select arrow_typeof(true and true), arrow_typeof(false and false);
+----
+Boolean Boolean
+
+
+onlyif postgres
+query ??
+select pg_typeof(true and true), pg_typeof(false and false);
+----
+bool bool
+
+query ??
+select true or true, false or false;
+----
+true false
+
+
+onlyif DataFusion
+query ??
+select arrow_typeof(true or true), arrow_typeof(false or false);
+----
+Boolean Boolean
+
+
+onlyif postgres
+query ??
+select pg_typeof(true or true), pg_typeof(false or false);
+----
+bool bool
+
+
+query ??
+select false and true, true and false;
+----
+false false
+
+
+onlyif DataFusion
+query ??
+select arrow_typeof(false and true), arrow_typeof(true and false);
+----
+Boolean Boolean
+
+
+onlyif postgres
+query ??
+select pg_typeof(false and true), pg_typeof(true and false);
+----
+bool bool
+
+
+query ??
+select false or true, true or false;
+----
+true true
+
+
+onlyif DataFusion
+query ??
+select arrow_typeof(false or true), arrow_typeof(true or false);
+----
+Boolean Boolean
+
+
+onlyif postgres
+query ??
+select pg_typeof(false or true), pg_typeof(true or false);
+----
+bool bool
+
+
+# TODO: run for DataFusion as well after #4335
+onlyif postgres
+query ??
+select null and null, null or null;
+----
+NULL NULL
+
+
+# TODO: uncomment after #4335
+#onlyif DataFusion
+#query ??
+#select arrow_typeof(null and null), arrow_typeof(null or null);
+#----
+#Boolean Boolean
+
+
+onlyif postgres
+query ??
+select pg_typeof(null and null), pg_typeof(null or null);
+----
+bool bool
+
+
+onlyif postgres
+query ????
+select true and null,
+       false and null,
+       null and true,
+       null and false;
+----
+NULL false NULL false
+
+
+onlyif DataFusion
+query ????
+select arrow_typeof(true and null),
+       arrow_typeof(false and null),
+       arrow_typeof(null and true),
+       arrow_typeof(null and false);
+----
+Boolean Boolean Boolean Boolean
+
+
+onlyif postgres
+query ????
+select pg_typeof(true and null),
+       pg_typeof(false and null),
+       pg_typeof(null and true),
+       pg_typeof(null and false);
+----
+bool bool bool bool
+
+
+onlyif postgres
+query ????
+select true or null,
+       false or null,
+       null or true,
+       null or false;
+----
+true NULL true NULL
+
+
+onlyif DataFusion
+query ????
+select arrow_typeof(true or null),
+       arrow_typeof(false or null),
+       arrow_typeof(null or true),
+       arrow_typeof(null or false);
+----
+Boolean Boolean Boolean Boolean
+
+
+onlyif postgres
+query ????
+select pg_typeof(true or null),
+       pg_typeof(false or null),
+       pg_typeof(null or true),
+       pg_typeof(null or false);
+----
+bool bool bool bool

--- a/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
@@ -34,6 +34,7 @@ select pg_typeof(true and true), pg_typeof(false and false);
 ----
 bool bool
 
+
 query ??
 select true or true, false or false;
 ----


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5147.

# Rationale for this change

In sqllogictest tests I could write a query for Datafusion like this one
```
select arrow_typeof(null and null), arrow_typeof(null or null);
```
I would like to write the same query for Postgres, so that not only values are checked for compatibility but also types
```
select pg_typeof(null and null), pg_typeof(null or null);
```
# What changes are included in this PR?

This pr includes handling of `regtype` results in Postgres sqllogictest client.

# Are these changes tested?

Github actions

# Are there any user-facing changes?

Sqllogictest only