### PR TITLE
[FIX] rename cast expression column name

### DIFF
--- a/datafusion/core/tests/sql/cast.rs
+++ b/datafusion/core/tests/sql/cast.rs
@@ -81,6 +81,9 @@ async fn cast_duplicate() -> Result<()> {
     assert_eq!(&DataType::Int64, actual[0].schema().field(0).data_type());
     assert_eq!("Int64(10)", actual[0].schema().field(0).name());
     assert_eq!(&DataType::Int8, actual[0].schema().field(1).data_type());
-    assert_eq!("CAST(Int64(10) AS Int8)", actual[0].schema().field(1).name());
+    assert_eq!(
+        "CAST(Int64(10) AS Int8)",
+        actual[0].schema().field(1).name()
+    );
     Ok(())
 }

--- a/datafusion/core/tests/sql/cast.rs
+++ b/datafusion/core/tests/sql/cast.rs
@@ -74,3 +74,13 @@ async fn cast_unsigned_bigint() -> Result<()> {
     assert_eq!(&DataType::UInt64, actual[0].schema().field(0).data_type());
     Ok(())
 }
+
+#[tokio::test]
+async fn cast_duplicate() -> Result<()> {
+    let actual = execute_sql("SELECT 10, cast(10 as tinyint)").await;
+    assert_eq!(&DataType::Int64, actual[0].schema().field(0).data_type());
+    assert_eq!("Int64(10)", actual[0].schema().field(0).name());
+    assert_eq!(&DataType::Int8, actual[0].schema().field(1).data_type());
+    assert_eq!("CAST(Int64(10) AS Int8)", actual[0].schema().field(1).name());
+    Ok(())
+}

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1200,13 +1200,13 @@ fn create_name(e: &Expr) -> Result<String> {
             name += "END";
             Ok(name)
         }
-        Expr::Cast(Cast { expr, .. }) => {
-            // CAST does not change the expression name
-            create_name(expr)
+        Expr::Cast(Cast { expr, data_type }) => {
+            let expr = create_name(expr)?;
+            Ok(format!("CAST({expr} AS {data_type})"))
         }
-        Expr::TryCast(TryCast { expr, .. }) => {
-            // CAST does not change the expression name
-            create_name(expr)
+        Expr::TryCast(TryCast { expr, data_type }) => {
+            let expr = create_name(expr)?;
+            Ok(format!("TRY_CAST({expr} AS {data_type})"))
         }
         Expr::Not(expr) => {
             let expr = create_name(expr)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This problem origin from https://github.com/dask-contrib/dask-sql/issues/948, which can be minimally reproduced by 

```sql
SELECT 10, cast(10 as tinyint)
```

And this is because 

- cast use the expr as column name

https://github.com/apache/arrow-datafusion/blob/224c682101949da57aebc36e92e5a881ef3040d4/datafusion/expr/src/expr.rs#L1203-L1210

- same column name is not validate

https://github.com/apache/arrow-datafusion/blob/224c682101949da57aebc36e92e5a881ef3040d4/datafusion/expr/src/logical_plan/builder.rs#L925-L948

There are two solutions:

- rename cast expression
- remove the unique column name validation

I choose the first way to pass these cases, by using `CAST(Int64(10) AS Int8)` instead of `Int64(10)`. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

As above.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes. Because column name chage for cast expression.