### PR TITLE
feat: `ParquetExec` predicate preservation

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -174,6 +174,11 @@ impl ParquetExec {
         &self.base_config
     }
 
+    /// Optional predicate.
+    pub fn predicate(&self) -> Option<&Arc<dyn PhysicalExpr>> {
+        self.predicate.as_ref()
+    }
+
     /// Optional reference to this parquet scan's pruning predicate
     pub fn pruning_predicate(&self) -> Option<&Arc<PruningPredicate>> {
         self.pruning_predicate.as_ref()

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -956,15 +956,15 @@ impl AsExecutionPlan for PhysicalPlanNode {
                 )),
             })
         } else if let Some(exec) = plan.downcast_ref::<ParquetExec>() {
-            let pruning_expr = exec
-                .pruning_predicate()
-                .map(|pred| pred.orig_expr().clone().try_into())
+            let predicate = exec
+                .predicate()
+                .map(|pred| pred.clone().try_into())
                 .transpose()?;
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::ParquetScan(
                     protobuf::ParquetScanExecNode {
                         base_conf: Some(exec.base_config().try_into()?),
-                        predicate: pruning_expr,
+                        predicate,
                     },
                 )),
             })


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
- Add public getter for `ParquetExec::predicate`. This should allow phys. optimizer passes to inspect the actual predicate.
- Use the actual predicate (not the pruning one which may contain less data) for serialization. This should avoid some confusion where predicates (when they are not used for pruning) are lost.

# What changes are included in this PR?
See rationale.

# Are these changes tested?
\-

# Are there any user-facing changes?
Improved `ParquetExec` handling.