### PR TITLE
feat: extend substrait type support, including type variations

### DIFF
--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -18,7 +18,7 @@
 pub mod logical_plan;
 pub mod physical_plan;
 pub mod serializer;
-mod variation_const;
+pub mod variation_const;
 
 // Re-export substrait crate
 pub use substrait;

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -765,28 +765,28 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
             r#type::Kind::I8(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int8),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt8),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::I16(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int16),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt16),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::I32(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int32),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt32),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::I64(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int64),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt64),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
@@ -805,21 +805,21 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 TIMESTAMP_NANO_TYPE_REF => {
                     Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
                 }
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::Date(date) => match date.type_variation_reference {
                 DATE_32_TYPE_REF => Ok(DataType::Date32),
                 DATE_64_TYPE_REF => Ok(DataType::Date64),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::Binary(binary) => match binary.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::Binary),
                 LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeBinary),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
@@ -829,13 +829,13 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
             r#type::Kind::String(string) => match string.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::Utf8),
                 LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeUtf8),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
             r#type::Kind::List(list) => {
                 let inner_type =
-                    from_substrait_type(&*list.r#type.as_ref().ok_or_else(|| {
+                    from_substrait_type(list.r#type.as_ref().ok_or_else(|| {
                         DataFusionError::Substrait(
                             "List type must have inner type".to_string(),
                         )
@@ -844,7 +844,7 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 match list.type_variation_reference {
                     DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::List(field)),
                     LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeList(field)),
-                    v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    v => Err(DataFusionError::NotImplemented(format!(
                         "Unsupported Substrait type variation {v} of type {s_kind:?}"
                     )))?,
                 }
@@ -856,7 +856,7 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 DECIMAL_256_TYPE_REF => {
                     Ok(DataType::Decimal256(d.precision as u8, d.scale as i8))
                 }
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ))),
             },
@@ -1027,28 +1027,28 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
             r#type::Kind::I8(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int8(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt8(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
             r#type::Kind::I16(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int16(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt16(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
             r#type::Kind::I32(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int32(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt32(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
             r#type::Kind::I64(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int64(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt64(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
@@ -1065,21 +1065,21 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                 TIMESTAMP_NANO_TYPE_REF => {
                     Ok(ScalarValue::TimestampNanosecond(None, None))
                 }
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
             r#type::Kind::Date(date) => match date.type_variation_reference {
                 DATE_32_TYPE_REF => Ok(ScalarValue::Date32(None)),
                 DATE_64_TYPE_REF => Ok(ScalarValue::Date64(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
             r#type::Kind::Binary(binary) => match binary.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Binary(None)),
                 LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeBinary(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },
@@ -1087,7 +1087,7 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
             r#type::Kind::String(string) => match string.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Utf8(None)),
                 LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeUtf8(None)),
-                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                v => Err(DataFusionError::NotImplemented(format!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
                 ))),
             },

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -32,6 +32,7 @@ use datafusion::{
     prelude::{Column, SessionContext},
     scalar::ScalarValue,
 };
+use substrait::proto::expression::Literal;
 use substrait::proto::{
     aggregate_function::AggregationInvocation,
     expression::{
@@ -689,109 +690,8 @@ pub async fn from_substrait_rex(
             }
         }
         Some(RexType::Literal(lit)) => {
-            match &lit.literal_type {
-                Some(LiteralType::I8(n)) => {
-                    if lit.type_variation_reference == 0 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::Int8(Some(*n as i8)))))
-                    } else if lit.type_variation_reference == 1 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::UInt8(Some(*n as u8)))))
-                    } else {
-                        Err(DataFusionError::Substrait(format!(
-                            "Unknown type variation reference {}",
-                            lit.type_variation_reference
-                        )))
-                    }
-                }
-                Some(LiteralType::I16(n)) => {
-                    if lit.type_variation_reference == 0 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::Int16(Some(*n as i16)))))
-                    } else if lit.type_variation_reference == 1 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::UInt16(Some(
-                            *n as u16,
-                        )))))
-                    } else {
-                        Err(DataFusionError::Substrait(format!(
-                            "Unknown type variation reference {}",
-                            lit.type_variation_reference
-                        )))
-                    }
-                }
-                Some(LiteralType::I32(n)) => {
-                    if lit.type_variation_reference == 0 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::Int32(Some(*n)))))
-                    } else if lit.type_variation_reference == 1 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::UInt32(Some(unsafe {
-                            std::mem::transmute_copy::<i32, u32>(n)
-                        })))))
-                    } else {
-                        Err(DataFusionError::Substrait(format!(
-                            "Unknown type variation reference {}",
-                            lit.type_variation_reference
-                        )))
-                    }
-                }
-                Some(LiteralType::I64(n)) => {
-                    if lit.type_variation_reference == 0 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::Int64(Some(*n)))))
-                    } else if lit.type_variation_reference == 1 {
-                        Ok(Arc::new(Expr::Literal(ScalarValue::UInt64(Some(unsafe {
-                            std::mem::transmute_copy::<i64, u64>(n)
-                        })))))
-                    } else {
-                        Err(DataFusionError::Substrait(format!(
-                            "Unknown type variation reference {}",
-                            lit.type_variation_reference
-                        )))
-                    }
-                }
-                Some(LiteralType::Boolean(b)) => {
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Boolean(Some(*b)))))
-                }
-                Some(LiteralType::Date(d)) => {
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Date32(Some(*d)))))
-                }
-                Some(LiteralType::Fp32(f)) => {
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Float32(Some(*f)))))
-                }
-                Some(LiteralType::Fp64(f)) => {
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Float64(Some(*f)))))
-                }
-                Some(LiteralType::Decimal(d)) => {
-                    let value: [u8; 16] = d.value.clone().try_into().or(Err(
-                        DataFusionError::Substrait(
-                            "Failed to parse decimal value".to_string(),
-                        ),
-                    ))?;
-                    let p = d.precision.try_into().map_err(|e| {
-                        DataFusionError::Substrait(format!(
-                            "Failed to parse decimal precision: {e}"
-                        ))
-                    })?;
-                    let s = d.scale.try_into().map_err(|e| {
-                        DataFusionError::Substrait(format!(
-                            "Failed to parse decimal scale: {e}"
-                        ))
-                    })?;
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Decimal128(
-                        Some(std::primitive::i128::from_le_bytes(value)),
-                        p,
-                        s,
-                    ))))
-                }
-                Some(LiteralType::String(s)) => {
-                    Ok(Arc::new(Expr::Literal(ScalarValue::Utf8(Some(s.clone())))))
-                }
-                Some(LiteralType::Binary(b)) => Ok(Arc::new(Expr::Literal(
-                    ScalarValue::Binary(Some(b.clone())),
-                ))),
-                Some(LiteralType::Null(ntype)) => {
-                    Ok(Arc::new(Expr::Literal(from_substrait_null(ntype)?)))
-                }
-                _ => Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported literal_type: {:?}",
-                    lit.literal_type
-                ))),
-            }
+            let scalar_value = from_substrait_literal(lit)?;
+            Ok(Arc::new(Expr::Literal(scalar_value)))
         }
         Some(RexType::Cast(cast)) => match cast.as_ref().r#type.as_ref() {
             Some(output_type) => Ok(Arc::new(Expr::Cast(Cast::new(
@@ -1008,20 +908,196 @@ fn from_substrait_bound(
     }
 }
 
+fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
+    let scalar_value = match &lit.literal_type {
+        Some(LiteralType::Boolean(b)) => ScalarValue::Boolean(Some(*b)),
+        Some(LiteralType::I8(n)) => match lit.type_variation_reference {
+            DEFAULT_TYPE_REF => ScalarValue::Int8(Some(*n as i8)),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt8(Some(*n as u8)),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::I16(n)) => match lit.type_variation_reference {
+            DEFAULT_TYPE_REF => ScalarValue::Int16(Some(*n as i16)),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt16(Some(*n as u16)),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::I32(n)) => match lit.type_variation_reference {
+            DEFAULT_TYPE_REF => ScalarValue::Int32(Some(*n)),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt32(Some(unsafe {
+                std::mem::transmute_copy::<i32, u32>(n)
+            })),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::I64(n)) => match lit.type_variation_reference {
+            DEFAULT_TYPE_REF => ScalarValue::Int64(Some(*n)),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt64(Some(unsafe {
+                std::mem::transmute_copy::<i64, u64>(n)
+            })),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::Fp32(f)) => ScalarValue::Float32(Some(*f)),
+        Some(LiteralType::Fp64(f)) => ScalarValue::Float64(Some(*f)),
+        Some(LiteralType::Timestamp(t)) => match lit.type_variation_reference {
+            TIMESTAMP_SECOND_TYPE_REF => ScalarValue::TimestampSecond(Some(*t), None),
+            TIMESTAMP_MILLI_TYPE_REF => ScalarValue::TimestampMillisecond(Some(*t), None),
+            TIMESTAMP_MICRO_TYPE_REF => ScalarValue::TimestampMicrosecond(Some(*t), None),
+            TIMESTAMP_NANO_TYPE_REF => ScalarValue::TimestampNanosecond(Some(*t), None),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::Date(d)) => ScalarValue::Date32(Some(*d)),
+        Some(LiteralType::String(s)) => match lit.type_variation_reference {
+            DEFAULT_CONTAINER_TYPE_REF => ScalarValue::Utf8(Some(s.clone())),
+            LARGE_CONTAINER_TYPE_REF => ScalarValue::LargeUtf8(Some(s.clone())),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::Binary(b)) => match lit.type_variation_reference {
+            DEFAULT_CONTAINER_TYPE_REF => ScalarValue::Binary(Some(b.clone())),
+            LARGE_CONTAINER_TYPE_REF => ScalarValue::LargeBinary(Some(b.clone())),
+            others => {
+                return Err(DataFusionError::Substrait(format!(
+                    "Unknown type variation reference {others}",
+                )));
+            }
+        },
+        Some(LiteralType::FixedBinary(b)) => {
+            ScalarValue::FixedSizeBinary(b.len() as _, Some(b.clone()))
+        }
+        Some(LiteralType::Decimal(d)) => {
+            let value: [u8; 16] =
+                d.value
+                    .clone()
+                    .try_into()
+                    .or(Err(DataFusionError::Substrait(
+                        "Failed to parse decimal value".to_string(),
+                    )))?;
+            let p = d.precision.try_into().map_err(|e| {
+                DataFusionError::Substrait(format!(
+                    "Failed to parse decimal precision: {e}"
+                ))
+            })?;
+            let s = d.scale.try_into().map_err(|e| {
+                DataFusionError::Substrait(format!("Failed to parse decimal scale: {e}"))
+            })?;
+            ScalarValue::Decimal128(
+                Some(std::primitive::i128::from_le_bytes(value)),
+                p,
+                s,
+            )
+        }
+        Some(LiteralType::Null(ntype)) => from_substrait_null(ntype)?,
+        _ => {
+            return Err(DataFusionError::NotImplemented(format!(
+                "Unsupported literal_type: {:?}",
+                lit.literal_type
+            )))
+        }
+    };
+
+    Ok(scalar_value)
+}
+
 fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
     if let Some(kind) = &null_type.kind {
         match kind {
-            r#type::Kind::I8(_) => Ok(ScalarValue::Int8(None)),
-            r#type::Kind::I16(_) => Ok(ScalarValue::Int16(None)),
-            r#type::Kind::I32(_) => Ok(ScalarValue::Int32(None)),
-            r#type::Kind::I64(_) => Ok(ScalarValue::Int64(None)),
+            r#type::Kind::Bool(_) => Ok(ScalarValue::Boolean(None)),
+            r#type::Kind::I8(integer) => match integer.type_variation_reference {
+                DEFAULT_TYPE_REF => Ok(ScalarValue::Int8(None)),
+                UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt8(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::I16(integer) => match integer.type_variation_reference {
+                DEFAULT_TYPE_REF => Ok(ScalarValue::Int16(None)),
+                UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt16(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::I32(integer) => match integer.type_variation_reference {
+                DEFAULT_TYPE_REF => Ok(ScalarValue::Int32(None)),
+                UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt32(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::I64(integer) => match integer.type_variation_reference {
+                DEFAULT_TYPE_REF => Ok(ScalarValue::Int64(None)),
+                UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt64(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::Fp32(_) => Ok(ScalarValue::Float32(None)),
+            r#type::Kind::Fp64(_) => Ok(ScalarValue::Float64(None)),
+            r#type::Kind::Timestamp(ts) => match ts.type_variation_reference {
+                TIMESTAMP_SECOND_TYPE_REF => Ok(ScalarValue::TimestampSecond(None, None)),
+                TIMESTAMP_MILLI_TYPE_REF => {
+                    Ok(ScalarValue::TimestampMillisecond(None, None))
+                }
+                TIMESTAMP_MICRO_TYPE_REF => {
+                    Ok(ScalarValue::TimestampMicrosecond(None, None))
+                }
+                TIMESTAMP_NANO_TYPE_REF => {
+                    Ok(ScalarValue::TimestampNanosecond(None, None))
+                }
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::Date(date) => match date.type_variation_reference {
+                DATE_32_TYPE_REF => Ok(ScalarValue::Date32(None)),
+                DATE_64_TYPE_REF => Ok(ScalarValue::Date64(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            r#type::Kind::Binary(binary) => match binary.type_variation_reference {
+                DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Binary(None)),
+                LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeBinary(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
+            // FixedBinary is not supported because `None` doesn't have length
+            r#type::Kind::String(string) => match string.type_variation_reference {
+                DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Utf8(None)),
+                LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeUtf8(None)),
+                v @ _ => Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported Substrait type variation {v} of type {kind:?}"
+                ))),
+            },
             r#type::Kind::Decimal(d) => Ok(ScalarValue::Decimal128(
                 None,
                 d.precision as u8,
                 d.scale as i8,
             )),
             _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported null kind: {kind:?}"
+                "Unsupported Substrait type: {kind:?}"
             ))),
         }
     } else {

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -644,49 +644,7 @@ pub fn to_substrait_rex(
                 ))),
             })
         }
-        Expr::Literal(value) => {
-            // let literal_type = match value {
-            //     ScalarValue::Int8(Some(n)) => Some(LiteralType::I8(*n as i32)),
-            //     ScalarValue::UInt8(Some(n)) => Some(LiteralType::I8(*n as i32)),
-            //     ScalarValue::Int16(Some(n)) => Some(LiteralType::I16(*n as i32)),
-            //     ScalarValue::UInt16(Some(n)) => Some(LiteralType::I16(*n as i32)),
-            //     ScalarValue::Int32(Some(n)) => Some(LiteralType::I32(*n)),
-            //     ScalarValue::UInt32(Some(n)) => Some(LiteralType::I32(unsafe {
-            //         mem::transmute_copy::<u32, i32>(n)
-            //     })),
-            //     ScalarValue::Int64(Some(n)) => Some(LiteralType::I64(*n)),
-            //     ScalarValue::UInt64(Some(n)) => Some(LiteralType::I64(unsafe {
-            //         mem::transmute_copy::<u64, i64>(n)
-            //     })),
-            //     ScalarValue::Boolean(Some(b)) => Some(LiteralType::Boolean(*b)),
-            //     ScalarValue::Float32(Some(f)) => Some(LiteralType::Fp32(*f)),
-            //     ScalarValue::Float64(Some(f)) => Some(LiteralType::Fp64(*f)),
-            //     ScalarValue::Decimal128(v, p, s) if v.is_some() => {
-            //         Some(LiteralType::Decimal(Decimal {
-            //             value: v.unwrap().to_le_bytes().to_vec(),
-            //             precision: *p as i32,
-            //             scale: *s as i32,
-            //         }))
-            //     }
-            //     ScalarValue::Utf8(Some(s)) => Some(LiteralType::String(s.clone())),
-            //     ScalarValue::LargeUtf8(Some(s)) => Some(LiteralType::String(s.clone())),
-            //     ScalarValue::Binary(Some(b)) => Some(LiteralType::Binary(b.clone())),
-            //     ScalarValue::LargeBinary(Some(b)) => Some(LiteralType::Binary(b.clone())),
-            //     ScalarValue::Date32(Some(d)) => Some(LiteralType::Date(*d)),
-            //     _ => Some(try_to_substrait_null(value)?),
-            // };
-
-            // let type_variation_reference = if value.is_unsigned() { 1 } else { 0 };
-
-            // Ok(Expression {
-            //     rex_type: Some(RexType::Literal(Literal {
-            //         nullable: true,
-            //         type_variation_reference,
-            //         literal_type,
-            //     })),
-            // })
-            to_substrait_literal(value)
-        }
+        Expr::Literal(value) => to_substrait_literal(value),
         Expr::Alias(expr, _alias) => to_substrait_rex(expr, schema, extension_info),
         Expr::WindowFunction(WindowFunction {
             fun,

--- a/datafusion/substrait/src/variation_const.rs
+++ b/datafusion/substrait/src/variation_const.rs
@@ -16,6 +16,14 @@
 // under the License.
 
 //! Type variation constants
+//!
+//! To add support for types not in the [core specification](https://substrait.io/types/type_classes/),
+//! we make use of the [simple extensions](https://substrait.io/extensions/#simple-extensions) of substrait
+//! type. This module contains the constants used to identify the type variation.
+//!
+//! The rules of type variations here are:
+//! - Default type reference is 0. It is used when the actual type is the same with the original type.
+//! - Extended variant type references start from 1, and ususlly increase by 1.
 
 pub const DEFAULT_TYPE_REF: u32 = 0;
 pub const UNSIGNED_INTEGER_TYPE_REF: u32 = 1;

--- a/datafusion/substrait/src/variation_const.rs
+++ b/datafusion/substrait/src/variation_const.rs
@@ -15,10 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod logical_plan;
-pub mod physical_plan;
-pub mod serializer;
-mod variation_const;
+//! Type variation constants
 
-// Re-export substrait crate
-pub use substrait;
+pub const DEFAULT_TYPE_REF: u32 = 0;
+pub const UNSIGNED_INTEGER_TYPE_REF: u32 = 1;
+pub const TIMESTAMP_SECOND_TYPE_REF: u32 = 0;
+pub const TIMESTAMP_MILLI_TYPE_REF: u32 = 1;
+pub const TIMESTAMP_MICRO_TYPE_REF: u32 = 2;
+pub const TIMESTAMP_NANO_TYPE_REF: u32 = 3;
+pub const DATE_32_TYPE_REF: u32 = 0;
+pub const DATE_64_TYPE_REF: u32 = 1;
+pub const DEFAULT_CONTAINER_TYPE_REF: u32 = 0;
+pub const LARGE_CONTAINER_TYPE_REF: u32 = 1;
+pub const DECIMAL_128_TYPE_REF: u32 = 0;
+pub const DECIMAL_256_TYPE_REF: u32 = 1;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/5717.

# Rationale for this change


Extend the type and literal support in substrait. Most of simple type/literal are supported (exception: `Date64` literal), and compound types except `FixedSizeUtf8`, `FixedSizeList`, `Dictionary` etc.

# What changes are included in this PR?



# Are these changes tested?

Some of, see comment below

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

Not breaking

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->