### PR TITLE
Minor: Run rust workflow on changes to .github

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,12 +26,14 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - ".github/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - ".github/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
# Which issue does this PR close?
N/a
# Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/5730 I noticed that the CI checks did not run even though we were changing the definition of what to run in `.github`

# What changes are included in this PR?

Change CI trigger to only ignore documentation related changes (not everything in .github which also includes workflow definitions)

# Are these changes tested?

I will test them manually in https://github.com/apache/arrow-datafusion/pull/5730

# Are there any user-facing changes?

No