### PR TITLE
fix(MemTable): make it cancel-safe and fix parallelism

### DIFF
--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -32,6 +32,7 @@ use crate::error::{DataFusionError, Result};
 use crate::execution::context::SessionState;
 use crate::logical_expr::Expr;
 use crate::physical_plan::common;
+use crate::physical_plan::common::AbortOnDropSingle;
 use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::{repartition::RepartitionExec, Partitioning};
@@ -76,10 +77,12 @@ impl MemTable {
             .map(|part_i| {
                 let task = state.task_ctx();
                 let exec = exec.clone();
-                tokio::spawn(async move {
+                let task = tokio::spawn(async move {
                     let stream = exec.execute(part_i, task)?;
                     common::collect(stream).await
-                })
+                });
+
+                AbortOnDropSingle::new(task)
             })
             // this collect *is needed* so that the join below can
             // switch between tasks
@@ -87,9 +90,13 @@ impl MemTable {
 
         let mut data: Vec<Vec<RecordBatch>> =
             Vec::with_capacity(exec.output_partitioning().partition_count());
-        for task in tasks {
-            let result = task.await.expect("MemTable::load could not join task")?;
-            data.push(result);
+
+        for result in futures::future::join_all(tasks).await {
+            data.push(result.map_err(|_| {
+                DataFusionError::Internal(
+                    "MemTable::load could not join task".to_string(),
+                )
+            })??)
         }
 
         let exec = MemoryExec::try_new(&data, schema.clone(), None)?;

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -92,11 +92,7 @@ impl MemTable {
             Vec::with_capacity(exec.output_partitioning().partition_count());
 
         for result in futures::future::join_all(tasks).await {
-            data.push(result.map_err(|_| {
-                DataFusionError::Internal(
-                    "MemTable::load could not join task".to_string(),
-                )
-            })??)
+            data.push(result.map_err(|e| DataFusionError::External(Box::new(e)))??)
         }
 
         let exec = MemoryExec::try_new(&data, schema.clone(), None)?;


### PR DESCRIPTION
# Which issue does this PR close?

The issue is close to #5178, but for `MemTable`.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

1. It should be cancel-safe
2. There was an issue with join - `await` was sequential
3. There was possible to get a panic instead of Error
 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Existed tests are passing

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->