### PR TITLE
FileStream: Open next file in parallel while decoding

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -22,6 +22,7 @@
 //! compliant with the `SendableRecordBatchStream` trait.
 
 use std::collections::VecDeque;
+use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
@@ -98,6 +99,8 @@ enum FileStreamState {
         partition_values: Vec<ScalarValue>,
         /// The reader instance
         reader: BoxStream<'static, Result<RecordBatch, ArrowError>>,
+        /// A [`FileOpenFuture`] for the next file to be processed
+        next: Option<(FileOpenFuture, Vec<ScalarValue>)>,
     },
     /// Encountered an error
     Error,
@@ -202,30 +205,39 @@ impl<F: FileOpener> FileStream<F> {
         })
     }
 
+    fn next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
+        let part_file = match self.file_iter.pop_front() {
+            Some(file) => file,
+            None => return None,
+        };
+
+        let file_meta = FileMeta {
+            object_meta: part_file.object_meta,
+            range: part_file.range,
+            extensions: part_file.extensions,
+        };
+
+        Some(
+            self.file_reader
+                .open(file_meta)
+                .map(|future| (future, part_file.partition_values)),
+        )
+    }
+
     fn poll_inner(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<RecordBatch>>> {
         loop {
             match &mut self.state {
                 FileStreamState::Idle => {
-                    let part_file = match self.file_iter.pop_front() {
-                        Some(file) => file,
-                        None => return Poll::Ready(None),
-                    };
-
-                    let file_meta = FileMeta {
-                        object_meta: part_file.object_meta,
-                        range: part_file.range,
-                        extensions: part_file.extensions,
-                    };
-
                     self.file_stream_metrics.time_opening.start();
 
-                    match self.file_reader.open(file_meta) {
-                        Ok(future) => {
+                    match self.next_file().transpose() {
+                        Ok(Some((future, partition_values))) => {
                             self.state = FileStreamState::Open {
                                 future,
-                                partition_values: part_file.partition_values,
+                                partition_values,
                             }
                         }
+                        Ok(None) => return Poll::Ready(None),
                         Err(e) => {
                             self.state = FileStreamState::Error;
                             return Poll::Ready(Some(Err(e)));
@@ -237,13 +249,34 @@ impl<F: FileOpener> FileStream<F> {
                     partition_values,
                 } => match ready!(future.poll_unpin(cx)) {
                     Ok(reader) => {
+                        let partition_values = mem::take(partition_values);
+
+                        let next = self.next_file().transpose();
+
                         self.file_stream_metrics.time_opening.stop();
                         self.file_stream_metrics.time_scanning_until_data.start();
                         self.file_stream_metrics.time_scanning_total.start();
-                        self.state = FileStreamState::Scan {
-                            partition_values: std::mem::take(partition_values),
-                            reader,
-                        };
+
+                        match next {
+                            Ok(Some((next_future, next_partition_values))) => {
+                                self.state = FileStreamState::Scan {
+                                    partition_values,
+                                    reader,
+                                    next: Some((next_future, next_partition_values)),
+                                };
+                            }
+                            Ok(None) => {
+                                self.state = FileStreamState::Scan {
+                                    reader,
+                                    partition_values,
+                                    next: None,
+                                };
+                            }
+                            Err(e) => {
+                                self.state = FileStreamState::Error;
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                        }
                     }
                     Err(e) => {
                         self.state = FileStreamState::Error;
@@ -253,6 +286,7 @@ impl<F: FileOpener> FileStream<F> {
                 FileStreamState::Scan {
                     reader,
                     partition_values,
+                    next,
                 } => match ready!(reader.poll_next_unpin(cx)) {
                     Some(result) => {
                         self.file_stream_metrics.time_scanning_until_data.stop();
@@ -287,7 +321,18 @@ impl<F: FileOpener> FileStream<F> {
                     None => {
                         self.file_stream_metrics.time_scanning_until_data.stop();
                         self.file_stream_metrics.time_scanning_total.stop();
-                        self.state = FileStreamState::Idle;
+
+                        match mem::take(next) {
+                            Some((future, partition_values)) => {
+                                self.file_stream_metrics.time_opening.start();
+
+                                self.state = FileStreamState::Open {
+                                    future,
+                                    partition_values,
+                                }
+                            }
+                            None => return Poll::Ready(None),
+                        }
                     }
                 },
                 FileStreamState::Error | FileStreamState::Limit => {

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -99,10 +99,10 @@ enum FileStreamState {
         partition_values: Vec<ScalarValue>,
         /// The reader instance
         reader: BoxStream<'static, Result<RecordBatch, ArrowError>>,
-        /// A [`FileOpenFuture`] for the next file to be processed, 
+        /// A [`FileOpenFuture`] for the next file to be processed,
         /// and its corresponding partition column values, if any.
         /// This allows the next file to be opened in parallel while the
-        /// current file is read. 
+        /// current file is read.
         next: Option<(FileOpenFuture, Vec<ScalarValue>)>,
     },
     /// Encountered an error
@@ -208,11 +208,11 @@ impl<F: FileOpener> FileStream<F> {
         })
     }
 
-    // Begin opening the next file in parallel while decoding the current file in FileStream. 
-    // Since file opening is mostly IO (and may involve a 
-    // bunch of sequential IO), it can be parallelized with decoding. 
+    // Begin opening the next file in parallel while decoding the current file in FileStream.
+    // Since file opening is mostly IO (and may involve a
+    // bunch of sequential IO), it can be parallelized with decoding.
     fn start_next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
-        let part_file =  self.file_iter.pop_front()?;
+        let part_file = self.file_iter.pop_front()?;
 
         let file_meta = FileMeta {
             object_meta: part_file.object_meta,

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -211,7 +211,7 @@ impl<F: FileOpener> FileStream<F> {
     // Begin opening the next file in parallel while decoding the current file in FileStream. 
     // Since file opening is mostly IO (and may involve a 
     // bunch of sequential IO), it can be parallelized with decoding. 
-    fn next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
+    fn start_next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
         let part_file =  self.file_iter.pop_front()?;
 
         let file_meta = FileMeta {
@@ -233,7 +233,7 @@ impl<F: FileOpener> FileStream<F> {
                 FileStreamState::Idle => {
                     self.file_stream_metrics.time_opening.start();
 
-                    match self.next_file().transpose() {
+                    match self.start_next_file().transpose() {
                         Ok(Some((future, partition_values))) => {
                             self.state = FileStreamState::Open {
                                 future,
@@ -254,7 +254,7 @@ impl<F: FileOpener> FileStream<F> {
                     Ok(reader) => {
                         let partition_values = mem::take(partition_values);
 
-                        let next = self.next_file().transpose();
+                        let next = self.start_next_file().transpose();
 
                         self.file_stream_metrics.time_opening.stop();
                         self.file_stream_metrics.time_scanning_until_data.start();

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -99,7 +99,10 @@ enum FileStreamState {
         partition_values: Vec<ScalarValue>,
         /// The reader instance
         reader: BoxStream<'static, Result<RecordBatch, ArrowError>>,
-        /// A [`FileOpenFuture`] for the next file to be processed
+        /// A [`FileOpenFuture`] for the next file to be processed, 
+        /// and its corresponding partition column values, if any.
+        /// This allows the next file to be opened in parallel while the
+        /// current file is read. 
         next: Option<(FileOpenFuture, Vec<ScalarValue>)>,
     },
     /// Encountered an error
@@ -205,11 +208,11 @@ impl<F: FileOpener> FileStream<F> {
         })
     }
 
+    // Begin opening the next file in parallel while decoding the current file in FileStream. 
+    // Since file opening is mostly IO (and may involve a 
+    // bunch of sequential IO), it can be parallelized with decoding. 
     fn next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
-        let part_file = match self.file_iter.pop_front() {
-            Some(file) => file,
-            None => return None,
-        };
+        let part_file =  self.file_iter.pop_front()?;
 
         let file_meta = FileMeta {
             object_meta: part_file.object_meta,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5129 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

File opening is mostly IO (and may involve a bunch of sequential IO) so it can probably be parallelized well with decoding. So we should open the next file in parallel while decoding the current file in `FileStream`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I think this should be covered by existing tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

`FileStreamMetrics.time_opening` is a slightly different metric now as it won't capture time spent opening but rather time spent opening while also not concurrently decoding. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->