### PR TITLE
Support `INTERVAL` SQL Type

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2155,6 +2155,9 @@ impl ScalarValue {
             DataType::Interval(IntervalUnit::YearMonth) => {
                 build_array_primitive!(IntervalYearMonthArray, IntervalYearMonth)
             }
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                build_array_primitive!(IntervalMonthDayNanoArray, IntervalMonthDayNano)
+            }
             DataType::List(fields) if fields.data_type() == &DataType::Int8 => {
                 build_array_list_primitive!(Int8Type, Int8, i8)
             }
@@ -2304,7 +2307,6 @@ impl ScalarValue {
             | DataType::Time64(TimeUnit::Millisecond)
             | DataType::Duration(_)
             | DataType::FixedSizeList(_, _)
-            | DataType::Interval(_)
             | DataType::LargeList(_)
             | DataType::Union(_, _, _)
             | DataType::Map(_, _)
@@ -2844,6 +2846,20 @@ impl ScalarValue {
                         true => None,
                         false => Some(array.value(index).into()),
                     },
+                )
+            }
+            DataType::Interval(IntervalUnit::DayTime) => {
+                typed_cast!(array, index, IntervalDayTimeArray, IntervalDayTime)
+            }
+            DataType::Interval(IntervalUnit::YearMonth) => {
+                typed_cast!(array, index, IntervalYearMonthArray, IntervalYearMonth)
+            }
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                typed_cast!(
+                    array,
+                    index,
+                    IntervalMonthDayNanoArray,
+                    IntervalMonthDayNano
                 )
             }
             other => {

--- a/datafusion/core/tests/sqllogictests/test_files/arrow_typeof.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/arrow_typeof.slt
@@ -279,8 +279,20 @@ query error Cannot automatically convert Interval\(DayTime\) to Interval\(MonthD
 ---
 select arrow_cast(interval '30 minutes', 'Interval(MonthDayNano)');
 
-query error DataFusion error: This feature is not implemented: Can't create a scalar from array of type "Interval\(MonthDayNano\)"
+query ?
+select arrow_cast('30 minutes', 'Interval(DayTime)');
+----
+0 years 0 mons 0 days 0 hours 30 mins 0.000 secs
+
+query ?
+select arrow_cast('1 year 5 months', 'Interval(YearMonth)');
+----
+1 years 5 mons 0 days 0 hours 0 mins 0.00 secs
+
+query ?
 select arrow_cast('30 minutes', 'Interval(MonthDayNano)');
+----
+0 years 0 mons 0 days 0 hours 30 mins 0.000000000 secs
 
 
 ## Duration

--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -17,6 +17,7 @@
 
 
 # Use `interval` SQL literal syntax
+# the types should be the same: https://github.com/apache/arrow-datafusion/issues/5801
 query TT
 select
   arrow_typeof(interval '5 months'),
@@ -25,7 +26,7 @@ select
 Interval(YearMonth) Interval(MonthDayNano)
 
 
-# use interval SQL type
+# Use interval SQL type
 query TT
 select
   arrow_typeof('5 months'::interval),
@@ -42,10 +43,10 @@ select
 Interval(MonthDayNano) Interval(MonthDayNano)
 
 
-# Create tables with interval values
-# (TODO file ticket)
-#statement error DataFusion error: This feature is not implemented: Unsupported value Interval \{ value: Value\(SingleQuotedString\("5 days 3 nanoseconds"\)\), leading_field: None, leading_precision: None, last_field: None, fractional_seconds_precision: None \} in a values list expression
-#create table t (i interval) as values (interval '5 days 3 nanoseconds');
+# Should work tables with interval values
+# https://github.com/apache/arrow-datafusion/issues/5802
+statement error DataFusion error: This feature is not implemented: Unsupported value Interval \{ value: Value\(SingleQuotedString\("5 days 3 nanoseconds"\)\), leading_field: None, leading_precision: None, last_field: None, fractional_seconds_precision: None \} in a values list expression
+create table t (i interval) as values (interval '5 days 3 nanoseconds');
 
 
 # Create tables with interval values
@@ -66,5 +67,3 @@ from t;
 
 statement ok
 drop table t;
-
-# TODO write tests for casting 'interval ...' sytax to ::interval

--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# Use `interval` SQL literal syntax
+query TT
+select
+  arrow_typeof(interval '5 months'),
+  arrow_typeof(interval '5 days 3 nanoseconds')
+----
+Interval(YearMonth) Interval(MonthDayNano)
+
+
+# use interval SQL type
+query TT
+select
+  arrow_typeof('5 months'::interval),
+  arrow_typeof('5 days 3 nanoseconds'::interval)
+----
+Interval(MonthDayNano) Interval(MonthDayNano)
+
+# cast with explicit cast sytax
+query TT
+select
+  arrow_typeof(cast ('5 months' as interval)),
+  arrow_typeof(cast ('5 days 3 nanoseconds' as interval))
+----
+Interval(MonthDayNano) Interval(MonthDayNano)
+
+
+# Create tables with interval values
+# (TODO file ticket)
+#statement error DataFusion error: This feature is not implemented: Unsupported value Interval \{ value: Value\(SingleQuotedString\("5 days 3 nanoseconds"\)\), leading_field: None, leading_precision: None, last_field: None, fractional_seconds_precision: None \} in a values list expression
+#create table t (i interval) as values (interval '5 days 3 nanoseconds');
+
+
+# Create tables with interval values
+statement ok
+create table t (i interval) as values ('5 days 3 nanoseconds'::interval);
+
+statement ok
+insert into t values ('6 days 7 nanoseconds'::interval)
+
+query ?T
+select
+  i,
+  arrow_typeof(i)
+from t;
+----
+0 years 0 mons 5 days 0 hours 0 mins 0.000000003 secs Interval(MonthDayNano)
+0 years 0 mons 6 days 0 hours 0 mins 0.000000007 secs Interval(MonthDayNano)
+
+statement ok
+drop table t;
+
+# TODO write tests for casting 'interval ...' sytax to ::interval

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -295,6 +295,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 make_decimal_type(precision, scale)
             }
             SQLDataType::Bytea => Ok(DataType::Binary),
+            SQLDataType::Interval => Ok(DataType::Interval(IntervalUnit::MonthDayNano)),
             // Explicitly list all other types so that if sqlparser
             // adds/changes the `SQLDataType` the compiler will tell us on upgrade
             // and avoid bugs like https://github.com/apache/arrow-datafusion/issues/3059
@@ -305,7 +306,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             | SQLDataType::Varbinary(_)
             | SQLDataType::Blob(_)
             | SQLDataType::Datetime(_)
-            | SQLDataType::Interval
             | SQLDataType::Regclass
             | SQLDataType::Custom(_, _)
             | SQLDataType::Array(_)

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -77,12 +77,12 @@ For example, to cast the output of `now()` to a `Timestamp` with second precisio
 
 ## Date/Time Types
 
-| SQL DataType | Arrow DataType                                  |
-| ------------ | :---------------------------------------------- |
-| `DATE`       | `Date32`                                        |
-| `TIME`       | `Time64(Nanosecond)`                            |
-| `TIMESTAMP`  | `Timestamp(Nanosecond, None)`                   |
-| `INTERVAL`   | `Interval(IntervalUnit)` or `Interval(DayTime)` |
+| SQL DataType | Arrow DataType                   |
+| ------------ | :------------------------------- |
+| `DATE`       | `Date32`                         |
+| `TIME`       | `Time64(Nanosecond)`             |
+| `TIMESTAMP`  | `Timestamp(Nanosecond, None)`    |
+| `INTERVAL`   | `Interval(IntervalMonthDayNano)` |
 
 ## Boolean Types
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/5651

# Rationale for this change

See https://github.com/apache/arrow-datafusion/issues/5651 (basically I want to be able to interact with intervals like normal). Also related to https://github.com/apache/arrow-datafusion/pull/5764 from @berkaysynnada

# What changes are included in this PR?
1. Add basic support for `INTERVAL` SQL --> `DataType::Interval(MonthDayNano)` arrow type
2. Add code to go to/from ScalarValue and Interval Arrays
3. Basic tests

# Are these changes tested?
Yes

# Are there any user-facing changes?

Yes (you can now do `SELECT '1 day'::interval`) and it works!