### PR TITLE
bugfix: move `inline_table_scan` after `subquery-unnest`.

### DIFF
--- a/datafusion/optimizer/src/inline_table_scan.rs
+++ b/datafusion/optimizer/src/inline_table_scan.rs
@@ -54,8 +54,9 @@ impl OptimizerRule for InlineTableScan {
                 if let Some(sub_plan) = source.get_logical_plan() {
                     let plan = LogicalPlanBuilder::from(sub_plan.clone())
                         .project(vec![Expr::Wildcard])?
-                        .alias(table_name)?;
-                    Ok(Some(plan.build()?))
+                        .alias(table_name)?
+                        .build()?;
+                    Ok(Some(plan))
                 } else {
                     Ok(None)
                 }

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -203,13 +203,13 @@ impl Optimizer {
     /// Create a new optimizer using the recommended list of rules
     pub fn new() -> Self {
         let rules: Vec<Arc<dyn OptimizerRule + Sync + Send>> = vec![
-            Arc::new(InlineTableScan::new()),
             Arc::new(TypeCoercion::new()),
             Arc::new(SimplifyExpressions::new()),
             Arc::new(UnwrapCastInComparison::new()),
             Arc::new(DecorrelateWhereExists::new()),
             Arc::new(DecorrelateWhereIn::new()),
             Arc::new(ScalarSubqueryToJoin::new()),
+            Arc::new(InlineTableScan::new()),
             Arc::new(ExtractEquijoinPredicate::new()),
             // simplify expressions does not simplify expressions in subqueries, so we
             // run it again after running the optimizations that potentially converted


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5364.

# Rationale for this change

# What changes are included in this PR?

move inline_table_scan after subquery-unnest. 

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->