### PR TITLE
fix: make `write_csv/json/parquet` cancel-safe

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/csv.rs
+++ b/datafusion/core/src/physical_plan/file_format/csv.rs
@@ -44,6 +44,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::task::Poll;
 use tokio::task::{self, JoinHandle};
+use tokio_util::sync::CancellationToken;
 
 use super::{get_output_ordering, FileScanConfig};
 
@@ -286,38 +287,44 @@ pub async fn plan_to_csv(
     let path = path.as_ref();
     // create directory to contain the CSV files (one per partition)
     let fs_path = Path::new(path);
-    match fs::create_dir(fs_path) {
-        Ok(()) => {
-            let mut tasks = vec![];
-            for i in 0..plan.output_partitioning().partition_count() {
-                let plan = plan.clone();
-                let filename = format!("part-{i}.csv");
-                let path = fs_path.join(filename);
-                let file = fs::File::create(path)?;
-                let mut writer = csv::Writer::new(file);
-                let task_ctx = Arc::new(TaskContext::from(state));
-                let stream = plan.execute(i, task_ctx)?;
-                let handle: JoinHandle<Result<()>> = task::spawn(async move {
-                    stream
-                        .map(|batch| writer.write(&batch?))
-                        .try_collect()
-                        .await
-                        .map_err(DataFusionError::from)
-                });
-                tasks.push(handle);
-            }
-            futures::future::join_all(tasks)
-                .await
-                .into_iter()
-                .try_for_each(|result| {
-                    result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
-                })?;
-            Ok(())
-        }
-        Err(e) => Err(DataFusionError::Execution(format!(
+    if let Err(e) = fs::create_dir(fs_path) {
+        return Err(DataFusionError::Execution(format!(
             "Could not create directory {path}: {e:?}"
-        ))),
+        )));
     }
+
+    let mut tasks = vec![];
+    // Create cancellation-token to interrupt background execution on drop.
+    let cancellation_token = CancellationToken::new();
+    let _guard = cancellation_token.clone().drop_guard();
+    for i in 0..plan.output_partitioning().partition_count() {
+        let plan = plan.clone();
+        let filename = format!("part-{i}.csv");
+        let path = fs_path.join(filename);
+        let file = fs::File::create(path)?;
+        let mut writer = csv::Writer::new(file);
+        let task_ctx = Arc::new(TaskContext::from(state));
+        let stream = plan.execute(i, task_ctx)?;
+
+        let cancellation_token = cancellation_token.child_token();
+        let handle: JoinHandle<Result<()>> = task::spawn(async move {
+            let exec_future = stream.map(|batch| writer.write(&batch?)).try_collect();
+
+            tokio::select! {
+                res = exec_future => res.map_err(DataFusionError::from),
+                _ = cancellation_token.cancelled() => Err(DataFusionError::Execution("Execution was stopped by the caller".to_string()))
+            }
+        });
+        tasks.push(handle);
+    }
+
+    futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .try_for_each(|result| {
+            result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
+        })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -43,6 +43,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::task::Poll;
 use tokio::task::{self, JoinHandle};
+use tokio_util::sync::CancellationToken;
 
 use super::{get_output_ordering, FileScanConfig};
 
@@ -230,38 +231,44 @@ pub async fn plan_to_json(
     let path = path.as_ref();
     // create directory to contain the CSV files (one per partition)
     let fs_path = Path::new(path);
-    match fs::create_dir(fs_path) {
-        Ok(()) => {
-            let mut tasks = vec![];
-            for i in 0..plan.output_partitioning().partition_count() {
-                let plan = plan.clone();
-                let filename = format!("part-{i}.json");
-                let path = fs_path.join(filename);
-                let file = fs::File::create(path)?;
-                let mut writer = json::LineDelimitedWriter::new(file);
-                let task_ctx = Arc::new(TaskContext::from(state));
-                let stream = plan.execute(i, task_ctx)?;
-                let handle: JoinHandle<Result<()>> = task::spawn(async move {
-                    stream
-                        .map(|batch| writer.write(batch?))
-                        .try_collect()
-                        .await
-                        .map_err(DataFusionError::from)
-                });
-                tasks.push(handle);
-            }
-            futures::future::join_all(tasks)
-                .await
-                .into_iter()
-                .try_for_each(|result| {
-                    result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
-                })?;
-            Ok(())
-        }
-        Err(e) => Err(DataFusionError::Execution(format!(
+    if let Err(e) = fs::create_dir(fs_path) {
+        return Err(DataFusionError::Execution(format!(
             "Could not create directory {path}: {e:?}"
-        ))),
+        )));
     }
+
+    let mut tasks = vec![];
+    // Create cancellation-token to interrupt background execution on drop.
+    let cancellation_token = CancellationToken::new();
+    let _guard = cancellation_token.clone().drop_guard();
+    for i in 0..plan.output_partitioning().partition_count() {
+        let plan = plan.clone();
+        let filename = format!("part-{i}.json");
+        let path = fs_path.join(filename);
+        let file = fs::File::create(path)?;
+        let mut writer = json::LineDelimitedWriter::new(file);
+        let task_ctx = Arc::new(TaskContext::from(state));
+        let stream = plan.execute(i, task_ctx)?;
+
+        let cancellation_token = cancellation_token.child_token();
+        let handle: JoinHandle<Result<()>> = task::spawn(async move {
+            let exec_future = stream.map(|batch| writer.write(batch?)).try_collect();
+
+            tokio::select! {
+                res = exec_future => res.map_err(DataFusionError::from),
+                _ = cancellation_token.cancelled() => Err(DataFusionError::Execution("Execution was stopped by the caller".to_string()))
+            }
+        });
+        tasks.push(handle);
+    }
+
+    futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .try_for_each(|result| {
+            result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
+        })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -60,6 +60,7 @@ use parquet::basic::{ConvertedType, LogicalType};
 use parquet::errors::ParquetError;
 use parquet::file::{metadata::ParquetMetaData, properties::WriterProperties};
 use parquet::schema::types::ColumnDescriptor;
+use tokio_util::sync::CancellationToken;
 
 mod metrics;
 mod page_filter;
@@ -706,45 +707,53 @@ pub async fn plan_to_parquet(
     let path = path.as_ref();
     // create directory to contain the Parquet files (one per partition)
     let fs_path = std::path::Path::new(path);
-    match fs::create_dir(fs_path) {
-        Ok(()) => {
-            let mut tasks = vec![];
-            for i in 0..plan.output_partitioning().partition_count() {
-                let plan = plan.clone();
-                let filename = format!("part-{i}.parquet");
-                let path = fs_path.join(filename);
-                let file = fs::File::create(path)?;
-                let mut writer =
-                    ArrowWriter::try_new(file, plan.schema(), writer_properties.clone())?;
-                let task_ctx = Arc::new(TaskContext::from(state));
-                let stream = plan.execute(i, task_ctx)?;
-                let handle: tokio::task::JoinHandle<Result<()>> =
-                    tokio::task::spawn(async move {
-                        stream
-                            .map(|batch| {
-                                writer
-                                    .write(&batch?)
-                                    .map_err(DataFusionError::ParquetError)
-                            })
-                            .try_collect()
-                            .await
-                            .map_err(DataFusionError::from)?;
-                        writer.close().map_err(DataFusionError::from).map(|_| ())
-                    });
-                tasks.push(handle);
-            }
-            futures::future::join_all(tasks)
-                .await
-                .into_iter()
-                .try_for_each(|result| {
-                    result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
-                })?;
-            Ok(())
-        }
-        Err(e) => Err(DataFusionError::Execution(format!(
+    if let Err(e) = fs::create_dir(fs_path) {
+        return Err(DataFusionError::Execution(format!(
             "Could not create directory {path}: {e:?}"
-        ))),
+        )));
     }
+
+    let mut tasks = vec![];
+    // Create cancellation-token to interrupt background execution on drop.
+    let cancellation_token = CancellationToken::new();
+    let _guard = cancellation_token.clone().drop_guard();
+    for i in 0..plan.output_partitioning().partition_count() {
+        let plan = plan.clone();
+        let filename = format!("part-{i}.parquet");
+        let path = fs_path.join(filename);
+        let file = fs::File::create(path)?;
+        let mut writer =
+            ArrowWriter::try_new(file, plan.schema(), writer_properties.clone())?;
+        let task_ctx = Arc::new(TaskContext::from(state));
+        let stream = plan.execute(i, task_ctx)?;
+
+        let cancellation_token = cancellation_token.child_token();
+        let handle: tokio::task::JoinHandle<Result<()>> = tokio::task::spawn(
+            async move {
+                let exec_future = stream
+                    .map(|batch| {
+                        writer.write(&batch?).map_err(DataFusionError::ParquetError)
+                    })
+                    .try_collect();
+
+                tokio::select! {
+                    res = exec_future => res.map_err(DataFusionError::from)?,
+                    _ = cancellation_token.cancelled() => return Err(DataFusionError::Execution("Execution was stopped by the caller".to_string()))
+                }
+
+                writer.close().map_err(DataFusionError::from).map(|_| ())
+            },
+        );
+        tasks.push(handle);
+    }
+
+    futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .try_for_each(|result| {
+            result.map_err(|e| DataFusionError::Execution(format!("{e}")))?
+        })?;
+    Ok(())
 }
 
 // Copy from the arrow-rs

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -60,13 +60,13 @@ use parquet::basic::{ConvertedType, LogicalType};
 use parquet::errors::ParquetError;
 use parquet::file::{metadata::ParquetMetaData, properties::WriterProperties};
 use parquet::schema::types::ColumnDescriptor;
-use tokio_util::sync::CancellationToken;
 
 mod metrics;
 mod page_filter;
 mod row_filter;
 mod row_groups;
 
+use crate::physical_plan::common::AbortOnDropSingle;
 use crate::physical_plan::file_format::parquet::page_filter::PagePruningPredicate;
 pub use metrics::ParquetFileMetrics;
 
@@ -714,9 +714,6 @@ pub async fn plan_to_parquet(
     }
 
     let mut tasks = vec![];
-    // Create cancellation-token to interrupt background execution on drop.
-    let cancellation_token = CancellationToken::new();
-    let _guard = cancellation_token.clone().drop_guard();
     for i in 0..plan.output_partitioning().partition_count() {
         let plan = plan.clone();
         let filename = format!("part-{i}.parquet");
@@ -726,25 +723,19 @@ pub async fn plan_to_parquet(
             ArrowWriter::try_new(file, plan.schema(), writer_properties.clone())?;
         let task_ctx = Arc::new(TaskContext::from(state));
         let stream = plan.execute(i, task_ctx)?;
-
-        let cancellation_token = cancellation_token.child_token();
-        let handle: tokio::task::JoinHandle<Result<()>> = tokio::task::spawn(
-            async move {
-                let exec_future = stream
+        let handle: tokio::task::JoinHandle<Result<()>> =
+            tokio::task::spawn(async move {
+                stream
                     .map(|batch| {
                         writer.write(&batch?).map_err(DataFusionError::ParquetError)
                     })
-                    .try_collect();
-
-                tokio::select! {
-                    res = exec_future => res.map_err(DataFusionError::from)?,
-                    _ = cancellation_token.cancelled() => return Err(DataFusionError::Execution("Execution was stopped by the caller".to_string()))
-                }
+                    .try_collect()
+                    .await
+                    .map_err(DataFusionError::from)?;
 
                 writer.close().map_err(DataFusionError::from).map(|_| ())
-            },
-        );
-        tasks.push(handle);
+            });
+        tasks.push(AbortOnDropSingle::new(handle));
     }
 
     futures::future::join_all(tasks)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5178

# Rationale for this change

Currently interruption from outside of datafusion don't stop spawned tasks and it continue to execute query.
It's very helpful to be able to restrict these methods by `timeout` or `select` for example.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

It's quite hard to cover with union-tests and such test could be too flaky (any ideas are welcome). 
However all existed tests are passing successfully. 

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->