### PR TITLE
Minor: intersect expressions optimization

### DIFF
--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -247,10 +247,12 @@ fn intersect(
     vec1: &[(Expr, Expr)],
     vec2: &[(Expr, Expr)],
 ) {
-    for x1 in vec1.iter() {
-        for x2 in vec2.iter() {
-            if x1.0 == x2.0 && x1.1 == x2.1 || x1.1 == x2.0 && x1.0 == x2.1 {
-                accum.push((x1.0.clone(), x1.1.clone()));
+    if !(vec1.is_empty() || vec2.is_empty()) {
+        for x1 in vec1.iter() {
+            for x2 in vec2.iter() {
+                if x1.0 == x2.0 && x1.1 == x2.1 || x1.1 == x2.0 && x1.0 == x2.1 {
+                    accum.push((x1.0.clone(), x1.1.clone()));
+                }
             }
         }
     }


### PR DESCRIPTION
Optimization of the function "intersect".

During the execution of the function "extract_possible_join_keys", if the operator of an expression equals OR, then the algorithm goes recursively in depth of the tree and joins keys in the array "accum". As bottom nodes are majority and they may not have right and left descendants, then the join does not happen. However, "intersect" in any cases iterates over all left join keys, which is costly.

This minor patch fixed the problem.

# Are these changes tested?
No new tests added

# Are there any user-facing changes?
No