### PR TITLE
Preserve casts in rewrite_sort_cols_by_aggs

### DIFF
--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -19,7 +19,7 @@
 
 use crate::expr::Sort;
 use crate::expr_rewriter::{normalize_col, rewrite_expr};
-use crate::{Expr, ExprSchemable, LogicalPlan};
+use crate::{Cast, Expr, ExprSchemable, LogicalPlan, TryCast};
 use datafusion_common::{Column, Result};
 
 /// Rewrite sort on aggregate expressions to sort on the column of aggregate output
@@ -116,7 +116,19 @@ fn rewrite_in_terms_of_projection(
 
         // look for the column named the same as this expr
         if let Some(found) = proj_exprs.iter().find(|a| expr_match(&search_col, a)) {
-            return Ok((*found).clone());
+            let found = found.clone();
+            let expr = match normalized_expr {
+                Expr::Cast(Cast { expr: _, data_type }) => Expr::Cast(Cast {
+                    expr: Box::new(found),
+                    data_type,
+                }),
+                Expr::TryCast(TryCast { expr: _, data_type }) => Expr::TryCast(TryCast {
+                    expr: Box::new(found),
+                    data_type,
+                }),
+                _ => found,
+            };
+            return Ok(expr);
         }
         Ok(expr)
     })
@@ -141,7 +153,8 @@ mod test {
     use arrow::datatypes::{DataType, Field, Schema};
 
     use crate::{
-        avg, col, lit, logical_plan::builder::LogicalTableSource, min, LogicalPlanBuilder,
+        avg, cast, col, lit, logical_plan::builder::LogicalTableSource, min, try_cast,
+        LogicalPlanBuilder,
     };
 
     use super::*;
@@ -238,6 +251,34 @@ mod test {
 
         for case in cases {
             case.run(&agg)
+        }
+    }
+
+    #[test]
+    fn preserve_cast() {
+        let plan = make_input()
+            .project(vec![col("c2").alias("c2")])
+            .unwrap()
+            .project(vec![col("c2").alias("c2")])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let cases = vec![
+            TestCase {
+                desc: "Cast is preserved by rewrite_sort_cols_by_aggs",
+                input: sort(cast(col("c2"), DataType::Int64)),
+                expected: sort(cast(col("c2").alias("c2"), DataType::Int64)),
+            },
+            TestCase {
+                desc: "TryCast is preserved by rewrite_sort_cols_by_aggs",
+                input: sort(try_cast(col("c2"), DataType::Int64)),
+                expected: sort(try_cast(col("c2").alias("c2"), DataType::Int64)),
+            },
+        ];
+
+        for case in cases {
+            case.run(&plan)
         }
     }
 

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -3253,6 +3253,17 @@ fn test_select_distinct_order_by() {
 }
 
 #[test]
+fn select_order_by_with_cast() {
+    let sql =
+        "SELECT first_name AS first_name FROM (SELECT first_name AS first_name FROM person) ORDER BY CAST(first_name as INT)";
+    let expected = "Sort: CAST(first_name AS first_name AS Int32) ASC NULLS LAST\
+                        \n  Projection: first_name AS first_name\
+                        \n    Projection: person.first_name AS first_name\
+                        \n      TableScan: person";
+    quick_test(sql, expected);
+}
+
+#[test]
 fn test_duplicated_left_join_key_inner_join() {
     //  person.id * 2 happen twice in left side.
     let sql = "SELECT person.id, person.age


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5610.

# Rationale for this change

I changed `rewrite_in_terms_of_projection` to add casts back, but I honestly have no idea if this is proper way to fix this but it does the trick and would appreciate some direction.

# What changes are included in this PR?

# Are these changes tested?

Added two new tests.

# Are there any user-facing changes?

Bugfix.