### PR TITLE
Improve performance of COUNT (distinct x) for dictionary columns #258

### DIFF
--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -32,7 +32,7 @@ use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::Accumulator;
 
 type DistinctScalarValues = ScalarValue;
-
+type ValueSet = HashSet<DistinctScalarValues, RandomState>;
 /// Expression for a COUNT(DISTINCT) aggregation.
 #[derive(Debug)]
 pub struct DistinctCount {
@@ -144,7 +144,7 @@ impl AggregateExpr for DistinctCount {
         &self.name
     }
 }
-type ValueSet = HashSet<DistinctScalarValues, RandomState>;
+
 // calculating the size of values hashset for fixed length values,
 // taking first batch size * number of batches.
 // This method is faster than full_size(), however it is not suitable for variable length
@@ -197,7 +197,7 @@ fn values_to_state(values: &ValueSet, datatype: &DataType) -> Result<Vec<ScalarV
 
 #[derive(Debug)]
 struct DistinctCountAccumulator {
-    values: HashSet<DistinctScalarValues, RandomState>,
+    values: ValueSet,
     state_data_type: DataType,
 }
 
@@ -243,7 +243,7 @@ where
     /// `K` is required when casting to dict array
     _dt: core::marker::PhantomData<K>,
     values_datatype: DataType,
-    values: HashSet<DistinctScalarValues, RandomState>,
+    values: ValueSet,
 }
 
 impl<K> std::fmt::Debug for CountDistinctDictAccumulator<K>

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -284,7 +284,7 @@ where
         let arr = as_dictionary_array::<K>(&values[0])?;
         let nvalues = arr.values().len();
         // map keys to whether their corresponding value has been seen or not
-        let mut seen_map = (0..nvalues).map(|_| false).collect::<Vec<_>>();
+        let mut seen_map = vec![(false; nvalues];
         for idx in arr.keys_iter().flatten() {
             seen_map[idx] = true;
         }

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -158,6 +158,7 @@ fn values_fixed_size(values: &ValueSet) -> usize {
             .unwrap_or(0)
 }
 // calculates the size as accurate as possible, call to this method is expensive
+// but necessary to correctly account for variable length strings
 fn values_full_size(values: &ValueSet) -> usize {
     (std::mem::size_of::<DistinctScalarValues>() * values.capacity())
         + values

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -298,13 +298,8 @@ where
             // init state
             self.state = Some((0..nvalues).map(|_| false).collect());
         }
-        for key in arr.keys_iter() {
-            if let Some(idx) = key {
-                self.state
-                    .as_mut()
-                    // state always will have been initialized at this point
-                    .unwrap()[idx] = true;
-            }
+        for idx in arr.keys_iter().flatten() {
+            self.state.as_mut().unwrap()[idx] = true;
         }
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #258.

# Rationale for this change
The count distinct physical expr was doing alot of unnecessary hashing when it is ran on dictionary types. Previously, every cell in the dictionary array was being added to the distinct values hashset, with this change, we only need to add each value type at most once (never if it is not present) to the array.

# What changes are included in this PR?
A new accumulator (`CountDistinctDictAccumulator`) that is returned by `DistinctCount` in the case that a dictionary array is being counted. There is a fair amount of shared logic between the accumulators so that was also pulled out into helper funcs.

# Are these changes tested?
Added some new unit tests.

# Are there any user-facing changes?