### PR TITLE
MINOR: nicer error messages for cli, use display format rather than debug

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -50,7 +50,7 @@ pub async fn exec_from_lines(
                 if line.ends_with(';') {
                     match exec_and_print(ctx, print_options, query).await {
                         Ok(_) => {}
-                        Err(err) => println!("{:?}", err),
+                        Err(err) => println!("{err}"),
                     }
                     query = "".to_owned();
                 } else {
@@ -67,7 +67,7 @@ pub async fn exec_from_lines(
     if !query.is_empty() {
         match exec_and_print(ctx, print_options, query).await {
             Ok(_) => {}
-            Err(err) => println!("{:?}", err),
+            Err(err) => println!("{err}"),
         }
     }
 }
@@ -138,7 +138,7 @@ pub async fn exec_from_repl(
                 rl.add_history_entry(line.trim_end());
                 match exec_and_print(ctx, &print_options, line).await {
                     Ok(_) => {}
-                    Err(err) => eprintln!("{:?}", err),
+                    Err(err) => eprintln!("{err}"),
                 }
             }
             Err(ReadlineError::Interrupted) => {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
Better user experience

# What changes are included in this PR?

Instead of:
```
❯ select not_a_column;
SchemaError(FieldNotFound { field: Column { relation: None, name: "not_a_column" }, valid_fields: [] })
```

it's
```
❯ select not_a_column;
Schema error: No field named 'not_a_column'.
```

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
datafusion-cli uses the nicely formatted error messages already available rather than debug format for errors

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->