### PR TITLE
Minor: Add crates.io / API links to website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,8 +31,19 @@ DataFusion offers SQL and Dataframe APIs, excellent
 CSV, Parquet, JSON, and Avro, extensive customization, and a great
 community.
 
-.. _toc.guide:
 
+.. _toc.links:
+.. toctree::
+   :maxdepth: 1
+   :caption: Links
+
+   Issue tracker <https://github.com/apache/arrow-datafusion/issues>
+   crates.io <https://crates.io/crates/datafusion>
+   API Docs <https://docs.rs/datafusion/21.1.0/datafusion/>
+   Github <https://github.com/apache/arrow-datafusion>
+   Code of conduct <https://github.com/apache/arrow-datafusion/blob/main/CODE_OF_CONDUCT.md>
+
+.. _toc.guide:
 .. toctree::
    :maxdepth: 1
    :caption: User Guide
@@ -63,6 +74,3 @@ community.
    contributor-guide/roadmap
    contributor-guide/quarterly_roadmap
    contributor-guide/specification/index
-   Github <https://github.com/apache/arrow-datafusion>
-   Issue tracker <https://github.com/apache/arrow-datafusion/issues>
-   Code of conduct <https://github.com/apache/arrow-datafusion/blob/main/CODE_OF_CONDUCT.md>


### PR DESCRIPTION
# Which issue does this PR close?

Related to #3058 

# Rationale for this change

I am trying to make sure people can find the information they are looking for when the come to the DataFusion webpage

# What changes are included in this PR?
1. Add crates.io and docs.rs links to the website
2. Move the links to the top

## Before
![Screenshot 2023-04-04 at 5 01 26 PM](https://user-images.githubusercontent.com/490673/229921175-4e4c6036-514e-467d-8f0a-e70ae3c84c73.png)

## After
(the links are at the top!)
![Screenshot 2023-04-04 at 4 59 35 PM](https://user-images.githubusercontent.com/490673/229921252-bb9b4e94-5ed7-4bf6-ac0f-5313b758d779.png)



# Are these changes tested?
No
# Are there any user-facing changes?
doc
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->