### PR TITLE
feat: Type coercion for Dictionary(_, _) to Utf8 for regex conditions

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -141,7 +141,7 @@ pub fn coerce_types(
         Operator::RegexMatch
         | Operator::RegexIMatch
         | Operator::RegexNotMatch
-        | Operator::RegexNotIMatch => string_coercion(lhs_type, rhs_type),
+        | Operator::RegexNotIMatch => regex_coercion(lhs_type, rhs_type),
         // "||" operator has its own rules, and always return a string type
         Operator::StringConcat => string_concat_coercion(lhs_type, rhs_type),
         Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
@@ -521,6 +521,13 @@ pub fn like_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
     string_coercion(lhs_type, rhs_type)
         .or_else(|| dictionary_coercion(lhs_type, rhs_type, false))
         .or_else(|| null_coercion(lhs_type, rhs_type))
+}
+
+/// coercion rules for regular expression comparison operations.
+/// This is a union of string coercion rules and dictionary coercion rules
+pub fn regex_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
+    string_coercion(lhs_type, rhs_type)
+        .or_else(|| dictionary_coercion(lhs_type, rhs_type, false))
 }
 
 /// Checks if the TimeUnit associated with a Time32 or Time64 type is consistent,
@@ -949,6 +956,30 @@ mod tests {
         );
         test_coercion_binary_rule!(
             DataType::Utf8,
+            DataType::Utf8,
+            Operator::RegexNotIMatch,
+            DataType::Utf8
+        );
+        test_coercion_binary_rule!(
+            DataType::Dictionary(DataType::Int32.into(), DataType::Utf8.into()),
+            DataType::Utf8,
+            Operator::RegexMatch,
+            DataType::Utf8
+        );
+        test_coercion_binary_rule!(
+            DataType::Dictionary(DataType::Int32.into(), DataType::Utf8.into()),
+            DataType::Utf8,
+            Operator::RegexIMatch,
+            DataType::Utf8
+        );
+        test_coercion_binary_rule!(
+            DataType::Dictionary(DataType::Int32.into(), DataType::Utf8.into()),
+            DataType::Utf8,
+            Operator::RegexNotMatch,
+            DataType::Utf8
+        );
+        test_coercion_binary_rule!(
+            DataType::Dictionary(DataType::Int32.into(), DataType::Utf8.into()),
             DataType::Utf8,
             Operator::RegexNotIMatch,
             DataType::Utf8


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5154

# Rationale for this change

This change teaches DataFusion how to coerce Dictionary(_, string-like-type) to a string-like type for regex conditional expressions, so the comparison may succeed.

# What changes are included in this PR?

Updated the type coercion rules when encountering one of the regular expression operators.

# Are these changes tested?

Yes, new tests were added to validate the changes.

# Are there any user-facing changes?

Queries that previously would fail with an error that the Dictionary type is incompatible with a regular expression condition will now succeed. IOx uses `Dictionary(Int32, Utf8)` columns for tags.

In some cases, regular expression queries succeed, such as:

```sql
SELECT usage_idle FROM cpu WHERE cpu ~ '9'
```

As the optimiser changes the filter plan from a regex conditional to a `LIKE '%9%'`, and the `LIKE` operator has additional code to coerce dictionary types:

https://github.com/apache/arrow-datafusion/blob/031534d94efb305eb26a7c16fd7e06ae3bcd88bb/datafusion/expr/src/type_coercion/binary.rs#L522

however, other cases unexpectedly fail:

```sql
SELECT usage_idle FROM cpu WHERE cpu ~ '9$'
```

as the optimiser does not rewrite this to a `LIKE` expression[^1]

[^1]: Incidentally, the optimiser could also rewrite this to `LIKE '%9'`

