### PR TITLE
Minor: Move TableProviderFactories up out of `RuntimeEnv` and into `SessionState`

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -18,7 +18,11 @@
 //! SessionContext contains methods for registering data sources and executing queries
 use crate::{
     catalog::catalog::{CatalogList, MemoryCatalogList},
-    datasource::listing::{ListingOptions, ListingTable},
+    datasource::{
+        datasource::TableProviderFactory,
+        listing::{ListingOptions, ListingTable},
+        listing_table_factory::ListingTableFactory,
+    },
     datasource::{MemTable, ViewTable},
     logical_expr::{PlanType, ToStringifiedPlan},
     optimizer::optimizer::Optimizer,
@@ -276,6 +280,15 @@ impl SessionContext {
     /// Return the `session_id` of this Session
     pub fn session_id(&self) -> String {
         self.session_id.clone()
+    }
+
+    /// Return the [`TableFactoryProvider`] that is registered for the
+    /// specified file type, if any.
+    pub fn table_factory(
+        &self,
+        file_type: &str,
+    ) -> Option<Arc<dyn TableProviderFactory>> {
+        self.state.read().table_factories().get(file_type).cloned()
     }
 
     /// Return the `enable_ident_normalization` of this Session
@@ -579,16 +592,16 @@ impl SessionContext {
     ) -> Result<Arc<dyn TableProvider>> {
         let state = self.state.read().clone();
         let file_type = cmd.file_type.to_uppercase();
-        let factory = &state
-            .runtime_env
-            .table_factories
-            .get(file_type.as_str())
-            .ok_or_else(|| {
-                DataFusionError::Execution(format!(
-                    "Unable to find factory for {}",
-                    cmd.file_type
-                ))
-            })?;
+        let factory =
+            &state
+                .table_factories
+                .get(file_type.as_str())
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "Unable to find factory for {}",
+                        cmd.file_type
+                    ))
+                })?;
         let table = (*factory).create(&state, cmd).await?;
         Ok(table)
     }
@@ -1510,6 +1523,14 @@ pub struct SessionState {
     config: SessionConfig,
     /// Execution properties
     execution_props: ExecutionProps,
+    /// TableProviderFactories for different file formats.
+    ///
+    /// Maps strings like "JSON" to an instance of  [`TableProviderFactory`]
+    ///
+    /// This is used to create [`TableProvider`] instances for the
+    /// `CREATE EXTERNAL TABLE ... STORED AS <FORMAT>` for custom file
+    /// formats other than those built into DataFusion
+    table_factories: HashMap<String, Arc<dyn TableProviderFactory>>,
     /// Runtime environment
     runtime_env: Arc<RuntimeEnv>,
 }
@@ -1543,6 +1564,15 @@ impl SessionState {
     ) -> Self {
         let session_id = Uuid::new_v4().to_string();
 
+        // Create table_factories for all default formats
+        let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> =
+            HashMap::new();
+        table_factories.insert("PARQUET".into(), Arc::new(ListingTableFactory::new()));
+        table_factories.insert("CSV".into(), Arc::new(ListingTableFactory::new()));
+        table_factories.insert("JSON".into(), Arc::new(ListingTableFactory::new()));
+        table_factories.insert("NDJSON".into(), Arc::new(ListingTableFactory::new()));
+        table_factories.insert("AVRO".into(), Arc::new(ListingTableFactory::new()));
+
         if config.create_default_catalog_and_schema() {
             let default_catalog = MemoryCatalogProvider::new();
 
@@ -1553,7 +1583,12 @@ impl SessionState {
                 )
                 .expect("memory catalog provider can register schema");
 
-            Self::register_default_schema(&config, &runtime, &default_catalog);
+            Self::register_default_schema(
+                &config,
+                &table_factories,
+                &runtime,
+                &default_catalog,
+            );
 
             catalog_list.register_catalog(
                 config.config_options().catalog.default_catalog.clone(),
@@ -1622,11 +1657,13 @@ impl SessionState {
             config,
             execution_props: ExecutionProps::new(),
             runtime_env: runtime,
+            table_factories,
         }
     }
 
     fn register_default_schema(
         config: &SessionConfig,
+        table_factories: &HashMap<String, Arc<dyn TableProviderFactory>>,
         runtime: &Arc<RuntimeEnv>,
         default_catalog: &MemoryCatalogProvider,
     ) {
@@ -1653,7 +1690,7 @@ impl SessionState {
             Ok(store) => store,
             _ => return,
         };
-        let factory = match runtime.table_factories.get(format.as_str()) {
+        let factory = match table_factories.get(format.as_str()) {
             Some(factory) => factory,
             _ => return,
         };
@@ -1757,6 +1794,18 @@ impl SessionState {
     ) -> Self {
         self.physical_optimizers.push(optimizer_rule);
         self
+    }
+
+    /// Get the table factories
+    pub fn table_factories(&self) -> &HashMap<String, Arc<dyn TableProviderFactory>> {
+        &self.table_factories
+    }
+
+    /// Get the table factories
+    pub fn table_factories_mut(
+        &mut self,
+    ) -> &mut HashMap<String, Arc<dyn TableProviderFactory>> {
+        &mut self.table_factories
     }
 
     /// Convert a SQL string into an AST Statement

--- a/datafusion/core/src/execution/runtime_env.rs
+++ b/datafusion/core/src/execution/runtime_env.rs
@@ -22,10 +22,7 @@ use crate::{
     error::Result,
     execution::disk_manager::{DiskManager, DiskManagerConfig},
 };
-use std::collections::HashMap;
 
-use crate::datasource::datasource::TableProviderFactory;
-use crate::datasource::listing_table_factory::ListingTableFactory;
 use crate::datasource::object_store::ObjectStoreRegistry;
 use crate::execution::memory_pool::{GreedyMemoryPool, MemoryPool, UnboundedMemoryPool};
 use datafusion_common::DataFusionError;
@@ -44,8 +41,6 @@ pub struct RuntimeEnv {
     pub disk_manager: Arc<DiskManager>,
     /// Object Store Registry
     pub object_store_registry: Arc<ObjectStoreRegistry>,
-    /// TableProviderFactories
-    pub table_factories: HashMap<String, Arc<dyn TableProviderFactory>>,
 }
 
 impl Debug for RuntimeEnv {
@@ -61,7 +56,6 @@ impl RuntimeEnv {
             memory_pool,
             disk_manager,
             object_store_registry,
-            table_factories,
         } = config;
 
         let memory_pool =
@@ -71,7 +65,6 @@ impl RuntimeEnv {
             memory_pool,
             disk_manager: DiskManager::try_new(disk_manager)?,
             object_store_registry,
-            table_factories,
         })
     }
 
@@ -92,14 +85,6 @@ impl RuntimeEnv {
     ) -> Option<Arc<dyn ObjectStore>> {
         self.object_store_registry
             .register_store(scheme, host, object_store)
-    }
-
-    /// Registers TableFactories
-    pub fn register_table_factories(
-        &mut self,
-        table_factories: HashMap<String, Arc<dyn TableProviderFactory>>,
-    ) {
-        self.table_factories.extend(table_factories)
     }
 
     /// Retrieves a `ObjectStore` instance for a url by consulting the
@@ -129,24 +114,12 @@ pub struct RuntimeConfig {
     pub memory_pool: Option<Arc<dyn MemoryPool>>,
     /// ObjectStoreRegistry to get object store based on url
     pub object_store_registry: Arc<ObjectStoreRegistry>,
-    /// Custom table factories for things like deltalake that are not part of core datafusion
-    pub table_factories: HashMap<String, Arc<dyn TableProviderFactory>>,
 }
 
 impl RuntimeConfig {
     /// New with default values
     pub fn new() -> Self {
-        let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> =
-            HashMap::new();
-        table_factories.insert("PARQUET".into(), Arc::new(ListingTableFactory::new()));
-        table_factories.insert("CSV".into(), Arc::new(ListingTableFactory::new()));
-        table_factories.insert("JSON".into(), Arc::new(ListingTableFactory::new()));
-        table_factories.insert("NDJSON".into(), Arc::new(ListingTableFactory::new()));
-        table_factories.insert("AVRO".into(), Arc::new(ListingTableFactory::new()));
-        Self {
-            table_factories,
-            ..Default::default()
-        }
+        Default::default()
     }
 
     /// Customize disk manager
@@ -167,15 +140,6 @@ impl RuntimeConfig {
         object_store_registry: Arc<ObjectStoreRegistry>,
     ) -> Self {
         self.object_store_registry = object_store_registry;
-        self
-    }
-
-    /// Customize object store registry
-    pub fn with_table_factories(
-        mut self,
-        table_factories: HashMap<String, Arc<dyn TableProviderFactory>>,
-    ) -> Self {
-        self.table_factories = table_factories;
         self
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/1754

# Rationale for this change
I am trying to extract the physical_plan code into its own crate; and to do so I need to remove the circular dependencies between core --> datasource --> execution --> datasource

Table factories are used for planning, not for execution, but RuntimeEnv is used for execution (and I am trying to move it into the `datafusion_execution` crate)

See more details in https://github.com/apache/arrow-datafusion/issues/1754#issuecomment-1452438453

# What changes are included in this PR?
1. Move table_factories off of RuntimeEnv and directly to SessionState

# Are these changes tested?
Covered by existing tests (and the test changes illustrate what happened to the API). I believe this will affect Ballista (@avantgardnerio ) and delta-rs (cc @roeap )

# Are there any user-facing changes?

Users who are specifying custom TableFactoryProviders have a slightly different API to register them. 