### PR TITLE
fix test of benchmarks warning

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -748,7 +748,7 @@ mod ci {
         let queries = get_query_sql(query)?;
         for query in queries {
             let plan = ctx.sql(&query).await?;
-            let plan = plan.to_logical_plan()?;
+            let plan = plan.into_optimized_plan()?;
             let bytes = logical_plan_to_bytes(&plan)?;
             let plan2 = logical_plan_from_bytes(&bytes, &ctx)?;
             let plan_formatted = format!("{}", plan.display_indent());

--- a/datafusion/proto/README.md
+++ b/datafusion/proto/README.md
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     ctx.register_csv("t1", "testdata/test.csv", CsvReadOptions::default())
         .await
         ?;
-    let plan = ctx.table("t1").await?.to_logical_plan()?;
+    let plan = ctx.table("t1").await?.into_optimized_plan()?;
     let bytes = logical_plan_to_bytes(&plan)?;
     let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx)?;
     assert_eq!(format!("{:?}", plan), format!("{:?}", logical_round_trip));
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     ctx.register_csv("t1", "testdata/test.csv", CsvReadOptions::default())
         .await
         ?;
-    let logical_plan = ctx.table("t1").await?.to_logical_plan()?;
+    let logical_plan = ctx.table("t1").await?.into_optimized_plan()?;
     let physical_plan = ctx.create_physical_plan(&logical_plan).await?;
     let bytes = physical_plan_to_bytes(physical_plan.clone())?;
     let physical_round_trip = physical_plan_from_bytes(&bytes, &ctx)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

fix test of benchmarks warning:

```shell
warning: use of deprecated associated function `datafusion::dataframe::DataFrame::to_logical_plan`: Use DataFrame::into_optimized_plan
   --> benchmarks/src/bin/tpch.rs:751:29
    |
751 |             let plan = plan.to_logical_plan()?;
    |                             ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `datafusion-benchmarks` (bin "tpch" test) generated 1 warning
```

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

use `into_optimized_plan` instead of deprecated `to_logical_plan`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->