### PR TITLE
Poll next open file future while scanning current file

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -304,6 +304,7 @@ impl<F: FileOpener> FileStream<F> {
                     partition_values,
                     next,
                 } => {
+                    // We need to poll the next `FileOpenFuture` here to drive it forward
                     if let Some((next_open_future, _)) = next {
                         if let NextOpen::Future(f) = next_open_future {
                             if let Poll::Ready(reader) = f.as_mut().poll(cx) {

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -83,9 +83,12 @@ pub struct FileStream<F: FileOpener> {
     baseline_metrics: BaselineMetrics,
 }
 
+/// Represents the state of the next `FileOpenFuture`. Since we need to poll
+/// this future while scanning the current file, we need to store the result if it 
+/// is ready
 enum NextOpen {
-    Future(FileOpenFuture),
-    Reader(Result<BoxStream<'static, Result<RecordBatch, ArrowError>>>),
+    Pending(FileOpenFuture),
+    Ready(Result<BoxStream<'static, Result<RecordBatch, ArrowError>>>),
 }
 
 enum FileStreamState {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5799.

# What changes are included in this PR?

Next file opening future will now be polled while the current file is being scanned.

# Are these changes tested?

I did not add any new tests as I believe this change should be covered by existing tests, but I am happy to add additional tests that I didn't think of.

# Are there any user-facing changes?

I believe not.