### PR TITLE
Minor: add the concise way for matching numerics

### DIFF
--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -314,77 +314,45 @@ pub fn sum_return_type(arg_type: &DataType) -> Result<DataType> {
 
 /// function return type of variance
 pub fn variance_return_type(arg_type: &DataType) -> Result<DataType> {
-    match arg_type {
-        DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Int64
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float32
-        | DataType::Float64 => Ok(DataType::Float64),
-        other => Err(DataFusionError::Plan(format!(
-            "VAR does not support {other:?}"
-        ))),
+    if NUMERICS.contains(&arg_type) {
+        Ok(DataType::Float64)
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "VAR does not support {arg_type:?}"
+        )))
     }
 }
 
 /// function return type of covariance
 pub fn covariance_return_type(arg_type: &DataType) -> Result<DataType> {
-    match arg_type {
-        DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Int64
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float32
-        | DataType::Float64 => Ok(DataType::Float64),
-        other => Err(DataFusionError::Plan(format!(
-            "COVAR does not support {other:?}"
-        ))),
+    if NUMERICS.contains(&arg_type) {
+        Ok(DataType::Float64)
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "COVAR does not support {arg_type:?}"
+        )))
     }
 }
 
 /// function return type of correlation
 pub fn correlation_return_type(arg_type: &DataType) -> Result<DataType> {
-    match arg_type {
-        DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Int64
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float32
-        | DataType::Float64 => Ok(DataType::Float64),
-        other => Err(DataFusionError::Plan(format!(
-            "CORR does not support {other:?}"
-        ))),
+    if NUMERICS.contains(&arg_type) {
+        Ok(DataType::Float64)
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "CORR does not support {arg_type:?}"
+        )))
     }
 }
 
 /// function return type of standard deviation
 pub fn stddev_return_type(arg_type: &DataType) -> Result<DataType> {
-    match arg_type {
-        DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Int64
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float32
-        | DataType::Float64 => Ok(DataType::Float64),
-        other => Err(DataFusionError::Plan(format!(
-            "STDDEV does not support {other:?}"
-        ))),
+    if NUMERICS.contains(&arg_type) {
+        Ok(DataType::Float64)
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "STDDEV does not support {arg_type:?}"
+        )))
     }
 }
 
@@ -398,16 +366,7 @@ pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
             let new_scale = DECIMAL128_MAX_SCALE.min(*scale + 4);
             Ok(DataType::Decimal128(new_precision, new_scale))
         }
-        DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Int64
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float32
-        | DataType::Float64 => Ok(DataType::Float64),
+        arg_type if NUMERICS.contains(&arg_type) => Ok(DataType::Float64),
         other => Err(DataFusionError::Plan(format!(
             "AVG does not support {other:?}"
         ))),
@@ -417,98 +376,44 @@ pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
 pub fn is_sum_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Decimal128(_, _)
+        arg_type if NUMERICS.contains(&arg_type)
+        || matches!(arg_type, DataType::Decimal128(_, _))
     )
 }
 
 pub fn is_avg_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Decimal128(_, _)
+        arg_type if NUMERICS.contains(&arg_type)
+            || matches!(arg_type, DataType::Decimal128(_, _))
     )
 }
 
 pub fn is_variance_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
+        arg_type if NUMERICS.contains(&arg_type)
     )
 }
 
 pub fn is_covariance_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
+        arg_type if NUMERICS.contains(&arg_type)
     )
 }
 
 pub fn is_stddev_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
+        arg_type if NUMERICS.contains(&arg_type)
     )
 }
 
 pub fn is_correlation_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
+        arg_type if NUMERICS.contains(&arg_type)
     )
 }
 
@@ -531,16 +436,7 @@ pub fn is_integer_arg_type(arg_type: &DataType) -> bool {
 pub fn is_approx_percentile_cont_supported_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
+        arg_type if NUMERICS.contains(&arg_type)
     )
 }
 

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -314,7 +314,7 @@ pub fn sum_return_type(arg_type: &DataType) -> Result<DataType> {
 
 /// function return type of variance
 pub fn variance_return_type(arg_type: &DataType) -> Result<DataType> {
-    if NUMERICS.contains(&arg_type) {
+    if NUMERICS.contains(arg_type) {
         Ok(DataType::Float64)
     } else {
         Err(DataFusionError::Plan(format!(
@@ -325,7 +325,7 @@ pub fn variance_return_type(arg_type: &DataType) -> Result<DataType> {
 
 /// function return type of covariance
 pub fn covariance_return_type(arg_type: &DataType) -> Result<DataType> {
-    if NUMERICS.contains(&arg_type) {
+    if NUMERICS.contains(arg_type) {
         Ok(DataType::Float64)
     } else {
         Err(DataFusionError::Plan(format!(
@@ -336,7 +336,7 @@ pub fn covariance_return_type(arg_type: &DataType) -> Result<DataType> {
 
 /// function return type of correlation
 pub fn correlation_return_type(arg_type: &DataType) -> Result<DataType> {
-    if NUMERICS.contains(&arg_type) {
+    if NUMERICS.contains(arg_type) {
         Ok(DataType::Float64)
     } else {
         Err(DataFusionError::Plan(format!(
@@ -347,7 +347,7 @@ pub fn correlation_return_type(arg_type: &DataType) -> Result<DataType> {
 
 /// function return type of standard deviation
 pub fn stddev_return_type(arg_type: &DataType) -> Result<DataType> {
-    if NUMERICS.contains(&arg_type) {
+    if NUMERICS.contains(arg_type) {
         Ok(DataType::Float64)
     } else {
         Err(DataFusionError::Plan(format!(
@@ -366,7 +366,7 @@ pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
             let new_scale = DECIMAL128_MAX_SCALE.min(*scale + 4);
             Ok(DataType::Decimal128(new_precision, new_scale))
         }
-        arg_type if NUMERICS.contains(&arg_type) => Ok(DataType::Float64),
+        arg_type if NUMERICS.contains(arg_type) => Ok(DataType::Float64),
         other => Err(DataFusionError::Plan(format!(
             "AVG does not support {other:?}"
         ))),
@@ -376,7 +376,7 @@ pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
 pub fn is_sum_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
         || matches!(arg_type, DataType::Decimal128(_, _))
     )
 }
@@ -384,7 +384,7 @@ pub fn is_sum_support_arg_type(arg_type: &DataType) -> bool {
 pub fn is_avg_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
             || matches!(arg_type, DataType::Decimal128(_, _))
     )
 }
@@ -392,28 +392,28 @@ pub fn is_avg_support_arg_type(arg_type: &DataType) -> bool {
 pub fn is_variance_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
     )
 }
 
 pub fn is_covariance_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
     )
 }
 
 pub fn is_stddev_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
     )
 }
 
 pub fn is_correlation_support_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
     )
 }
 
@@ -436,7 +436,7 @@ pub fn is_integer_arg_type(arg_type: &DataType) -> bool {
 pub fn is_approx_percentile_cont_supported_arg_type(arg_type: &DataType) -> bool {
     matches!(
         arg_type,
-        arg_type if NUMERICS.contains(&arg_type)
+        arg_type if NUMERICS.contains(arg_type)
     )
 }
 


### PR DESCRIPTION
# Rationale for this change
The array "NUMERICS", that are defined in the file "datafusion/expr/src/type_coercion/aggregates.rs" (see https://github.com/apache/arrow-datafusion/blob/main/datafusion/expr/src/type_coercion/aggregates.rs#L30-L41) contains all types, which found in many "match" and "matches!" cases.

I think this PR suggests more concise way for these cases.

# What changes are included in this PR?
Rewritten "match" statements and "matches!" macros.

# Are these changes tested?
Yes

# Are there any user-facing changes?
No