### PR TITLE
Minor: Trigger docs CI build on changes to asf.yaml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
     paths:
+      - .asf.yaml
       - .github/workflows/docs.yaml
       - docs/**
 

--- a/datafusion/core/tests/parquet/row_group_pruning.rs
+++ b/datafusion/core/tests/parquet/row_group_pruning.rs
@@ -511,7 +511,7 @@ async fn prune_periods_in_column_names() {
         Scenario::PeriodsInColumnNames,
         "SELECT \"name\", \"service.name\" FROM t WHERE \"service.name\" = 'frontend' AND \"name\" != 'HTTP GET / DISPATCH'",
         Some(0),
-        Some(2), // prune out  middle and last row group
+        Some(2), // prune out middle and last row group
         2,
     )
     .await;


### PR DESCRIPTION
# Which issue does this PR close?

Related to #5500 

# Rationale for this change

Publishing the docs is configured  by `asf.yaml` and thus if that files changes we should also retrigger the docs workflow

As suggested by @kou  on  https://github.com/apache/arrow-datafusion/pull/5703#pullrequestreview-1355709963

# What changes are included in this PR?
1. Trigger docs CI build on changes to asf.yaml

# Are these changes tested?
No

# Are there any user-facing changes?
No