### PR TITLE
Minor: remove typed_min_max_batch_decimal128

### DIFF
--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -172,7 +172,14 @@ macro_rules! min_max_batch {
     ($VALUES:expr, $OP:ident) => {{
         match $VALUES.data_type() {
             DataType::Decimal128(precision, scale) => {
-                typed_min_max_batch!($VALUES, Decimal128Array, Decimal128, $OP, precision, scale)
+                typed_min_max_batch!(
+                    $VALUES,
+                    Decimal128Array,
+                    Decimal128,
+                    $OP,
+                    precision,
+                    scale
+                )
             }
             // all types that have a natural order
             DataType::Float64 => {


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-rs/issues/1010

# Rationale for this change
This function is not necessary now.

# What changes are included in this PR?
Remove the function "remove typed_min_max_batch_decimal128".

# Are these changes tested?
Yes

# Are there any user-facing changes?
No