### PR TITLE
bugfix: fix eval `nullalbe()` in `simplify_exprs`

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -18,8 +18,9 @@
 //! Simplify expressions optimizer rule and implementation
 
 use super::{ExprSimplifier, SimplifyContext};
+use crate::utils::merge_schema;
 use crate::{OptimizerConfig, OptimizerRule};
-use datafusion_common::Result;
+use datafusion_common::{DFSchemaRef, Result};
 use datafusion_expr::{logical_plan::LogicalPlan, utils::from_plan};
 use datafusion_physical_expr::execution_props::ExecutionProps;
 
@@ -59,13 +60,12 @@ impl SimplifyExpressions {
         plan: &LogicalPlan,
         execution_props: &ExecutionProps,
     ) -> Result<LogicalPlan> {
-        // We need to pass down the all schemas within the plan tree to `optimize_expr` in order to
-        // to evaluate expression types. For example, a projection plan's schema will only include
-        // projected columns. With just the projected schema, it's not possible to infer types for
-        // expressions that references non-projected columns within the same project plan or its
-        // children plans.
-        let info = plan
-            .all_schemas()
+        // Pass down the `children merge schema` and `plan schema` to evaluate expression types.
+        // pass all `child schema` and `plan schema` isn't enough, because like `t1 semi join t2 on
+        // on t1.id = t2.id`, each individual schema can't contain all the columns in it.
+        let children_merge_schema = DFSchemaRef::new(merge_schema(plan.inputs()));
+        let schemas = vec![plan.schema(), &children_merge_schema];
+        let info = schemas
             .into_iter()
             .fold(SimplifyContext::new(execution_props), |context, schema| {
                 context.with_schema(schema.clone())


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5191.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Remove use `all_schemas()`  but use the plan schema + children_merge_schema().

set `pub skip_failed_rules: bool, default = false`

Before this PR, `right_anti_filter_push_down` and `right_semi_with_alias_filter` will fail.
After this PR, they will success.

# Are these changes tested?

Current test can cover it (we just need to disable skip_fail)

# Are there any user-facing changes?

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->