### PR TITLE
Backport: Update version and Changelog for `21.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 ]
 
 [workspace.package]
-version = "21.0.0"
+version = "21.1.0"
 edition = "2021"
 readme = "README.md"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-benchmarks"
 description = "DataFusion Benchmarks"
-version = "21.0.0"
+version = "21.1.0"
 edition = "2021"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-datafusion"
@@ -34,7 +34,7 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = { workspace = true }
-datafusion = { path = "../datafusion/core", version = "21.0.0", features = ["scheduler"] }
+datafusion = { path = "../datafusion/core", version = "21.1.0", features = ["scheduler"] }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }
@@ -48,4 +48,4 @@ test-utils = { path = "../test-utils/", version = "0.1.0" }
 tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 
 [dev-dependencies]
-datafusion-proto = { path = "../datafusion/proto", version = "21.0.0" }
+datafusion-proto = { path = "../datafusion/proto", version = "21.1.0" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-cli"
 description = "Command Line Client for DataFusion query engine."
-version = "21.0.0"
+version = "21.1.0"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2021"
 keywords = ["arrow", "datafusion", "query", "sql"]
@@ -32,7 +32,7 @@ readme = "README.md"
 arrow = "34.0.0"
 async-trait = "0.1.41"
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../datafusion/core", version = "21.0.0" }
+datafusion = { path = "../datafusion/core", version = "21.1.0" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion/CHANGELOG.md
+++ b/datafusion/CHANGELOG.md
@@ -19,6 +19,16 @@
 
 # Changelog
 
+## [21.1.0](https://github.com/apache/arrow-datafusion/tree/21.1.0) (2023-03-24)
+
+[Full Changelog](https://github.com/apache/arrow-datafusion/compare/21.0.0...21.1.0)
+
+
+**Fixed bugs:**
+
+- fix: Use consistent arrow version (do not use both `arrow 34.0.0` and `arrow-array 35.0.0`) [#5765](https://github.com/apache/arrow-datafusion/pull/5765)
+
+
 ## [21.0.0](https://github.com/apache/arrow-datafusion/tree/21.0.0) (2023-03-24)
 
 [Full Changelog](https://github.com/apache/arrow-datafusion/compare/20.0.0...21.0.0)

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -67,14 +67,14 @@ bytes = "1.4"
 bzip2 = { version = "0.4.3", optional = true }
 chrono = { version = "0.4.23", default-features = false }
 dashmap = "5.4.0"
-datafusion-common = { path = "../common", version = "21.0.0", features = ["parquet", "object_store"] }
-datafusion-execution = { path = "../execution", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
-datafusion-jit = { path = "../jit", version = "21.0.0", optional = true }
-datafusion-optimizer = { path = "../optimizer", version = "21.0.0", default-features = false }
-datafusion-physical-expr = { path = "../physical-expr", version = "21.0.0", default-features = false }
-datafusion-row = { path = "../row", version = "21.0.0" }
-datafusion-sql = { path = "../sql", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0", features = ["parquet", "object_store"] }
+datafusion-execution = { path = "../execution", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
+datafusion-jit = { path = "../jit", version = "21.1.0", optional = true }
+datafusion-optimizer = { path = "../optimizer", version = "21.1.0", default-features = false }
+datafusion-physical-expr = { path = "../physical-expr", version = "21.1.0", default-features = false }
+datafusion-row = { path = "../row", version = "21.1.0" }
+datafusion-sql = { path = "../sql", version = "21.1.0" }
 flate2 = { version = "1.0.24", optional = true }
 futures = "0.3"
 glob = "0.3.0"

--- a/datafusion/execution/Cargo.toml
+++ b/datafusion/execution/Cargo.toml
@@ -34,8 +34,8 @@ path = "src/lib.rs"
 
 [dependencies]
 dashmap = "5.4.0"
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
 hashbrown = { version = "0.13", features = ["raw"] }
 log = "^0.4"
 object_store = "0.5.4"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/lib.rs"
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 arrow = { workspace = true, default-features = false }
-datafusion-common = { path = "../common", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0" }
 sqlparser = "0.32"
 
 [dev-dependencies]

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -41,7 +41,7 @@ cranelift = "0.89.0"
 cranelift-jit = "0.89.0"
 cranelift-module = "0.89.0"
 cranelift-native = "0.89.0"
-datafusion-common = { path = "../common", version = "21.0.0", features = ["jit"] }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0", features = ["jit"] }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
 
 parking_lot = "0.12"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -43,9 +43,9 @@ unicode_expressions = ["datafusion-physical-expr/unicode_expressions"]
 arrow = { workspace = true }
 async-trait = "0.1.41"
 chrono = { version = "0.4.23", default-features = false }
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "21.0.0", default-features = false }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
+datafusion-physical-expr = { path = "../physical-expr", version = "21.1.0", default-features = false }
 hashbrown = { version = "0.13", features = ["raw"] }
 itertools = "0.10"
 log = "^0.4"
@@ -53,5 +53,5 @@ regex-syntax = "0.6.28"
 
 [dev-dependencies]
 ctor = "0.1.22"
-datafusion-sql = { path = "../sql", version = "21.0.0" }
+datafusion-sql = { path = "../sql", version = "21.1.0" }
 env_logger = "0.10.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -49,9 +49,9 @@ arrow-schema = { workspace = true }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4.23", default-features = false }
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
-datafusion-row = { path = "../row", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
+datafusion-row = { path = "../row", version = "21.1.0" }
 half = { version = "2.1", default-features = false }
 hashbrown = { version = "0.13", features = ["raw"] }
 indexmap = "1.9.2"

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -42,9 +42,9 @@ json = ["pbjson", "serde", "serde_json"]
 [dependencies]
 arrow = { workspace = true }
 chrono = { version = "0.4", default-features = false }
-datafusion = { path = "../core", version = "21.0.0" }
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
+datafusion = { path = "../core", version = "21.1.0" }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
 object_store = { version = "0.5.4" }
 pbjson = { version = "0.5", optional = true }
 prost = "0.11.0"

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -38,7 +38,7 @@ jit = ["datafusion-jit"]
 
 [dependencies]
 arrow = { workspace = true }
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-jit = { path = "../jit", version = "21.0.0", optional = true }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-jit = { path = "../jit", version = "21.1.0", optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -38,8 +38,8 @@ unicode_expressions = []
 
 [dependencies]
 arrow-schema = { workspace = true }
-datafusion-common = { path = "../common", version = "21.0.0" }
-datafusion-expr = { path = "../expr", version = "21.0.0" }
+datafusion-common = { path = "../common", version = "21.1.0" }
+datafusion-expr = { path = "../expr", version = "21.1.0" }
 log = "^0.4"
 sqlparser = "0.32"
 

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -30,7 +30,7 @@ rust-version = { workspace = true }
 [dependencies]
 async-recursion = "1.0"
 chrono = "0.4.23"
-datafusion = { version = "21.0.0", path = "../core" }
+datafusion = { version = "21.1.0", path = "../core" }
 itertools = "0.10.5"
 object_store = "0.5.4"
 prost = "0.11"

--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -44,6 +44,22 @@ crates = {
     'datafusion-examples': 'datafusion-examples/Cargo.toml',
 }
 
+def update_workspace_version(new_version: str):
+    cargo_toml = 'Cargo.toml'
+    print(f'updating {cargo_toml}')
+    with open(cargo_toml) as f:
+        data = f.read()
+
+    doc = tomlkit.parse(data)
+    pkg = doc.get('workspace').get('package')
+
+    print('workspace pacakge', pkg)
+    pkg['version'] = new_version
+
+    with open(cargo_toml, 'w') as f:
+        f.write(tomlkit.dumps(doc))
+
+
 def update_datafusion_version(cargo_toml: str, new_version: str):
     print(f'updating {cargo_toml}')
     with open(cargo_toml) as f:
@@ -56,7 +72,6 @@ def update_datafusion_version(cargo_toml: str, new_version: str):
 
     with open(cargo_toml, 'w') as f:
         f.write(tomlkit.dumps(doc))
-
 
 def update_downstream_versions(cargo_toml: str, new_version: str):
     with open(cargo_toml) as f:
@@ -100,6 +115,9 @@ def main():
 
     new_version = args.new_version
     repo_root = Path(__file__).parent.parent.absolute()
+
+    print(f'Updating workspace in {repo_root} to {new_version}')
+    update_workspace_version(new_version)
 
     print(f'Updating datafusion crate versions in {repo_root} to {new_version}')
     for cargo_toml in crates.values():


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/5744

# Rationale for this change

Prepare for `22.1.0` release as described on https://github.com/apache/arrow-datafusion/issues/5744

# What changes are included in this PR?

Update version to `22.1.0` and add (manual) Changelog entry on `branch-21`

# Are these changes tested?
No

# Are there any user-facing changes?

Eventually they will be 