### PR TITLE
Also push down all filters in TableProvider

### DIFF
--- a/datafusion/core/src/datasource/datasource.rs
+++ b/datafusion/core/src/datasource/datasource.rs
@@ -72,11 +72,25 @@ pub trait TableProvider: Sync + Send {
 
     /// Tests whether the table provider can make use of a filter expression
     /// to optimise data retrieval.
+    #[deprecated(since = "20.0.0", note = "use supports_filters_pushdown instead")]
     fn supports_filter_pushdown(
         &self,
         _filter: &Expr,
     ) -> Result<TableProviderFilterPushDown> {
         Ok(TableProviderFilterPushDown::Unsupported)
+    }
+
+    /// Tests whether the table provider can make use of any or all filter expressions
+    /// to optimise data retrieval.
+    #[allow(deprecated)]
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        filters
+            .iter()
+            .map(|f| self.supports_filter_pushdown(f))
+            .collect()
     }
 
     /// Get statistics for this table, if available

--- a/datafusion/core/src/datasource/default_table_source.rs
+++ b/datafusion/core/src/datasource/default_table_source.rs
@@ -52,13 +52,13 @@ impl TableSource for DefaultTableSource {
         self.table_provider.schema()
     }
 
-    /// Tests whether the table provider can make use of a filter expression
+    /// Tests whether the table provider can make use of any or all filter expressions
     /// to optimise data retrieval.
-    fn supports_filter_pushdown(
+    fn supports_filters_pushdown(
         &self,
-        filter: &Expr,
-    ) -> datafusion_common::Result<TableProviderFilterPushDown> {
-        self.table_provider.supports_filter_pushdown(filter)
+        filter: &[&Expr],
+    ) -> datafusion_common::Result<Vec<TableProviderFilterPushDown>> {
+        self.table_provider.supports_filters_pushdown(filter)
     }
 
     fn get_logical_plan(&self) -> Option<&datafusion_expr::LogicalPlan> {

--- a/datafusion/optimizer/src/type_coercion.rs
+++ b/datafusion/optimizer/src/type_coercion.rs
@@ -472,8 +472,7 @@ fn coerce_scalar_range_aware(
             coerce_scalar(largest_type, value).map_or_else(
                 |_| {
                     Err(DataFusionError::Execution(format!(
-                        "Cannot cast {:?} to {:?}",
-                        value, target_type
+                        "Cannot cast {value:?} to {target_type:?}"
                     )))
                 },
                 |_| ScalarValue::try_from(target_type),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5418.

# Rationale for this change

Described in issue.

# What changes are included in this PR?

Update to TableProvider

# Are these changes tested?

Yes, existing tests should cover this case.

# Are there any user-facing changes?

They will have to update their TableProviders once we do away with the Deprecation and switch for real.