### PR TITLE
fix: misc phys. expression display bugs

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -238,35 +238,6 @@ impl BinaryExpr {
     pub fn new(left: Box<Expr>, op: Operator, right: Box<Expr>) -> Self {
         Self { left, op, right }
     }
-
-    /// Get the operator precedence
-    /// use <https://www.postgresql.org/docs/7.0/operators.htm#AEN2026> as a reference
-    pub fn precedence(&self) -> u8 {
-        match self.op {
-            Operator::Or => 5,
-            Operator::And => 10,
-            Operator::NotEq
-            | Operator::Eq
-            | Operator::Lt
-            | Operator::LtEq
-            | Operator::Gt
-            | Operator::GtEq => 20,
-            Operator::Plus | Operator::Minus => 30,
-            Operator::Multiply | Operator::Divide | Operator::Modulo => 40,
-            Operator::IsDistinctFrom
-            | Operator::IsNotDistinctFrom
-            | Operator::RegexMatch
-            | Operator::RegexNotMatch
-            | Operator::RegexIMatch
-            | Operator::RegexNotIMatch
-            | Operator::BitwiseAnd
-            | Operator::BitwiseOr
-            | Operator::BitwiseShiftLeft
-            | Operator::BitwiseShiftRight
-            | Operator::BitwiseXor
-            | Operator::StringConcat => 0,
-        }
-    }
 }
 
 impl Display for BinaryExpr {
@@ -283,7 +254,7 @@ impl Display for BinaryExpr {
         ) -> fmt::Result {
             match expr {
                 Expr::BinaryExpr(child) => {
-                    let p = child.precedence();
+                    let p = child.op.precedence();
                     if p == 0 || p < precedence {
                         write!(f, "({child})")?;
                     } else {
@@ -295,7 +266,7 @@ impl Display for BinaryExpr {
             Ok(())
         }
 
-        let precedence = self.precedence();
+        let precedence = self.op.precedence();
         write_child(f, self.left.as_ref(), precedence)?;
         write!(f, " {} ", self.op)?;
         write_child(f, self.right.as_ref(), precedence)

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -142,6 +142,35 @@ impl Operator {
             | Operator::StringConcat => None,
         }
     }
+
+    /// Get the operator precedence
+    /// use <https://www.postgresql.org/docs/7.0/operators.htm#AEN2026> as a reference
+    pub fn precedence(&self) -> u8 {
+        match self {
+            Operator::Or => 5,
+            Operator::And => 10,
+            Operator::NotEq
+            | Operator::Eq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq => 20,
+            Operator::Plus | Operator::Minus => 30,
+            Operator::Multiply | Operator::Divide | Operator::Modulo => 40,
+            Operator::IsDistinctFrom
+            | Operator::IsNotDistinctFrom
+            | Operator::RegexMatch
+            | Operator::RegexNotMatch
+            | Operator::RegexIMatch
+            | Operator::RegexNotIMatch
+            | Operator::BitwiseAnd
+            | Operator::BitwiseOr
+            | Operator::BitwiseShiftLeft
+            | Operator::BitwiseShiftRight
+            | Operator::BitwiseXor
+            | Operator::StringConcat => 0,
+        }
+    }
 }
 
 impl fmt::Display for Operator {

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -58,7 +58,7 @@ impl TryCastExpr {
 
 impl fmt::Display for TryCastExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "CAST({} AS {:?})", self.expr, self.cast_type)
+        write!(f, "TRY_CAST({} AS {:?})", self.expr, self.cast_type)
     }
 }
 
@@ -132,7 +132,7 @@ pub fn try_cast(
         Ok(Arc::new(TryCastExpr::new(expr, cast_type)))
     } else {
         Err(DataFusionError::NotImplemented(format!(
-            "Unsupported CAST from {expr_type:?} to {cast_type:?}"
+            "Unsupported TRY_CAST from {expr_type:?} to {cast_type:?}"
         )))
     }
 }
@@ -155,7 +155,7 @@ mod tests {
 
     // runs an end-to-end test of physical type cast
     // 1. construct a record batch with a column "a" of type A
-    // 2. construct a physical expression of CAST(a AS B)
+    // 2. construct a physical expression of TRY_CAST(a AS B)
     // 3. evaluate the expression
     // 4. verify that the resulting expression is of type B
     // 5. verify that the resulting values are downcastable and correct
@@ -171,7 +171,7 @@ mod tests {
 
             // verify that its display is correct
             assert_eq!(
-                format!("CAST(a@0 AS {:?})", $TYPE),
+                format!("TRY_CAST(a@0 AS {:?})", $TYPE),
                 format!("{}", expression)
             );
 
@@ -202,7 +202,7 @@ mod tests {
 
     // runs an end-to-end test of physical type cast
     // 1. construct a record batch with a column "a" of type A
-    // 2. construct a physical expression of CAST(a AS B)
+    // 2. construct a physical expression of TRY_CAST(a AS B)
     // 3. evaluate the expression
     // 4. verify that the resulting expression is of type B
     // 5. verify that the resulting values are downcastable and correct
@@ -218,7 +218,7 @@ mod tests {
 
             // verify that its display is correct
             assert_eq!(
-                format!("CAST(a@0 AS {:?})", $TYPE),
+                format!("TRY_CAST(a@0 AS {:?})", $TYPE),
                 format!("{}", expression)
             );
 
@@ -542,7 +542,7 @@ mod tests {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
         let result = try_cast(col("a", &schema).unwrap(), &schema, DataType::LargeBinary);
-        result.expect_err("expected Invalid CAST");
+        result.expect_err("expected Invalid TRY_CAST");
     }
 
     // create decimal array with the specified precision and scale


### PR DESCRIPTION
# Which issue does this PR close?
Found while working on #4695.

# Rationale for this change
Broken display code makes debugging and testing hard.

# What changes are included in this PR?
- `TryCast` should display as `TRY_CAST`, not as `CAST`
- `BinaryExpr` should use parenthesis

# Are these changes tested?
- fix the two display bugs mentioned above
- move `precedence` from logical binary expression to `Operator`, so I can reuse this in the phys. expr. display code

# Are there any user-facing changes?
Slight changes in debug outputs.

**Breaking:** `BinaryExpr::precedence` is gone