### PR TITLE
minor: derive Ord/PartialOrd/Eq/PartialEq traits for `ObjectStoreUrl`

### DIFF
--- a/datafusion/core/src/datasource/object_store.rs
+++ b/datafusion/core/src/datasource/object_store.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use url::Url;
 
 /// A parsed URL identifying a particular [`ObjectStore`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectStoreUrl {
     url: Url,
 }


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Improves integration of `ObjectStoreUrl` w/ other code bases.

# What changes are included in this PR?
Derive the following traits for `ObjectStoreUrl`:

- `Ord`/`PartialOrd`
- `Eq`/`PartialEq`
- `Hash`

# Are these changes tested?
Auto-derive, no testing needed.

# Are there any user-facing changes?
`ObjectStoreUrl` is better usable.