### PR TITLE
Change back SmallVec to Vec for JoinHashMap - Issue 5940

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -726,7 +726,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand",
- "smallvec",
  "sqlparser",
  "tempfile",
  "tokio",

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -88,7 +88,6 @@ percent-encoding = "2.2.0"
 pin-project-lite = "^0.2.7"
 rand = "0.8"
 rayon = { version = "1.5", optional = true }
-smallvec = { version = "1.6", features = ["union"] }
 sqlparser = { version = "0.32", features = ["visitor"] }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }

--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -597,7 +597,9 @@ pub fn update_hash(
     let row_end = offset + hash_values.len();
     for (row, hash_value) in (row_start..row_end).zip(hash_values.iter()) {
         // the hash value is the key, always true
-        let item = hash_map.0.get_mut(*hash_value, |_| true);
+        let item = hash_map
+            .0
+            .get_mut(*hash_value, |(hash, _)| *hash_value == *hash);
         if let Some((_, indices)) = item {
             indices.push(row as u64);
         } else {
@@ -760,7 +762,10 @@ pub fn build_equal_condition_join_indices(
         // For every item on the build and probe we check if it matches
         // This possibly contains rows with hash collisions,
         // So we have to check here whether rows are equal or not
-        if let Some((_, indices)) = build_hashmap.0.get(*hash_value, |_| true) {
+        if let Some((_, indices)) = build_hashmap
+            .0
+            .get(*hash_value, |(hash, _)| *hash_value == *hash)
+        {
             for &i in indices {
                 // Check hash collisions
                 let offset_build_index = i as usize - offset_value;

--- a/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
@@ -677,15 +677,10 @@ fn prune_hash_values(
         }
     }
     for (hash_value, index_set) in hash_value_map.iter() {
-        if let Some((_, separation_chain)) = hashmap
-            .0
-            .get_mut(*hash_value, |(hash, _)| hash_value == hash)
-        {
+        if let Some((_, separation_chain)) = hashmap.0.get_mut(*hash_value, |_| true) {
             separation_chain.retain(|n| !index_set.contains(n));
             if separation_chain.is_empty() {
-                hashmap
-                    .0
-                    .remove_entry(*hash_value, |(hash, _)| hash_value == hash);
+                hashmap.0.remove_entry(*hash_value, |_| true);
             }
         }
     }

--- a/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
@@ -677,10 +677,15 @@ fn prune_hash_values(
         }
     }
     for (hash_value, index_set) in hash_value_map.iter() {
-        if let Some((_, separation_chain)) = hashmap.0.get_mut(*hash_value, |_| true) {
+        if let Some((_, separation_chain)) = hashmap
+            .0
+            .get_mut(*hash_value, |(hash, _)| *hash_value == *hash)
+        {
             separation_chain.retain(|n| !index_set.contains(n));
             if separation_chain.is_empty() {
-                hashmap.0.remove_entry(*hash_value, |_| true);
+                hashmap
+                    .0
+                    .remove_entry(*hash_value, |(hash, _)| *hash_value == *hash);
             }
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5940.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After applying patches based on #5866 and #5904, based on the flame graph for q17 generated by 
`sudo CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --freq 500 --bin tpch -- benchmark datafusion --path ./data-parquet/ --format parquet --partitions 1 -q 17 --iterations 10`

![flamegraph-5941-before](https://user-images.githubusercontent.com/90197956/230892563-0e92c9c3-058f-4c30-a0e6-5425e24358ba.svg)

we found the bottleneck happens at **### physical_plan::joins::hash_join::update_hash**.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Change back SmallVec to Vec for JoinHashMap.

After applying the patch proposed from this PR, the flame graph becomes
![flamegraph-5941-after](https://user-images.githubusercontent.com/90197956/230893133-7b3d4423-a864-4d68-b8fa-405fcdde2495.svg)

We can see the samples for the vector capacity changing significantly decreased. It's expected especially when doing joining with one big table and the other is relatively small.

To end to end query performance for q17 is improved from 7000ms to 6500ms.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->