### PR TITLE
just match for BinaryExpr Date/Time +/- Interval

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -656,7 +656,7 @@ SELECT ts1 + i FROM foo;
 2003-07-12T01:31:15.000123463
 
 # Timestamp + Timestamp => error
-statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, None\) Timestamp\(Nanosecond, None\) is an unsupported operation. addition/subtraction on dates/timestamps only supported with interval types
+statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, None\) \+ Timestamp\(Nanosecond, None\) can't be evaluated because there isn't a common type to coerce the types to
 SELECT ts1 + ts2
 FROM foo;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

- remove result in temporal_add_sub_coercion()
- just match for BinaryExpr Date/Time +/- Interval

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->