### PR TITLE
fix: treat unsupported SQL plans as "not implemented"

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1114,7 +1114,7 @@ impl DefaultPhysicalPlanner {
                     // TABLE" -- it must be handled at a higher level (so
                     // that the appropriate table can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: CreateExternalTable".to_string(),
                     ))
                 }
@@ -1122,7 +1122,7 @@ impl DefaultPhysicalPlanner {
                     // There is no default plan for "PREPARE" -- it must be
                     // handled at a higher level (so that the appropriate
                     // statement can be prepared)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: Prepare".to_string(),
                     ))
                 }
@@ -1131,7 +1131,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: CreateCatalogSchema".to_string(),
                     ))
                 }
@@ -1140,7 +1140,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: CreateCatalog".to_string(),
                     ))
                 }
@@ -1149,7 +1149,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: CreateMemoryTable".to_string(),
                     ))
                 }
@@ -1158,7 +1158,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: DropTable".to_string(),
                     ))
                 }
@@ -1167,7 +1167,7 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: DropView".to_string(),
                     ))
                 }
@@ -1176,13 +1176,13 @@ impl DefaultPhysicalPlanner {
                     // It must be handled at a higher level (so
                     // that the schema can be registered with
                     // the context)
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: CreateView".to_string(),
                     ))
                 }
                 LogicalPlan::Dml(_) => {
                     // DataFusion is a read-only query engine, but also a library, so consumers may implement this
-                    Err(DataFusionError::Internal(
+                    Err(DataFusionError::NotImplemented(
                         "Unsupported logical plan: Dml".to_string(),
                     ))
                 }

--- a/datafusion/core/tests/sql/errors.rs
+++ b/datafusion/core/tests/sql/errors.rs
@@ -146,8 +146,7 @@ async fn unsupported_sql_returns_error() -> Result<()> {
     assert!(physical_plan.is_err());
     assert_eq!(
         format!("{}", physical_plan.unwrap_err()),
-        "Internal error: Unsupported logical plan: CreateView. \
-        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+        "This feature is not implemented: Unsupported logical plan: CreateView"
     );
     // // drop view
     let sql = "drop view test_view";
@@ -156,8 +155,7 @@ async fn unsupported_sql_returns_error() -> Result<()> {
     assert!(physical_plan.is_err());
     assert_eq!(
         format!("{}", physical_plan.unwrap_err()),
-        "Internal error: Unsupported logical plan: DropView. \
-        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+        "This feature is not implemented: Unsupported logical plan: DropView"
     );
     // // drop table
     let sql = "drop table aggregate_test_100";
@@ -166,8 +164,7 @@ async fn unsupported_sql_returns_error() -> Result<()> {
     assert!(physical_plan.is_err());
     assert_eq!(
         format!("{}", physical_plan.unwrap_err()),
-        "Internal error: Unsupported logical plan: DropTable. \
-        This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker"
+        "This feature is not implemented: Unsupported logical plan: DropTable"
     );
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?
\--

# Rationale for this change
Use the correct error type because API users may rely on that (e.g. to generate appropriate HTTP error codes).

# What changes are included in this PR?
Change some errors from `Internal` to `NotImplemented`.

# Are these changes tested?
SQL test, see changed test.

# Are there any user-facing changes?
Improved error types.