### PR TITLE
Minor: change doc formatting to force a republish

### DIFF
--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -19,9 +19,9 @@
 
 # Introduction
 
-DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in
-[Rust](http://rustlang.org), using the [Apache Arrow](https://arrow.apache.org)
-in-memory format.
+DataFusion is a very fast, extensible query engine for building
+high-quality data-centric systems in [Rust](http://rustlang.org),
+using the [Apache Arrow](https://arrow.apache.org) in-memory format.
 
 DataFusion offers SQL and Dataframe APIs, excellent [performance](https://benchmark.clickhouse.com/), built-in support for CSV, Parquet, JSON, and Avro, extensive customization, and a great community.
 


### PR DESCRIPTION
# Which issue does this PR close?

Related to #5500 

# Rationale for this change

The  https://arrow.apache.org/datafusion/ site is currently broken

![Screenshot 2023-03-23 at 7 12 14 AM](https://user-images.githubusercontent.com/490673/227186442-23a5b6ff-ea0f-46ea-8dee-028c80e3e797.png)

Somehow related to https://github.com/apache/arrow-site/pull/336#issuecomment-1480389066

# What changes are included in this PR?

Change formatting of markdown (no content) to get the datafusion site to rebuild and republish

# Are these changes tested?
No (I am testing live)

# Are there any user-facing changes?
Docs