### PR TITLE
bugfix: fix error when `get_coerced_window_frame` meet `utf8`

### DIFF
--- a/datafusion/expr/src/type_coercion.rs
+++ b/datafusion/expr/src/type_coercion.rs
@@ -72,6 +72,10 @@ pub fn is_date(dt: &DataType) -> bool {
     matches!(dt, DataType::Date32 | DataType::Date64)
 }
 
+pub fn is_uft8(dt: &DataType) -> bool {
+    matches!(dt, DataType::Utf8)
+}
+
 pub mod aggregates;
 pub mod binary;
 pub mod functions;

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -34,7 +34,7 @@ use datafusion_expr::type_coercion::functions::data_types;
 use datafusion_expr::type_coercion::other::{
     get_coerce_type_for_case_when, get_coerce_type_for_list,
 };
-use datafusion_expr::type_coercion::{is_date, is_numeric, is_timestamp};
+use datafusion_expr::type_coercion::{is_date, is_numeric, is_timestamp, is_uft8};
 use datafusion_expr::utils::from_plan;
 use datafusion_expr::{
     aggregate_function, function, is_false, is_not_false, is_not_true, is_not_unknown,
@@ -478,7 +478,7 @@ fn get_coerced_window_frame(
     expressions: &[Expr],
 ) -> Result<WindowFrame> {
     fn get_coerced_type(column_type: &DataType) -> Result<DataType> {
-        if is_numeric(column_type) {
+        if is_numeric(column_type) | is_uft8(column_type) {
             Ok(column_type.clone())
         } else if is_timestamp(column_type) || is_date(column_type) {
             Ok(DataType::Interval(IntervalUnit::MonthDayNano))


### PR DESCRIPTION
# Which issue does this PR close?

Closes  #5233.
Part of #4685

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
 

# Are these changes tested?

No need, current tests can cover this problem, but it was hidden by skip_failed_rules.

set `pub skip_failed_rules: bool, default = false`

Before this PR, `sort_on_window_null_string` will fail.
After this PR, they will success.

# Are there any user-facing changes?
