### PR TITLE
Move error check from pipeline fixer to pipeline checker

### DIFF
--- a/datafusion/core/src/physical_optimizer/pipeline_checker.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_checker.rs
@@ -314,7 +314,7 @@ mod sql_tests {
                   FROM test
                   LIMIT 5".to_string(),
             cases: vec![Arc::new(test1), Arc::new(test2)],
-            error_operator: "Window Error".to_string()
+            error_operator: "Sort Error".to_string()
         };
 
         case.run().await?;
@@ -337,7 +337,7 @@ mod sql_tests {
                         SUM(c9) OVER(ORDER BY c9 ASC ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) as sum1
                   FROM test".to_string(),
             cases: vec![Arc::new(test1), Arc::new(test2)],
-            error_operator: "Window Error".to_string()
+            error_operator: "Sort Error".to_string()
         };
         case.run().await?;
         Ok(())

--- a/datafusion/core/src/physical_optimizer/pipeline_fixer.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_fixer.rs
@@ -33,6 +33,7 @@ use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::DataFusionError;
 use datafusion_expr::logical_plan::JoinType;
 
+use crate::physical_plan::windows::{BoundedWindowAggExec, WindowAggExec};
 use std::sync::Arc;
 
 /// The [`PipelineFixer`] rule tries to modify a given plan so that it can
@@ -64,6 +65,7 @@ impl PhysicalOptimizerRule for PipelineFixer {
         let physical_optimizer_subrules: Vec<Box<PipelineFixerSubrule>> = vec![
             Box::new(hash_join_convert_symmetric_subrule),
             Box::new(hash_join_swap_subrule),
+            Box::new(reverse_window),
         ];
         let state = pipeline.transform_up(&|p| {
             apply_subrules_and_check_finiteness_requirements(
@@ -192,6 +194,55 @@ fn hash_join_swap_subrule(
     } else {
         None
     }
+}
+
+/// If possible (e.g. reverse window expressions can be calculated with bounded memory),
+/// this rule converts from `WindowAggExec` to `BoundedWindowAggExec`
+/// when input source is unbounded. (To prevent pipeline breaking)
+fn reverse_window(
+    input: PipelineStatePropagator,
+) -> Option<Result<PipelineStatePropagator>> {
+    let plan = input.plan;
+    if let Some(exec) = plan.as_any().downcast_ref::<WindowAggExec>() {
+        // WindowAggExec has single child
+        let child_unbounded = input.children_unbounded[0];
+        if !child_unbounded {
+            // If children is bounded, no need to convert to BoundedWindowAggExec
+            return None;
+        }
+        let window_expr = exec.window_expr();
+        if let Some(window_expr) = window_expr
+            .iter()
+            .map(|e| e.get_reverse_expr())
+            .collect::<Option<Vec<_>>>()
+        {
+            let uses_bounded_memory = window_expr.iter().all(|e| e.uses_bounded_memory());
+            if !uses_bounded_memory {
+                // If reversed window expression cannot be calculated with bounded memory
+                // Cannot convert it to BoundedWindowAggExec
+                return None;
+            }
+
+            // We can use BoundedWindowAggExec
+            let input = exec.input();
+
+            let new_exec = BoundedWindowAggExec::try_new(
+                window_expr.to_vec(),
+                input.clone(),
+                input.schema(),
+                exec.partition_keys.clone(),
+            );
+            let new_plan = new_exec.map(|elem| Arc::new(elem) as _);
+
+            return Some(new_plan.map(|plan| PipelineStatePropagator {
+                plan,
+                unbounded: child_unbounded,
+                children_unbounded: vec![child_unbounded],
+            }));
+        }
+    }
+    // There is no way to change current Executor to BoundedWindowAggExec
+    None
 }
 
 /// This function swaps sides of a hash join to make it runnable even if one of its

--- a/datafusion/core/src/physical_optimizer/pipeline_fixer.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_fixer.rs
@@ -33,7 +33,6 @@ use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::DataFusionError;
 use datafusion_expr::logical_plan::JoinType;
 
-use crate::physical_plan::windows::{BoundedWindowAggExec, WindowAggExec};
 use std::sync::Arc;
 
 /// The [`PipelineFixer`] rule tries to modify a given plan so that it can
@@ -65,7 +64,6 @@ impl PhysicalOptimizerRule for PipelineFixer {
         let physical_optimizer_subrules: Vec<Box<PipelineFixerSubrule>> = vec![
             Box::new(hash_join_convert_symmetric_subrule),
             Box::new(hash_join_swap_subrule),
-            Box::new(reverse_window),
         ];
         let state = pipeline.transform_up(&|p| {
             apply_subrules_and_check_finiteness_requirements(
@@ -196,53 +194,6 @@ fn hash_join_swap_subrule(
     }
 }
 
-/// If possible (e.g. reverse window expressions can be calculated with bounded memory),
-/// this rule converts from `WindowAggExec` to `BoundedWindowAggExec`
-/// when input source is unbounded. (To prevent pipeline breaking)
-fn reverse_window(
-    mut input: PipelineStatePropagator,
-) -> Option<Result<PipelineStatePropagator>> {
-    if let Some(exec) = input.plan.as_any().downcast_ref::<WindowAggExec>() {
-        // WindowAggExec has single child
-        let child_unbounded = input.children_unbounded[0];
-        if !child_unbounded {
-            // If children is bounded, no need to convert to BoundedWindowAggExec
-            return None;
-        }
-        let window_expr = exec.window_expr();
-        if let Some(window_expr) = window_expr
-            .iter()
-            .map(|e| e.get_reverse_expr())
-            .collect::<Option<Vec<_>>>()
-        {
-            let uses_bounded_memory = window_expr.iter().all(|e| e.uses_bounded_memory());
-            if !uses_bounded_memory {
-                // If reversed window expression cannot be calculated with bounded memory
-                // Cannot convert it to BoundedWindowAggExec
-                return None;
-            }
-
-            // We can use BoundedWindowAggExec
-            let input_exec = exec.input();
-
-            let new_exec = BoundedWindowAggExec::try_new(
-                window_expr,
-                input_exec.clone(),
-                input_exec.schema(),
-                exec.partition_keys.clone(),
-            );
-            let new_plan = new_exec.map(|elem| Arc::new(elem) as _);
-
-            return Some(new_plan.map(|plan| {
-                input.plan = plan;
-                input
-            }));
-        }
-    }
-    // There is no way to change current Executor to BoundedWindowAggExec
-    None
-}
-
 /// This function swaps sides of a hash join to make it runnable even if one of its
 /// inputs are infinite. Note that this is not always possible; i.e. [JoinType::Full],
 /// [JoinType::Right], [JoinType::RightAnti] and [JoinType::RightSemi] can not run with
@@ -278,13 +229,16 @@ fn apply_subrules_and_check_finiteness_requirements(
             input = value;
         }
     }
-    input
+    let is_unbounded = input
         .plan
         .unbounded_output(&input.children_unbounded)
-        .map(|value| {
-            input.unbounded = value;
-            Transformed::Yes(input)
-        })
+        // Treat the cases where executor cannot be run on unbounded data
+        // as generating unbounded data. These executors may be fixed during optimization
+        // (Sort will be removed, Window will be swapped etc.), If cannot
+        // be fixed Pipeline checker will generate error anyway.
+        .unwrap_or(true);
+    input.unbounded = is_unbounded;
+    Ok(Transformed::Yes(input))
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -19,8 +19,10 @@
 
 pub mod parquet;
 
+use arrow::array::Int32Array;
 use std::any::Any;
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -40,10 +42,13 @@ use crate::prelude::{CsvReadOptions, SessionContext};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
+use datafusion_common::from_slice::FromSlice;
 use datafusion_common::{Statistics, TableReference};
-use datafusion_expr::{CreateExternalTable, Expr, TableType};
+use datafusion_execution::config::SessionConfig;
+use datafusion_expr::{col, CreateExternalTable, Expr, TableType};
 use datafusion_physical_expr::PhysicalSortExpr;
 use futures::Stream;
+use tempfile::TempDir;
 
 /// Compares formatted output of a record batch with an expected
 /// vector of strings, with the result of pretty formatting record
@@ -286,6 +291,108 @@ pub fn aggr_test_schema_with_missing_col() -> SchemaRef {
     ]);
 
     Arc::new(schema)
+}
+
+// Return a static RecordBatch and its ordering for tests. RecordBatch is ordered by ts
+fn get_test_data() -> Result<(RecordBatch, Vec<Expr>)> {
+    let ts_field = Field::new("ts", DataType::Int32, false);
+    let inc_field = Field::new("inc_col", DataType::Int32, false);
+    let desc_field = Field::new("desc_col", DataType::Int32, false);
+
+    let schema = Arc::new(Schema::new(vec![ts_field, inc_field, desc_field]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from_slice([
+                1, 1, 5, 9, 10, 11, 16, 21, 22, 26, 26, 28, 31, 33, 38, 42, 47, 51, 53,
+                53, 58, 63, 67, 68, 70, 72, 72, 76, 81, 85, 86, 88, 91, 96, 97, 98, 100,
+                101, 102, 104, 104, 108, 112, 113, 113, 114, 114, 117, 122, 126, 131,
+                131, 136, 136, 136, 139, 141, 146, 147, 147, 152, 154, 159, 161, 163,
+                164, 167, 172, 173, 177, 180, 185, 186, 191, 195, 195, 199, 203, 207,
+                210, 213, 218, 221, 224, 226, 230, 232, 235, 238, 238, 239, 244, 245,
+                247, 250, 254, 258, 262, 264, 264,
+            ])),
+            Arc::new(Int32Array::from_slice([
+                1, 5, 10, 15, 20, 21, 26, 29, 30, 33, 37, 40, 43, 44, 45, 49, 51, 53, 58,
+                61, 65, 70, 75, 78, 83, 88, 90, 91, 95, 97, 100, 105, 109, 111, 115, 119,
+                120, 124, 126, 129, 131, 135, 140, 143, 144, 147, 148, 149, 151, 155,
+                156, 159, 160, 163, 165, 170, 172, 177, 181, 182, 186, 187, 192, 196,
+                197, 199, 203, 207, 209, 213, 214, 216, 219, 221, 222, 225, 226, 231,
+                236, 237, 242, 245, 247, 248, 253, 254, 259, 261, 266, 269, 272, 275,
+                278, 283, 286, 289, 291, 296, 301, 305,
+            ])),
+            Arc::new(Int32Array::from_slice([
+                100, 98, 93, 91, 86, 84, 81, 77, 75, 71, 70, 69, 64, 62, 59, 55, 50, 45,
+                41, 40, 39, 36, 31, 28, 23, 22, 17, 13, 10, 6, 5, 2, 1, -1, -4, -5, -6,
+                -8, -12, -16, -17, -19, -24, -25, -29, -34, -37, -42, -47, -48, -49, -53,
+                -57, -58, -61, -65, -67, -68, -71, -73, -75, -76, -78, -83, -87, -91,
+                -95, -98, -101, -105, -106, -111, -114, -116, -120, -125, -128, -129,
+                -134, -139, -142, -143, -146, -150, -154, -158, -163, -168, -172, -176,
+                -181, -184, -189, -193, -196, -201, -203, -208, -210, -213,
+            ])),
+        ],
+    )?;
+    let file_sort_order = vec![col("ts").sort(true, false)];
+    Ok((batch, file_sort_order))
+}
+
+/// Creates a test_context with table name `annotated_data` which has 100 rows.
+// Columns in the table are ts, inc_col, desc_col. Source is CsvExec which is ordered by
+// ts column.
+pub async fn get_test_context(
+    tmpdir: &TempDir,
+    infinite_source: bool,
+    session_config: SessionConfig,
+) -> Result<SessionContext> {
+    get_test_context_helper(tmpdir, infinite_source, session_config, get_test_data).await
+}
+
+async fn get_test_context_helper(
+    tmpdir: &TempDir,
+    infinite_source: bool,
+    session_config: SessionConfig,
+    data_receiver: fn() -> Result<(RecordBatch, Vec<Expr>)>,
+) -> Result<SessionContext> {
+    let ctx = SessionContext::with_config(session_config);
+
+    let csv_read_options = CsvReadOptions::default();
+    let (batch, file_sort_order) = data_receiver()?;
+
+    let options_sort = csv_read_options
+        .to_listing_options(&ctx.copied_config())
+        .with_file_sort_order(Some(file_sort_order))
+        .with_infinite_source(infinite_source);
+
+    write_test_data_to_csv(tmpdir, 1, &batch)?;
+    let sql_definition = None;
+    ctx.register_listing_table(
+        "annotated_data",
+        tmpdir.path().to_string_lossy(),
+        options_sort.clone(),
+        Some(batch.schema()),
+        sql_definition,
+    )
+    .await
+    .unwrap();
+    Ok(ctx)
+}
+
+fn write_test_data_to_csv(
+    tmpdir: &TempDir,
+    n_file: usize,
+    batch: &RecordBatch,
+) -> Result<()> {
+    let n_chunk = batch.num_rows() / n_file;
+    for i in 0..n_file {
+        let target_file = tmpdir.path().join(format!("{i}.csv"));
+        let file = File::create(target_file)?;
+        let chunks_start = i * n_chunk;
+        let cur_batch = batch.slice(chunks_start, n_chunk);
+        let mut writer = arrow::csv::Writer::new(file);
+        writer.write(&cur_batch)?;
+    }
+    Ok(())
 }
 
 /// TableFactory for tests

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -16,9 +16,6 @@
 // under the License.
 
 use super::*;
-use ::parquet::arrow::arrow_writer::ArrowWriter;
-use ::parquet::file::properties::WriterProperties;
-use datafusion::execution::options::ReadOptions;
 
 #[tokio::test]
 async fn window_frame_creation_type_checking() -> Result<()> {
@@ -63,118 +60,15 @@ async fn window_frame_creation_type_checking() -> Result<()> {
     .await
 }
 
-fn split_record_batch(batch: RecordBatch, n_split: usize) -> Vec<RecordBatch> {
-    let n_chunk = batch.num_rows() / n_split;
-    let mut res = vec![];
-    for i in 0..n_split - 1 {
-        let chunk = batch.slice(i * n_chunk, n_chunk);
-        res.push(chunk);
-    }
-    let start = (n_split - 1) * n_chunk;
-    let len = batch.num_rows() - start;
-    res.push(batch.slice(start, len));
-    res
-}
-
-fn get_test_data(n_split: usize) -> Result<Vec<RecordBatch>> {
-    let ts_field = Field::new("ts", DataType::Int32, false);
-    let inc_field = Field::new("inc_col", DataType::Int32, false);
-    let desc_field = Field::new("desc_col", DataType::Int32, false);
-
-    let schema = Arc::new(Schema::new(vec![ts_field, inc_field, desc_field]));
-
-    let batch = RecordBatch::try_new(
-        schema,
-        vec![
-            Arc::new(Int32Array::from_slice([
-                1, 1, 5, 9, 10, 11, 16, 21, 22, 26, 26, 28, 31, 33, 38, 42, 47, 51, 53,
-                53, 58, 63, 67, 68, 70, 72, 72, 76, 81, 85, 86, 88, 91, 96, 97, 98, 100,
-                101, 102, 104, 104, 108, 112, 113, 113, 114, 114, 117, 122, 126, 131,
-                131, 136, 136, 136, 139, 141, 146, 147, 147, 152, 154, 159, 161, 163,
-                164, 167, 172, 173, 177, 180, 185, 186, 191, 195, 195, 199, 203, 207,
-                210, 213, 218, 221, 224, 226, 230, 232, 235, 238, 238, 239, 244, 245,
-                247, 250, 254, 258, 262, 264, 264,
-            ])),
-            Arc::new(Int32Array::from_slice([
-                1, 5, 10, 15, 20, 21, 26, 29, 30, 33, 37, 40, 43, 44, 45, 49, 51, 53, 58,
-                61, 65, 70, 75, 78, 83, 88, 90, 91, 95, 97, 100, 105, 109, 111, 115, 119,
-                120, 124, 126, 129, 131, 135, 140, 143, 144, 147, 148, 149, 151, 155,
-                156, 159, 160, 163, 165, 170, 172, 177, 181, 182, 186, 187, 192, 196,
-                197, 199, 203, 207, 209, 213, 214, 216, 219, 221, 222, 225, 226, 231,
-                236, 237, 242, 245, 247, 248, 253, 254, 259, 261, 266, 269, 272, 275,
-                278, 283, 286, 289, 291, 296, 301, 305,
-            ])),
-            Arc::new(Int32Array::from_slice([
-                100, 98, 93, 91, 86, 84, 81, 77, 75, 71, 70, 69, 64, 62, 59, 55, 50, 45,
-                41, 40, 39, 36, 31, 28, 23, 22, 17, 13, 10, 6, 5, 2, 1, -1, -4, -5, -6,
-                -8, -12, -16, -17, -19, -24, -25, -29, -34, -37, -42, -47, -48, -49, -53,
-                -57, -58, -61, -65, -67, -68, -71, -73, -75, -76, -78, -83, -87, -91,
-                -95, -98, -101, -105, -106, -111, -114, -116, -120, -125, -128, -129,
-                -134, -139, -142, -143, -146, -150, -154, -158, -163, -168, -172, -176,
-                -181, -184, -189, -193, -196, -201, -203, -208, -210, -213,
-            ])),
-        ],
-    )?;
-    Ok(split_record_batch(batch, n_split))
-}
-
-fn write_test_data_to_parquet(tmpdir: &TempDir, n_split: usize) -> Result<()> {
-    let batches = get_test_data(n_split)?;
-    for (i, batch) in batches.into_iter().enumerate() {
-        let target_file = tmpdir.path().join(format!("{i}.parquet"));
-        let file = File::create(target_file).unwrap();
-        // Default writer properties
-        let props = WriterProperties::builder().build();
-        let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
-
-        writer.write(&batch).expect("Writing batch");
-
-        // writer must be closed to write footer
-        writer.close().unwrap();
-    }
-    Ok(())
-}
-
-async fn get_test_context(tmpdir: &TempDir, n_batch: usize) -> Result<SessionContext> {
-    let session_config = SessionConfig::new().with_target_partitions(1);
-    let ctx = SessionContext::with_config(session_config);
-
-    let parquet_read_options = ParquetReadOptions::default();
-    let file_sort_order = [col("ts")]
-        .into_iter()
-        .map(|e| {
-            let ascending = true;
-            let nulls_first = false;
-            e.sort(ascending, nulls_first)
-        })
-        .collect::<Vec<_>>();
-
-    let options_sort = parquet_read_options
-        .to_listing_options(&ctx.copied_config())
-        .with_file_sort_order(Some(file_sort_order));
-
-    write_test_data_to_parquet(tmpdir, n_batch)?;
-    let provided_schema = None;
-    let sql_definition = None;
-    ctx.register_listing_table(
-        "annotated_data",
-        tmpdir.path().to_string_lossy(),
-        options_sort.clone(),
-        provided_schema,
-        sql_definition,
-    )
-    .await
-    .unwrap();
-    Ok(ctx)
-}
-
 mod tests {
     use super::*;
+    use datafusion::test_util::get_test_context;
 
     #[tokio::test]
     async fn test_source_sorted_aggregate() -> Result<()> {
-        let tmpdir = TempDir::new().unwrap();
-        let ctx = get_test_context(&tmpdir, 1).await?;
+        let tmpdir = TempDir::new()?;
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let ctx = get_test_context(&tmpdir, false, session_config).await?;
 
         let sql = "SELECT
             SUM(inc_col) OVER(ORDER BY ts RANGE BETWEEN 10 PRECEDING AND 1 FOLLOWING) as sum1,
@@ -248,8 +142,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_source_sorted_builtin() -> Result<()> {
-        let tmpdir = TempDir::new().unwrap();
-        let ctx = get_test_context(&tmpdir, 1).await?;
+        let tmpdir = TempDir::new()?;
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let ctx = get_test_context(&tmpdir, false, session_config).await?;
 
         let sql = "SELECT
             FIRST_VALUE(inc_col) OVER(ORDER BY ts RANGE BETWEEN 10 PRECEDING and 1 FOLLOWING) as fv1,
@@ -322,8 +217,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_source_sorted_unbounded_preceding() -> Result<()> {
-        let tmpdir = TempDir::new().unwrap();
-        let ctx = get_test_context(&tmpdir, 1).await?;
+        let tmpdir = TempDir::new()?;
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let ctx = get_test_context(&tmpdir, false, session_config).await?;
 
         let sql = "SELECT
             SUM(inc_col) OVER(ORDER BY ts ASC RANGE BETWEEN UNBOUNDED PRECEDING AND 5 FOLLOWING) as sum1,
@@ -382,7 +278,8 @@ mod tests {
     #[tokio::test]
     async fn test_source_sorted_unbounded_preceding_builtin() -> Result<()> {
         let tmpdir = TempDir::new().unwrap();
-        let ctx = get_test_context(&tmpdir, 1).await?;
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        let ctx = get_test_context(&tmpdir, false, session_config).await?;
 
         let sql = "SELECT
            FIRST_VALUE(inc_col) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as first_value1,
@@ -406,6 +303,59 @@ mod tests {
                 "      ProjectionExec: expr=[FIRST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@5 as first_value1, FIRST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@3 as first_value2, LAST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@6 as last_value1, LAST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@4 as last_value2, NTH_VALUE(annotated_data.inc_col,Int64(2)) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@7 as nth_value1, inc_col@1 as inc_col]",
                 "        BoundedWindowAggExec: wdw=[FIRST_VALUE(annotated_data.inc_col): Ok(Field { name: \"FIRST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, LAST_VALUE(annotated_data.inc_col): Ok(Field { name: \"LAST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, NTH_VALUE(annotated_data.inc_col,Int64(2)): Ok(Field { name: \"NTH_VALUE(annotated_data.inc_col,Int64(2))\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }]",
                 "          BoundedWindowAggExec: wdw=[FIRST_VALUE(annotated_data.inc_col): Ok(Field { name: \"FIRST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }, LAST_VALUE(annotated_data.inc_col): Ok(Field { name: \"LAST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }]",
+            ]
+        };
+
+        let actual: Vec<&str> = formatted.trim().lines().collect();
+        let actual_len = actual.len();
+        let actual_trim_last = &actual[..actual_len - 1];
+        assert_eq!(
+            expected, actual_trim_last,
+            "\n\nexpected:\n\n{expected:#?}\nactual:\n\n{actual:#?}\n\n"
+        );
+
+        let actual = execute_to_batches(&ctx, sql).await;
+        let expected = vec![
+            "+--------------+--------------+-------------+-------------+------------+",
+            "| first_value1 | first_value2 | last_value1 | last_value2 | nth_value1 |",
+            "+--------------+--------------+-------------+-------------+------------+",
+            "| 1            | 15           | 5           | 1           | 5          |",
+            "| 1            | 20           | 10          | 1           | 5          |",
+            "| 1            | 21           | 15          | 1           | 5          |",
+            "| 1            | 26           | 20          | 1           | 5          |",
+            "| 1            | 29           | 21          | 1           | 5          |",
+            "+--------------+--------------+-------------+-------------+------------+",
+        ];
+        assert_batches_eq!(expected, &actual);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_source_sorted_unbounded_source() -> Result<()> {
+        let tmpdir = TempDir::new().unwrap();
+        let session_config = SessionConfig::new().with_target_partitions(1);
+        // Use an unbounded source
+        let ctx = get_test_context(&tmpdir, true, session_config).await?;
+
+        let sql = "SELECT
+           FIRST_VALUE(inc_col) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as first_value1,
+           FIRST_VALUE(inc_col) OVER(ORDER BY ts DESC ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING) as first_value2,
+           LAST_VALUE(inc_col) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as last_value1,
+           LAST_VALUE(inc_col) OVER(ORDER BY ts DESC ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING) as last_value2,
+           NTH_VALUE(inc_col, 2) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as nth_value1
+           FROM annotated_data
+           LIMIT 5";
+
+        let msg = format!("Creating logical plan for '{sql}'");
+        let dataframe = ctx.sql(sql).await.expect(&msg);
+        let physical_plan = dataframe.create_physical_plan().await?;
+        let formatted = displayable(physical_plan.as_ref()).indent().to_string();
+        let expected = {
+            vec![
+                "ProjectionExec: expr=[FIRST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@5 as first_value1, FIRST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@3 as first_value2, LAST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@6 as last_value1, LAST_VALUE(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@4 as last_value2, NTH_VALUE(annotated_data.inc_col,Int64(2)) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@7 as nth_value1]",
+                "  GlobalLimitExec: skip=0, fetch=5",
+                "    BoundedWindowAggExec: wdw=[FIRST_VALUE(annotated_data.inc_col): Ok(Field { name: \"FIRST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, LAST_VALUE(annotated_data.inc_col): Ok(Field { name: \"LAST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, NTH_VALUE(annotated_data.inc_col,Int64(2)): Ok(Field { name: \"NTH_VALUE(annotated_data.inc_col,Int64(2))\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }]",
+                "      BoundedWindowAggExec: wdw=[FIRST_VALUE(annotated_data.inc_col): Ok(Field { name: \"FIRST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }, LAST_VALUE(annotated_data.inc_col): Ok(Field { name: \"LAST_VALUE(annotated_data.inc_col)\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }]",
             ]
         };
 

--- a/datafusion/core/tests/sql/window.rs
+++ b/datafusion/core/tests/sql/window.rs
@@ -343,6 +343,7 @@ mod tests {
            COUNT(inc_col) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as count1,
            COUNT(inc_col) OVER(ORDER BY ts DESC ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING) as count2
            FROM annotated_data
+           ORDER BY ts ASC
            LIMIT 5";
 
         let msg = format!("Creating logical plan for '{sql}'");
@@ -351,10 +352,11 @@ mod tests {
         let formatted = displayable(physical_plan.as_ref()).indent().to_string();
         let expected = {
             vec![
-                "ProjectionExec: expr=[SUM(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@5 as sum1, SUM(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@3 as sum2, COUNT(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@6 as count1, COUNT(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@4 as count2]",
+                "ProjectionExec: expr=[sum1@0 as sum1, sum2@1 as sum2, count1@2 as count1, count2@3 as count2]",
                 "  GlobalLimitExec: skip=0, fetch=5",
-                "    BoundedWindowAggExec: wdw=[SUM(annotated_data.inc_col): Ok(Field { name: \"SUM(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, COUNT(annotated_data.inc_col): Ok(Field { name: \"COUNT(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }]",
-                "      BoundedWindowAggExec: wdw=[SUM(annotated_data.inc_col): Ok(Field { name: \"SUM(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }, COUNT(annotated_data.inc_col): Ok(Field { name: \"COUNT(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }]",
+                "    ProjectionExec: expr=[SUM(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@5 as sum1, SUM(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@3 as sum2, COUNT(annotated_data.inc_col) ORDER BY [annotated_data.ts ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING@6 as count1, COUNT(annotated_data.inc_col) ORDER BY [annotated_data.ts DESC NULLS FIRST] ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING@4 as count2, ts@0 as ts]",
+                "      BoundedWindowAggExec: wdw=[SUM(annotated_data.inc_col): Ok(Field { name: \"SUM(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }, COUNT(annotated_data.inc_col): Ok(Field { name: \"COUNT(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(1)) }]",
+                "        BoundedWindowAggExec: wdw=[SUM(annotated_data.inc_col): Ok(Field { name: \"SUM(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }, COUNT(annotated_data.inc_col): Ok(Field { name: \"COUNT(annotated_data.inc_col)\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: Following(UInt64(3)) }]",
             ]
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
Sometimes `PipelineFixer` will receive executors that cannot run on unbounded data. In these cases currently, we generate error. However, during optimization stages these pipeline breaking executors may be removed, may be changed, etc. Hence, `PipelineFixer` shouldn't give pre-mature decisions. 

For instance, If window expression is in the form 
`SUM(inc_col) OVER(ORDER BY ts DESC ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) as sum1` it would be calculated with `WindowAggExec`. However, it can be converted to the equivalent form 
`SUM(inc_col) OVER(ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) as sum1`
Second form can be calculated with `BoundedWindowAggExec` without breaking the pipeline (given that its input is already ordered with `ts ASC`).  
If source is unbounded, during optimization we may convert expression in the form 1 to in the form 2 which is not breaking pipeline. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
With this PR, `PipelineFixer` doesn't generate an error, when some executor cannot be run unbounded data (Those cases may be fixed during optimization.) If those executors cannot be fixed, we generate error in `PipelineChecker` anyway.
Util codes to construct test table are moved from `window.rs` to under `test_util/mod.rs` to be able to use utils in other files.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes `test_source_sorted_unbounded_source` is added to check this behaviour.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->