### PR TITLE
Use generics instead of borrow for zero-cost

### DIFF
--- a/datafusion/core/src/physical_optimizer/sort_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/sort_pushdown.rs
@@ -127,9 +127,8 @@ pub(crate) fn pushdown_sorts(
             plan.equivalence_properties()
         }) {
             // If the current plan is a SortExec, modify it to satisfy parent requirements:
-            let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-                parent_required.ok_or_else(err)?.iter().cloned(),
-            );
+            let parent_required_expr =
+                PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
             new_plan = sort_exec.input.clone();
             add_sort_above(&mut new_plan, parent_required_expr)?;
         };
@@ -171,9 +170,8 @@ pub(crate) fn pushdown_sorts(
             }))
         } else {
             // Can not push down requirements, add new SortExec:
-            let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-                parent_required.ok_or_else(err)?.iter().cloned(),
-            );
+            let parent_required_expr =
+                PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
             let mut new_plan = plan.clone();
             add_sort_above(&mut new_plan, parent_required_expr)?;
             Ok(Transformed::Yes(SortPushDown::init(new_plan)))
@@ -209,9 +207,8 @@ fn pushdown_requirement_to_children(
     } else if let Some(smj) = plan.as_any().downcast_ref::<SortMergeJoinExec>() {
         // If the current plan is SortMergeJoinExec
         let left_columns_len = smj.left.schema().fields().len();
-        let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-            parent_required.ok_or_else(err)?.iter().cloned(),
-        );
+        let parent_required_expr =
+            PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
         let expr_source_side =
             expr_source_sides(&parent_required_expr, smj.join_type, left_columns_len);
         match expr_source_side {

--- a/datafusion/physical-expr/src/sort_expr.rs
+++ b/datafusion/physical-expr/src/sort_expr.rs
@@ -180,13 +180,15 @@ impl PhysicalSortRequirement {
     ///
     /// This method takes `&'a PhysicalSortExpr` to make it easy to
     /// use implementing [`ExecutionPlan::required_input_ordering`].
-    pub fn from_sort_exprs<'a>(
-        ordering: impl IntoIterator<Item = &'a PhysicalSortExpr>,
-    ) -> Vec<PhysicalSortRequirement> {
+    pub fn from_sort_exprs<T>(
+        ordering: impl IntoIterator<Item = T>,
+    ) -> Vec<PhysicalSortRequirement>
+    where
+        PhysicalSortRequirement: From<T>,
+    {
         ordering
             .into_iter()
-            .cloned()
-            .map(PhysicalSortRequirement::from)
+            .map(|e| PhysicalSortRequirement::from(e))
             .collect()
     }
 
@@ -196,12 +198,15 @@ impl PhysicalSortRequirement {
     /// This function converts `PhysicalSortRequirement` to `PhysicalSortExpr`
     /// for each entry in the input. If required ordering is None for an entry
     /// default ordering `ASC, NULLS LAST` if given (see [`into_sort_expr`])
-    pub fn to_sort_exprs(
-        requirements: impl IntoIterator<Item = PhysicalSortRequirement>,
-    ) -> Vec<PhysicalSortExpr> {
+    pub fn to_sort_exprs<T>(
+        requirements: impl IntoIterator<Item = T>,
+    ) -> Vec<PhysicalSortExpr>
+    where
+        PhysicalSortExpr: From<T>,
+    {
         requirements
             .into_iter()
-            .map(PhysicalSortExpr::from)
+            .map(|e| PhysicalSortExpr::from(e))
             .collect()
     }
 


### PR DESCRIPTION
This is based on @ozankabak 's PR https://github.com/alamb/arrow-datafusion/pull/11

I tried to pull the commits from that branch to make this work on `main`

It currently failing to compile with

```
error[E0277]: the trait bound `PhysicalSortExpr: From<&PhysicalSortRequirement>` is not satisfied
   --> datafusion/core/src/physical_optimizer/sort_pushdown.rs:131:17
    |
131 |                 PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&PhysicalSortRequirement>` is not implemented for `PhysicalSortExpr`
    |
    = help: the trait `From<PhysicalSortRequirement>` is implemented for `PhysicalSortExpr`
note: required by a bound in `PhysicalSortRequirement::to_sort_exprs`
```