### PR TITLE
Scalar arithmetic should return error when overflows.

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3760,7 +3760,7 @@ mod tests {
         let int_value = ScalarValue::Int32(Some(i32::MAX));
         let int_value_2 = ScalarValue::Int32(Some(i32::MIN));
         assert!(matches!(
-            int_value.sub(&int_value_2),
+            int_value.sub_checked(&int_value_2),
             Err(DataFusionError::Execution(msg)) if msg == "Overflow while calculating ScalarValue."
         ));
         Ok(())
@@ -3780,7 +3780,7 @@ mod tests {
         let int_value = ScalarValue::Int64(Some(i64::MAX));
         let int_value_2 = ScalarValue::Int64(Some(i64::MIN));
         assert!(matches!(
-            int_value.sub(&int_value_2),
+            int_value.sub_checked(&int_value_2),
             Err(DataFusionError::Execution(msg)) if msg == "Overflow while calculating ScalarValue."
         ));
         Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5810.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Repro in the bug itself. ScalarValue returns an error for many arithmetic errors, but not overflows. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Use `checked_*` and check results.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tests added.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->