### PR TITLE
feat: add accessor to SessionContext fields for ContextProvider impl

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1839,6 +1839,16 @@ impl SessionState {
     pub fn catalog_list(&self) -> Arc<dyn CatalogList> {
         self.catalog_list.clone()
     }
+
+    /// Return reference to scalar_functions
+    pub fn scalar_functions(&self) -> &HashMap<String, Arc<ScalarUDF>> {
+        &self.scalar_functions
+    }
+
+    /// Return reference to aggregate_functions
+    pub fn aggregate_functions(&self) -> &HashMap<String, Arc<AggregateUDF>> {
+        &self.aggregate_functions
+    }
 }
 
 struct SessionContextProvider<'a> {
@@ -1856,11 +1866,11 @@ impl<'a> ContextProvider for SessionContextProvider<'a> {
     }
 
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
-        self.state.scalar_functions.get(name).cloned()
+        self.state.scalar_functions().get(name).cloned()
     }
 
     fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
-        self.state.aggregate_functions.get(name).cloned()
+        self.state.aggregate_functions().get(name).cloned()
     }
 
     fn get_variable_type(&self, variable_names: &[String]) -> Option<DataType> {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5317 

# Rationale for this change

As described in #5317 , accessors are need in new `SessionContext` api.

# What changes are included in this PR?



# Are these changes tested?

Changes are dead simple 

# Are there any user-facing changes?

N/A