### PR TITLE
Remove `unsafe` code (`transmute`) in datafusion-proto

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -453,7 +453,12 @@ pub async fn from_substrait_sorts(
         let asc_nullfirst = match &s.sort_kind {
             Some(k) => match k {
                 Direction(d) => {
-                    let direction: SortDirection = unsafe { ::std::mem::transmute(*d) };
+                    let Some(direction) = SortDirection::from_i32(*d) else {
+                        return Err(DataFusionError::NotImplemented(
+                            format!("Unsupported Substrait SortDirection value {d}"),
+                        ))
+                    };
+
                     match direction {
                         SortDirection::AscNullsFirst => Ok((true, true)),
                         SortDirection::AscNullsLast => Ok((true, false)),
@@ -908,7 +913,7 @@ fn from_substrait_bound(
     }
 }
 
-fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
+pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
     let scalar_value = match &lit.literal_type {
         Some(LiteralType::Boolean(b)) => ScalarValue::Boolean(Some(*b)),
         Some(LiteralType::I8(n)) => match lit.type_variation_reference {
@@ -931,9 +936,7 @@ fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
         },
         Some(LiteralType::I32(n)) => match lit.type_variation_reference {
             DEFAULT_TYPE_REF => ScalarValue::Int32(Some(*n)),
-            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt32(Some(unsafe {
-                std::mem::transmute_copy::<i32, u32>(n)
-            })),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt32(Some(*n as u32)),
             others => {
                 return Err(DataFusionError::Substrait(format!(
                     "Unknown type variation reference {others}",
@@ -942,9 +945,7 @@ fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
         },
         Some(LiteralType::I64(n)) => match lit.type_variation_reference {
             DEFAULT_TYPE_REF => ScalarValue::Int64(Some(*n)),
-            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt64(Some(unsafe {
-                std::mem::transmute_copy::<i64, u64>(n)
-            })),
+            UNSIGNED_INTEGER_TYPE_REF => ScalarValue::UInt64(Some(*n as u64)),
             others => {
                 return Err(DataFusionError::Substrait(format!(
                     "Unknown type variation reference {others}",

--- a/datafusion/substrait/tests/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/roundtrip_logical_plan.rs
@@ -274,7 +274,7 @@ mod tests {
     #[tokio::test]
     async fn all_type_literal() -> Result<()> {
         roundtrip_all_types(
-            "select * from data where 
+            "select * from data where
             bool_col = TRUE AND
             int8_col = arrow_cast('0', 'Int8') AND
             uint8_col = arrow_cast('0', 'UInt8') AND


### PR DESCRIPTION
# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/issues/5717


# Rationale for this change

During the review of https://github.com/apache/arrow-datafusion/pull/5775 I noticed there was unsafe code in `datafusion-proto` for seemingly unecessary reasons. See https://github.com/apache/arrow-datafusion/pull/5775#discussion_r1161492804 with @waynexia 

# What changes are included in this PR?

1. Remove `unsafe` code. 
2. Add boundary tests to ensure substrait roundtrip casting works

# Are these changes tested?
Yes new tests are added

# Are there any user-facing changes?

No