### PR TITLE
Minor: fix docs build

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -24,5 +24,5 @@ rm -rf temp 2> /dev/null
 mkdir temp
 cp -rf source/* temp/
 # replace relative URLs with absolute URLs
-sed -i '' 's/\.\.\/\.\.\/\.\.\//https:\/\/github.com\/apache\/arrow-datafusion\/blob\/main\//g' temp/contributor-guide/index.md
+sed -i -e 's/\.\.\/\.\.\/\.\.\//https:\/\/github.com\/apache\/arrow-datafusion\/blob\/main\//g' temp/contributor-guide/index.md
 make SOURCEDIR=`pwd`/temp html


### PR DESCRIPTION
# Which issue does this PR close?

NA
# Rationale for this change

https://github.com/apache/arrow-datafusion/pull/5780 unfortunately broke the docs build (see https://github.com/apache/arrow-datafusion/actions/runs/4566861530/jobs/8059935571)

I think this is because @sanderson fixed the script to work on mac (it previously was broken) but that sadly broke it on linux. 

# What changes are included in this PR?
Mess with `sed` command line

# Are these changes tested?

No -- will test 'live'

# Are there any user-facing changes?

Not really