### PR TITLE
Switch to use sum kernel from arrow-rs for Decimal128

### DIFF
--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -161,21 +161,10 @@ macro_rules! typed_sum_delta_batch {
     }};
 }
 
-// TODO implement this in arrow-rs with simd
-// https://github.com/apache/arrow-rs/issues/1010
 fn sum_decimal_batch(values: &ArrayRef, precision: u8, scale: i8) -> Result<ScalarValue> {
     let array = downcast_value!(values, Decimal128Array);
-
-    if array.null_count() == array.len() {
-        return Ok(ScalarValue::Decimal128(None, precision, scale));
-    }
-
-    let result = array.into_iter().fold(0_i128, |s, element| match element {
-        Some(v) => s + v,
-        None => s,
-    });
-
-    Ok(ScalarValue::Decimal128(Some(result), precision, scale))
+    let result = compute::sum(array);
+    Ok(ScalarValue::Decimal128(result, precision, scale))
 }
 
 // sums the array and returns a ScalarValue of its corresponding type.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fixes a TODO item in the codebase.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fixes a TODO item in `sum` aggregation: replace the sum logic for `Decimal128` with the usage of `sum` kernel provided by `arrow-rs`, which also uses SIMD and potentially can give better performance.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, with existing tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->