### PR TITLE
Improve file scan time opening metric to include start_next_file

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -264,9 +264,9 @@ impl<F: FileOpener> FileStream<F> {
                     Ok(reader) => {
                         let partition_values = mem::take(partition_values);
 
-                        let next = self.start_next_file().transpose();
-
+                        // include time needed to start opening in `start_next_file`
                         self.file_stream_metrics.time_opening.stop();
+                        let next = self.start_next_file().transpose();
                         self.file_stream_metrics.time_scanning_until_data.start();
                         self.file_stream_metrics.time_scanning_total.start();
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/5899

# Rationale for this change

See https://github.com/apache/arrow-datafusion/pull/5790#discussion_r1155734134 -- I was messing around in this code anyways so I figured I would also make the proposed change

# What changes are included in this PR?

1. Include the time to call `start_file_opening` in the `time_opening` FileStream metrics

# Are these changes tested?
No -- I don't have any good idea of how to test it

# Are there any user-facing changes?
(Slighly) better metrics