### PR TITLE
Add index interface method

### DIFF
--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion_common::Statistics;
+use datafusion_common::{Column, Statistics};
 use datafusion_expr::{CreateExternalTable, LogicalPlan};
 pub use datafusion_expr::{TableProviderFilterPushDown, TableType};
 
@@ -29,6 +29,7 @@ use crate::arrow::datatypes::SchemaRef;
 use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::logical_expr::Expr;
+use crate::physical_plan::sorts::sort::SortOptions;
 use crate::physical_plan::ExecutionPlan;
 
 /// Source table
@@ -77,6 +78,11 @@ pub trait TableProvider: Sync + Send {
         _filter: &Expr,
     ) -> Result<TableProviderFilterPushDown> {
         Ok(TableProviderFilterPushDown::Unsupported)
+    }
+
+    /// Returns a vector of indexes, each of which is represented by a vector of sorted columns
+    fn ordered_indexes(&self) -> Result<Vec<Vec<(Column, SortOptions)>>> {
+        Ok(vec![])
     }
 
     /// Get statistics for this table, if available


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5357.

# Rationale for this change

If the planner/optimizer has information about how a table is / can be sorted, then it opens up the ability to push more predicates down to the TableProvider.

For example, TPC-H query 9 might perform far better, since the table could be naturally ordered on the primary key `(PS_PARTKEY, PS_SUPPKEY)`:

```
SELECT
     nation,
     o_year,
     SUM(amount) AS sum_profit
FROM
     (
		SELECT
			n_name AS nation,
			YEAR(o_orderdate) AS o_year,
			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
		FROM
			part,
			supplier,
			lineitem,
			partsupp,
			orders,
			nation
		WHERE
			s_suppkey = l_suppkey
			AND ps_suppkey = l_suppkey
			AND ps_partkey = l_partkey
```

after the subquery is de-correlated, it will be trying to join on the primary key, so it will likely:

```
EquiJoin( ps_suppkey = l_suppkey and ps_partkey = l_partkey)
   Sort(PS_PARTKEY, PS_SUPPKEY) 
      TableScan [filter=s_suppkey]
```

When the filter could actually filter far more rows using both columns, and the sort could be avoided entirely.

# What changes are included in this PR?

An interface change to allow `TableProviders` to inform the planner about single or multi-column, primary or secondary indexes, so that a future (fast-follow) PR can push predicates down to filter & sort in the `TableProvider` automatically.

# Are these changes tested?

No, it's an interface change.. though maybe I could test that?

# Are there any user-facing changes?

No, existing `TableProvider`s should be fine.