### PR TITLE
fix: return schema of ExtensionPlan instead of its children's

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2381,4 +2381,71 @@ mod tests {
             .build()
             .unwrap()
     }
+
+    /// Extension plan that panic when trying to access its input plan
+    #[derive(Debug)]
+    struct NoChildExtension {
+        empty_schema: DFSchemaRef,
+    }
+
+    impl NoChildExtension {
+        fn empty() -> Self {
+            Self {
+                empty_schema: Arc::new(DFSchema::empty()),
+            }
+        }
+    }
+
+    impl UserDefinedLogicalNode for NoChildExtension {
+        fn as_any(&self) -> &dyn std::any::Any {
+            unimplemented!()
+        }
+
+        fn name(&self) -> &str {
+            unimplemented!()
+        }
+
+        fn inputs(&self) -> Vec<&LogicalPlan> {
+            panic!("Should not be called")
+        }
+
+        fn schema(&self) -> &DFSchemaRef {
+            &self.empty_schema
+        }
+
+        fn expressions(&self) -> Vec<Expr> {
+            unimplemented!()
+        }
+
+        fn fmt_for_explain(&self, _: &mut fmt::Formatter) -> fmt::Result {
+            unimplemented!()
+        }
+
+        fn from_template(
+            &self,
+            _: &[Expr],
+            _: &[LogicalPlan],
+        ) -> Arc<dyn UserDefinedLogicalNode> {
+            unimplemented!()
+        }
+
+        fn dyn_hash(&self, _: &mut dyn Hasher) {
+            unimplemented!()
+        }
+
+        fn dyn_eq(&self, _: &dyn UserDefinedLogicalNode) -> bool {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_extension_all_schemas() {
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoChildExtension::empty()),
+        });
+
+        let schemas = plan.all_schemas();
+        assert_eq!(1, schemas.len());
+        assert_eq!(0, schemas[0].fields().len());
+    }
 }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -201,13 +201,13 @@ impl LogicalPlan {
             | LogicalPlan::Values(_)
             | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Union(_)
+            | LogicalPlan::Extension(_)
             | LogicalPlan::TableScan(_) => {
                 vec![self.schema()]
             }
             // return children schemas
             LogicalPlan::Limit(_)
             | LogicalPlan::Subquery(_)
-            | LogicalPlan::Extension(_)
             | LogicalPlan::Repartition(_)
             | LogicalPlan::Sort(_)
             | LogicalPlan::CreateMemoryTable(_)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #5513, but not close it as there is another unfinished discussion.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#5236 returns chindren's schema rather than `ExtensionPlan`'s in `all_schema`, which will break other places that make use of `ExtensionPlan`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Correct `all_schema`'s behavior

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->