### PR TITLE
bugfix: fix `TableScan` may contain fields not included in `schema`

### DIFF
--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -291,6 +291,10 @@ fn optimize_plan(
         // scans:
         // * remove un-used columns from the scan projection
         LogicalPlan::TableScan(scan) => {
+            // filter expr mayn't exist in expr in projection.
+            // like: TableScan: t1 projection=[bool_col, int_col], full_filters=[t1.id = Int32(1)]
+            // projection=[bool_col, int_col] don't contain `ti.id`.
+            exprlist_to_columns(&scan.filters, &mut new_required_columns)?;
             push_down_scan(scan, &new_required_columns, has_projection)
         }
         LogicalPlan::Explain { .. } => Err(DataFusionError::Internal(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4793.

# Rationale for this change


# What changes are included in this PR?

When tablescan projection don't contain field in scan-projection, we should push them into scan-projection

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->