### PR TITLE
Minor: Move RuntimeEnv to `datafusion_execution`

### DIFF
--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -43,12 +43,12 @@
 pub mod context;
 // backwards compatibility
 pub use crate::datasource::file_format::options;
-pub mod runtime_env;
 
 // backwards compatibility
 pub use datafusion_execution::disk_manager;
 pub use datafusion_execution::memory_pool;
 pub use datafusion_execution::registry;
+pub use datafusion_execution::runtime_env;
 
 pub use disk_manager::DiskManager;
 pub use registry::FunctionRegistry;

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -19,3 +19,4 @@ pub mod disk_manager;
 pub mod memory_pool;
 pub mod object_store;
 pub mod registry;
+pub mod runtime_env;

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -19,15 +19,12 @@
 //! and various system level components that are used during physical plan execution.
 
 use crate::{
-    error::Result,
-    execution::disk_manager::{DiskManager, DiskManagerConfig},
-};
-
-use datafusion_common::DataFusionError;
-use datafusion_execution::{
+    disk_manager::{DiskManager, DiskManagerConfig},
     memory_pool::{GreedyMemoryPool, MemoryPool, UnboundedMemoryPool},
     object_store::ObjectStoreRegistry,
 };
+
+use datafusion_common::{DataFusionError, Result};
 use object_store::ObjectStore;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/1754

# Rationale for this change
I am trying to extract the physical_plan code into its own crate; and to do so I need to remove the circular dependencies between core --> datasource --> execution --> datasource

The `RuntimeEnv` is used at runtime, so it belongs in the `datafusion_execution` crate

See more details in https://github.com/apache/arrow-datafusion/issues/1754#issuecomment-1452438453

# What changes are included in this PR?
1. Move RuntimeEnv to `datafusion_execution`

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?

No, I added a `pub use` so this code movement should not affect users
