### PR TITLE
Minor: Reduce clones in AnalyzerRule

### DIFF
--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -35,8 +35,8 @@ impl CountWildcardRule {
 }
 
 impl AnalyzerRule for CountWildcardRule {
-    fn analyze(&self, plan: &LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
-        plan.clone().transform_down(&analyze_internal)
+    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+        plan.transform_down(&analyze_internal)
     }
 
     fn name(&self) -> &str {

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -41,8 +41,8 @@ impl InlineTableScan {
 }
 
 impl AnalyzerRule for InlineTableScan {
-    fn analyze(&self, plan: &LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
-        plan.clone().transform_up(&analyze_internal)
+    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+        plan.transform_up(&analyze_internal)
     }
 
     fn name(&self) -> &str {

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -41,7 +41,7 @@ use std::time::Instant;
 /// it the same result in some more optimal way.
 pub trait AnalyzerRule {
     /// Rewrite `plan`
-    fn analyze(&self, plan: &LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan>;
+    fn analyze(&self, plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan>;
 
     /// A human readable name for this analyzer rule
     fn name(&self) -> &str;
@@ -86,7 +86,7 @@ impl Analyzer {
 
         // TODO add common rule executor for Analyzer and Optimizer
         for rule in &self.rules {
-            new_plan = rule.analyze(&new_plan, config)?;
+            new_plan = rule.analyze(new_plan, config)?;
         }
         check_plan(&new_plan)?;
         log_plan("Final analyzed plan", &new_plan);


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/pull/5705

# Rationale for this change

The current signature of `AnalyzerRule` requires the `LogicalPlan` to be `clone()`ed. 

@mingmwang  says that was an oversight
https://github.com/apache/arrow-datafusion/pull/5705#discussion_r1147073711

# What changes are included in this PR?
Change signature to take owned LogicalPlan

# Are these changes tested?
Existing tests

# Are there any user-facing changes?

No