### PR TITLE
Add support to SQL parser for unnest function.

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -174,6 +174,8 @@ pub enum BuiltinScalarFunction {
     Struct,
     /// arrow_typeof
     ArrowTypeof,
+    /// unnest
+    Unnest,
 }
 
 impl BuiltinScalarFunction {
@@ -261,6 +263,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Struct => Volatility::Immutable,
             BuiltinScalarFunction::FromUnixtime => Volatility::Immutable,
             BuiltinScalarFunction::ArrowTypeof => Volatility::Immutable,
+            BuiltinScalarFunction::Unnest => Volatility::Immutable,
 
             // Stable builtin functions
             BuiltinScalarFunction::Now => Volatility::Stable,
@@ -312,6 +315,7 @@ impl FromStr for BuiltinScalarFunction {
 
             // array functions
             "make_array" => BuiltinScalarFunction::MakeArray,
+            "unnest" => BuiltinScalarFunction::Unnest,
 
             // string functions
             "ascii" => BuiltinScalarFunction::Ascii,

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -257,6 +257,16 @@ pub fn return_type(
 
         BuiltinScalarFunction::ArrowTypeof => Ok(DataType::Utf8),
 
+        BuiltinScalarFunction::Unnest => match &input_expr_types[0] {
+            // Unnest function called on
+            DataType::List(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::LargeList(field) => Ok(field.data_type().clone()),
+            _ => Err(DataFusionError::Internal(
+                "The unnest function only accepts list columns.".to_string(),
+            )),
+        },
+
         BuiltinScalarFunction::Abs
         | BuiltinScalarFunction::Acos
         | BuiltinScalarFunction::Asin
@@ -608,6 +618,7 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
             fun.volatility(),
         ),
         BuiltinScalarFunction::ArrowTypeof => Signature::any(1, fun.volatility()),
+        BuiltinScalarFunction::Unnest => Signature::any(1, fun.volatility()),
         // math expressions expect 1 argument of type f64 or f32
         // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
         // return the best approximation for it (in f64).

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -519,6 +519,7 @@ enum ScalarFunction {
   CurrentDate = 70;
   CurrentTime = 71;
   Uuid = 72;
+  Unnest = 73;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -16821,6 +16821,7 @@ impl serde::Serialize for ScalarFunction {
             Self::CurrentDate => "CurrentDate",
             Self::CurrentTime => "CurrentTime",
             Self::Uuid => "Uuid",
+            Self::Unnest => "Unnest",
         };
         serializer.serialize_str(variant)
     }
@@ -16905,6 +16906,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
             "CurrentDate",
             "CurrentTime",
             "Uuid",
+            "Unnest",
         ];
 
         struct GeneratedVisitor;
@@ -17020,6 +17022,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
                     "CurrentDate" => Ok(ScalarFunction::CurrentDate),
                     "CurrentTime" => Ok(ScalarFunction::CurrentTime),
                     "Uuid" => Ok(ScalarFunction::Uuid),
+                    "Unnest" => Ok(ScalarFunction::Unnest),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2100,6 +2100,7 @@ pub enum ScalarFunction {
     CurrentDate = 70,
     CurrentTime = 71,
     Uuid = 72,
+    Unnest = 73,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2181,6 +2182,7 @@ impl ScalarFunction {
             ScalarFunction::CurrentDate => "CurrentDate",
             ScalarFunction::CurrentTime => "CurrentTime",
             ScalarFunction::Uuid => "Uuid",
+            ScalarFunction::Unnest => "Unnest",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2259,6 +2261,7 @@ impl ScalarFunction {
             "CurrentDate" => Some(Self::CurrentDate),
             "CurrentTime" => Some(Self::CurrentTime),
             "Uuid" => Some(Self::Uuid),
+            "Unnest" => Some(Self::Unnest),
             _ => None,
         }
     }

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -472,6 +472,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::FromUnixtime => Self::FromUnixtime,
             ScalarFunction::Atan2 => Self::Atan2,
             ScalarFunction::ArrowTypeof => Self::ArrowTypeof,
+            ScalarFunction::Unnest => Self::Unnest,
         }
     }
 }

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1286,6 +1286,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::FromUnixtime => Self::FromUnixtime,
             BuiltinScalarFunction::Atan2 => Self::Atan2,
             BuiltinScalarFunction::ArrowTypeof => Self::ArrowTypeof,
+            BuiltinScalarFunction::Unnest => Self::Unnest,
         };
 
         Ok(scalar_function)

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -2399,6 +2399,16 @@ fn select_groupby_orderby() {
     quick_test(sql, expected);
 }
 
+#[test]
+fn unnest_column() {
+    let sql = r#"SELECT first_name, last_name, UNNEST(aliases) FROM unnested_test"#;
+    // expect projection with unnest call on aliases.
+    let expected =
+        "Projection: unnested_test.first_name, unnested_test.last_name, unnest(unnested_test.aliases)\
+        \n  TableScan: unnested_test";
+    quick_test(sql, expected);
+}
+
 fn logical_plan(sql: &str) -> Result<LogicalPlan> {
     logical_plan_with_options(sql, ParserOptions::default())
 }
@@ -2541,6 +2551,15 @@ impl ContextProvider for MockContextProvider {
                 Field::new("c11", DataType::Float32, false),
                 Field::new("c12", DataType::Float64, false),
                 Field::new("c13", DataType::Utf8, false),
+            ])),
+            "unnested_test" => Ok(Schema::new(vec![
+                Field::new("first_name", DataType::Utf8, false),
+                Field::new("last_name", DataType::Utf8, false),
+                Field::new(
+                    "aliases",
+                    DataType::List(Box::new(Field::new("item", DataType::Utf8, false))),
+                    false,
+                ),
             ])),
             _ => Err(DataFusionError::Plan(format!(
                 "No table named: {} found",


### PR DESCRIPTION
# Which issue does this PR close?

This PR introduces initial changes to add support for calling `unnest` function in SQL as requested in #212.

I am going to try to implement the functionality by creating small PRs so that is easier to review, this PR only adds support for parsing the query.  

# Rationale for this change

Following #5106 that adds `unnest_column` to `DataFrame` this PR starts to add support for the following SQL:

```sql
SELECT first_name, last_name, UNNEST(aliases) FROM unnested_test
```

that will unnest the aliases column if it is an array column.

# What changes are included in this PR?

- Add `Unnest` to the list of built in functions enums
- Add support for getting `Unnest` function return type
- Add `Unnest` function to the list of scalar functions in protobuf definition
- Add integration test for parsing query with `Unnest` call.

# Are these changes tested?

Add SQL parsing test [here](https://github.com/vincev/arrow-datafusion/blob/27ceec775ace5766d1c926d5f6cd46c18cb54705/datafusion/sql/tests/integration_test.rs#L2403)

# Are there any user-facing changes?

No facing changes as this PR add initial plumbing.