### PR TITLE
support `date_trunc` with `millisecond` and `microsecond` and keep the same type as the input

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1442,6 +1442,39 @@ async fn test_arrow_typeof() -> Result<()> {
     ];
     assert_batches_eq!(expected, &actual);
 
+    let sql = "select arrow_typeof(date_trunc('second', to_timestamp_millis(61)));";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+---------------------------------------------------------------------+",
+        "| arrowtypeof(datetrunc(Utf8(\"second\"),totimestampmillis(Int64(61)))) |",
+        "+---------------------------------------------------------------------+",
+        "| Timestamp(Millisecond, None)                                        |",
+        "+---------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "select arrow_typeof(date_trunc('millisecond', to_timestamp_micros(61)));";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+--------------------------------------------------------------------------+",
+        "| arrowtypeof(datetrunc(Utf8(\"millisecond\"),totimestampmicros(Int64(61)))) |",
+        "+--------------------------------------------------------------------------+",
+        "| Timestamp(Microsecond, None)                                             |",
+        "+--------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    let sql = "select arrow_typeof(date_trunc('microsecond', to_timestamp(61)));";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+--------------------------------------------------------------------+",
+        "| arrowtypeof(datetrunc(Utf8(\"microsecond\"),totimestamp(Int64(61)))) |",
+        "+--------------------------------------------------------------------+",
+        "| Timestamp(Nanosecond, None)                                        |",
+        "+--------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
     Ok(())
 }
 

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -1427,6 +1427,25 @@ async fn cast_timestamp_before_1970() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_arrow_typeof() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select arrow_typeof(date_trunc('minute', to_timestamp_seconds(61)));";
+    let actual = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+----------------------------------------------------------------------+",
+        "| arrowtypeof(datetrunc(Utf8(\"minute\"),totimestampseconds(Int64(61)))) |",
+        "+----------------------------------------------------------------------+",
+        "| Timestamp(Second, None)                                              |",
+        "+----------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn cast_timestamp_to_timestamptz() -> Result<()> {
     let ctx = SessionContext::new();
     let table_a = make_timestamp_table::<TimestampNanosecondType>()?;

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -133,7 +133,7 @@ pub fn return_type(
         BuiltinScalarFunction::ConcatWithSeparator => Ok(DataType::Utf8),
         BuiltinScalarFunction::DatePart => Ok(DataType::Float64),
         BuiltinScalarFunction::DateTrunc => match input_expr_types[1] {
-            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+            DataType::Timestamp(TimeUnit::Nanosecond, _) | DataType::Utf8 => {
                 Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -132,9 +132,24 @@ pub fn return_type(
         BuiltinScalarFunction::Concat => Ok(DataType::Utf8),
         BuiltinScalarFunction::ConcatWithSeparator => Ok(DataType::Utf8),
         BuiltinScalarFunction::DatePart => Ok(DataType::Float64),
-        BuiltinScalarFunction::DateTrunc => {
-            Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
-        }
+        BuiltinScalarFunction::DateTrunc => match input_expr_types[1] {
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
+            }
+            DataType::Timestamp(TimeUnit::Second, _) => {
+                Ok(DataType::Timestamp(TimeUnit::Second, None))
+            }
+            _ => Err(DataFusionError::Internal(
+                "The date_trunc function can only accept timestamp as the second arg."
+                    .to_string(),
+            )),
+        },
         BuiltinScalarFunction::DateBin => {
             Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
         }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -222,7 +222,7 @@ fn date_trunc_single(granularity: &str, value: i64) -> Result<i64> {
         })?
         .with_nanosecond(0);
     let value = match granularity {
-        "second" => value,
+        "second" | "millisecond" | "microsecond" => value,
         "minute" => value.and_then(|d| d.with_second(0)),
         "hour" => value
             .and_then(|d| d.with_second(0))
@@ -289,6 +289,22 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(second)
+                }
+                "second" => {
+                    // cast to millisecond
+                    let mill = ScalarValue::TimestampMillisecond(
+                        Some(nano.unwrap() / 1_000_000),
+                        tz_opt.clone(),
+                    );
+                    ColumnarValue::Scalar(mill)
+                }
+                "millisecond" => {
+                    // cast to microsecond
+                    let micro = ScalarValue::TimestampMicrosecond(
+                        Some(nano.unwrap() / 1_000),
+                        tz_opt.clone(),
+                    );
+                    ColumnarValue::Scalar(micro)
                 }
                 _ => {
                     // cast to nanosecond


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5750

# Rationale for this change
`date_trunc` will return `TimestampSecond` when truncing minute.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->