### PR TITLE
revert accidently deleted size code in count_distinct

### DIFF
--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -3144,7 +3144,7 @@ mod tests {
                 None,
                 &join_type,
                 PartitionMode::Partitioned,
-                &false,
+                false,
             )?;
 
             let stream = join.execute(1, task_ctx)?;

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -112,7 +112,7 @@ impl DistinctCountAccumulator {
                 .values
                 .iter()
                 .next()
-                .map(|vals| ScalarValue::size(vals) - std::mem::size_of_val(&vals))
+                .map(|vals| ScalarValue::size(vals) - std::mem::size_of_val(vals))
                 .unwrap_or(0)
             + std::mem::size_of::<DataType>()
     }
@@ -124,7 +124,7 @@ impl DistinctCountAccumulator {
             + self
                 .values
                 .iter()
-                .map(|vals| ScalarValue::size(vals) - std::mem::size_of_val(&vals))
+                .map(|vals| ScalarValue::size(vals) - std::mem::size_of_val(vals))
                 .sum::<usize>()
             + std::mem::size_of::<DataType>()
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5534.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The `.size` was accidently corrupted during #5408
# What changes are included in this PR?
Put the size logic back
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->