### PR TITLE
fix: do not depend on time 0.1

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 async-recursion = "1.0"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", default-features = false }
 datafusion = { version = "22.0.0", path = "../core" }
 itertools = "0.10.5"
 object_store = "0.5.4"


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Limit chrono features so we don't pull in time 0.1 which suffers from <https://rustsec.org/advisories/RUSTSEC-2020-0071>.

# What changes are included in this PR?
Dependency adjustment.

# Are these changes tested?
Existing tests pass.

# Are there any user-facing changes?
\-