### PR TITLE
Minor: Add db-benchmark URL to db-benchmark readme

### DIFF
--- a/benchmarks/db-benchmark/README.md
+++ b/benchmarks/db-benchmark/README.md
@@ -19,6 +19,8 @@
 
 # Run db-benchmark
 
+This directory contains scripts for running DataFusion with the https://github.com/h2oai/db-benchmark
+
 ## Directions
 
 Run the following from root `arrow-datafusion` directory


### PR DESCRIPTION

# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/5502

# Rationale for this change

I was researching benchmarks as part of https://github.com/apache/arrow-datafusion/issues/5502 and I had to do some digging to figure out what db-benchmark was

# What changes are included in this PR?

See subj

# Are these changes tested?
no
# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->