### PR TITLE
Minor: refactor ParquetExec roundtrip tests

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -552,9 +552,10 @@ pub(crate) mod test_util {
 
     /// Writes `batches` to a temporary parquet file
     ///
-    /// If multi_page is set to `true`, the parquet file is written
+    /// If multi_page is set to `true`, all batches are written into 
+    /// one temporary parquet file and the parquet file is written
     /// with 2 rows per data page (used to test page filtering and
-    /// boundaries)
+    /// boundaries).
     pub async fn store_parquet(
         batches: Vec<RecordBatch>,
         multi_page: bool,

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -550,6 +550,11 @@ pub(crate) mod test_util {
     use parquet::file::properties::WriterProperties;
     use tempfile::NamedTempFile;
 
+    /// Writes `batches` to a temporary parquet file
+    ///
+    /// If multi_page is set to `true`, the parquet file is written
+    /// with 2 rows per data page (used to test page filtering and
+    /// boundaries)
     pub async fn store_parquet(
         batches: Vec<RecordBatch>,
         multi_page: bool,

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -836,7 +836,8 @@ mod tests {
 
     /// round-trip record batches by writing each individual RecordBatch to
     /// a parquet file and then reading that parquet file with the specified
-    /// options
+    /// options. If page_index_predicate is set to `true`, all RecordBatches
+    /// are written into a parquet file instead.
     #[derive(Debug, Default)]
     struct RoundTrip {
         projection: Option<Vec<usize>>,


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/5104


# Rationale for this change
I am trying to write a test for https://github.com/apache/arrow-datafusion/issues/5104 and getting lost in the maze of parameters passed to `round_trip` and `round_trip_to_parquet`

It is also hard for me to evaluate which combinations of tests are covered

# What changes are included in this PR?

Move the parameters to run the roundtrip test into a structure, with better documentation

# Are these changes tested?
Yes

# Are there any user-facing changes?

no