### PR TITLE
Enable hash joins on FixedSizeBinary columns

### DIFF
--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -23,10 +23,10 @@ use ahash::RandomState;
 use arrow::{
     array::{
         ArrayData, ArrayRef, BooleanArray, Date32Array, Date64Array, Decimal128Array,
-        DictionaryArray, LargeStringArray, PrimitiveArray, Time32MillisecondArray,
-        Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
-        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampSecondArray,
-        UInt32BufferBuilder, UInt64BufferBuilder,
+        DictionaryArray, FixedSizeBinaryArray, LargeStringArray, PrimitiveArray,
+        Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+        Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampSecondArray, UInt32BufferBuilder, UInt64BufferBuilder,
     },
     datatypes::{
         Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type,
@@ -1025,6 +1025,9 @@ fn equal_rows(
             }
             DataType::LargeUtf8 => {
                 equal_rows_elem!(LargeStringArray, l, r, left, right, null_equals_null)
+            }
+            DataType::FixedSizeBinary(_) => {
+                equal_rows_elem!(FixedSizeBinaryArray, l, r, left, right, null_equals_null)
             }
             DataType::Decimal128(_, lscale) => match r.data_type() {
                 DataType::Decimal128(_, rscale) => {

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -960,6 +960,7 @@ pub fn can_hash(data_type: &DataType) -> bool {
         DataType::Decimal128(_, _) => true,
         DataType::Date32 => true,
         DataType::Date64 => true,
+        DataType::FixedSizeBinary(_) => true,
         DataType::Dictionary(key_type, value_type)
             if *value_type.as_ref() == DataType::Utf8 =>
         {


### PR DESCRIPTION
This helps ameliorate the performance issues in #5456 though the correctness issues identified in that issue still exist.

Before:
```
358946 rows in set. Query took 356.370 seconds.
```

After:
```
358946 rows in set. Query took 2.073 seconds.
```