### PR TITLE
Update docs/source/contributor-guide/index.md

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -129,7 +129,7 @@ There are several tests of the public interface of the DataFusion library in the
 You can run these tests individually using a command such as
 
 ```shell
-cargo test -p datafusion --tests sql_integration
+cargo test -p datafusion --test sql_integration
 ```
 
 One very important test is the [sql_integration](https://github.com/apache/arrow-datafusion/blob/main/datafusion/core/tests/sql_integration.rs) test which validates DataFusion's ability to run a large assortment of SQL queries against an assortment of data setups.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

NA

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
I tried `cargo test -p datafusion --tests sql_integration`, no tests [under sql directory](https://github.com/apache/arrow-datafusion/tree/main/datafusion/core/tests/sql) will run as stated in [sql_integration.rs](https://github.com/apache/arrow-datafusion/blob/main/datafusion/core/tests/sql_integration.rs)

my cargo version is `cargo 1.68.2 (6feb7c9cf 2023-03-26)`
`cargo test --help` said:
```
      --test [<NAME>]           Test only the specified test target
      --tests                   Test all tests
```
So only `--test` seem to accept filter, and I tried `cargo test -p datafusion --test sql_integration`, tests will run as expected.
# What changes are included in this PR?
NA
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
NA
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
NA
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->