### PR TITLE
UDF zero params #5378

### DIFF
--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -121,6 +121,64 @@ async fn scalar_udf() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn scalar_udf_zero_params() -> Result<()> {
+    let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        vec![Arc::new(Int32Array::from_slice([1, 10, 10, 100]))],
+    )?;
+    let ctx = SessionContext::new();
+
+    ctx.register_batch("t", batch)?;
+    // create function just returns 100 regardless of inp
+    let myfunc = |args: &[ArrayRef]| {
+        let num_rows = args[0].len();
+        Ok(Arc::new((0..num_rows).map(|_| 100).collect::<Int32Array>()) as ArrayRef)
+    };
+    let myfunc = make_scalar_function(myfunc);
+
+    ctx.register_udf(create_udf(
+        "get_100",
+        vec![],
+        Arc::new(DataType::Int32),
+        Volatility::Immutable,
+        myfunc,
+    ));
+
+    let result = plan_and_collect(&ctx, "select get_100() a from t").await?;
+    let expected = vec![
+        "+-----+", //
+        "| a   |", //
+        "+-----+", //
+        "| 100 |", //
+        "| 100 |", //
+        "| 100 |", //
+        "| 100 |", //
+        "+-----+", //
+    ];
+    assert_batches_eq!(expected, &result);
+
+    let result = plan_and_collect(&ctx, "select get_100() a").await?;
+    let expected = vec![
+        "+-----+", //
+        "| a   |", //
+        "+-----+", //
+        "| 100 |", //
+        "+-----+", //
+    ];
+    assert_batches_eq!(expected, &result);
+
+    let result = plan_and_collect(&ctx, "select get_100() from t where a=999").await?;
+    let expected = vec![
+        "++", //
+        "++",
+    ];
+    assert_batches_eq!(expected, &result);
+    Ok(())
+}
+
 /// tests the creation, registration and usage of a UDAF
 #[tokio::test]
 async fn simple_udaf() -> Result<()> {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -393,7 +393,10 @@ pub fn create_physical_expr(
                     execution_props,
                 )?);
             }
-
+            // udfs with zero params expect null array as input
+            if args.len() == 0 {
+                physical_args.push(Arc::new(Literal::new(ScalarValue::Null)));
+            }
             udf::create_physical_expr(fun.clone().as_ref(), &physical_args, input_schema)
         }
         Expr::Between(Between {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -394,7 +394,7 @@ pub fn create_physical_expr(
                 )?);
             }
             // udfs with zero params expect null array as input
-            if args.len() == 0 {
+            if args.is_empty() {
                 physical_args.push(Arc::new(Literal::new(ScalarValue::Null)));
             }
             udf::create_physical_expr(fun.clone().as_ref(), &physical_args, input_schema)


### PR DESCRIPTION
# Which issue does this PR close?
Closes #5378.

# Rationale for this change

UDFs with zero arguments were not working before.

# What changes are included in this PR?

- Change UDF planning to receive null as input if it takes no args
    - This is following the existing docs specification: 
    - > ...with the exception of zero param function, where a singular element vec
will be passed. In that case the single element is a null array to indicate
the batch's row count (so that the generative zero-argument function can know
the result array size).


- Add test for zero param UDF to sql integration test suite

# Are these changes tested?
Yes.

# Are there any user-facing changes?
Fixing user-facing bug.