### PR TITLE
Avoid circular(ish) dependency parquet-test-utils on datafusion

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -114,7 +114,6 @@ ctor = "0.1.22"
 doc-comment = "0.3"
 env_logger = "0.10"
 half = "2.2.1"
-parquet-test-utils = { path = "../../parquet-test-utils" }
 postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["derive", "with-chrono-0_4"] }
 rstest = "0.16.0"


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/5453

# Rationale for this change

Improve the DataFusion development cycle time by `cargo test -p datafusion` having to compile datafusion lib, then the parquet-test-utils, and then the tests.

"A little copying is better than a lot of dependency"

 https://www.youtube.com/watch?v=PAAkCSZUG1c

# What changes are included in this PR?

Copy a (subset) part of ParquetTestFile into the datafusion core test that uses them

# Are these changes tested?

Yes (existing tests)

# Are there any user-facing changes?
No