### PR TITLE
minor: disable tpcds-q41 due to not support decorrelate disjunction subquery

### DIFF
--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -235,6 +235,9 @@ async fn tpcds_logical_q40() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore]
+// Optimizer rule 'scalar_subquery_to_join' failed: Optimizing disjunctions not supported!
+// issue: https://github.com/apache/arrow-datafusion/issues/5368
 async fn tpcds_logical_q41() -> Result<()> {
     create_logical_plan(41).await
 }


### PR DESCRIPTION
# Which issue does this PR close?

related #5368 .

# Rationale for this change

# What changes are included in this PR?

disable tpcds-q41

# Are these changes tested?

N/A

# Are there any user-facing changes?

N/A