### PR TITLE
fix: support `date - timestamp` and `timestamp - date`

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/dates.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/dates.slt
@@ -88,3 +88,19 @@ h
 statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, Some\("\+00:00"\)\) \+ Utf8 can't be evaluated because there isn't a common type to coerce the types to
 select i_item_desc from test
 where d3_date > now() + '5 days';
+
+# DATE minus DATE
+query error DataFusion error: Error during planning: Date32 \- Date32 can't be evaluated because there isn't a common type to coerce the types to
+SELECT DATE '2023-04-09' - DATE '2023-04-02';
+
+# DATE minus Timestamp
+query P
+SELECT DATE '2023-04-09' - '2000-01-01T00:00:00'::timestamp;
+----
+0 years 0 mons 8499 days 0 hours 0 mins 0.000000000 secs
+
+# Timestamp minus DATE
+query P
+SELECT '2023-01-01T00:00:00'::timestamp - DATE '2021-01-01';
+----
+0 years 0 mons 730 days 0 hours 0 mins 0.000000000 secs

--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -660,6 +660,18 @@ statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, 
 SELECT ts1 + ts2
 FROM foo;
 
+# Timestamp - Timestamp
+query ?
+SELECT '2000-01-01T00:00:00'::timestamp - '2000-01-01T00:00:00'::timestamp;
+----
+0 years 0 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# large timestamp - small timestamp
+query ?
+SELECT '2000-01-01T00:00:00'::timestamp - '2010-01-01T00:00:00'::timestamp;
+----
+0 years 0 mons -3653 days 0 hours 0 mins 0.000000000 secs
+
 # Interval - Timestamp => error
 statement error DataFusion error: Error during planning: Interval\(MonthDayNano\) - Timestamp\(Nanosecond, None\) can't be evaluated because there isn't a common type to coerce the types to
 SELECT i - ts1 from FOO;

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -266,8 +266,7 @@ fn check_arg_count(
         TypeSignature::VariadicAny => {
             if input_types.is_empty() {
                 return Err(DataFusionError::Plan(format!(
-                    "The function {:?} expects at least one argument",
-                    agg_fun
+                    "The function {agg_fun:?} expects at least one argument"
                 )));
             }
         }

--- a/datafusion/physical-expr/src/type_coercion.rs
+++ b/datafusion/physical-expr/src/type_coercion.rs
@@ -18,7 +18,7 @@
 //! Type coercion rules for functions with multiple valid signatures
 //!
 //! Coercion is performed automatically by DataFusion when the types
-//! of arguments passed to a function do not exacty match the types
+//! of arguments passed to a function do not exactly match the types
 //! required by that function. In this case, DataFusion will attempt to
 //! *coerce* the arguments to types accepted by the function by
 //! inserting CAST operations.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5931 .

# Rationale for this change

support data/timestamp minus in type coercion.

# What changes are included in this PR?

Add test in slt.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->