### PR TITLE
Add primary key information to CreateMemoryTable LogicalPlan node

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -344,8 +344,15 @@ impl SessionContext {
                 input,
                 if_not_exists,
                 or_replace,
-                ..
+                primary_key,
             }) => {
+                if !primary_key.is_empty() {
+                    Err(DataFusionError::Execution(
+                        "Primary keys on MemoryTables are not currently supported!"
+                            .to_string(),
+                    ))?;
+                }
+
                 let input = Arc::try_unwrap(input).unwrap_or_else(|e| e.as_ref().clone());
                 let table = self.table(&name).await;
 

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -344,6 +344,7 @@ impl SessionContext {
                 input,
                 if_not_exists,
                 or_replace,
+                ..
             }) => {
                 let input = Arc::try_unwrap(input).unwrap_or_else(|e| e.as_ref().clone());
                 let table = self.table(&name).await;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1046,9 +1046,17 @@ impl LogicalPlan {
                         write!(f, "CreateExternalTable: {name:?}")
                     }
                     LogicalPlan::CreateMemoryTable(CreateMemoryTable {
-                        name, ..
+                        name,
+                        primary_key,
+                        ..
                     }) => {
-                        write!(f, "CreateMemoryTable: {name:?}")
+                        let pk: Vec<String> =
+                            primary_key.iter().map(|c| c.name.to_string()).collect();
+                        let mut pk = pk.join(", ");
+                        if !pk.is_empty() {
+                            pk = format!(" primary_key=[{pk}]");
+                        }
+                        write!(f, "CreateMemoryTable: {name:?}{pk}")
                     }
                     LogicalPlan::CreateView(CreateView { name, .. }) => {
                         write!(f, "CreateView: {name:?}")

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1490,6 +1490,8 @@ pub struct Union {
 pub struct CreateMemoryTable {
     /// The table name
     pub name: OwnedTableReference,
+    /// The ordered list of columns in the primary key, or an empty vector if none
+    pub primary_key: Vec<Column>,
     /// The logical plan
     pub input: Arc<LogicalPlan>,
     /// Option to not error if table already exists

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -843,6 +843,7 @@ pub fn from_plan(
             ..
         }) => Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
             input: Arc::new(inputs[0].clone()),
+            primary_key: vec![],
             name: name.clone(),
             if_not_exists: *if_not_exists,
             or_replace: *or_replace,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -45,8 +45,8 @@ use datafusion_expr::{
 use sqlparser::ast;
 use sqlparser::ast::{
     Assignment, Expr as SQLExpr, Expr, Ident, ObjectName, ObjectType, OrderByExpr, Query,
-    SchemaName, SetExpr, ShowCreateObject, ShowStatementFilter, Statement, TableFactor,
-    TableWithJoins, TransactionMode, UnaryOperator, Value,
+    SchemaName, SetExpr, ShowCreateObject, ShowStatementFilter, Statement,
+    TableConstraint, TableFactor, TableWithJoins, TransactionMode, UnaryOperator, Value,
 };
 
 use sqlparser::parser::ParserError::ParserError;
@@ -128,69 +128,91 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 if_not_exists,
                 or_replace,
                 ..
-            } if constraints.is_empty()
-                && table_properties.is_empty()
-                && with_options.is_empty() =>
-            {
-                match query {
-                    Some(query) => {
-                        let plan = self.query_to_plan(*query, planner_context)?;
-                        let input_schema = plan.schema();
+            } if table_properties.is_empty() && with_options.is_empty() => match query {
+                Some(query) => {
+                    let plan = self.query_to_plan(*query, planner_context)?;
+                    let input_schema = plan.schema();
 
-                        let plan = if !columns.is_empty() {
-                            let schema = self.build_schema(columns)?.to_dfschema_ref()?;
-                            if schema.fields().len() != input_schema.fields().len() {
-                                return Err(DataFusionError::Plan(format!(
+                    let plan = if !columns.is_empty() {
+                        let schema = self.build_schema(columns)?.to_dfschema_ref()?;
+                        if schema.fields().len() != input_schema.fields().len() {
+                            return Err(DataFusionError::Plan(format!(
                             "Mismatch: {} columns specified, but result has {} columns",
                             schema.fields().len(),
                             input_schema.fields().len()
                         )));
-                            }
-                            let input_fields = input_schema.fields();
-                            let project_exprs = schema
-                                .fields()
-                                .iter()
-                                .zip(input_fields)
-                                .map(|(field, input_field)| {
-                                    cast(
-                                        col(input_field.name()),
-                                        field.data_type().clone(),
-                                    )
+                        }
+                        let input_fields = input_schema.fields();
+                        let project_exprs = schema
+                            .fields()
+                            .iter()
+                            .zip(input_fields)
+                            .map(|(field, input_field)| {
+                                cast(col(input_field.name()), field.data_type().clone())
                                     .alias(field.name())
-                                })
-                                .collect::<Vec<_>>();
-                            LogicalPlanBuilder::from(plan.clone())
-                                .project(project_exprs)?
-                                .build()?
-                        } else {
-                            plan
-                        };
+                            })
+                            .collect::<Vec<_>>();
+                        LogicalPlanBuilder::from(plan.clone())
+                            .project(project_exprs)?
+                            .build()?
+                    } else {
+                        plan
+                    };
 
-                        Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
-                            name: self.object_name_to_table_reference(name)?,
-                            input: Arc::new(plan),
-                            if_not_exists,
-                            or_replace,
-                        }))
-                    }
-
-                    None => {
-                        let schema = self.build_schema(columns)?.to_dfschema_ref()?;
-                        let plan = EmptyRelation {
-                            produce_one_row: false,
-                            schema,
-                        };
-                        let plan = LogicalPlan::EmptyRelation(plan);
-
-                        Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
-                            name: self.object_name_to_table_reference(name)?,
-                            input: Arc::new(plan),
-                            if_not_exists,
-                            or_replace,
-                        }))
-                    }
+                    Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
+                        name: self.object_name_to_table_reference(name)?,
+                        primary_key: vec![],
+                        input: Arc::new(plan),
+                        if_not_exists,
+                        or_replace,
+                    }))
                 }
-            }
+
+                None => {
+                    let pk: Option<Vec<Ident>> = constraints
+                        .iter()
+                        .filter_map(|c: &TableConstraint| match c {
+                            TableConstraint::Unique {
+                                columns,
+                                is_primary,
+                                ..
+                            } => match is_primary {
+                                true => Some(columns),
+                                false => None,
+                            },
+                            TableConstraint::ForeignKey { .. } => None,
+                            TableConstraint::Check { .. } => None,
+                            TableConstraint::Index { .. } => None,
+                            TableConstraint::FulltextOrSpatial { .. } => None,
+                        })
+                        .last()
+                        .cloned();
+                    let primary_key: Vec<Column> =
+                        pk.map_or(vec![], |cols: Vec<Ident>| {
+                            cols.iter()
+                                .map(|c| Column {
+                                    relation: None,
+                                    name: c.value.clone(),
+                                })
+                                .collect()
+                        });
+
+                    let schema = self.build_schema(columns)?.to_dfschema_ref()?;
+                    let plan = EmptyRelation {
+                        produce_one_row: false,
+                        schema,
+                    };
+                    let plan = LogicalPlan::EmptyRelation(plan);
+
+                    Ok(LogicalPlan::CreateMemoryTable(CreateMemoryTable {
+                        name: self.object_name_to_table_reference(name)?,
+                        primary_key,
+                        input: Arc::new(plan),
+                        if_not_exists,
+                        or_replace,
+                    }))
+                }
+            },
 
             Statement::CreateView {
                 or_replace,

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -203,10 +203,29 @@ fn cast_to_invalid_decimal_type() {
 fn plan_create_table_with_pk() {
     let sql = "create table person (id int, name string, primary key(id))";
     let plan = r#"
+CreateMemoryTable: Bare { table: "person" } primary_key=[id]
+  EmptyRelation
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_create_table_no_pk() {
+    let sql = "create table person (id int, name string)";
+    let plan = r#"
 CreateMemoryTable: Bare { table: "person" }
   EmptyRelation
     "#
     .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
+#[should_panic(expected = "Non-primary unique constraints are not supported")]
+fn plan_create_table_check_constraint() {
+    let sql = "create table person (id int, name string, unique(id))";
+    let plan = "";
     quick_test(sql, plan);
 }
 

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -200,6 +200,17 @@ fn cast_to_invalid_decimal_type() {
 }
 
 #[test]
+fn plan_create_table_with_pk() {
+    let sql = "create table person (id int, name string, primary key(id))";
+    let plan = r#"
+CreateMemoryTable: Bare { table: "person" }
+  EmptyRelation
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
 fn plan_start_transaction() {
     let sql = "start transaction";
     let plan = "TransactionStart: ReadWrite Serializable";


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5834.

# Rationale for this change

As a developer building a database atop DataFusion, it would be useful to have knowledge of primary keys retained in the LogicalPlan.

# What changes are included in this PR?

A new `primary_key` field on `LogicalPlan::CreateMemoryTable`

# Are these changes tested?

Sort of - there's a test that broke before, but I couldn't figure out what prints this LogicalPlan node, so I wasn't able to add the pk info to the `Debug` trait and assert that.

# Are there any user-facing changes?

`create table` statements that used to fail (e.g. with `primary key` clauses) will now not fail. I'm not sure if that's an issue for anyone.