### PR TITLE
fix: failed to execute sql with subquery

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/subquery.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/subquery.slt
@@ -60,3 +60,42 @@ where t1.t1_id + 12 not in (
                            )
 ----
 22 b 2
+
+# in subquery with two parentheses, see #5529
+query ITI rowsort
+select t1.t1_id,
+       t1.t1_name,
+       t1.t1_int
+from t1
+where t1.t1_id in ((
+                       select t2.t2_id from t2
+                  ))
+----
+11 a 1
+22 b 2
+44 d 4
+
+query ITI rowsort
+select t1.t1_id,
+       t1.t1_name,
+       t1.t1_int
+from t1
+where t1.t1_id in ((
+                       select t2.t2_id from t2
+                  ))
+and t1.t1_int < 3
+----
+11 a 1
+22 b 2
+
+query ITI rowsort
+select t1.t1_id,
+       t1.t1_name,
+       t1.t1_int
+from t1
+where t1.t1_id not in ((
+                            select t2.t2_id from t2 where t2.t2_int = 3
+                      ))
+----
+22 b 2
+33 c 3

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -2721,7 +2721,7 @@ mod tests {
                 vec![scalar_subquery(subquery.clone())],
                 true
             )),
-            not_in_subquery(col("c1"), subquery.clone())
+            not_in_subquery(col("c1"), subquery)
         );
     }
 

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -390,6 +390,22 @@ impl<'a, S: SimplifyInfo> ExprRewriter for Simplifier<'a, S> {
                 lit(negated)
             }
 
+            // expr IN ((subquery)) -> expr IN (subquery), see ##5529
+            Expr::InList {
+                expr,
+                mut list,
+                negated,
+            } if list.len() == 1
+                && matches!(list.first(), Some(Expr::ScalarSubquery { .. })) =>
+            {
+                let Expr::ScalarSubquery(subquery) = list.remove(0) else { unreachable!() };
+                Expr::InSubquery {
+                    expr,
+                    subquery,
+                    negated,
+                }
+            }
+
             // if expr is a single column reference:
             // expr IN (A, B, ...) --> (expr = A) OR (expr = B) OR (expr = C)
             Expr::InList {
@@ -1110,6 +1126,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::test::test_table_scan_with_name;
     use arrow::{
         array::{ArrayRef, Int32Array},
         datatypes::{DataType, Field, Schema},
@@ -2687,6 +2704,24 @@ mod tests {
         assert_eq!(
             simplify(in_list(col("c1"), vec![lit(1), lit(2)], true)),
             col("c1").not_eq(lit(2)).and(col("c1").not_eq(lit(1)))
+        );
+
+        let subquery = Arc::new(test_table_scan_with_name("test").unwrap());
+        assert_eq!(
+            simplify(in_list(
+                col("c1"),
+                vec![scalar_subquery(subquery.clone())],
+                false
+            )),
+            in_subquery(col("c1"), subquery.clone())
+        );
+        assert_eq!(
+            simplify(in_list(
+                col("c1"),
+                vec![scalar_subquery(subquery.clone())],
+                true
+            )),
+            not_in_subquery(col("c1"), subquery.clone())
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5529 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

fix: failed to run "where x in ((select ...))"

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

rewrite `Expr::InList` with only one subquery to `Expr::InSubquery` during logical plan optimization

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

no