### PR TITLE
Executing LocalLimitExec with no column should not return an Err

### DIFF
--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -31,7 +31,7 @@ use crate::physical_plan::{
 };
 use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 
 use super::expressions::PhysicalSortExpr;
 use super::{
@@ -462,7 +462,8 @@ impl LimitStream {
                 .iter()
                 .map(|col| col.slice(0, col.len().min(batch_rows)))
                 .collect();
-            Some(RecordBatch::try_new(batch.schema(), limited_columns).unwrap())
+            let options = RecordBatchOptions::new().with_row_count(Option::from(batch_rows));
+            Some(RecordBatch::try_new_with_options(batch.schema(), limited_columns, &options).unwrap())
         }
     }
 }

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -462,8 +462,16 @@ impl LimitStream {
                 .iter()
                 .map(|col| col.slice(0, col.len().min(batch_rows)))
                 .collect();
-            let options = RecordBatchOptions::new().with_row_count(Option::from(batch_rows));
-            Some(RecordBatch::try_new_with_options(batch.schema(), limited_columns, &options).unwrap())
+            let options =
+                RecordBatchOptions::new().with_row_count(Option::from(batch_rows));
+            Some(
+                RecordBatch::try_new_with_options(
+                    batch.schema(),
+                    limited_columns,
+                    &options,
+                )
+                .unwrap(),
+            )
         }
     }
 }

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -33,7 +33,7 @@ use crate::test_util::{aggr_test_schema, arrow_test_data};
 use array::ArrayRef;
 use arrow::array::{self, Array, Decimal128Builder, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 #[cfg(feature = "compression")]
 use bzip2::write::BzEncoder;
 #[cfg(feature = "compression")]
@@ -273,6 +273,14 @@ pub fn make_partition(sz: i32) -> RecordBatch {
     let arr = arr as ArrayRef;
 
     RecordBatch::try_new(schema, vec![arr]).unwrap()
+}
+
+/// Return a RecordBatch with a single array with row_count sz
+pub fn make_batch_no_column(sz: usize) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![]));
+
+    let options = RecordBatchOptions::new().with_row_count(Option::from(sz));
+    RecordBatch::try_new_with_options(schema, vec![], &options).unwrap()
 }
 
 /// Return a new table which provide this decimal column


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/5701

# Rationale for this change
Bug fix

# What changes are included in this PR?
Use `options` to explicitly set `row_count`, closely related / similar solution to https://github.com/apache/arrow-datafusion/pull/4912

# Are these changes tested?
Yes

# Are there any user-facing changes?
No
