### PR TITLE
Enhance Asynchronous Performance of SHJ Implementation 

### DIFF
--- a/datafusion/core/tests/fifo.rs
+++ b/datafusion/core/tests/fifo.rs
@@ -238,14 +238,14 @@ mod unix_test {
             "a1,a2\n".to_owned(),
             lines.clone(),
             waiting.clone(),
-            TEST_BATCH_SIZE * 2,
+            TEST_BATCH_SIZE,
         ));
         tasks.push(create_writing_thread(
             right_fifo.clone(),
             "a1,a2\n".to_owned(),
             lines.clone(),
             waiting.clone(),
-            TEST_BATCH_SIZE * 2,
+            TEST_BATCH_SIZE,
         ));
 
         // Create schema

--- a/datafusion/core/tests/fifo.rs
+++ b/datafusion/core/tests/fifo.rs
@@ -238,14 +238,14 @@ mod unix_test {
             "a1,a2\n".to_owned(),
             lines.clone(),
             waiting.clone(),
-            TEST_BATCH_SIZE,
+            TEST_BATCH_SIZE * 2,
         ));
         tasks.push(create_writing_thread(
             right_fifo.clone(),
             "a1,a2\n".to_owned(),
             lines.clone(),
             waiting.clone(),
-            TEST_BATCH_SIZE,
+            TEST_BATCH_SIZE * 2,
         ));
 
         // Create schema

--- a/datafusion/core/tests/fifo.rs
+++ b/datafusion/core/tests/fifo.rs
@@ -22,13 +22,12 @@
 mod unix_test {
     use arrow::array::Array;
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::execution::options::ReadOptions;
+    use datafusion::test_util::register_unbounded_file_with_ordering;
     use datafusion::{
         prelude::{CsvReadOptions, SessionConfig, SessionContext},
         test_util::{aggr_test_schema, arrow_test_data},
     };
     use datafusion_common::{DataFusionError, Result};
-    use datafusion_expr::Expr;
     use futures::StreamExt;
     use itertools::enumerate;
     use nix::sys::stat;
@@ -36,7 +35,6 @@ mod unix_test {
     use rstest::*;
     use std::fs::{File, OpenOptions};
     use std::io::Write;
-    use std::path::Path;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -197,35 +195,6 @@ mod unix_test {
             }
             drop(file);
         })
-    }
-
-    /// This function creates an unbounded sorted file for testing purposes.
-    pub async fn register_unbounded_file_with_ordering(
-        ctx: &SessionContext,
-        schema: arrow::datatypes::SchemaRef,
-        file_path: &Path,
-        table_name: &str,
-        file_sort_order: Option<Vec<Expr>>,
-        with_unbounded_execution: bool,
-    ) -> Result<()> {
-        // Mark infinite and provide schema:
-        let fifo_options = CsvReadOptions::new()
-            .schema(schema.as_ref())
-            .mark_infinite(with_unbounded_execution);
-        // Get listing options:
-        let options_sort = fifo_options
-            .to_listing_options(&ctx.copied_config())
-            .with_file_sort_order(file_sort_order);
-        // Register table:
-        ctx.register_listing_table(
-            table_name,
-            file_path.as_os_str().to_str().unwrap(),
-            options_sort,
-            Some(schema),
-            None,
-        )
-        .await?;
-        Ok(())
     }
 
     // This test provides a relatively realistic end-to-end scenario where


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/5714.

# Rationale for this change

To optimize the asynchronous performance of the `SymmetricHashJoin` operator, we propose merging the two child streams using `futures::select`. This will enable simultaneous polling of both streams and execute the branch corresponding to the future that completes first.

# What changes are included in this PR?

- Single stream SHJ implementation on `poll_next()`
- Refactor on fifo tests and reduce code duplication.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No