### PR TITLE
fix: return `NotImplemented` when execute `SELECT INTO` syntax

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -61,6 +61,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if !select.sort_by.is_empty() {
             return Err(DataFusionError::NotImplemented("SORT BY".to_string()));
         }
+        if select.into.is_some() {
+            return Err(DataFusionError::NotImplemented("INTO".to_string()));
+        }
 
         // process `from` clause
         let plan = self.plan_from_tables(select.from, planner_context)?;

--- a/datafusion/sql/tests/integration_test.rs
+++ b/datafusion/sql/tests/integration_test.rs
@@ -3350,6 +3350,37 @@ fn test_select_distinct_order_by() {
     assert_eq!(err.to_string(), expected);
 }
 
+#[rstest]
+#[case::select_cluster_by_unsupported(
+    "SELECT customer_name, SUM(order_total) as total_order_amount FROM orders CLUSTER BY customer_name",
+    "This feature is not implemented: CLUSTER BY"
+)]
+#[case::select_lateral_view_unsupported(
+    "SELECT id, number FROM person LATERAL VIEW explode(numbers) exploded_table AS number",
+    "This feature is not implemented: LATERAL VIEWS"
+)]
+#[case::select_qualify_unsupported(
+    "SELECT i, p, o FROM person QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
+    "This feature is not implemented: QUALIFY"
+)]
+#[case::select_top_unsupported(
+    "SELECT TOP (5) * FROM person",
+    "This feature is not implemented: TOP"
+)]
+#[case::select_sort_by_unsupported(
+    "SELECT * FROM person SORT BY id",
+    "This feature is not implemented: SORT BY"
+)]
+#[case::select_into_unsupported(
+    "SELECT * INTO test FROM person",
+    "This feature is not implemented: INTO"
+)]
+#[test]
+fn test_select_unsupported_syntax_errors(#[case] sql: &str, #[case] error: &str) {
+    let err = logical_plan(sql).unwrap_err();
+    assert_eq!(err.to_string(), error)
+}
+
 #[test]
 fn select_order_by_with_cast() {
     let sql =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related issue #5943 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #5943 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Temporarily disable `SELECT INTO` support. But, this does not close #5943 , it does prevent confusion from users.
I will spend additional time implementing support for `SELECT INTO`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->