### PR TITLE
Return an error for invalid placeholder `$0` instead of panicking

### DIFF
--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -97,6 +97,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // Parse the placeholder as a number because it is the only support from sqlparser and postgres
         let index = param[1..].parse::<usize>();
         let idx = match index {
+            Ok(0) => {
+                return Err(DataFusionError::Plan(format!(
+                    "Invalid placeholder, zero is not a valid index: {param}"
+                )));
+            }
             Ok(index) => index - 1,
             Err(_) => {
                 return Err(DataFusionError::Plan(format!(

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -3335,6 +3335,17 @@ fn test_prepare_statement_to_plan_panic_param_format() {
 }
 
 #[test]
+#[should_panic(
+    expected = "value: Plan(\"Invalid placeholder, zero is not a valid index: $0\""
+)]
+fn test_prepare_statement_to_plan_panic_param_zero() {
+    // param is zero following the $ sign
+    // panic due to error returned from the parser
+    let sql = "PREPARE my_plan(INT) AS SELECT id, age  FROM person WHERE age = $0";
+    logical_plan(sql).unwrap();
+}
+
+#[test]
 #[should_panic(expected = "value: SQL(ParserError(\"Expected AS, found: SELECT\"))")]
 fn test_prepare_statement_to_plan_panic_prepare_wrong_syntax() {
     // param is not number following the $ sign


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5786.

# Rationale for this change

Fixing a bug.

# What changes are included in this PR?

Updates `SqlToRel::create_placeholder_expr` to handle the case where `index == Ok(0)` by returning an `Err(_)` value with an appropriate error description.

# Are these changes tested?

This PR adds a test case `test_prepare_statement_to_plan_panic_param_zero` (based on `test_prepare_statement_to_plan_panic_param_format`) to check this case.

https://github.com/apache/arrow-datafusion/blob/ed8f914d5621adccbcfc375c865036a37efdbcc1/datafusion/sql/tests/integration_test.rs#L3337-L3346

# Are there any user-facing changes?

The invalid placeholder will now cause `SessionState::statement_to_plan` to fail gracefully instead of panicking (if overflow checks are enabled) or interpreting it as `$18446744073709551616` (otherwise).

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->