### PR TITLE
Change `FileFormat` to depends on `TaskContext` rather than `SessionState`

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -387,7 +387,7 @@ async fn get_table(
     let config = ListingTableConfig::new(table_path).with_listing_options(options);
 
     let config = match table_format {
-        "parquet" => config.infer_schema(&state).await?,
+        "parquet" => config.infer_schema(&state.task_ctx()).await?,
         "tbl" => config.with_schema(Arc::new(get_tbl_tpch_table_schema(table))),
         "csv" => config.with_schema(Arc::new(get_tpch_table_schema(table))),
         _ => unreachable!(),

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -576,9 +576,9 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -659,7 +659,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -676,7 +676,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1103,7 +1103,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1507,9 +1507,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "ef2c45001fb108f37d41bed8efd715769acb14674c1ce3e266ef0e317ef5f877"
 dependencies = [
  "cc",
  "libc",
@@ -1597,9 +1597,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "92666043c712f7f5c756d07443469ddcda6dd971cc15258bb7f3c3216fd1b7aa"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ea8f683b4f89a64181393742c041520a1a87e9775e6b4c0dd5a3281af05fc6"
+checksum = "ec9cd6ca25e796a49fa242876d1c4de36a24a6da5258e9f0bc062dbf5e81c53b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1969,18 +1969,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.27.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
 dependencies = [
  "memchr",
  "serde",
@@ -2148,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.5"
+version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
+checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
 dependencies = [
  "bitflags",
  "errno",
@@ -2276,7 +2276,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2455,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2509,7 +2509,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2573,7 +2573,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/datafusion-cli/src/catalog.rs
+++ b/datafusion-cli/src/catalog.rs
@@ -147,9 +147,9 @@ impl SchemaProvider for DynamicFileSchemaProvider {
 
         // if the inner schema provider didn't have a table by
         // that name, try to treat it as a listing table
-        let state = self.state.upgrade()?.read().clone();
+        let task_ctx = self.state.upgrade()?.read().task_ctx();
         let config = ListingTableConfig::new(ListingTableUrl::parse(name).ok()?)
-            .infer(&state)
+            .infer(&task_ctx)
             .await
             .ok()?;
         Some(Arc::new(ListingTable::try_new(config).ok()?))

--- a/datafusion-examples/examples/flight_server.rs
+++ b/datafusion-examples/examples/flight_server.rs
@@ -59,7 +59,7 @@ impl FlightService for FlightServiceImpl {
 
         let ctx = SessionContext::new();
         let schema = listing_options
-            .infer_schema(&ctx.state(), &table_path)
+            .infer_schema(&ctx.task_ctx(), &table_path)
             .await
             .unwrap();
 

--- a/datafusion/core/src/catalog/schema.rs
+++ b/datafusion/core/src/catalog/schema.rs
@@ -180,7 +180,7 @@ mod tests {
         let ctx = SessionContext::new();
 
         let config = ListingTableConfig::new(table_path)
-            .infer(&ctx.state())
+            .infer(&ctx.task_ctx())
             .await
             .unwrap();
         let table = ListingTable::try_new(config).unwrap();

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -36,8 +36,8 @@ use crate::error::Result;
 use crate::physical_plan::file_format::FileScanConfig;
 use crate::physical_plan::{ExecutionPlan, Statistics};
 
-use crate::execution::context::SessionState;
 use async_trait::async_trait;
+use datafusion_execution::TaskContext;
 use datafusion_physical_expr::PhysicalExpr;
 use object_store::{ObjectMeta, ObjectStore};
 
@@ -58,7 +58,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
     /// the files have schemas that cannot be merged.
     async fn infer_schema(
         &self,
-        state: &SessionState,
+        state: &TaskContext,
         store: &Arc<dyn ObjectStore>,
         objects: &[ObjectMeta],
     ) -> Result<SchemaRef>;
@@ -72,7 +72,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
     /// TODO: should the file source return statistics for only columns referred to in the table schema?
     async fn infer_stats(
         &self,
-        state: &SessionState,
+        state: &TaskContext,
         store: &Arc<dyn ObjectStore>,
         table_schema: SchemaRef,
         object: &ObjectMeta,
@@ -82,7 +82,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
     /// according to this file format.
     async fn create_physical_plan(
         &self,
-        state: &SessionState,
+        state: &TaskContext,
         conf: FileScanConfig,
         filters: Option<&Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
@@ -106,7 +106,7 @@ pub(crate) mod test_util {
     use tokio::io::AsyncWrite;
 
     pub async fn scan_format(
-        state: &SessionState,
+        state: &TaskContext,
         format: &dyn FileFormat,
         store_root: &str,
         file_name: &str,

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -59,6 +59,7 @@ impl TableProviderFactory for ListingTableFactory {
         state: &SessionState,
         cmd: &CreateExternalTable,
     ) -> datafusion_common::Result<Arc<dyn TableProvider>> {
+        let task_ctx = state.task_ctx();
         let file_compression_type = FileCompressionType::from(cmd.file_compression_type);
         let file_type = FileType::from_str(cmd.file_type.as_str()).map_err(|_| {
             DataFusionError::Execution(format!("Unknown FileType {}", cmd.file_type))
@@ -139,7 +140,7 @@ impl TableProviderFactory for ListingTableFactory {
 
         let table_path = ListingTableUrl::parse(&cmd.location)?;
         let resolved_schema = match provided_schema {
-            None => options.infer_schema(state, &table_path).await?,
+            None => options.infer_schema(&task_ctx, &table_path).await?,
             Some(s) => s,
         };
         let config = ListingTableConfig::new(table_path)

--- a/datafusion/core/src/physical_plan/file_format/avro.rs
+++ b/datafusion/core/src/physical_plan/file_format/avro.rs
@@ -245,6 +245,7 @@ mod tests {
     async fn test_with_stores(store: Arc<dyn ObjectStore>) -> Result<()> {
         let session_ctx = SessionContext::new();
         let state = session_ctx.state();
+        let task_ctx = session_ctx.task_ctx();
 
         let url = Url::parse("file://").unwrap();
         state
@@ -256,7 +257,7 @@ mod tests {
         let meta = local_unpartitioned_file(filename);
 
         let file_schema = AvroFormat {}
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&task_ctx, &store, &[meta.clone()])
             .await?;
 
         let avro_exec = AvroExec::new(FileScanConfig {
@@ -321,7 +322,7 @@ mod tests {
         let object_store_url = ObjectStoreUrl::local_filesystem();
         let meta = local_unpartitioned_file(filename);
         let actual_schema = AvroFormat {}
-            .infer_schema(&state, &object_store, &[meta.clone()])
+            .infer_schema(&state.task_ctx(), &object_store, &[meta.clone()])
             .await?;
 
         let mut fields = actual_schema.fields().clone();
@@ -394,7 +395,7 @@ mod tests {
         let object_store_url = ObjectStoreUrl::local_filesystem();
         let meta = local_unpartitioned_file(filename);
         let file_schema = AvroFormat {}
-            .infer_schema(&state, &object_store, &[meta.clone()])
+            .infer_schema(&state.task_ctx(), &object_store, &[meta.clone()])
             .await?;
 
         let mut partitioned_file = PartitionedFile::from(meta);

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -298,8 +298,9 @@ mod tests {
         state: &SessionState,
         file_compression_type: FileCompressionType,
     ) -> (ObjectStoreUrl, Vec<Vec<PartitionedFile>>, SchemaRef) {
+        let task_ctx = state.task_ctx();
         let store_url = ObjectStoreUrl::local_filesystem();
-        let store = state.runtime_env().object_store(&store_url).unwrap();
+        let store = task_ctx.runtime_env().object_store(&store_url).unwrap();
 
         let filename = "1.json";
         let file_groups = partitioned_file_groups(
@@ -319,7 +320,7 @@ mod tests {
             .object_meta;
         let schema = JsonFormat::default()
             .with_file_compression_type(file_compression_type.to_owned())
-            .infer_schema(state, &store, &[meta.clone()])
+            .infer_schema(&task_ctx, &store, &[meta.clone()])
             .await
             .unwrap();
 

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -1530,7 +1530,7 @@ mod tests {
         let state = session_ctx.state();
         let task_ctx = state.task_ctx();
         let parquet_exec = scan_format(
-            &state,
+            &task_ctx,
             &ParquetFormat::default(),
             &testdata,
             filename,
@@ -1619,7 +1619,7 @@ mod tests {
 
         let store = Arc::new(LocalFileSystem::new()) as _;
         let file_schema = ParquetFormat::default()
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&state.task_ctx(), &store, &[meta.clone()])
             .await?;
 
         let group_empty = vec![vec![file_range(&meta, 0, 5)]];
@@ -1651,7 +1651,7 @@ mod tests {
         let meta = local_unpartitioned_file(filename);
 
         let schema = ParquetFormat::default()
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&task_ctx, &store, &[meta.clone()])
             .await
             .unwrap();
 

--- a/datafusion/core/tests/parquet/page_pruning.rs
+++ b/datafusion/core/tests/parquet/page_pruning.rs
@@ -49,7 +49,7 @@ async fn get_parquet_exec(state: &SessionState, filter: Expr) -> ParquetExec {
     };
 
     let schema = ParquetFormat::default()
-        .infer_schema(state, &store, &[meta.clone()])
+        .infer_schema(&state.task_ctx(), &store, &[meta.clone()])
         .await
         .unwrap();
 

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -576,7 +576,7 @@ async fn register_partitioned_alltypes_parquet(
         ListingTableUrl::parse(format!("mirror:///{}", store_paths[0])).unwrap();
 
     let file_schema = options
-        .infer_schema(&ctx.state(), &store_path)
+        .infer_schema(&ctx.task_ctx(), &store_path)
         .await
         .expect("Parquet schema inference failed");
 

--- a/datafusion/core/tests/row.rs
+++ b/datafusion/core/tests/row.rs
@@ -92,18 +92,19 @@ async fn get_exec(
 
     let meta = object_store.head(&path).await.unwrap();
 
+    let task_ctx = state.task_ctx();
     let file_schema = format
-        .infer_schema(state, &object_store, &[meta.clone()])
+        .infer_schema(&task_ctx, &object_store, &[meta.clone()])
         .await
         .expect("Schema inference");
     let statistics = format
-        .infer_stats(state, &object_store, file_schema.clone(), &meta)
+        .infer_stats(&task_ctx, &object_store, file_schema.clone(), &meta)
         .await
         .expect("Stats inference");
     let file_groups = vec![vec![meta.into()]];
     let exec = format
         .create_physical_plan(
-            state,
+            &task_ctx,
             FileScanConfig {
                 object_store_url,
                 file_schema,

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -32,7 +32,8 @@ use std::sync::Arc;
 use url::Url;
 
 #[derive(Clone)]
-/// Execution runtime environment.
+/// Execution runtime environment for managing access to external
+/// resources such as memory, disk and object stores.
 pub struct RuntimeEnv {
     /// Runtime memory management
     pub memory_pool: Arc<dyn MemoryPool>,

--- a/datafusion/execution/src/task.rs
+++ b/datafusion/execution/src/task.rs
@@ -32,6 +32,10 @@ use crate::{
 };
 
 /// Task Execution Context
+///
+/// Contains all information needed to execte a DataFusion plan. It
+/// does not contain information needed by the planner such as table
+/// sources.
 pub struct TaskContext {
     /// Session Id
     session_id: String,
@@ -101,6 +105,11 @@ impl TaskContext {
     /// Return the SessionConfig associated with the Task
     pub fn session_config(&self) -> &SessionConfig {
         &self.session_config
+    }
+
+    /// Return the [`ConfigOptions`] associated with the Task
+    pub fn options(&self) -> &ConfigOptions {
+        self.session_config.options()
     }
 
     /// Return the `session_id` of this [TaskContext]


### PR DESCRIPTION

# Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/1754

# Rationale for this change
I am trying to extract the physical_plan code into its own crate; and to do so I need to remove the circular dependencies between core --> datasource --> execution --> datasource

Since  `SessionState` is staying in `datafusion` core crate, in order to pull out datasource into its own crate (and only depend on datafusion_execution) it can not depend on `SessionState`

Conveniently, `TaskContext` is designed to be exactly the part of `SessionState` needed for execution

See more details in https://github.com/apache/arrow-datafusion/issues/1754#issuecomment-1452438453

# What changes are included in this PR?
1. Change `FileFormat` to depends on `TaskContext` rather than SessionState

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?

Technically the `FileFormat` / `ListingTable` is a public API; However, I don't think the `FileFormat` is widely used outside of DataFusion so I expect this to have minimal impact on users

I expect the change of TableProvider to use `TaskContext` to be the most disruptive and I am saving it for last.
