### PR TITLE
Implement `Debug` for `ExecutionProps` and `VarProvider`

### DIFF
--- a/datafusion/core/src/test/variable.rs
+++ b/datafusion/core/src/test/variable.rs
@@ -23,7 +23,7 @@ use crate::variable::VarProvider;
 use arrow::datatypes::DataType;
 
 /// System variable
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SystemVar {}
 
 impl SystemVar {
@@ -46,7 +46,7 @@ impl VarProvider for SystemVar {
 }
 
 /// user defined variable
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct UserDefinedVar {}
 
 impl UserDefinedVar {

--- a/datafusion/physical-expr/src/execution_props.rs
+++ b/datafusion/physical-expr/src/execution_props.rs
@@ -92,6 +92,6 @@ mod test {
     #[test]
     fn debug() {
         let props = ExecutionProps::new();
-        assert_eq!("foo", format!("{props:?}"));
+        assert_eq!("ExecutionProps { query_execution_start_time: 1970-01-01T00:00:00Z, var_providers: None }", format!("{props:?}"));
     }
 }

--- a/datafusion/physical-expr/src/execution_props.rs
+++ b/datafusion/physical-expr/src/execution_props.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 /// done so during predicate pruning and expression simplification
 ///
 /// [`LogicalPlan`]: datafusion_expr::LogicalPlan
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExecutionProps {
     pub query_execution_start_time: DateTime<Utc>,
     /// Providers for scalar variables
@@ -83,5 +83,15 @@ impl ExecutionProps {
         self.var_providers
             .as_ref()
             .and_then(|var_providers| var_providers.get(&var_type).map(Arc::clone))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn debug() {
+        let props = ExecutionProps::new();
+        assert_eq!("foo", format!("{props:?}"));
     }
 }

--- a/datafusion/physical-expr/src/var_provider.rs
+++ b/datafusion/physical-expr/src/var_provider.rs
@@ -30,7 +30,7 @@ pub enum VarType {
 }
 
 /// A var provider for @variable
-pub trait VarProvider {
+pub trait VarProvider: std::fmt::Debug {
     /// Get variable value
     fn get_value(&self, var_names: Vec<String>) -> Result<ScalarValue>;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/5488

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See https://github.com/apache/arrow-datafusion/issues/5488

# What changes are included in this PR?

1. `#[derive(Debug)]` for `ExecutionProps`
2. Add `Debug` to the `VarProvider` trait -- this is technically a breaking change, but I think it is an improvement in usability

# Are these changes tested?
Yes, unit test

# Are there any user-facing changes?

Anyone who has implemented `VarProvider` will also have to now ensure they implement the `Debug` for that struct