### PR TITLE
Minor: fix flaking test

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -56,7 +56,7 @@ create table t (i interval) as values ('5 days 3 nanoseconds'::interval);
 statement ok
 insert into t values ('6 days 7 nanoseconds'::interval)
 
-query ?T
+query ?T rowsort
 select
   i,
   arrow_typeof(i)


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/pull/5792

# Rationale for this change

One of the tests added in https://github.com/apache/arrow-datafusion/pull/5792 intermittently fails due to ordering mismatch -- for example 

https://github.com/apache/arrow-datafusion/actions/runs/4568420322/jobs/8063658835?pr=5803

```
[Diff] (-expected|+actual)
-   0 years 0 mons 5 days 0 hours 0 mins 0.000000003 secs Interval(MonthDayNano)
-   0 years 0 mons 6 days 0 hours 0 mins 0.000000007 secs Interval(MonthDayNano)
+   0 years 0 mons 6 days 0 hours 0 mins 0.000000007 secs Interval(MonthDayNano)
+   0 years 0 mons 5 days 0 hours 0 mins 0.000000003 secs Interval(MonthDayNano)
at tests/sqllogictests/test_files/interval.slt:59

```

# What changes are included in this PR?
Add sorting to test script to make test deterministic

# Are these changes tested?

yes 

# Are there any user-facing changes?

no