### PR TITLE
Use type aliases ExprOrdering and OrderingRequirements to simplify ordering-related type signatures

### DIFF
--- a/benchmarks/src/bin/parquet.rs
+++ b/benchmarks/src/bin/parquet.rs
@@ -20,8 +20,8 @@ use datafusion::common::Result;
 use datafusion::logical_expr::{lit, or, Expr};
 use datafusion::optimizer::utils::disjunction;
 use datafusion::physical_expr::PhysicalSortExpr;
-use datafusion::physical_plan::collect;
 use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::{collect, ExprOrderingRef};
 use datafusion::prelude::{col, SessionConfig, SessionContext};
 use datafusion::test_util::parquet::{ParquetScanOptions, TestParquetFile};
 use datafusion_benchmarks::BenchmarkRun;
@@ -319,7 +319,7 @@ async fn exec_scan(
 
 async fn exec_sort(
     ctx: &SessionContext,
-    expr: &[PhysicalSortExpr],
+    expr: ExprOrderingRef<'_>,
     test_file: &TestParquetFile,
     debug: bool,
 ) -> Result<(usize, std::time::Duration)> {

--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -24,7 +24,7 @@ use datafusion::datasource::provider_as_source;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result;
 use datafusion::execution::context::{SessionState, TaskContext};
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
+use datafusion::physical_plan::expressions::ExprOrderingRef;
 use datafusion::physical_plan::memory::MemoryStream;
 use datafusion::physical_plan::{
     project_schema, ExecutionPlan, SendableRecordBatchStream, Statistics,
@@ -217,7 +217,7 @@ impl ExecutionPlan for CustomExec {
         datafusion::physical_plan::Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/benches/merge.rs
+++ b/datafusion/core/benches/merge.rs
@@ -89,7 +89,7 @@ use datafusion::{
     },
     prelude::SessionContext,
 };
-use datafusion_physical_expr::{expressions::col, PhysicalSortExpr};
+use datafusion_physical_expr::{expressions::col, ExprOrdering, PhysicalSortExpr};
 use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -304,7 +304,7 @@ impl MergeBenchCase {
 }
 
 /// Make sort exprs for each column in `schema`
-fn make_sort_exprs(schema: &Schema) -> Vec<PhysicalSortExpr> {
+fn make_sort_exprs(schema: &Schema) -> ExprOrdering {
     schema
         .fields()
         .iter()

--- a/datafusion/core/benches/sort.rs
+++ b/datafusion/core/benches/sort.rs
@@ -35,7 +35,7 @@ use datafusion::{
     physical_plan::{memory::MemoryExec, sorts::sort::SortExec, ExecutionPlan},
     prelude::SessionContext,
 };
-use datafusion_physical_expr::{expressions::col, PhysicalSortExpr};
+use datafusion_physical_expr::{expressions::col, ExprOrdering, PhysicalSortExpr};
 use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -288,7 +288,7 @@ impl SortBenchCasePreservePartitioning {
 }
 
 /// Make sort exprs for each column in `schema`
-fn make_sort_exprs(schema: &Schema) -> Vec<PhysicalSortExpr> {
+fn make_sort_exprs(schema: &Schema) -> ExprOrdering {
     schema
         .fields()
         .iter()

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -27,7 +27,7 @@ use dashmap::DashMap;
 use datafusion_common::ToDFSchema;
 use datafusion_expr::expr::Sort;
 use datafusion_optimizer::utils::conjunction;
-use datafusion_physical_expr::{create_physical_expr, PhysicalSortExpr};
+use datafusion_physical_expr::{create_physical_expr, ExprOrdering, PhysicalSortExpr};
 use futures::{future, stream, StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::ObjectMeta;
@@ -611,7 +611,7 @@ impl ListingTable {
     }
 
     /// If file_sort_order is specified, creates the appropriate physical expressions
-    fn try_create_output_ordering(&self) -> Result<Option<Vec<PhysicalSortExpr>>> {
+    fn try_create_output_ordering(&self) -> Result<Option<ExprOrdering>> {
         let file_sort_order =
             if let Some(file_sort_order) = self.options.file_sort_order.as_ref() {
                 file_sort_order

--- a/datafusion/core/src/physical_optimizer/dist_enforcement.rs
+++ b/datafusion/core/src/physical_optimizer/dist_enforcement.rs
@@ -949,7 +949,7 @@ mod tests {
     use datafusion_expr::Operator;
     use datafusion_physical_expr::{
         expressions, expressions::binary, expressions::lit, expressions::Column,
-        PhysicalExpr, PhysicalSortExpr,
+        ExprOrdering, PhysicalExpr, PhysicalSortExpr,
     };
     use std::ops::Deref;
 
@@ -982,9 +982,7 @@ mod tests {
         parquet_exec_with_sort(None)
     }
 
-    fn parquet_exec_with_sort(
-        output_ordering: Option<Vec<PhysicalSortExpr>>,
-    ) -> Arc<ParquetExec> {
+    fn parquet_exec_with_sort(output_ordering: Option<ExprOrdering>) -> Arc<ParquetExec> {
         Arc::new(ParquetExec::new(
             FileScanConfig {
                 object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),

--- a/datafusion/core/src/physical_optimizer/repartition.rs
+++ b/datafusion/core/src/physical_optimizer/repartition.rs
@@ -340,7 +340,7 @@ mod tests {
     use crate::physical_plan::union::UnionExec;
     use crate::physical_plan::{displayable, DisplayFormatType, Statistics};
     use datafusion_physical_expr::{
-        make_sort_requirements_from_exprs, PhysicalSortRequirement,
+        make_requirements_from_ordering, ExprOrderingRef, OrderingRequirement,
     };
 
     fn schema() -> SchemaRef {
@@ -1150,7 +1150,7 @@ mod tests {
             self.input.output_partitioning()
         }
 
-        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        fn output_ordering(&self) -> Option<ExprOrderingRef> {
             self.input.output_ordering()
         }
 
@@ -1159,10 +1159,8 @@ mod tests {
         }
 
         // model that it requires the output ordering of its input
-        fn required_input_ordering(&self) -> Vec<Option<Vec<PhysicalSortRequirement>>> {
-            vec![self
-                .output_ordering()
-                .map(make_sort_requirements_from_exprs)]
+        fn required_input_ordering(&self) -> Vec<Option<OrderingRequirement>> {
+            vec![self.output_ordering().map(make_requirements_from_ordering)]
         }
 
         fn with_new_children(

--- a/datafusion/core/src/physical_optimizer/sort_enforcement.rs
+++ b/datafusion/core/src/physical_optimizer/sort_enforcement.rs
@@ -53,7 +53,7 @@ use datafusion_physical_expr::utils::{
     make_sort_exprs_from_requirements, ordering_satisfy,
     ordering_satisfy_requirement_concrete,
 };
-use datafusion_physical_expr::{PhysicalExpr, PhysicalSortExpr};
+use datafusion_physical_expr::{ExprOrderingRef, PhysicalExpr, PhysicalSortExpr};
 use itertools::{concat, izip};
 use std::iter::zip;
 use std::sync::Arc;
@@ -766,7 +766,7 @@ fn remove_corresponding_sort_from_sub_plan(
 }
 
 /// Converts an [ExecutionPlan] trait object to a [PhysicalSortExpr] slice when possible.
-fn get_sort_exprs(sort_any: &Arc<dyn ExecutionPlan>) -> Result<&[PhysicalSortExpr]> {
+fn get_sort_exprs(sort_any: &Arc<dyn ExecutionPlan>) -> Result<ExprOrderingRef> {
     if let Some(sort_exec) = sort_any.as_any().downcast_ref::<SortExec>() {
         Ok(sort_exec.expr())
     } else if let Some(sort_preserving_merge_exec) =
@@ -795,9 +795,9 @@ pub struct ColumnInfo {
 /// remove physical sort expressions from the plan.
 pub fn can_skip_sort(
     partition_keys: &[Arc<dyn PhysicalExpr>],
-    required: &[PhysicalSortExpr],
+    required: ExprOrderingRef,
     input_schema: &SchemaRef,
-    physical_ordering: &[PhysicalSortExpr],
+    physical_ordering: ExprOrderingRef,
 ) -> Result<(bool, bool)> {
     if required.len() > physical_ordering.len() {
         return Ok((false, false));

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -31,7 +31,7 @@ use crate::physical_plan::windows::{BoundedWindowAggExec, WindowAggExec};
 use crate::physical_plan::{with_new_children_if_necessary, ExecutionPlan};
 use datafusion_common::tree_node::Transformed;
 use datafusion_physical_expr::utils::ordering_satisfy;
-use datafusion_physical_expr::PhysicalSortExpr;
+use datafusion_physical_expr::ExprOrdering;
 use std::sync::Arc;
 
 /// Convenience rule for writing optimizers: recursively invoke
@@ -60,7 +60,7 @@ pub fn optimize_children(
 /// given ordering requirements while preserving the original partitioning.
 pub fn add_sort_above(
     node: &mut Arc<dyn ExecutionPlan>,
-    sort_expr: Vec<PhysicalSortExpr>,
+    sort_expr: ExprOrdering,
 ) -> Result<()> {
     // If the ordering requirement is already satisfied, do not add a sort.
     if !ordering_satisfy(node.output_ordering(), Some(&sort_expr), || {

--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -33,7 +33,7 @@ use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::Accumulator;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::{
-    expressions, AggregateExpr, PhysicalExpr, PhysicalSortExpr,
+    expressions, AggregateExpr, ExprOrderingRef, PhysicalExpr,
 };
 use std::any::Any;
 use std::collections::HashMap;
@@ -354,7 +354,7 @@ impl ExecutionPlan for AggregateExec {
         }
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -725,7 +725,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use datafusion_common::{DataFusionError, Result, ScalarValue};
     use datafusion_physical_expr::expressions::{lit, ApproxDistinct, Count, Median};
-    use datafusion_physical_expr::{AggregateExpr, PhysicalExpr, PhysicalSortExpr};
+    use datafusion_physical_expr::{AggregateExpr, ExprOrderingRef, PhysicalExpr};
     use futures::{FutureExt, Stream};
     use std::any::Any;
     use std::sync::Arc;
@@ -991,7 +991,7 @@ mod tests {
             Partitioning::UnknownPartitioning(1)
         }
 
-        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        fn output_ordering(&self) -> Option<ExprOrderingRef> {
             None
         }
 

--- a/datafusion/core/src/physical_plan/analyze.rs
+++ b/datafusion/core/src/physical_plan/analyze.rs
@@ -30,7 +30,7 @@ use crate::{
 use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
 use futures::StreamExt;
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::{stream::RecordBatchReceiverStream, Distribution, SendableRecordBatchStream};
 use crate::execution::context::TaskContext;
 
@@ -95,7 +95,7 @@ impl ExecutionPlan for AnalyzeExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/coalesce_batches.rs
+++ b/datafusion/core/src/physical_plan/coalesce_batches.rs
@@ -36,7 +36,7 @@ use arrow::record_batch::RecordBatch;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::metrics::{BaselineMetrics, MetricsSet};
 use super::{metrics::ExecutionPlanMetricsSet, Statistics};
 
@@ -102,7 +102,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
         Ok(children[0])
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         // The coalesce batches operator does not make any changes to the sorting of its input
         self.input.output_ordering()
     }

--- a/datafusion/core/src/physical_plan/coalesce_partitions.rs
+++ b/datafusion/core/src/physical_plan/coalesce_partitions.rs
@@ -29,7 +29,7 @@ use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 
 use super::common::AbortOnDropMany;
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use super::{RecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
@@ -91,7 +91,7 @@ impl ExecutionPlan for CoalescePartitionsExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/empty.rs
+++ b/datafusion/core/src/physical_plan/empty.rs
@@ -29,7 +29,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use log::debug;
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::{common, SendableRecordBatchStream, Statistics};
 
 use crate::execution::context::TaskContext;
@@ -113,7 +113,7 @@ impl ExecutionPlan for EmptyExec {
         Partitioning::UnknownPartitioning(self.partitions)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/explain.rs
+++ b/datafusion/core/src/physical_plan/explain.rs
@@ -31,7 +31,7 @@ use crate::{
 use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
 use log::debug;
 
-use super::{expressions::PhysicalSortExpr, SendableRecordBatchStream};
+use super::{expressions::ExprOrderingRef, SendableRecordBatchStream};
 use crate::execution::context::TaskContext;
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 
@@ -93,7 +93,7 @@ impl ExecutionPlan for ExplainExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/file_format/avro.rs
+++ b/datafusion/core/src/physical_plan/file_format/avro.rs
@@ -17,7 +17,7 @@
 
 //! Execution plan for reading line-delimited Avro files
 use crate::error::Result;
-use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::expressions::ExprOrderingRef;
 use crate::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
@@ -76,7 +76,7 @@ impl ExecutionPlan for AvroExec {
         Ok(self.base_config().infinite_source)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         get_output_ordering(&self.base_config)
     }
 

--- a/datafusion/core/src/physical_plan/file_format/csv.rs
+++ b/datafusion/core/src/physical_plan/file_format/csv.rs
@@ -20,7 +20,7 @@
 use crate::datasource::file_format::file_type::FileCompressionType;
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::TaskContext;
-use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::expressions::ExprOrderingRef;
 use crate::physical_plan::file_format::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
@@ -117,7 +117,7 @@ impl ExecutionPlan for CsvExec {
     }
 
     /// See comments on `impl ExecutionPlan for ParquetExec`: output order can't be
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         get_output_ordering(&self.base_config)
     }
 

--- a/datafusion/core/src/physical_plan/file_format/json.rs
+++ b/datafusion/core/src/physical_plan/file_format/json.rs
@@ -19,7 +19,7 @@
 use crate::datasource::file_format::file_type::FileCompressionType;
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::TaskContext;
-use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::expressions::ExprOrderingRef;
 use crate::physical_plan::file_format::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
@@ -97,7 +97,7 @@ impl ExecutionPlan for NdJsonExec {
         Ok(self.base_config.infinite_source)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         get_output_ordering(&self.base_config)
     }
 

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -36,7 +36,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 pub use avro::AvroExec;
-use datafusion_physical_expr::PhysicalSortExpr;
+use datafusion_physical_expr::{ExprOrdering, ExprOrderingRef};
 pub use file_stream::{FileOpenFuture, FileOpener, FileStream};
 pub(crate) use json::plan_to_json;
 pub use json::NdJsonExec;
@@ -149,7 +149,7 @@ pub struct FileScanConfig {
     /// The partitioning columns
     pub table_partition_cols: Vec<(String, DataType)>,
     /// The order in which the data is sorted, if known.
-    pub output_ordering: Option<Vec<PhysicalSortExpr>>,
+    pub output_ordering: Option<ExprOrdering>,
     /// Indicates whether this plan may produce an infinite stream of records.
     pub infinite_source: bool,
 }
@@ -704,7 +704,7 @@ impl From<ObjectMeta> for FileMeta {
 ///```
 pub(crate) fn get_output_ordering(
     base_config: &FileScanConfig,
-) -> Option<&[PhysicalSortExpr]> {
+) -> Option<ExprOrderingRef> {
     base_config.output_ordering.as_ref()
         .map(|output_ordering| if base_config.file_groups.iter().any(|group| group.len() > 1) {
             debug!("Skipping specified output ordering {:?}. Some file group had more than one file: {:?}",

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -39,7 +39,7 @@ use crate::{
     execution::context::TaskContext,
     physical_optimizer::pruning::PruningPredicate,
     physical_plan::{
-        expressions::PhysicalSortExpr,
+        expressions::ExprOrderingRef,
         file_format::{FileScanConfig, SchemaAdapter},
         metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet},
         DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
@@ -342,7 +342,7 @@ impl ExecutionPlan for ParquetExec {
         Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         get_output_ordering(&self.base_config)
     }
 
@@ -448,7 +448,7 @@ impl ExecutionPlan for ParquetExec {
     }
 }
 
-fn make_output_ordering_string(ordering: &[PhysicalSortExpr]) -> String {
+fn make_output_ordering_string(ordering: ExprOrderingRef) -> String {
     use std::fmt::Write;
     let mut w: String = ", output_ordering=[".into();
 

--- a/datafusion/core/src/physical_plan/filter.rs
+++ b/datafusion/core/src/physical_plan/filter.rs
@@ -23,7 +23,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::{ColumnStatistics, RecordBatchStream, SendableRecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{
@@ -113,7 +113,7 @@ impl ExecutionPlan for FilterExec {
         Ok(children[0])
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.input.output_ordering()
     }
 

--- a/datafusion/core/src/physical_plan/joins/cross_join.rs
+++ b/datafusion/core/src/physical_plan/joins/cross_join.rs
@@ -30,8 +30,8 @@ use crate::execution::memory_pool::{SharedOptionalMemoryReservation, TryGrow};
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use crate::physical_plan::{
     coalesce_batches::concat_batches, coalesce_partitions::CoalescePartitionsExec,
-    ColumnStatistics, DisplayFormatType, Distribution, EquivalenceProperties,
-    ExecutionPlan, Partitioning, PhysicalSortExpr, RecordBatchStream,
+    expressions::ExprOrderingRef, ColumnStatistics, DisplayFormatType, Distribution,
+    EquivalenceProperties, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
 use crate::{error::Result, scalar::ScalarValue};
@@ -200,7 +200,7 @@ impl ExecutionPlan for CrossJoinExec {
     }
 
     // TODO check the output ordering of CrossJoin
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -58,8 +58,7 @@ use hashbrown::raw::RawTable;
 use crate::physical_plan::{
     coalesce_batches::concat_batches,
     coalesce_partitions::CoalescePartitionsExec,
-    expressions::Column,
-    expressions::PhysicalSortExpr,
+    expressions::{Column, ExprOrderingRef},
     hash_utils::create_hashes,
     joins::utils::{
         adjust_right_output_partitioning, build_join_schema, check_join_is_valid,
@@ -335,7 +334,7 @@ impl ExecutionPlan for HashJoinExec {
 
     // TODO Output ordering might be kept for some cases.
     // For example if it is inner join then the stream side order can be kept
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/joins/nested_loop_join.rs
+++ b/datafusion/core/src/physical_plan/joins/nested_loop_join.rs
@@ -40,7 +40,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::bit_util;
 use datafusion_common::{DataFusionError, Statistics};
 use datafusion_expr::JoinType;
-use datafusion_physical_expr::{EquivalenceProperties, PhysicalSortExpr};
+use datafusion_physical_expr::{EquivalenceProperties, ExprOrderingRef};
 use futures::{ready, Stream, StreamExt, TryStreamExt};
 use std::any::Any;
 use std::fmt::Formatter;
@@ -157,7 +157,7 @@ impl ExecutionPlan for NestedLoopJoinExec {
         }
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         // no specified order for the output
         None
     }

--- a/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
@@ -53,8 +53,7 @@ use crate::execution::context::TaskContext;
 use crate::logical_expr::JoinType;
 use crate::physical_plan::joins::hash_join_utils::convert_sort_expr_with_filter_schema;
 use crate::physical_plan::{
-    expressions::Column,
-    expressions::PhysicalSortExpr,
+    expressions::{Column, ExprOrderingRef},
     joins::{
         hash_join::{build_join_indices, update_hash, JoinHashMap},
         hash_join_utils::{build_filter_input_order, SortedFilterExpr},
@@ -411,7 +410,7 @@ impl ExecutionPlan for SymmetricHashJoinExec {
     }
 
     // TODO: Output ordering might be kept for some cases.
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -1521,7 +1520,7 @@ mod tests {
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{binary, col, Column};
     use datafusion_physical_expr::intervals::test_utils::gen_conjunctive_numeric_expr;
-    use datafusion_physical_expr::PhysicalExpr;
+    use datafusion_physical_expr::{ExprOrdering, PhysicalExpr, PhysicalSortExpr};
 
     use crate::physical_plan::joins::{
         hash_join_utils::tests::complicated_filter, HashJoinExec, PartitionMode,
@@ -1823,8 +1822,8 @@ mod tests {
     fn create_memory_table(
         left_batch: RecordBatch,
         right_batch: RecordBatch,
-        left_sorted: Option<Vec<PhysicalSortExpr>>,
-        right_sorted: Option<Vec<PhysicalSortExpr>>,
+        left_sorted: Option<ExprOrdering>,
+        right_sorted: Option<ExprOrdering>,
         batch_size: usize,
     ) -> Result<(Arc<dyn ExecutionPlan>, Arc<dyn ExecutionPlan>)> {
         let mut left = MemoryExec::try_new(

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -33,7 +33,7 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::{
     metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet},
     RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -112,7 +112,7 @@ impl ExecutionPlan for GlobalLimitExec {
         false
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.input.output_ordering()
     }
 
@@ -288,7 +288,7 @@ impl ExecutionPlan for LocalLimitExec {
     }
 
     // Local limit will not change the input plan's ordering
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.input.output_ordering()
     }
 

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -22,7 +22,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::{ExprOrdering, ExprOrderingRef};
 use super::{
     common, project_schema, DisplayFormatType, ExecutionPlan, Partitioning,
     RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -46,7 +46,7 @@ pub struct MemoryExec {
     /// Optional projection
     projection: Option<Vec<usize>>,
     // Optional sort information
-    sort_information: Option<Vec<PhysicalSortExpr>>,
+    sort_information: Option<ExprOrdering>,
 }
 
 impl fmt::Debug for MemoryExec {
@@ -78,7 +78,7 @@ impl ExecutionPlan for MemoryExec {
         Partitioning::UnknownPartitioning(self.partitions.len())
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.sort_information.as_deref()
     }
 
@@ -151,10 +151,7 @@ impl MemoryExec {
     }
 
     /// Set sort information
-    pub fn with_sort_information(
-        mut self,
-        sort_information: Vec<PhysicalSortExpr>,
-    ) -> Self {
+    pub fn with_sort_information(mut self, sort_information: ExprOrdering) -> Self {
         self.sort_information = Some(sort_information);
         self
     }

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -24,7 +24,6 @@ use self::{
 };
 pub use crate::common::{ColumnStatistics, Statistics};
 use crate::error::Result;
-use crate::physical_plan::expressions::PhysicalSortExpr;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
@@ -127,7 +126,7 @@ pub trait ExecutionPlan: Debug + Send + Sync {
     ///
     /// It is safe to return `None` here if your operator does not
     /// have any particular output order here
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]>;
+    fn output_ordering(&self) -> Option<ExprOrderingRef>;
 
     /// Specifies the data distribution requirements for all the
     /// children for this operator, By default it's [[Distribution::UnspecifiedDistribution]] for each child,
@@ -142,7 +141,7 @@ pub trait ExecutionPlan: Debug + Send + Sync {
     /// NOTE that checking `!is_empty()` does **not** check for a
     /// required input ordering. Instead, the correct check is that at
     /// least one entry must be `Some`
-    fn required_input_ordering(&self) -> Vec<Option<Vec<PhysicalSortRequirement>>> {
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirement>> {
         vec![None; self.children().len()]
     }
 
@@ -589,13 +588,15 @@ impl Distribution {
     }
 }
 
-use datafusion_physical_expr::expressions::Column;
 pub use datafusion_physical_expr::window::WindowExpr;
 use datafusion_physical_expr::{
-    expr_list_eq_strict_order, normalize_expr_with_equivalence_properties,
+    expr_list_eq_strict_order, expressions::Column,
+    normalize_expr_with_equivalence_properties, EquivalenceProperties,
+    OrderingRequirement,
 };
-pub use datafusion_physical_expr::{AggregateExpr, PhysicalExpr};
-use datafusion_physical_expr::{EquivalenceProperties, PhysicalSortRequirement};
+pub use datafusion_physical_expr::{
+    AggregateExpr, ExprOrdering, ExprOrderingRef, PhysicalExpr,
+};
 
 /// Applies an optional projection to a [`SchemaRef`], returning the
 /// projected schema

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1856,6 +1856,7 @@ mod tests {
         col, lit, sum, Extension, GroupingSet, LogicalPlanBuilder,
         UserDefinedLogicalNodeCore,
     };
+    use datafusion_physical_expr::ExprOrderingRef;
     use fmt::Debug;
     use std::collections::HashMap;
     use std::convert::TryFrom;
@@ -2422,7 +2423,7 @@ Internal error: Optimizer rule 'type_coercion' failed due to unexpected error: E
             Partitioning::UnknownPartitioning(1)
         }
 
-        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        fn output_ordering(&self) -> Option<ExprOrderingRef> {
             None
         }
 

--- a/datafusion/core/src/physical_plan/projection.rs
+++ b/datafusion/core/src/physical_plan/projection.rs
@@ -29,7 +29,7 @@ use std::task::{Context, Poll};
 use crate::error::Result;
 use crate::physical_plan::{
     ColumnStatistics, DisplayFormatType, EquivalenceProperties, ExecutionPlan,
-    Partitioning, PhysicalExpr,
+    ExprOrdering, ExprOrderingRef, Partitioning, PhysicalExpr,
 };
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
@@ -54,7 +54,7 @@ pub struct ProjectionExec {
     /// The input plan
     input: Arc<dyn ExecutionPlan>,
     /// The output ordering
-    output_ordering: Option<Vec<PhysicalSortExpr>>,
+    output_ordering: Option<ExprOrdering>,
     /// The alias map used to normalize out expressions like Partitioning and PhysicalSortExpr
     /// The key is the column from the input schema and the values are the columns from the output schema
     alias_map: HashMap<Column, Vec<Column>>,
@@ -191,7 +191,7 @@ impl ExecutionPlan for ProjectionExec {
         }
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.output_ordering.as_deref()
     }
 

--- a/datafusion/core/src/physical_plan/repartition/mod.rs
+++ b/datafusion/core/src/physical_plan/repartition/mod.rs
@@ -38,7 +38,7 @@ use log::debug;
 use self::distributor_channels::{DistributionReceiver, DistributionSender};
 
 use super::common::{AbortOnDropMany, AbortOnDropSingle, SharedMemoryReservation};
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{RecordBatchStream, SendableRecordBatchStream};
 
@@ -328,7 +328,7 @@ impl ExecutionPlan for RepartitionExec {
         self.partitioning.clone()
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         if self.maintains_input_order()[0] {
             self.input().output_ordering()
         } else {

--- a/datafusion/core/src/physical_plan/streaming.rs
+++ b/datafusion/core/src/physical_plan/streaming.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use futures::stream::StreamExt;
 
 use datafusion_common::{DataFusionError, Result, Statistics};
-use datafusion_physical_expr::PhysicalSortExpr;
+use datafusion_physical_expr::ExprOrderingRef;
 
 use crate::datasource::streaming::PartitionStream;
 use crate::execution::context::TaskContext;
@@ -85,7 +85,7 @@ impl ExecutionPlan for StreamingTableExec {
         Partitioning::UnknownPartitioning(self.partitions.len())
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -36,7 +36,7 @@ use log::debug;
 use log::warn;
 
 use super::{
-    expressions::PhysicalSortExpr,
+    expressions::ExprOrderingRef,
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
     ColumnStatistics, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -218,7 +218,7 @@ impl ExecutionPlan for UnionExec {
         }
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         // If the Union is partition aware, there is no output ordering.
         // Otherwise, the output ordering is the "meet" of its input orderings.
         // The meet is the finest ordering that satisfied by all the input

--- a/datafusion/core/src/physical_plan/unnest.rs
+++ b/datafusion/core/src/physical_plan/unnest.rs
@@ -33,8 +33,8 @@ use std::{any::Any, sync::Arc};
 use crate::execution::context::TaskContext;
 use crate::physical_plan::{
     coalesce_batches::concat_batches, expressions::Column, DisplayFormatType,
-    Distribution, EquivalenceProperties, ExecutionPlan, Partitioning, PhysicalExpr,
-    PhysicalSortExpr, RecordBatchStream, SendableRecordBatchStream, Statistics,
+    Distribution, EquivalenceProperties, ExecutionPlan, ExprOrderingRef, Partitioning,
+    PhysicalExpr, RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use crate::{
     error::{DataFusionError, Result},
@@ -102,7 +102,7 @@ impl ExecutionPlan for UnnestExec {
         self.input.output_partitioning()
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/physical_plan/values.rs
+++ b/datafusion/core/src/physical_plan/values.rs
@@ -17,7 +17,7 @@
 
 //! Values execution plan
 
-use super::expressions::PhysicalSortExpr;
+use super::expressions::ExprOrderingRef;
 use super::{common, SendableRecordBatchStream, Statistics};
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::TaskContext;
@@ -112,7 +112,7 @@ impl ExecutionPlan for ValuesExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/scheduler/pipeline/execution.rs
+++ b/datafusion/core/src/scheduler/pipeline/execution.rs
@@ -29,7 +29,7 @@ use crate::arrow::datatypes::SchemaRef;
 use crate::arrow::record_batch::RecordBatch;
 use crate::error::Result;
 use crate::execution::context::TaskContext;
-use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::expressions::ExprOrderingRef;
 use crate::physical_plan::metrics::MetricsSet;
 use crate::physical_plan::{
     displayable, DisplayFormatType, Distribution, ExecutionPlan, Partitioning,
@@ -231,7 +231,7 @@ impl ExecutionPlan for ProxyExecutionPlan {
         self.inner.output_partitioning()
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         self.inner.output_ordering()
     }
 

--- a/datafusion/core/src/test/exec.rs
+++ b/datafusion/core/src/test/exec.rs
@@ -32,7 +32,7 @@ use arrow::{
 use futures::Stream;
 
 use crate::execution::context::TaskContext;
-use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::expressions::ExprOrderingRef;
 use crate::physical_plan::{
     common, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -146,7 +146,7 @@ impl ExecutionPlan for MockExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -284,7 +284,7 @@ impl ExecutionPlan for BarrierExec {
         Partitioning::UnknownPartitioning(self.data.len())
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -384,7 +384,7 @@ impl ExecutionPlan for ErrorExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -462,7 +462,7 @@ impl ExecutionPlan for StatisticsExec {
         Partitioning::UnknownPartitioning(2)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 
@@ -560,7 +560,7 @@ impl ExecutionPlan for BlockingExec {
         Partitioning::UnknownPartitioning(self.n_partitions)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -41,7 +41,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion_common::{Statistics, TableReference};
 use datafusion_expr::{CreateExternalTable, Expr, TableType};
-use datafusion_physical_expr::PhysicalSortExpr;
+use datafusion_physical_expr::ExprOrderingRef;
 use futures::Stream;
 
 /// Compares formatted output of a record batch with an expected
@@ -378,7 +378,7 @@ impl ExecutionPlan for UnboundedExec {
     fn unbounded_output(&self, _children: &[bool]) -> Result<bool> {
         Ok(self.batch_produce.is_none())
     }
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/tests/custom_sources.rs
+++ b/datafusion/core/tests/custom_sources.rs
@@ -25,7 +25,7 @@ use datafusion::logical_expr::{
     col, Expr, LogicalPlan, LogicalPlanBuilder, TableScan, UNNAMED_TABLE,
 };
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
+use datafusion::physical_plan::expressions::ExprOrderingRef;
 use datafusion::physical_plan::{
     project_schema, ColumnStatistics, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -113,7 +113,7 @@ impl ExecutionPlan for CustomExecutionPlan {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/tests/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/provider_filter_pushdown.rs
@@ -24,7 +24,7 @@ use datafusion::error::Result;
 use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::common::SizedRecordBatchStream;
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
+use datafusion::physical_plan::expressions::ExprOrderingRef;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MemTrackingMetrics};
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
@@ -72,7 +72,7 @@ impl ExecutionPlan for CustomPlan {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/tests/statistics.rs
+++ b/datafusion/core/tests/statistics.rs
@@ -25,7 +25,7 @@ use datafusion::{
     error::Result,
     logical_expr::Expr,
     physical_plan::{
-        expressions::PhysicalSortExpr, project_schema, ColumnStatistics,
+        expressions::ExprOrderingRef, project_schema, ColumnStatistics,
         DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
         Statistics,
     },
@@ -124,7 +124,7 @@ impl ExecutionPlan for StatisticsValidation {
         Partitioning::UnknownPartitioning(2)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/core/tests/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined_plan.rs
@@ -80,7 +80,7 @@ use datafusion::{
     },
     optimizer::{optimize_children, OptimizerConfig, OptimizerRule},
     physical_plan::{
-        expressions::PhysicalSortExpr,
+        expressions::ExprOrderingRef,
         planner::{DefaultPhysicalPlanner, ExtensionPlanner},
         DisplayFormatType, Distribution, ExecutionPlan, Partitioning, PhysicalPlanner,
         RecordBatchStream, SendableRecordBatchStream, Statistics,
@@ -437,7 +437,7 @@ impl ExecutionPlan for TopKExec {
         Partitioning::UnknownPartitioning(1)
     }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+    fn output_ordering(&self) -> Option<ExprOrderingRef> {
         None
     }
 

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -95,7 +95,7 @@ pub use try_cast::{try_cast, TryCastExpr};
 pub fn format_state_name(name: &str, state_name: &str) -> String {
     format!("{name}[{state_name}]")
 }
-pub use crate::PhysicalSortExpr;
+pub use crate::{ExprOrdering, ExprOrderingRef, PhysicalSortExpr};
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -54,7 +54,8 @@ pub use physical_expr::{AnalysisContext, ExprBoundaries, PhysicalExpr, PhysicalE
 pub use planner::create_physical_expr;
 pub use scalar_function::ScalarFunctionExpr;
 pub use sort_expr::{
-    make_sort_requirements_from_exprs, PhysicalSortExpr, PhysicalSortRequirement,
+    make_requirements_from_ordering, ExprOrdering, ExprOrderingRef, OrderingRequirement,
+    PhysicalSortExpr, PhysicalSortRequirement,
 };
 pub use utils::{
     expr_list_eq_any_order, expr_list_eq_strict_order,

--- a/datafusion/physical-expr/src/sort_expr.rs
+++ b/datafusion/physical-expr/src/sort_expr.rs
@@ -116,9 +116,11 @@ impl PhysicalSortRequirement {
     }
 }
 
-pub fn make_sort_requirements_from_exprs(
-    ordering: &[PhysicalSortExpr],
-) -> Vec<PhysicalSortRequirement> {
+pub type ExprOrdering = Vec<PhysicalSortExpr>;
+pub type ExprOrderingRef<'a> = &'a [PhysicalSortExpr];
+pub type OrderingRequirement = Vec<PhysicalSortRequirement>;
+
+pub fn make_requirements_from_ordering(ordering: ExprOrderingRef) -> OrderingRequirement {
     ordering.iter().map(|e| e.clone().into()).collect()
 }
 

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -33,7 +33,7 @@ use crate::window::window_expr::{reverse_order_bys, AggregateWindowExpr};
 use crate::window::{
     PartitionBatches, PartitionWindowAggStates, SlidingAggregateWindowExpr, WindowExpr,
 };
-use crate::{expressions::PhysicalSortExpr, AggregateExpr, PhysicalExpr};
+use crate::{AggregateExpr, ExprOrdering, ExprOrderingRef, PhysicalExpr};
 
 /// A window expr that takes the form of an aggregate function
 /// Aggregate Window Expressions that have the form
@@ -45,7 +45,7 @@ use crate::{expressions::PhysicalSortExpr, AggregateExpr, PhysicalExpr};
 pub struct PlainAggregateWindowExpr {
     aggregate: Arc<dyn AggregateExpr>,
     partition_by: Vec<Arc<dyn PhysicalExpr>>,
-    order_by: Vec<PhysicalSortExpr>,
+    order_by: ExprOrdering,
     window_frame: Arc<WindowFrame>,
 }
 
@@ -54,7 +54,7 @@ impl PlainAggregateWindowExpr {
     pub fn new(
         aggregate: Arc<dyn AggregateExpr>,
         partition_by: &[Arc<dyn PhysicalExpr>],
-        order_by: &[PhysicalSortExpr],
+        order_by: ExprOrderingRef,
         window_frame: Arc<WindowFrame>,
     ) -> Self {
         Self {
@@ -126,7 +126,7 @@ impl WindowExpr for PlainAggregateWindowExpr {
         &self.partition_by
     }
 
-    fn order_by(&self) -> &[PhysicalSortExpr] {
+    fn order_by(&self) -> ExprOrderingRef {
         &self.order_by
     }
 

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -30,7 +30,7 @@ use crate::window::window_expr::{
 use crate::window::{
     PartitionBatches, PartitionWindowAggStates, WindowAggState, WindowState,
 };
-use crate::{expressions::PhysicalSortExpr, PhysicalExpr};
+use crate::{ExprOrdering, ExprOrderingRef, PhysicalExpr};
 use arrow::array::{new_empty_array, Array, ArrayRef};
 use arrow::compute::SortOptions;
 use arrow::datatypes::Field;
@@ -43,7 +43,7 @@ use datafusion_expr::WindowFrame;
 pub struct BuiltInWindowExpr {
     expr: Arc<dyn BuiltInWindowFunctionExpr>,
     partition_by: Vec<Arc<dyn PhysicalExpr>>,
-    order_by: Vec<PhysicalSortExpr>,
+    order_by: ExprOrdering,
     window_frame: Arc<WindowFrame>,
 }
 
@@ -52,7 +52,7 @@ impl BuiltInWindowExpr {
     pub fn new(
         expr: Arc<dyn BuiltInWindowFunctionExpr>,
         partition_by: &[Arc<dyn PhysicalExpr>],
-        order_by: &[PhysicalSortExpr],
+        order_by: ExprOrderingRef,
         window_frame: Arc<WindowFrame>,
     ) -> Self {
         Self {
@@ -91,7 +91,7 @@ impl WindowExpr for BuiltInWindowExpr {
         &self.partition_by
     }
 
-    fn order_by(&self) -> &[PhysicalSortExpr] {
+    fn order_by(&self) -> ExprOrderingRef {
         &self.order_by
     }
 

--- a/datafusion/physical-expr/src/window/sliding_aggregate.rs
+++ b/datafusion/physical-expr/src/window/sliding_aggregate.rs
@@ -32,7 +32,7 @@ use crate::window::window_expr::{reverse_order_bys, AggregateWindowExpr};
 use crate::window::{
     PartitionBatches, PartitionWindowAggStates, PlainAggregateWindowExpr, WindowExpr,
 };
-use crate::{expressions::PhysicalSortExpr, AggregateExpr, PhysicalExpr};
+use crate::{AggregateExpr, ExprOrdering, ExprOrderingRef, PhysicalExpr};
 
 /// A window expr that takes the form of an aggregate function
 /// Aggregate Window Expressions that have the form
@@ -44,7 +44,7 @@ use crate::{expressions::PhysicalSortExpr, AggregateExpr, PhysicalExpr};
 pub struct SlidingAggregateWindowExpr {
     aggregate: Arc<dyn AggregateExpr>,
     partition_by: Vec<Arc<dyn PhysicalExpr>>,
-    order_by: Vec<PhysicalSortExpr>,
+    order_by: ExprOrdering,
     window_frame: Arc<WindowFrame>,
 }
 
@@ -53,7 +53,7 @@ impl SlidingAggregateWindowExpr {
     pub fn new(
         aggregate: Arc<dyn AggregateExpr>,
         partition_by: &[Arc<dyn PhysicalExpr>],
-        order_by: &[PhysicalSortExpr],
+        order_by: ExprOrderingRef,
         window_frame: Arc<WindowFrame>,
     ) -> Self {
         Self {
@@ -108,7 +108,7 @@ impl WindowExpr for SlidingAggregateWindowExpr {
         &self.partition_by
     }
 
-    fn order_by(&self) -> &[PhysicalSortExpr] {
+    fn order_by(&self) -> ExprOrderingRef {
         &self.order_by
     }
 

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -17,7 +17,7 @@
 
 use crate::window::partition_evaluator::PartitionEvaluator;
 use crate::window::window_frame_state::WindowFrameContext;
-use crate::{PhysicalExpr, PhysicalSortExpr};
+use crate::{ExprOrdering, ExprOrderingRef, PhysicalExpr, PhysicalSortExpr};
 use arrow::array::{new_empty_array, Array, ArrayRef};
 use arrow::compute::kernels::partition::lexicographical_partition_ranges;
 use arrow::compute::kernels::sort::SortColumn;
@@ -103,7 +103,7 @@ pub trait WindowExpr: Send + Sync + Debug {
     fn partition_by(&self) -> &[Arc<dyn PhysicalExpr>];
 
     /// Expressions that's from the window function's order by clause, empty if absent
-    fn order_by(&self) -> &[PhysicalSortExpr];
+    fn order_by(&self) -> ExprOrderingRef;
 
     /// Get order by columns, empty if absent
     fn order_by_columns(&self, batch: &RecordBatch) -> Result<Vec<SortColumn>> {
@@ -276,7 +276,7 @@ pub trait AggregateWindowExpr: WindowExpr {
 /// Reverses the ORDER BY expression, which is useful during equivalent window
 /// expression construction. For instance, 'ORDER BY a ASC, NULLS LAST' turns into
 /// 'ORDER BY a DESC, NULLS FIRST'.
-pub fn reverse_order_bys(order_bys: &[PhysicalSortExpr]) -> Vec<PhysicalSortExpr> {
+pub fn reverse_order_bys(order_bys: ExprOrderingRef) -> ExprOrdering {
     order_bys
         .iter()
         .map(|e| PhysicalSortExpr {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -28,7 +28,7 @@ use datafusion::execution::context::ExecutionProps;
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::window_function::WindowFunction;
 use datafusion::physical_expr::expressions::DateTimeIntervalExpr;
-use datafusion::physical_expr::{PhysicalSortExpr, ScalarFunctionExpr};
+use datafusion::physical_expr::{ExprOrdering, PhysicalSortExpr, ScalarFunctionExpr};
 use datafusion::physical_plan::expressions::GetIndexedFieldExpr;
 use datafusion::physical_plan::expressions::LikeExpr;
 use datafusion::physical_plan::file_format::FileScanConfig;
@@ -421,7 +421,7 @@ pub fn parse_protobuf_file_scan_config(
                 },
             })
         })
-        .collect::<Result<Vec<PhysicalSortExpr>>>()?;
+        .collect::<Result<ExprOrdering>>()?;
     let output_ordering = if output_ordering.is_empty() {
         None
     } else {


### PR DESCRIPTION
# Which issue does this PR close?

Takes a first step at addressing [this concern](https://github.com/apache/arrow-datafusion/pull/5661#discussion_r1148371213).

# Rationale for this change

Function signatures involving types related to expression ordering are starting to get overly verbose/complex. We would like to have simpler types/function signatures for readability and maintainability reasons.

# What changes are included in this PR?

We are introducing the following aliases:
```rust
pub type ExprOrdering = Vec<PhysicalSortExpr>;
pub type ExprOrderingRef<'a> = &'a [PhysicalSortExpr];
pub type OrderingRequirement = Vec<PhysicalSortRequirement>;
```
to simplify function signatures. If these aliases don't suffice in the future and we decide to use full-fledged types for this purpose, this PR will serve as a first step in that refactoring too.

# Are these changes tested?

Yes, all existing tests pass.

# Are there any user-facing changes?

Yes and no. Type-wise, nothing has changed (as these are type aliases). But a cursory look at traits and function signatures may give the impression that they have changed.