### PR TITLE
Support page skipping / page_index pushdown for evolved schemas

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -570,7 +570,7 @@ pub(crate) mod test_util {
 
                 let builder = WriterProperties::builder();
                 let props = if multi_page {
-                    builder.set_data_page_row_count_limit(2)
+                    builder.set_data_page_row_count_limit(ROWS_PER_PAGE)
                 } else {
                     builder
                 }

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -550,50 +550,63 @@ pub(crate) mod test_util {
     use parquet::file::properties::WriterProperties;
     use tempfile::NamedTempFile;
 
+    /// How many rows per page should be written
+    const ROWS_PER_PAGE: usize = 2;
+
     /// Writes `batches` to a temporary parquet file
     ///
-    /// If multi_page is set to `true`, all batches are written into
-    /// one temporary parquet file and the parquet file is written
+    /// If multi_page is set to `true`, the parquet file(s) are written
     /// with 2 rows per data page (used to test page filtering and
     /// boundaries).
     pub async fn store_parquet(
         batches: Vec<RecordBatch>,
         multi_page: bool,
     ) -> Result<(Vec<ObjectMeta>, Vec<NamedTempFile>)> {
-        if multi_page {
-            // All batches write in to one file, each batch must have same schema.
-            let mut output = NamedTempFile::new().expect("creating temp file");
-            let mut builder = WriterProperties::builder();
-            builder = builder.set_data_page_row_count_limit(2);
-            let proper = builder.build();
-            let mut writer =
-                ArrowWriter::try_new(&mut output, batches[0].schema(), Some(proper))
-                    .expect("creating writer");
-            for b in batches {
-                writer.write(&b).expect("Writing batch");
-            }
-            writer.close().unwrap();
-            Ok((vec![local_unpartitioned_file(&output)], vec![output]))
-        } else {
-            // Each batch writes to their own file
-            let files: Vec<_> = batches
-                .into_iter()
-                .map(|batch| {
-                    let mut output = NamedTempFile::new().expect("creating temp file");
+        // Each batch writes to their own file
+        let files: Vec<_> = batches
+            .into_iter()
+            .map(|batch| {
+                let mut output = NamedTempFile::new().expect("creating temp file");
 
-                    let props = WriterProperties::builder().build();
-                    let mut writer =
-                        ArrowWriter::try_new(&mut output, batch.schema(), Some(props))
-                            .expect("creating writer");
+                let builder = WriterProperties::builder();
+                let props = if multi_page {
+                    builder.set_data_page_row_count_limit(2)
+                } else {
+                    builder
+                }
+                .build();
 
+                let mut writer =
+                    ArrowWriter::try_new(&mut output, batch.schema(), Some(props))
+                        .expect("creating writer");
+
+                if multi_page {
+                    // write in smaller batches as the parquet writer
+                    // only checks datapage size limits on the boundaries of each batch
+                    write_in_chunks(&mut writer, &batch, ROWS_PER_PAGE);
+                } else {
                     writer.write(&batch).expect("Writing batch");
-                    writer.close().unwrap();
-                    output
-                })
-                .collect();
+                };
+                writer.close().unwrap();
+                output
+            })
+            .collect();
 
-            let meta: Vec<_> = files.iter().map(local_unpartitioned_file).collect();
-            Ok((meta, files))
+        let meta: Vec<_> = files.iter().map(local_unpartitioned_file).collect();
+        Ok((meta, files))
+    }
+
+    //// write batches chunk_size rows at a time
+    fn write_in_chunks<W: std::io::Write>(
+        writer: &mut ArrowWriter<W>,
+        batch: &RecordBatch,
+        chunk_size: usize,
+    ) {
+        let mut i = 0;
+        while i < batch.num_rows() {
+            let num = chunk_size.min(batch.num_rows() - i);
+            writer.write(&batch.slice(i, num)).unwrap();
+            i += num;
         }
     }
 }

--- a/datafusion/core/src/physical_plan/file_format/parquet/page_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet/page_filter.rs
@@ -139,6 +139,10 @@ impl PagePruningPredicate {
         let page_index_predicates = &self.predicates;
         let groups = file_metadata.row_groups();
 
+        if groups.is_empty() {
+            return Ok(None);
+        }
+
         let file_offset_indexes = file_metadata.offset_indexes();
         let file_page_indexes = file_metadata.page_indexes();
         let (file_offset_indexes, file_page_indexes) =
@@ -155,30 +159,25 @@ impl PagePruningPredicate {
 
         let mut row_selections = Vec::with_capacity(page_index_predicates.len());
         for predicate in page_index_predicates {
-            // `extract_page_index_push_down_predicates` only return predicate with one col.
-            //  when building `PruningPredicate`, some single column filter like `abs(i) = 1`
-            //  will be rewrite to `lit(true)`, so may have an empty required_columns.
-            let col_id =
-                if let Some(&col_id) = predicate.need_input_columns_ids().iter().next() {
-                    col_id
-                } else {
-                    continue;
-                };
+            // find column index by looking in the row group metadata.
+            let col_idx = find_column_index(predicate, &groups[0]);
 
             let mut selectors = Vec::with_capacity(row_groups.len());
             for r in row_groups.iter() {
+                let row_group_metadata = &groups[*r];
+
                 let rg_offset_indexes = file_offset_indexes.get(*r);
                 let rg_page_indexes = file_page_indexes.get(*r);
-                if let (Some(rg_page_indexes), Some(rg_offset_indexes)) =
-                    (rg_page_indexes, rg_offset_indexes)
+                if let (Some(rg_page_indexes), Some(rg_offset_indexes), Some(col_idx)) =
+                    (rg_page_indexes, rg_offset_indexes, col_idx)
                 {
                     selectors.extend(
                         prune_pages_in_one_row_group(
-                            &groups[*r],
+                            row_group_metadata,
                             predicate,
-                            rg_offset_indexes.get(col_id),
-                            rg_page_indexes.get(col_id),
-                            groups[*r].column(col_id).column_descr(),
+                            rg_offset_indexes.get(col_idx),
+                            rg_page_indexes.get(col_idx),
+                            groups[*r].column(col_idx).column_descr(),
                             file_metrics,
                         )
                         .map_err(|e| {
@@ -190,7 +189,7 @@ impl PagePruningPredicate {
                 } else {
                     trace!(
                         "Did not have enough metadata to prune with page indexes, \
-                         falling back, falling back to all rows",
+                         falling back to all rows",
                     );
                     // fallback select all rows
                     let all_selected =
@@ -221,6 +220,64 @@ impl PagePruningPredicate {
         file_metrics.page_index_rows_filtered.add(total_skip);
         Ok(Some(final_selection))
     }
+}
+
+/// Returns the column index in the row group metadata for the single
+/// column of a single column pruning predicate.
+///
+/// For example, give the predicate `y > 5`
+///
+/// And columns in the RowGroupMetadata like `['x', 'y', 'z']` will
+/// return 1.
+///
+/// Returns `None` if the column is not found, or if there are no
+/// required columns, which is the case for predicate like `abs(i) =
+/// 1` which are rewritten to `lit(true)`
+///
+/// Panics:
+///
+/// If the predicate contains more than one column reference (assumes
+/// that `extract_page_index_push_down_predicates` only return
+/// predicate with one col)
+///
+fn find_column_index(
+    predicate: &PruningPredicate,
+    row_group_metadata: &RowGroupMetaData,
+) -> Option<usize> {
+    let mut found_required_column: Option<&Column> = None;
+
+    for required_column_details in predicate.required_columns().iter() {
+        let column = &required_column_details.0;
+        if let Some(found_required_column) = found_required_column.as_ref() {
+            // make sure it is the same name we have seen previously
+            assert_eq!(
+                column.name, found_required_column.name,
+                "Unexpected multi column predicate"
+            );
+        } else {
+            found_required_column = Some(column);
+        }
+    }
+
+    let column = if let Some(found_required_column) = found_required_column.as_ref() {
+        found_required_column
+    } else {
+        trace!("No column references in pruning predicate");
+        return None;
+    };
+
+    let col_idx = row_group_metadata
+        .columns()
+        .iter()
+        .enumerate()
+        .find(|(_idx, c)| c.column_descr().name() == column.name)
+        .map(|(idx, _c)| idx);
+
+    if col_idx.is_none() {
+        trace!("Can not find column {} in row group meta", column.name);
+    }
+
+    col_idx
 }
 
 /// Intersects the [`RowSelector`]s


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/5104

# Rationale for this change

See https://github.com/apache/arrow-datafusion/issues/5104

I want to turn on page index pushdown for all queries. I can't do that if it causes errors for queries across parquet files where the schema is not the same

# What changes are included in this PR?

Fix a bug (I will describe inline)

# Are these changes tested?

Yes

IN PROGRESS -- testing against https://github.com/apache/arrow-datafusion/pull/5099

# Are there any user-facing changes?
Less bugs