### PR TITLE
minor: Add doc comments to clarify what Analyzer is for

### DIFF
--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -27,8 +27,16 @@ use log::{debug, trace};
 use std::sync::Arc;
 use std::time::Instant;
 
-/// `AnalyzerRule` transforms the unresolved ['LogicalPlan']s and unresolved ['Expr']s into
-/// the resolved form.
+/// [`AnalyzerRule`]s transform [`LogicalPlan`]s in some way to make
+/// the plan valid prior to the rest of the DataFusion optimization process.
+///
+/// For example, it may resolve [`Expr]s into more specific forms such
+/// as a subquery reference, to do type coercion to ensure the types
+/// of operands are correct.
+///
+/// This is different than an [`OptimizerRule`](crate::OptimizerRule)
+/// which should preserve the semantics of the LogicalPlan but compute
+/// it the same result in some more optimal way.
 pub trait AnalyzerRule {
     /// Rewrite `plan`
     fn analyze(&self, plan: &LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan>;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -52,7 +52,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
-/// `OptimizerRule` transforms one ['LogicalPlan'] into another which
+/// `OptimizerRule` transforms one [`LogicalPlan`] into another which
 /// computes the same results, but in a potentially more efficient
 /// way. If there are no suitable transformations for the input plan,
 /// the optimizer can simply return it as is.


### PR DESCRIPTION
# Which issue does this PR close?

Related to the discussion on https://github.com/apache/arrow-datafusion/pull/5683 with @jackwener  and @mingmwang  

# Rationale for this change

I was not clear exactly what should be an `OptimizerRule` and what should be an `AnalyzerRule`

# What changes are included in this PR?

Add doc strings explaining the difference per @jackwener 's comment https://github.com/apache/arrow-datafusion/pull/5683#issuecomment-1480536552

# Are these changes tested?

N/A

# Are there any user-facing changes?
Better doc strings