### PR TITLE
add a unit test that cover cast bug.

### DIFF
--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -668,7 +668,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: fix this test.
+    #[ignore] // TODO: https://github.com/apache/arrow-datafusion/issues/5396
     fn test_cast_decimal() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int64, false)]);
         let a = Int64Array::from(vec![100]);

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -666,4 +666,20 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    #[ignore] // TODO: fix this test.
+    fn test_cast_decimal() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, false)]);
+        let a = Int64Array::from(vec![100]);
+        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+        let expression = cast_with_options(
+            col("a", &schema)?,
+            &schema,
+            DataType::Decimal128(38, 38),
+            DEFAULT_DATAFUSION_CAST_OPTIONS,
+        )?;
+        expression.evaluate(&batch)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

related #5396 

# Rationale for this change

This test is minimum reproduce case of a bug in tpcds-q58.

"CAST(Int64(100) AS Decimal128(38, 38))"

It will fail in 

```rust
let col_val = phys_expr.evaluate(&self.input_batch)?;
```

and throw "ArrowError(ComputeError("Overflow happened on: 100 * 100000000000000000000000000000000000000"))"

# What changes are included in this PR?

Add a unit test reproduce a bug.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->