### PR TITLE
Compare NULL types

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/pg_compat/pg_compat_type_coercion.slt
@@ -95,20 +95,17 @@ select pg_typeof(false or true), pg_typeof(true or false);
 bool bool
 
 
-# TODO: run for DataFusion as well after #4335
-onlyif postgres
 query ??
 select null and null, null or null;
 ----
 NULL NULL
 
 
-# TODO: uncomment after #4335
-#onlyif DataFusion
-#query ??
-#select arrow_typeof(null and null), arrow_typeof(null or null);
-#----
-#Boolean Boolean
+onlyif DataFusion
+query ??
+select arrow_typeof(null and null), arrow_typeof(null or null);
+----
+Boolean Boolean
 
 
 onlyif postgres

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -100,7 +100,7 @@ pub fn coerce_types(
         Operator::And | Operator::Or => match (lhs_type, rhs_type) {
             // logical binary boolean operators can only be evaluated in bools or nulls
             (DataType::Boolean, DataType::Boolean) => Some(DataType::Boolean),
-            (DataType::Null, DataType::Null) => Some(DataType::Null),
+            (DataType::Null, DataType::Null) => Some(DataType::Boolean),
             (DataType::Boolean, DataType::Null) | (DataType::Null, DataType::Boolean) => {
                 Some(DataType::Boolean)
             }
@@ -1147,13 +1147,13 @@ mod tests {
             DataType::Null,
             DataType::Null,
             Operator::Or,
-            DataType::Null
+            DataType::Boolean
         );
         test_coercion_binary_rule!(
             DataType::Null,
             DataType::Null,
             Operator::And,
-            DataType::Null
+            DataType::Boolean
         );
         test_coercion_binary_rule!(
             DataType::Null,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4335.

# Rationale for this change

These queries should produce a value instead of an error
```
❯ select null and null;
❯ select null or null;
```

# What changes are included in this PR?

Null comparison coercion and tests.

I made the null logical comparison produce booleans. This is the Postgres does it, and DataFusion seems to be compatible with Postgres.

# Are these changes tested?
Sqllogictests and unit tests

# Are there any user-facing changes?

`null and null` and `null or null` would produce Boolean null value instead of an error.