### PR TITLE
Implement LogicalPlan support for transactions

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1157,6 +1157,18 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: Dml".to_string(),
                     ))
                 }
+                LogicalPlan::TransactionStart(_) => {
+                    // DataFusion is a read-only query engine, but also a library, so consumers may implement this
+                    Err(DataFusionError::NotImplemented(
+                        "Unsupported logical plan: TransactionStart".to_string(),
+                    ))
+                }
+                LogicalPlan::TransactionEnd(_) => {
+                    // DataFusion is a read-only query engine, but also a library, so consumers may implement this
+                    Err(DataFusionError::NotImplemented(
+                        "Unsupported logical plan: TransactionEnd".to_string(),
+                    ))
+                }
                 LogicalPlan::SetVariable(_) => {
                     Err(DataFusionError::Internal(
                         "Unsupported logical plan: SetVariable must be root of the plan".to_string(),

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -27,9 +27,8 @@ pub use plan::{
     DropTable, DropView, EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint,
     JoinType, Limit, LogicalPlan, Partitioning, PlanType, Prepare, Projection,
     Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, TransactionAccessMode, TransactionConclusion, TransactionEndNode,
-    TransactionIsolationLevel, TransactionStartNode, Union, Unnest, Values, Window,
-    WriteOp,
+    ToStringifiedPlan, TransactionAccessMode, TransactionConclusion, TransactionEnd,
+    TransactionIsolationLevel, TransactionStart, Union, Unnest, Values, Window, WriteOp,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -27,7 +27,9 @@ pub use plan::{
     DropTable, DropView, EmptyRelation, Explain, Extension, Filter, Join, JoinConstraint,
     JoinType, Limit, LogicalPlan, Partitioning, PlanType, Prepare, Projection,
     Repartition, SetVariable, Sort, StringifiedPlan, Subquery, SubqueryAlias, TableScan,
-    ToStringifiedPlan, Union, Unnest, Values, Window, WriteOp,
+    ToStringifiedPlan, TransactionAccessMode, TransactionConclusion, TransactionEndNode,
+    TransactionIsolationLevel, TransactionStartNode, Union, Unnest, Values, Window,
+    WriteOp,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -127,9 +127,9 @@ pub enum LogicalPlan {
     /// Unnest a column that contains a nested list type.
     Unnest(Unnest),
     // Begin a transaction
-    TransactionStart(TransactionStartNode),
+    TransactionStart(TransactionStart),
     // Commit or rollback a transaction
-    TransactionEnd(TransactionEndNode),
+    TransactionEnd(TransactionEnd),
 }
 
 impl LogicalPlan {
@@ -175,8 +175,8 @@ impl LogicalPlan {
             }
             LogicalPlan::Dml(DmlStatement { table_schema, .. }) => table_schema,
             LogicalPlan::Unnest(Unnest { schema, .. }) => schema,
-            LogicalPlan::TransactionStart(TransactionStartNode { schema, .. }) => schema,
-            LogicalPlan::TransactionEnd(TransactionEndNode { schema, .. }) => schema,
+            LogicalPlan::TransactionStart(TransactionStart { schema, .. }) => schema,
+            LogicalPlan::TransactionEnd(TransactionEnd { schema, .. }) => schema,
         }
     }
 
@@ -1076,7 +1076,7 @@ impl LogicalPlan {
                     }) => {
                         write!(f, "TransactionStart: {access_mode:?} {isolation_level:?}")
                     }
-                    LogicalPlan::TransactionEnd(TransactionEndNode {
+                    LogicalPlan::TransactionEnd(TransactionEnd {
                         conclusion,
                         chain,
                         ..
@@ -1616,7 +1616,7 @@ pub enum TransactionIsolationLevel {
 
 /// Indicator that the following statements should be committed or rolled back atomically
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct TransactionStartNode {
+pub struct TransactionStart {
     /// indicates if transaction is allowed to write
     pub access_mode: TransactionAccessMode,
     // indicates ANSI isolation level
@@ -1627,7 +1627,7 @@ pub struct TransactionStartNode {
 
 /// Indicator that any current transaction should be terminated
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct TransactionEndNode {
+pub struct TransactionEnd {
     /// whether the transaction committed or aborted
     pub conclusion: TransactionConclusion,
     /// if specified a new transaction is immediately started with same characteristics

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1069,7 +1069,7 @@ impl LogicalPlan {
                     }) => {
                         write!(f, "DropTable: {name:?} if not exist:={if_exists}")
                     }
-                    LogicalPlan::TransactionStart(TransactionStartNode {
+                    LogicalPlan::TransactionStart(TransactionStart {
                         access_mode,
                         isolation_level,
                         ..

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -913,6 +913,8 @@ pub fn from_plan(
         | LogicalPlan::CreateExternalTable(_)
         | LogicalPlan::DropTable(_)
         | LogicalPlan::DropView(_)
+        | LogicalPlan::TransactionStart(_)
+        | LogicalPlan::TransactionEnd(_)
         | LogicalPlan::SetVariable(_)
         | LogicalPlan::CreateCatalogSchema(_)
         | LogicalPlan::CreateCatalog(_) => {

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -237,6 +237,8 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::CreateCatalog(_)
             | LogicalPlan::DropTable(_)
             | LogicalPlan::DropView(_)
+            | LogicalPlan::TransactionStart(_)
+            | LogicalPlan::TransactionEnd(_)
             | LogicalPlan::SetVariable(_)
             | LogicalPlan::DescribeTable(_)
             | LogicalPlan::Distinct(_)

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1366,6 +1366,12 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::Dml(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for Dml",
             )),
+            LogicalPlan::TransactionStart(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for Transactions",
+            )),
+            LogicalPlan::TransactionEnd(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for Transactions",
+            )),
             LogicalPlan::DescribeTable(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DescribeTable",
             )),

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -31,8 +31,8 @@ use datafusion_common::{
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::builder::project;
 use datafusion_expr::logical_plan::{
-    Analyze, Prepare, TransactionAccessMode, TransactionConclusion, TransactionEndNode,
-    TransactionIsolationLevel, TransactionStartNode,
+    Analyze, Prepare, TransactionAccessMode, TransactionConclusion, TransactionEnd,
+    TransactionIsolationLevel, TransactionStart,
 };
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
@@ -437,21 +437,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         TransactionAccessMode::ReadWrite
                     }
                 };
-                Ok(LogicalPlan::TransactionStart(TransactionStartNode {
+                Ok(LogicalPlan::TransactionStart(TransactionStart {
                     access_mode,
                     isolation_level,
                     schema: DFSchemaRef::new(DFSchema::empty()),
                 }))
             }
             Statement::Commit { chain } => {
-                Ok(LogicalPlan::TransactionEnd(TransactionEndNode {
+                Ok(LogicalPlan::TransactionEnd(TransactionEnd {
                     conclusion: TransactionConclusion::Commit,
                     chain,
                     schema: DFSchemaRef::new(DFSchema::empty()),
                 }))
             }
             Statement::Rollback { chain } => {
-                Ok(LogicalPlan::TransactionEnd(TransactionEndNode {
+                Ok(LogicalPlan::TransactionEnd(TransactionEnd {
                     conclusion: TransactionConclusion::Rollback,
                     chain,
                     schema: DFSchemaRef::new(DFSchema::empty()),

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -30,7 +30,10 @@ use datafusion_common::{
 };
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::builder::project;
-use datafusion_expr::logical_plan::{Analyze, Prepare};
+use datafusion_expr::logical_plan::{
+    Analyze, Prepare, TransactionAccessMode, TransactionConclusion, TransactionEndNode,
+    TransactionIsolationLevel, TransactionStartNode,
+};
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
     cast, col, CreateCatalog, CreateCatalogSchema,
@@ -43,7 +46,7 @@ use sqlparser::ast;
 use sqlparser::ast::{
     Assignment, Expr as SQLExpr, Expr, Ident, ObjectName, ObjectType, OrderByExpr, Query,
     SchemaName, SetExpr, ShowCreateObject, ShowStatementFilter, Statement, TableFactor,
-    TableWithJoins, UnaryOperator, Value,
+    TableWithJoins, TransactionMode, UnaryOperator, Value,
 };
 
 use sqlparser::parser::ParserError::ParserError;
@@ -391,6 +394,68 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     ))?;
                 }
                 self.delete_to_plan(table_name, selection)
+            }
+
+            Statement::StartTransaction { modes } => {
+                let isolation_level: ast::TransactionIsolationLevel = modes
+                    .iter()
+                    .filter_map(|m: &ast::TransactionMode| match m {
+                        TransactionMode::AccessMode(_) => None,
+                        TransactionMode::IsolationLevel(level) => Some(level),
+                    })
+                    .last()
+                    .copied()
+                    .unwrap_or(ast::TransactionIsolationLevel::Serializable);
+                let access_mode: ast::TransactionAccessMode = modes
+                    .iter()
+                    .filter_map(|m: &ast::TransactionMode| match m {
+                        TransactionMode::AccessMode(mode) => Some(mode),
+                        TransactionMode::IsolationLevel(_) => None,
+                    })
+                    .last()
+                    .copied()
+                    .unwrap_or(ast::TransactionAccessMode::ReadWrite);
+                let isolation_level = match isolation_level {
+                    ast::TransactionIsolationLevel::ReadUncommitted => {
+                        TransactionIsolationLevel::ReadUncommitted
+                    }
+                    ast::TransactionIsolationLevel::ReadCommitted => {
+                        TransactionIsolationLevel::ReadCommitted
+                    }
+                    ast::TransactionIsolationLevel::RepeatableRead => {
+                        TransactionIsolationLevel::RepeatableRead
+                    }
+                    ast::TransactionIsolationLevel::Serializable => {
+                        TransactionIsolationLevel::Serializable
+                    }
+                };
+                let access_mode = match access_mode {
+                    ast::TransactionAccessMode::ReadOnly => {
+                        TransactionAccessMode::ReadOnly
+                    }
+                    ast::TransactionAccessMode::ReadWrite => {
+                        TransactionAccessMode::ReadWrite
+                    }
+                };
+                Ok(LogicalPlan::TransactionStart(TransactionStartNode {
+                    access_mode,
+                    isolation_level,
+                    schema: DFSchemaRef::new(DFSchema::empty()),
+                }))
+            }
+            Statement::Commit { chain } => {
+                Ok(LogicalPlan::TransactionEnd(TransactionEndNode {
+                    conclusion: TransactionConclusion::Commit,
+                    chain,
+                    schema: DFSchemaRef::new(DFSchema::empty()),
+                }))
+            }
+            Statement::Rollback { chain } => {
+                Ok(LogicalPlan::TransactionEnd(TransactionEndNode {
+                    conclusion: TransactionConclusion::Rollback,
+                    chain,
+                    schema: DFSchemaRef::new(DFSchema::empty()),
+                }))
             }
 
             _ => Err(DataFusionError::NotImplemented(format!(

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -200,6 +200,73 @@ fn cast_to_invalid_decimal_type() {
 }
 
 #[test]
+fn plan_start_transaction() {
+    let sql = "start transaction";
+    let plan = "TransactionStart: ReadWrite Serializable";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_start_transaction_isolation() {
+    let sql = "start transaction isolation level read committed";
+    let plan = "TransactionStart: ReadWrite ReadCommitted";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_start_transaction_read_only() {
+    let sql = "start transaction read only";
+    let plan = "TransactionStart: ReadOnly Serializable";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_start_transaction_fully_qualified() {
+    let sql = "start transaction isolation level read committed read only";
+    let plan = "TransactionStart: ReadOnly ReadCommitted";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_start_transaction_overly_qualified() {
+    let sql = r#"start transaction
+isolation level read committed
+read only
+isolation level repeatable read
+"#;
+    let plan = "TransactionStart: ReadOnly RepeatableRead";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_commit_transaction() {
+    let sql = "commit transaction";
+    let plan = "TransactionEnd: Commit chain:=false";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_commit_transaction_chained() {
+    let sql = "commit transaction and chain";
+    let plan = "TransactionEnd: Commit chain:=true";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_rollback_transaction() {
+    let sql = "rollback transaction";
+    let plan = "TransactionEnd: Rollback chain:=false";
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_rollback_transaction_chained() {
+    let sql = "rollback transaction and chain";
+    let plan = "TransactionEnd: Rollback chain:=true";
+    quick_test(sql, plan);
+}
+
+#[test]
 fn plan_insert() {
     let sql =
         "insert into person (id, first_name, last_name) values (1, 'Alan', 'Turing')";


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5826.

# Rationale for this change

To make it easier for folks to build execution engines on top of DataFusion's planner (see issue for more detail).

# What changes are included in this PR?

Two LogicalPlan nodes for starting and ending transactions.

# Are these changes tested?

Additional tests were added to the planner.

# Are there any user-facing changes?

When users try to run begin and end transaction statements, they will now fail in physical instead of logical planning.