### PR TITLE
refactor: correct the implementation of `all_schemas()`

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -174,7 +174,7 @@ impl LogicalPlan {
         }
     }
 
-    /// Get a vector of references to all schemas in every node of the logical plan
+    /// Get all meaningful schemas of a plan and its children plan.
     pub fn all_schemas(&self) -> Vec<&DFSchemaRef> {
         match self {
             // return self and children schemas


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5192.

# Rationale for this change

Currently, all_schema() can return schema of child of child. (due to recursively call `all_schema()`)
But, plan shouldn't get schema of child of child (or child of child of child of child ......).
It should just get info of itself and children.

For example
```sql
A join (Project (B.id = 3) -- B)
```

join shouldn't get schema of `B`.

So, I refactor this implementation, remove recursion.

# What changes are included in this PR?

Just return children schema and itself schema

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->