### PR TITLE
feat: `date_bin` supports MonthDayNano, microsecond and nanosecond units

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -76,6 +76,28 @@ SELECT DATE_BIN(INTERVAL '15 minutes', TIMESTAMP '2022-08-03 14:38:50Z', TIMESTA
 ----
 2022-08-03T14:30:00
 
+# Supports Month-Day-Nano nanosecond interval
+query P
+SELECT DATE_BIN(INTERVAL '10 nanoseconds', TIMESTAMP '2022-08-03 14:38:50.000000016Z', TIMESTAMP '1970-01-01T00:00:00Z')
+----
+2022-08-03T14:38:50.000000010
+
+# Supports Month-Day-Nano nanosecond interval via fractions
+query P
+SELECT DATE_BIN(INTERVAL '0.000000010 seconds', TIMESTAMP '2022-08-03 14:38:50.000000016Z', TIMESTAMP '1970-01-01T00:00:00Z')
+----
+2022-08-03T14:38:50.000000010
+
+# Supports Month-Day-Nano microsecond interval
+query P
+SELECT DATE_BIN(INTERVAL '5 microseconds', TIMESTAMP '2022-08-03 14:38:50.000006Z', TIMESTAMP '1970-01-01T00:00:00Z')
+----
+2022-08-03T14:38:50.000005
+
+# Does not support months for Month-Day-Nano interval
+statement error This feature is not implemented: DATE_BIN stride does not support month intervals
+SELECT DATE_BIN(INTERVAL '1 month 5 nanoseconds', TIMESTAMP '2022-08-03 14:38:50.000000006Z', TIMESTAMP '1970-01-01T00:00:00Z')
+
 # Can coerce string interval arguments
 query P
 SELECT DATE_BIN('15 minutes', TIMESTAMP '2022-08-03 14:38:50Z', TIMESTAMP '1970-01-01T00:00:00Z')

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -456,7 +456,16 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
                 ]),
                 TypeSignature::Exact(vec![
+                    DataType::Interval(IntervalUnit::MonthDayNano),
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ]),
+                TypeSignature::Exact(vec![
                     DataType::Interval(IntervalUnit::DayTime),
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ]),
+                TypeSignature::Exact(vec![
+                    DataType::Interval(IntervalUnit::MonthDayNano),
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
                 ]),
             ],

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -28,8 +28,8 @@ use arrow::{
     compute::kernels::cast_utils::string_to_timestamp_nanos,
     datatypes::{
         ArrowNumericType, ArrowPrimitiveType, ArrowTemporalType, DataType,
-        IntervalDayTimeType, TimestampMicrosecondType, TimestampMillisecondType,
-        TimestampNanosecondType, TimestampSecondType,
+        IntervalDayTimeType, IntervalMonthDayNanoType, TimestampMicrosecondType,
+        TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
     },
 };
 use chrono::prelude::*;
@@ -344,6 +344,24 @@ fn date_bin_impl(
         ColumnarValue::Scalar(ScalarValue::IntervalDayTime(Some(v))) => {
             let (days, ms) = IntervalDayTimeType::to_parts(*v);
             let nanos = (Duration::days(days as i64) + Duration::milliseconds(ms as i64))
+                .num_nanoseconds();
+            match nanos {
+                Some(v) => v,
+                _ => {
+                    return Err(DataFusionError::Execution(
+                        "DATE_BIN stride argument is too large".to_string(),
+                    ))
+                }
+            }
+        }
+        ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(v))) => {
+            let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(*v);
+            if months != 0 {
+                return Err(DataFusionError::NotImplemented(
+                    "DATE_BIN stride does not support month intervals".to_string(),
+                ));
+            }
+            let nanos = (Duration::days(days as i64) + Duration::nanoseconds(nanos))
                 .num_nanoseconds();
             match nanos {
                 Some(v) => v,
@@ -802,6 +820,14 @@ mod tests {
         ]);
         assert!(res.is_ok());
 
+        // stride supports month-day-nano
+        let res = date_bin(&[
+            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(1))),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+        ]);
+        assert!(res.is_ok());
+
         //
         // Fallible test cases
         //
@@ -816,16 +842,16 @@ mod tests {
 
         // stride: invalid type
         let res = date_bin(&[
-            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(1))),
+            ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(Some(1))),
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
         ]);
         assert_eq!(
             res.err().unwrap().to_string(),
-            "Execution error: DATE_BIN expects stride argument to be an INTERVAL but got Interval(MonthDayNano)"
+            "Execution error: DATE_BIN expects stride argument to be an INTERVAL but got Interval(YearMonth)"
         );
 
-        // stride: overflow
+        // stride: overflow of day-time interval
         let res = date_bin(&[
             ColumnarValue::Scalar(ScalarValue::IntervalDayTime(Some(i64::MAX))),
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
@@ -834,6 +860,28 @@ mod tests {
         assert_eq!(
             res.err().unwrap().to_string(),
             "Execution error: DATE_BIN stride argument is too large"
+        );
+
+        // stride: overflow of month-day-nano interval
+        let res = date_bin(&[
+            ColumnarValue::Scalar(ScalarValue::new_interval_mdn(0, i32::MAX, 1)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+        ]);
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Execution error: DATE_BIN stride argument is too large"
+        );
+
+        // stride: month intervals
+        let res = date_bin(&[
+            ColumnarValue::Scalar(ScalarValue::new_interval_mdn(1, 1, 1)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+        ]);
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "This feature is not implemented: DATE_BIN stride does not support month intervals"
         );
 
         // origin: invalid type


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5697

# Rationale for this change

Teach `date_bin` to support for microsecond and nanosecond precision of intervals via the `MonthDayNano` type. Note that months are complicated to support and will require additional work. In doing so, we can also address #5689.

# What changes are included in this PR?

`date_bin` is now capable of parsing fractional intervals with a precision of microseconds and greater. The interval parser is also capable of interpreting the additional units `microsecond`, `microseconds`, `nanosecond` and `nanoseconds`, which should be additive.

# Are these changes tested?

Yes, unit tests for parsing intervals, validating arguments to `date_bin` and new SQL tests in the `timestamps.slt` file.

# Are there any user-facing changes?

Yes, users can now use additional units for intervals, such as:

```sql
select date_bin('500 microseconds', ...)
```

and the `date_bin` function is capable of binning microsecond and nanosecond precision intervals.