### PR TITLE
[FOLLOWUP] eliminate the duplicated sort keys in Order By clause

### DIFF
--- a/datafusion/core/tests/sql/order.rs
+++ b/datafusion/core/tests/sql/order.rs
@@ -39,3 +39,86 @@ async fn sort_with_lots_of_repetition_values() -> Result<()> {
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn sort_with_duplicate_sort_exprs() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let t1_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, true),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+
+    let t1_data = RecordBatch::try_new(
+        t1_schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![2, 4, 9, 3, 4])),
+            Arc::new(StringArray::from_slice(["a", "b", "c", "d", "e"])),
+        ],
+    )?;
+    ctx.register_batch("t1", t1_data)?;
+
+    let sql = "select * from t1 order by id desc, id, name, id asc";
+    let msg = format!("Creating logical plan for '{sql}'");
+    let dataframe = ctx.sql(sql).await.expect(&msg);
+    let plan = dataframe.into_optimized_plan().unwrap();
+    let expected = vec![
+        "Sort: t1.id DESC NULLS FIRST, t1.name ASC NULLS LAST [id:Int32;N, name:Utf8;N]",
+        "  TableScan: t1 projection=[id, name] [id:Int32;N, name:Utf8;N]",
+    ];
+
+    let formatted = plan.display_indent_schema().to_string();
+    let actual: Vec<&str> = formatted.trim().lines().collect();
+    assert_eq!(
+        expected, actual,
+        "\n\nexpected:\n\n{expected:#?}\nactual:\n\n{actual:#?}\n\n"
+    );
+
+    let expected = vec![
+        "+----+------+",
+        "| id | name |",
+        "+----+------+",
+        "| 9  | c    |",
+        "| 4  | b    |",
+        "| 4  | e    |",
+        "| 3  | d    |",
+        "| 2  | a    |",
+        "+----+------+",
+    ];
+
+    let results = execute_to_batches(&ctx, sql).await;
+    assert_batches_eq!(expected, &results);
+
+    let sql = "select * from t1 order by id asc, id, name, id desc;";
+    let msg = format!("Creating logical plan for '{sql}'");
+    let dataframe = ctx.sql(sql).await.expect(&msg);
+    let plan = dataframe.into_optimized_plan().unwrap();
+    let expected = vec![
+        "Sort: t1.id ASC NULLS LAST, t1.name ASC NULLS LAST [id:Int32;N, name:Utf8;N]",
+        "  TableScan: t1 projection=[id, name] [id:Int32;N, name:Utf8;N]",
+    ];
+
+    let formatted = plan.display_indent_schema().to_string();
+    let actual: Vec<&str> = formatted.trim().lines().collect();
+    assert_eq!(
+        expected, actual,
+        "\n\nexpected:\n\n{expected:#?}\nactual:\n\n{actual:#?}\n\n"
+    );
+
+    let expected = vec![
+        "+----+------+",
+        "| id | name |",
+        "+----+------+",
+        "| 2  | a    |",
+        "| 3  | d    |",
+        "| 4  | b    |",
+        "| 4  | e    |",
+        "| 9  | c    |",
+        "+----+------+",
+    ];
+
+    let results = execute_to_batches(&ctx, sql).await;
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -120,10 +120,10 @@ mod tests {
     fn eliminate_sort_exprs_with_options() -> Result<()> {
         let table_scan = test_table_scan().unwrap();
         let sort_exprs = vec![
-            Expr::Sort(ExprSort::new(Box::new(col("a")), true, true)),
-            Expr::Sort(ExprSort::new(Box::new(col("b")), true, false)),
-            Expr::Sort(ExprSort::new(Box::new(col("a")), false, false)),
-            Expr::Sort(ExprSort::new(Box::new(col("b")), false, true)),
+            col("a").sort(true, true),
+            col("b").sort(true, false),
+            col("a").sort(false, false),
+            col("b").sort(false, true),
         ];
         let plan = LogicalPlanBuilder::from(table_scan)
             .sort(sort_exprs)?

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -18,7 +18,6 @@
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
-use datafusion_expr::expr::Sort as ExprSort;
 use datafusion_expr::logical_plan::LogicalPlan;
 use datafusion_expr::{Expr, Sort};
 use hashbrown::HashSet;

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -18,6 +18,7 @@
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
+use datafusion_expr::expr::Sort as ExprSort;
 use datafusion_expr::logical_plan::LogicalPlan;
 use datafusion_expr::{Expr, Sort};
 use hashbrown::HashSet;
@@ -90,7 +91,6 @@ impl OptimizerRule for EliminateDuplicatedExpr {
 mod tests {
     use super::*;
     use crate::test::*;
-    use datafusion_expr::expr::Sort as ExprSort;
     use datafusion_expr::{col, logical_plan::builder::LogicalPlanBuilder};
     use std::sync::Arc;
 

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -18,8 +18,9 @@
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
+use datafusion_expr::expr::Sort as ExprSort;
 use datafusion_expr::logical_plan::LogicalPlan;
-use datafusion_expr::Sort;
+use datafusion_expr::{Expr, Sort};
 use hashbrown::HashSet;
 
 /// Optimization rule that eliminate duplicated expr.
@@ -41,15 +42,28 @@ impl OptimizerRule for EliminateDuplicatedExpr {
     ) -> Result<Option<LogicalPlan>> {
         match plan {
             LogicalPlan::Sort(sort) => {
+                let normalized_sort_keys = sort
+                    .expr
+                    .iter()
+                    .map(|e| match e {
+                        Expr::Sort(ExprSort { expr, .. }) => {
+                            Expr::Sort(ExprSort::new(expr.clone(), true, false))
+                        }
+                        _ => e.clone(),
+                    })
+                    .collect::<Vec<_>>();
+
                 // dedup sort.expr and keep order
                 let mut dedup_expr = Vec::new();
                 let mut dedup_set = HashSet::new();
-                for expr in &sort.expr {
-                    if !dedup_set.contains(expr) {
-                        dedup_expr.push(expr);
-                        dedup_set.insert(expr.clone());
-                    }
-                }
+                sort.expr.iter().zip(normalized_sort_keys.iter()).for_each(
+                    |(expr, normalized_expr)| {
+                        if !dedup_set.contains(normalized_expr) {
+                            dedup_expr.push(expr);
+                            dedup_set.insert(normalized_expr);
+                        }
+                    },
+                );
                 if dedup_expr.len() == sort.expr.len() {
                     Ok(None)
                 } else {
@@ -77,6 +91,7 @@ impl OptimizerRule for EliminateDuplicatedExpr {
 mod tests {
     use super::*;
     use crate::test::*;
+    use datafusion_expr::expr::Sort as ExprSort;
     use datafusion_expr::{col, logical_plan::builder::LogicalPlanBuilder};
     use std::sync::Arc;
 
@@ -97,6 +112,25 @@ mod tests {
             .build()?;
         let expected = "Limit: skip=5, fetch=10\
         \n  Sort: test.a, test.b, test.c\
+        \n    TableScan: test";
+        assert_optimized_plan_eq(&plan, expected)
+    }
+
+    #[test]
+    fn eliminate_sort_exprs_with_options() -> Result<()> {
+        let table_scan = test_table_scan().unwrap();
+        let sort_exprs = vec![
+            Expr::Sort(ExprSort::new(Box::new(col("a")), true, true)),
+            Expr::Sort(ExprSort::new(Box::new(col("b")), true, false)),
+            Expr::Sort(ExprSort::new(Box::new(col("a")), false, false)),
+            Expr::Sort(ExprSort::new(Box::new(col("b")), false, true)),
+        ];
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .sort(sort_exprs)?
+            .limit(5, Some(10))?
+            .build()?;
+        let expected = "Limit: skip=5, fetch=10\
+        \n  Sort: test.a ASC NULLS FIRST, test.b ASC NULLS LAST\
         \n    TableScan: test";
         assert_optimized_plan_eq(&plan, expected)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
Follow up mentioned in the PR
https://github.com/apache/arrow-datafusion/pull/5462

# Rationale for this change

Dedup sort keys should ignoring sort options:

For example `select * from t1 order by id desc, id, name, id asc`;
The real sort key should be: `Sort Key: id DESC, name`

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->