### PR TITLE
Minor: Add `Extensions::new()`

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -557,7 +557,7 @@ pub trait ExtensionOptions: Send + Sync + std::fmt::Debug + 'static {
 }
 
 /// A type-safe container for [`ConfigExtension`]
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Extensions(BTreeMap<&'static str, ExtensionBox>);
 
 impl Extensions {

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -557,10 +557,15 @@ pub trait ExtensionOptions: Send + Sync + std::fmt::Debug + 'static {
 }
 
 /// A type-safe container for [`ConfigExtension`]
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Extensions(BTreeMap<&'static str, ExtensionBox>);
 
 impl Extensions {
+    /// Create a new, empty [`Extensions`]
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
     /// Registers a [`ConfigExtension`] with this [`ConfigOptions`]
     pub fn insert<T: ConfigExtension>(&mut self, extension: T) {
         assert_ne!(T::PREFIX, "datafusion");

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -2620,7 +2620,7 @@ mod tests {
     fn task_context_extensions() -> Result<()> {
         let runtime = Arc::new(RuntimeEnv::default());
         let task_props = HashMap::from([("test.value".to_string(), "24".to_string())]);
-        let mut extensions = Extensions::default();
+        let mut extensions = Extensions::new();
         extensions.insert(TestExtension::default());
 
         let task_context = TaskContext::try_new(


### PR DESCRIPTION
# Which issue does this PR close?
N/A

# Rationale for this change
@andygrove  reported on [ASF Slack](https://the-asf.slack.com/archives/C01QUFS30TD/p1679408811522469

> I am trying to upgrade Ray SQL to DataFusion 20, and running into problems trying to create the new Extensions param to TaskContext::try_new
> The struct is defined as:
> #[derive(Debug, Default, Clone)]
> pub struct Extensions(BTreeMap<&'static str, ExtensionBox>);

> I am hitting this error:
> error[E0423]: cannot initialize a tuple struct which contains private fields
>   --> src/context.rs:177:13
>     |
> 177 |             Extensions(BTreeMap::new())
>     |             ^^^^^^^^^^
>     |
> note: constructor is not visible here due to private fields

> Am I missing something obvious here, or is it no longer possible to create TaskContext outside of the core project?


Turns out the answer was `Extensions::default`:

>  [11:10 AM](https://the-asf.slack.com/archives/C01QUFS30TD/p1679411408660439)
> ah, nm, ... `
> Extensions::default()

# What changes are included in this PR?

Add an `Extensions::new()` which is the idiomatic way to create "new" objects in Rust

# Are these changes tested?

Yes -- updated existing tests

# Are there any user-facing changes?
Slightly better ergonomics and discoverability