### PR TITLE
Make SQL query consistent with API syntax expression in code examples

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -78,7 +78,7 @@
 //! ctx.register_csv("example", "tests/data/example.csv", CsvReadOptions::new()).await?;
 //!
 //! // create a plan
-//! let df = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100").await?;
+//! let df = ctx.sql("SELECT a, MIN(b) FROM example WHERE a <= b GROUP BY a LIMIT 100").await?;
 //!
 //! // execute the plan
 //! let results: Vec<RecordBatch> = df.collect().await?;

--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -42,7 +42,7 @@ async fn main() -> datafusion::error::Result<()> {
   ctx.register_csv("example", "tests/data/example.csv", CsvReadOptions::new()).await?;
 
   // create a plan to run a SQL query
-  let df = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100").await?;
+  let df = ctx.sql("SELECT a, MIN(b) FROM example WHERE a <= b GROUP BY a LIMIT 100").await?;
 
   // execute and print results
   df.show().await?;
@@ -99,7 +99,7 @@ async fn main() -> datafusion::error::Result<()> {
   ctx.register_csv("example", "tests/data/capitalized_example.csv", CsvReadOptions::new()).await?;
 
   // create a plan to run a SQL query
-  let df = ctx.sql("SELECT \"A\", MIN(b) FROM example GROUP BY \"A\" LIMIT 100").await?;
+  let df = ctx.sql("SELECT \"A\", MIN(b) FROM example WHERE \"A\" <= c GROUP BY \"A\" LIMIT 100").await?;
 
   // execute and print results
   df.show().await?;


### PR DESCRIPTION
# Which issue does this PR close?

This is a minor document fix, does not introduce new features or fix bugs.

# Rationale for this change

Examples are provides for both SQL query and DataFrame API respectively, and they should be semantically consistent.
The DataFrame API example on this page calls `filter` methods on `df`, but the DataFrame API one does not contains relevant part of `WHERE` expression, this could be confusing for newcomers.

# What changes are included in this PR?

This PR adds `WHERE` express to SQL query examples to match API syntax expression.

# Are these changes tested?

Code blocks should covered by doctest.

# Are there any user-facing changes?

No.