### PR TITLE
Move file format config.rs to live with the rest of the datasource code

### DIFF
--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -24,6 +24,7 @@ pub mod avro;
 pub mod csv;
 pub mod file_type;
 pub mod json;
+pub mod options;
 pub mod parquet;
 
 use std::any::Any;

--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -23,7 +23,6 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion_common::DataFusionError;
 
-use super::context::{SessionConfig, SessionState};
 use crate::datasource::file_format::avro::DEFAULT_AVRO_EXTENSION;
 use crate::datasource::file_format::csv::DEFAULT_CSV_EXTENSION;
 use crate::datasource::file_format::file_type::FileCompressionType;
@@ -38,6 +37,7 @@ use crate::datasource::{
     listing::ListingOptions,
 };
 use crate::error::Result;
+use crate::execution::context::{SessionConfig, SessionState};
 
 /// Options that control the reading of CSV files.
 ///

--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -43,7 +43,8 @@
 pub mod context;
 pub mod disk_manager;
 pub mod memory_pool;
-pub mod options;
+// backwards compatibility
+pub use crate::datasource::file_format::options;
 pub mod registry;
 pub mod runtime_env;
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/5405 (splitting out execution)



# Rationale for this change

I am trying to split out the physical plan into its own crate. While extracting the execution code, I found that config.rs which contains file format configuration


# What changes are included in this PR?

Move config.rs which contains file format configuration to live with the rest of the datasource code

# Are these changes tested?
Existing coverage

# Are there any user-facing changes?
None intended (I left a backwards compatible `pub use` )