### PR TITLE
Docs: Add logo back to sidebar

### DIFF
--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -14,3 +14,8 @@
     {% endif %}
   </div>
 </nav>
+
+
+<a class="navbar-brand" href="{{ pathto(master_doc) }}">
+  <img src="{{ pathto('_static/images/DataFusion-Logo-Background-White.png', 1) }}" class="logo" alt="logo">
+</a>


### PR DESCRIPTION
# Which issue does this PR close?
re #5500 

# Rationale for this change

While working https://github.com/apache/arrow-datafusion/pull/5670 we lost the sidebar logo

![Screenshot 2023-03-22 at 7 22 38 AM](https://user-images.githubusercontent.com/490673/226889765-6b702bc4-5eac-4e1e-bdcd-c8f998dbeb78.png)

# What changes are included in this PR?

Add the logo back in

![Screenshot 2023-03-22 at 7 21 55 AM](https://user-images.githubusercontent.com/490673/226889601-3697c200-5d21-485c-86ec-210f18157855.png)

# Are these changes tested?

Tested locally

# Are there any user-facing changes?

docs