### PR TITLE
Create disk manager spill folder if doesn't exist

### DIFF
--- a/datafusion/core/src/execution/disk_manager.rs
+++ b/datafusion/core/src/execution/disk_manager.rs
@@ -139,6 +139,9 @@ fn create_local_dirs(local_dirs: Vec<PathBuf>) -> Result<Vec<TempDir>> {
     local_dirs
         .iter()
         .map(|root| {
+            if !std::path::Path::new(root).exists() {
+                std::fs::create_dir(root)?;
+            }
             Builder::new()
                 .prefix("datafusion-")
                 .tempdir_in(root)
@@ -212,6 +215,16 @@ mod tests {
             manager.create_tmp_file("Testing").unwrap_err().to_string(),
             "Resources exhausted: Memory Exhausted while Testing (DiskManager is disabled)",
         )
+    }
+
+    #[test]
+    fn test_disk_manager_create_spill_folder() {
+        let config = DiskManagerConfig::new_specified(vec!["DOESNT_EXIST".into()]);
+
+        DiskManager::try_new(config)
+            .unwrap()
+            .create_tmp_file("Testing")
+            .unwrap();
     }
 
     /// Asserts that `file_path` is found anywhere in any of `dir` directories


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5186 .

# Rationale for this change
DiskManager fails if the spill folder doesn't exist, that is bit annoying.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


# What changes are included in this PR?
Create disk manager spill folder if doesn't exist
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Test attached
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->