### PR TITLE
Move `TaskContext` to DataFusion execution without SessionConfig

### DIFF
--- a/datafusion/core/src/catalog/information_schema.rs
+++ b/datafusion/core/src/catalog/information_schema.rs
@@ -644,10 +644,7 @@ impl PartitionStream for InformationSchemaDfSettings {
             // TODO: Stream this
             futures::stream::once(async move {
                 // create a mem table with the names of tables
-                config.make_df_settings(
-                    ctx.session_config().config_options(),
-                    &mut builder,
-                );
+                config.make_df_settings(ctx.config_options(), &mut builder);
                 Ok(builder.finish())
             }),
         ))

--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -43,12 +43,12 @@
 pub mod context;
 // backwards compatibility
 pub use crate::datasource::file_format::options;
-pub mod runtime_env;
 
 // backwards compatibility
 pub use datafusion_execution::disk_manager;
 pub use datafusion_execution::memory_pool;
 pub use datafusion_execution::registry;
+pub use datafusion_execution::runtime_env;
 
 pub use disk_manager::DiskManager;
 pub use registry::FunctionRegistry;

--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -272,7 +272,7 @@ impl AggregateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<StreamType> {
-        let batch_size = context.session_config().batch_size();
+        let batch_size = context.batch_size();
         let input = self.input.execute(partition, Arc::clone(&context))?;
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
         if self.group_by.expr.is_empty() {
@@ -343,7 +343,7 @@ impl ExecutionPlan for AggregateExec {
 
     /// Specifies whether this plan generates an infinite stream of records.
     /// If the plan does not support pipelining, but it its input(s) are
-    /// infinite, returns an error to indicate this.    
+    /// infinite, returns an error to indicate this.
     fn unbounded_output(&self, children: &[bool]) -> Result<bool> {
         if children[0] {
             Err(DataFusionError::Plan(

--- a/datafusion/core/src/physical_plan/file_format/csv.rs
+++ b/datafusion/core/src/physical_plan/file_format/csv.rs
@@ -143,7 +143,7 @@ impl ExecutionPlan for CsvExec {
             .object_store(&self.base_config.object_store_url)?;
 
         let config = Arc::new(CsvConfig {
-            batch_size: context.session_config().batch_size(),
+            batch_size: context.batch_size(),
             file_schema: Arc::clone(&self.base_config.file_schema),
             file_projection: self.base_config.file_column_projection_indices(),
             has_header: self.has_header,

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -112,7 +112,7 @@ impl ExecutionPlan for NdJsonExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let batch_size = context.session_config().batch_size();
+        let batch_size = context.batch_size();
         let (projected_schema, _) = self.base_config.project();
 
         let object_store = context

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -372,12 +372,12 @@ impl ExecutionPlan for ParquetExec {
                     })
             })?;
 
-        let config_options = ctx.session_config().config_options();
+        let config_options = ctx.config_options();
 
         let opener = ParquetOpener {
             partition_index,
             projection: Arc::from(projection),
-            batch_size: ctx.session_config().batch_size(),
+            batch_size: ctx.batch_size(),
             limit: self.base_config.limit,
             predicate: self.predicate.clone(),
             pruning_predicate: self.pruning_predicate.clone(),

--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -303,7 +303,7 @@ impl ExecutionPlan for SortMergeJoinExec {
         let buffered = buffered.execute(partition, context.clone())?;
 
         // create output buffer
-        let batch_size = context.session_config().batch_size();
+        let batch_size = context.batch_size();
 
         // create join stream
         Ok(Box::pin(SMJStream::try_new(

--- a/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -226,7 +226,7 @@ impl ExecutionPlan for SortPreservingMergeExec {
                     schema,
                     &self.expr,
                     tracking_metrics,
-                    context.session_config().batch_size(),
+                    context.batch_size(),
                 )?);
 
                 debug!("Got stream result from SortPreservingMergeStream::new_from_receivers");
@@ -1302,7 +1302,7 @@ mod tests {
             batches.schema(),
             sort.as_slice(),
             tracking_metrics,
-            task_ctx.session_config().batch_size(),
+            task_ctx.batch_size(),
         )
         .unwrap();
 

--- a/datafusion/execution/src/any_map.rs
+++ b/datafusion/execution/src/any_map.rs
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    hash::{BuildHasherDefault, Hasher},
+    sync::Arc,
+};
+
+/// Map that holds opaque objects indexed by their type.
+///
+/// Data is wrapped into an [`Arc`] to enable [`Clone`] while still being [object safe].
+///
+/// [object safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
+pub type AnyMap =
+    HashMap<TypeId, Arc<dyn Any + Send + Sync + 'static>, BuildHasherDefault<IdHasher>>;
+
+/// Hasher for [`AnyMap`].
+///
+/// With [`TypeId`]s as keys, there's no need to hash them. They are already hashes themselves, coming from the compiler.
+/// The [`IdHasher`] just holds the [`u64`] of the [`TypeId`], and then returns it, instead of doing any bit fiddling.
+#[derive(Default)]
+pub struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -19,3 +19,4 @@ pub mod disk_manager;
 pub mod memory_pool;
 pub mod object_store;
 pub mod registry;
+pub mod runtime_env;

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod any_map;
 pub mod disk_manager;
 pub mod memory_pool;
 pub mod object_store;
 pub mod registry;
 pub mod runtime_env;
+pub mod task_context;

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -19,15 +19,12 @@
 //! and various system level components that are used during physical plan execution.
 
 use crate::{
-    error::Result,
-    execution::disk_manager::{DiskManager, DiskManagerConfig},
-};
-
-use datafusion_common::DataFusionError;
-use datafusion_execution::{
+    disk_manager::{DiskManager, DiskManagerConfig},
     memory_pool::{GreedyMemoryPool, MemoryPool, UnboundedMemoryPool},
     object_store::ObjectStoreRegistry,
 };
+
+use datafusion_common::{DataFusionError, Result};
 use object_store::ObjectStore;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;

--- a/datafusion/execution/src/task_context.rs
+++ b/datafusion/execution/src/task_context.rs
@@ -58,9 +58,10 @@ impl TaskContext {
         scalar_functions: HashMap<String, Arc<ScalarUDF>>,
         aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
         runtime: Arc<RuntimeEnv>,
-        extensions: Extensions,
+        extensions: AnyMap,
+        config_extensions: Extensions,
     ) -> Result<Self> {
-        let mut config_options = ConfigOptions::new().with_extensions(extensions);
+        let mut config_options = ConfigOptions::new().with_extensions(config_extensions);
         for (k, v) in task_props {
             config_options.set(&k, &v)?;
         }
@@ -69,11 +70,32 @@ impl TaskContext {
             task_id: Some(task_id),
             session_id,
             config_options,
-            extensions: Default::default(),
+            extensions,
             scalar_functions,
             aggregate_functions,
             runtime,
         })
+    }
+
+    /// Create a new task context instance
+    pub fn new(
+        session_id: String,
+        task_id: Option<String>,
+        config_options: ConfigOptions,
+        extensions: AnyMap,
+        scalar_functions: HashMap<String, Arc<ScalarUDF>>,
+        aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
+        runtime: Arc<RuntimeEnv>,
+    ) -> Self {
+        Self {
+            session_id,
+            task_id,
+            config_options,
+            extensions,
+            scalar_functions,
+            aggregate_functions,
+            runtime,
+        }
     }
 
     /// Return a handle to the configuration options.
@@ -99,6 +121,16 @@ impl TaskContext {
     /// Return the [RuntimeEnv] associated with this [TaskContext]
     pub fn runtime_env(&self) -> Arc<RuntimeEnv> {
         self.runtime.clone()
+    }
+
+    /// Get the currently configured batch size
+    pub fn batch_size(&self) -> usize {
+        self.config_options.execution.batch_size
+    }
+
+    /// Get the current extensions
+    pub fn extensions(&self) -> &AnyMap {
+        &self.extensions
     }
 }
 

--- a/datafusion/execution/src/task_context.rs
+++ b/datafusion/execution/src/task_context.rs
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use datafusion_common::{
+    config::{ConfigOptions, Extensions},
+    DataFusionError, Result,
+};
+use datafusion_expr::{AggregateUDF, ScalarUDF};
+
+use crate::{
+    any_map::AnyMap, memory_pool::MemoryPool, registry::FunctionRegistry,
+    runtime_env::RuntimeEnv,
+};
+
+/// Task Execution Context
+pub struct TaskContext {
+    /// Session Id
+    session_id: String,
+    /// Optional Task Identify
+    task_id: Option<String>,
+    /// Configuration options
+    config_options: ConfigOptions,
+    /// Opaque extensions.
+    extensions: AnyMap,
+    /// Scalar functions associated with this task context
+    scalar_functions: HashMap<String, Arc<ScalarUDF>>,
+    /// Aggregate functions associated with this task context
+    aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
+    /// Runtime environment associated with this task context
+    runtime: Arc<RuntimeEnv>,
+}
+
+impl TaskContext {
+    /// Create a new task context instance
+    pub fn try_new(
+        task_id: String,
+        session_id: String,
+        task_props: HashMap<String, String>,
+        scalar_functions: HashMap<String, Arc<ScalarUDF>>,
+        aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
+        runtime: Arc<RuntimeEnv>,
+        extensions: Extensions,
+    ) -> Result<Self> {
+        let mut config_options = ConfigOptions::new().with_extensions(extensions);
+        for (k, v) in task_props {
+            config_options.set(&k, &v)?;
+        }
+
+        Ok(Self {
+            task_id: Some(task_id),
+            session_id,
+            config_options,
+            extensions: Default::default(),
+            scalar_functions,
+            aggregate_functions,
+            runtime,
+        })
+    }
+
+    /// Return a handle to the configuration options.
+    pub fn config_options(&self) -> &ConfigOptions {
+        &self.config_options
+    }
+
+    /// Return the `session_id` of this [TaskContext]
+    pub fn session_id(&self) -> String {
+        self.session_id.clone()
+    }
+
+    /// Return the `task_id` of this [TaskContext]
+    pub fn task_id(&self) -> Option<String> {
+        self.task_id.clone()
+    }
+
+    /// Return the [`MemoryPool`] associated with this [TaskContext]
+    pub fn memory_pool(&self) -> &Arc<dyn MemoryPool> {
+        &self.runtime.memory_pool
+    }
+
+    /// Return the [RuntimeEnv] associated with this [TaskContext]
+    pub fn runtime_env(&self) -> Arc<RuntimeEnv> {
+        self.runtime.clone()
+    }
+}
+
+impl FunctionRegistry for TaskContext {
+    fn udfs(&self) -> HashSet<String> {
+        self.scalar_functions.keys().cloned().collect()
+    }
+
+    fn udf(&self, name: &str) -> Result<Arc<ScalarUDF>> {
+        let result = self.scalar_functions.get(name);
+
+        result.cloned().ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "There is no UDF named \"{name}\" in the TaskContext"
+            ))
+        })
+    }
+
+    fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>> {
+        let result = self.aggregate_functions.get(name);
+
+        result.cloned().ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "There is no UDAF named \"{name}\" in the TaskContext"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::{config::ConfigExtension, extensions_options};
+
+    use super::*;
+    extensions_options! {
+        struct TestExtension {
+            value: usize, default = 42
+        }
+    }
+
+    impl ConfigExtension for TestExtension {
+        const PREFIX: &'static str = "test";
+    }
+
+    #[test]
+    fn task_context_extensions() -> Result<()> {
+        let runtime = Arc::new(RuntimeEnv::default());
+        let task_props = HashMap::from([("test.value".to_string(), "24".to_string())]);
+        let mut extensions = Extensions::default();
+        extensions.insert(TestExtension::default());
+
+        let task_context = TaskContext::try_new(
+            "task_id".to_string(),
+            "session_id".to_string(),
+            task_props,
+            HashMap::default(),
+            HashMap::default(),
+            runtime,
+            extensions,
+        )?;
+
+        let test = task_context
+            .config_options()
+            .extensions
+            .get::<TestExtension>();
+        assert!(test.is_some());
+
+        assert_eq!(test.unwrap().value, 24);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Draft as builds on https://github.com/apache/arrow-datafusion/pull/5580

# Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/1754

# Rationale for this change
I am trying to extract the physical_plan code into its own crate; and to do so I need to remove the circular dependencies between core --> datasource --> execution --> datasource

The `TaskContext` is the part of the `SessionState` that is used at runtime, so I want it it into the `datafusion_execution` crate.

See more details in https://github.com/apache/arrow-datafusion/issues/1754#issuecomment-1452438453

# What changes are included in this PR?
1. Move `TaskContext` to `datafusion_execution`
2. Change ` session_config: SessionConfig,` field to its two fields `extensions` and `config_options`

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?
Yes, anyone who uses SessionConfig in their execution plans will have to update their code to use `config_options` or `extensions` directly. 

I am worried that this is too much API churn (though I think the resulting API is cleaner).  I also have a PR to move `SessionConfig` into `datafusion_execution`. 
https://github.com/apache/arrow-datafusion/pull/5581