### PR TITLE
Row accumulator support update Scalar values

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -1454,7 +1454,7 @@ impl std::hash::Hash for ScalarValue {
 /// return a reference to the values array and the index into it for a
 /// dictionary array
 #[inline]
-fn get_dict_value<K: ArrowDictionaryKeyType>(
+pub fn get_dict_value<K: ArrowDictionaryKeyType>(
     array: &dyn Array,
     index: usize,
 ) -> (&ArrayRef, Option<usize>) {

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -43,17 +43,9 @@ use arrow::array::*;
 use arrow::compute::{cast, filter};
 use arrow::datatypes::{DataType, Schema, UInt32Type};
 use arrow::{compute, datatypes::SchemaRef, record_batch::RecordBatch};
-use arrow_array::types::{
-    Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt64Type, UInt8Type,
-};
-use arrow_schema::{IntervalUnit, TimeUnit};
-use datafusion_common::cast::{
-    as_boolean_array, as_decimal128_array, as_fixed_size_binary_array,
-    as_fixed_size_list_array, as_list_array, as_struct_array,
-};
-use datafusion_common::scalar::get_dict_value;
+use datafusion_common::cast::as_boolean_array;
 use datafusion_common::utils::get_arrayref_at_indices;
-use datafusion_common::{DataFusionError, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::Accumulator;
 use datafusion_row::accessor::RowAccessor;
 use datafusion_row::layout::RowLayout;
@@ -866,23 +858,6 @@ fn slice_and_maybe_filter(
     Ok(filtered_arrays)
 }
 
-macro_rules! typed_cast_to_scalar {
-    ($array:expr, $index:expr, $ARRAYTYPE:ident, $SCALAR:ident) => {{
-        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
-        Ok(ScalarValue::$SCALAR(Some(array.value($index).into())))
-    }};
-}
-
-macro_rules! typed_cast_tz_to_scalar {
-    ($array:expr, $index:expr, $ARRAYTYPE:ident, $SCALAR:ident, $TZ:expr) => {{
-        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
-        Ok(ScalarValue::$SCALAR(
-            Some(array.value($index).into()),
-            $TZ.clone(),
-        ))
-    }};
-}
-
 /// This method is similar to Scalar::try_from_array except for the Null handling.
 /// This method returns [ScalarValue::Null] instead of [ScalarValue::Type(None)]
 fn col_to_scalar(
@@ -898,199 +873,9 @@ fn col_to_scalar(
             return Ok(ScalarValue::Null);
         }
     }
-    match array.data_type() {
-        DataType::Null => Ok(ScalarValue::Null),
-        DataType::Boolean => {
-            typed_cast_to_scalar!(array, row_index, BooleanArray, Boolean)
-        }
-        DataType::Int8 => typed_cast_to_scalar!(array, row_index, Int8Array, Int8),
-        DataType::Int16 => typed_cast_to_scalar!(array, row_index, Int16Array, Int16),
-        DataType::Int32 => typed_cast_to_scalar!(array, row_index, Int32Array, Int32),
-        DataType::Int64 => typed_cast_to_scalar!(array, row_index, Int64Array, Int64),
-        DataType::UInt8 => typed_cast_to_scalar!(array, row_index, UInt8Array, UInt8),
-        DataType::UInt16 => {
-            typed_cast_to_scalar!(array, row_index, UInt16Array, UInt16)
-        }
-        DataType::UInt32 => {
-            typed_cast_to_scalar!(array, row_index, UInt32Array, UInt32)
-        }
-        DataType::UInt64 => {
-            typed_cast_to_scalar!(array, row_index, UInt64Array, UInt64)
-        }
-        DataType::Float32 => {
-            typed_cast_to_scalar!(array, row_index, Float32Array, Float32)
-        }
-        DataType::Float64 => {
-            typed_cast_to_scalar!(array, row_index, Float64Array, Float64)
-        }
-        DataType::Decimal128(p, s) => {
-            let array = as_decimal128_array(array)?;
-            Ok(ScalarValue::Decimal128(
-                Some(array.value(row_index)),
-                *p,
-                *s,
-            ))
-        }
-        DataType::Binary => {
-            typed_cast_to_scalar!(array, row_index, BinaryArray, Binary)
-        }
-        DataType::LargeBinary => {
-            typed_cast_to_scalar!(array, row_index, LargeBinaryArray, LargeBinary)
-        }
-        DataType::Utf8 => typed_cast_to_scalar!(array, row_index, StringArray, Utf8),
-        DataType::LargeUtf8 => {
-            typed_cast_to_scalar!(array, row_index, LargeStringArray, LargeUtf8)
-        }
-        DataType::List(nested_type) => {
-            let list_array = as_list_array(array)?;
-
-            let nested_array = list_array.value(row_index);
-            let scalar_vec = (0..nested_array.len())
-                .map(|i| ScalarValue::try_from_array(&nested_array, i))
-                .collect::<Result<Vec<_>>>()?;
-            let value = Some(scalar_vec);
-            Ok(ScalarValue::new_list(
-                value,
-                nested_type.data_type().clone(),
-            ))
-        }
-        DataType::Date32 => {
-            typed_cast_to_scalar!(array, row_index, Date32Array, Date32)
-        }
-        DataType::Date64 => {
-            typed_cast_to_scalar!(array, row_index, Date64Array, Date64)
-        }
-        DataType::Time32(TimeUnit::Second) => {
-            typed_cast_to_scalar!(array, row_index, Time32SecondArray, Time32Second)
-        }
-        DataType::Time32(TimeUnit::Millisecond) => typed_cast_to_scalar!(
-            array,
-            row_index,
-            Time32MillisecondArray,
-            Time32Millisecond
-        ),
-        DataType::Time64(TimeUnit::Microsecond) => typed_cast_to_scalar!(
-            array,
-            row_index,
-            Time64MicrosecondArray,
-            Time64Microsecond
-        ),
-        DataType::Time64(TimeUnit::Nanosecond) => typed_cast_to_scalar!(
-            array,
-            row_index,
-            Time64NanosecondArray,
-            Time64Nanosecond
-        ),
-        DataType::Timestamp(TimeUnit::Second, tz_opt) => typed_cast_tz_to_scalar!(
-            array,
-            row_index,
-            TimestampSecondArray,
-            TimestampSecond,
-            tz_opt
-        ),
-        DataType::Timestamp(TimeUnit::Millisecond, tz_opt) => {
-            typed_cast_tz_to_scalar!(
-                array,
-                row_index,
-                TimestampMillisecondArray,
-                TimestampMillisecond,
-                tz_opt
-            )
-        }
-        DataType::Timestamp(TimeUnit::Microsecond, tz_opt) => {
-            typed_cast_tz_to_scalar!(
-                array,
-                row_index,
-                TimestampMicrosecondArray,
-                TimestampMicrosecond,
-                tz_opt
-            )
-        }
-        DataType::Timestamp(TimeUnit::Nanosecond, tz_opt) => {
-            typed_cast_tz_to_scalar!(
-                array,
-                row_index,
-                TimestampNanosecondArray,
-                TimestampNanosecond,
-                tz_opt
-            )
-        }
-        DataType::Dictionary(key_type, _) => {
-            let (values_array, values_index) = match key_type.as_ref() {
-                DataType::Int8 => get_dict_value::<Int8Type>(array, row_index),
-                DataType::Int16 => get_dict_value::<Int16Type>(array, row_index),
-                DataType::Int32 => get_dict_value::<Int32Type>(array, row_index),
-                DataType::Int64 => get_dict_value::<Int64Type>(array, row_index),
-                DataType::UInt8 => get_dict_value::<UInt8Type>(array, row_index),
-                DataType::UInt16 => get_dict_value::<UInt16Type>(array, row_index),
-                DataType::UInt32 => get_dict_value::<UInt32Type>(array, row_index),
-                DataType::UInt64 => get_dict_value::<UInt64Type>(array, row_index),
-                _ => unreachable!("Invalid dictionary keys type: {:?}", key_type),
-            };
-            // look up the index in the values dictionary
-            match values_index {
-                Some(values_index) => {
-                    let value = ScalarValue::try_from_array(values_array, values_index)?;
-                    Ok(ScalarValue::Dictionary(key_type.clone(), Box::new(value)))
-                }
-                // else entry was null, so return null
-                None => Ok(ScalarValue::Null),
-            }
-        }
-        DataType::Struct(fields) => {
-            let array = as_struct_array(array)?;
-            let mut field_values: Vec<ScalarValue> = Vec::new();
-            for col_index in 0..array.num_columns() {
-                let col_array = array.column(col_index);
-                let col_scalar = ScalarValue::try_from_array(col_array, row_index)?;
-                field_values.push(col_scalar);
-            }
-            Ok(ScalarValue::Struct(Some(field_values), fields.clone()))
-        }
-        DataType::FixedSizeList(nested_type, _len) => {
-            let list_array = as_fixed_size_list_array(array)?;
-            match list_array.is_null(row_index) {
-                true => Ok(ScalarValue::Null),
-                false => {
-                    let nested_array = list_array.value(row_index);
-                    let scalar_vec = (0..nested_array.len())
-                        .map(|i| ScalarValue::try_from_array(&nested_array, i))
-                        .collect::<Result<Vec<_>>>()?;
-                    Ok(ScalarValue::new_list(
-                        Some(scalar_vec),
-                        nested_type.data_type().clone(),
-                    ))
-                }
-            }
-        }
-        DataType::FixedSizeBinary(_) => {
-            let array = as_fixed_size_binary_array(array)?;
-            let size = match array.data_type() {
-                DataType::FixedSizeBinary(size) => *size,
-                _ => unreachable!(),
-            };
-            Ok(ScalarValue::FixedSizeBinary(
-                size,
-                Some(array.value(row_index).into()),
-            ))
-        }
-        DataType::Interval(IntervalUnit::DayTime) => {
-            typed_cast_to_scalar!(array, row_index, IntervalDayTimeArray, IntervalDayTime)
-        }
-        DataType::Interval(IntervalUnit::YearMonth) => typed_cast_to_scalar!(
-            array,
-            row_index,
-            IntervalYearMonthArray,
-            IntervalYearMonth
-        ),
-        DataType::Interval(IntervalUnit::MonthDayNano) => typed_cast_to_scalar!(
-            array,
-            row_index,
-            IntervalMonthDayNanoArray,
-            IntervalMonthDayNano
-        ),
-        other => Err(DataFusionError::NotImplemented(format!(
-            "GroupedHashAggregate: can't create a scalar from array of type \"{other:?}\""
-        ))),
+    let mut res = ScalarValue::try_from_array(array, row_index)?;
+    if res.is_null() {
+        res = ScalarValue::Null;
     }
+    Ok(res)
 }

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -873,9 +873,5 @@ fn col_to_scalar(
             return Ok(ScalarValue::Null);
         }
     }
-    let mut res = ScalarValue::try_from_array(array, row_index)?;
-    if res.is_null() {
-        res = ScalarValue::Null;
-    }
-    Ok(res)
+    ScalarValue::try_from_array(array, row_index)
 }

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -31,6 +31,7 @@ use futures::stream::{Stream, StreamExt};
 
 use crate::execution::context::TaskContext;
 use crate::execution::memory_pool::proxy::{RawTableAllocExt, VecAllocExt};
+use crate::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use crate::physical_plan::aggregates::{
     evaluate_group_by, evaluate_many, evaluate_optional, group_schema, AccumulatorItem,
     AggregateMode, PhysicalGroupBy, RowAccumulatorItem,
@@ -38,21 +39,28 @@ use crate::physical_plan::aggregates::{
 use crate::physical_plan::metrics::{BaselineMetrics, RecordOutput};
 use crate::physical_plan::{aggregates, AggregateExpr, PhysicalExpr};
 use crate::physical_plan::{RecordBatchStream, SendableRecordBatchStream};
-
-use crate::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use arrow::array::{new_null_array, Array, ArrayRef, PrimitiveArray, UInt32Builder};
+use arrow::array::*;
 use arrow::compute::{cast, filter};
 use arrow::datatypes::{DataType, Schema, UInt32Type};
 use arrow::{compute, datatypes::SchemaRef, record_batch::RecordBatch};
-use datafusion_common::cast::as_boolean_array;
+use arrow_array::types::{
+    Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt64Type, UInt8Type,
+};
+use arrow_schema::{IntervalUnit, TimeUnit};
+use datafusion_common::cast::{
+    as_boolean_array, as_decimal128_array, as_fixed_size_binary_array,
+    as_fixed_size_list_array, as_list_array, as_struct_array,
+};
+use datafusion_common::scalar::get_dict_value;
 use datafusion_common::utils::get_arrayref_at_indices;
-use datafusion_common::{Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::Accumulator;
 use datafusion_row::accessor::RowAccessor;
 use datafusion_row::layout::RowLayout;
 use datafusion_row::reader::{read_row, RowReader};
 use datafusion_row::{MutableRecordBatch, RowType};
 use hashbrown::raw::RawTable;
+use itertools::izip;
 
 /// Grouping aggregate with row-format aggregation states inside.
 ///
@@ -410,7 +418,7 @@ impl GroupedHashAggregateStream {
 
     // Update the accumulator results, according to row_aggr_state.
     #[allow(clippy::too_many_arguments)]
-    fn update_accumulators(
+    fn update_accumulators_using_batch(
         &mut self,
         groups_with_rows: &[usize],
         offsets: &[usize],
@@ -491,6 +499,44 @@ impl GroupedHashAggregateStream {
         Ok(())
     }
 
+    // Update the accumulator results, according to row_aggr_state.
+    fn update_accumulators_using_scalar(
+        &mut self,
+        groups_with_rows: &[usize],
+        row_values: &[Vec<ArrayRef>],
+        row_filter_values: &[Option<ArrayRef>],
+    ) -> Result<()> {
+        let filter_bool_array = row_filter_values
+            .iter()
+            .map(|filter_opt| match filter_opt {
+                Some(f) => Ok(Some(as_boolean_array(f)?)),
+                None => Ok(None),
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        for group_idx in groups_with_rows {
+            let group_state = &mut self.aggr_state.group_states[*group_idx];
+            let mut state_accessor =
+                RowAccessor::new_from_layout(self.row_aggr_layout.clone());
+            state_accessor.point_to(0, group_state.aggregation_buffer.as_mut_slice());
+            for idx in &group_state.indices {
+                for (accumulator, values, filter_array) in izip!(
+                    self.row_accumulators.iter_mut(),
+                    row_values.iter(),
+                    filter_bool_array.iter()
+                ) {
+                    let scalar_value =
+                        vec![col_to_scalar(&values[0], filter_array, *idx as usize)?];
+                    accumulator.update_scalar(&scalar_value, &mut state_accessor)?;
+                }
+            }
+            // clear the group indices in this group
+            group_state.indices.clear();
+        }
+
+        Ok(())
+    }
+
     /// Perform group-by aggregation for the given [`RecordBatch`].
     ///
     /// If successful, this returns the additional number of bytes that were allocated during this process.
@@ -516,35 +562,50 @@ impl GroupedHashAggregateStream {
         for group_values in &group_by_values {
             let groups_with_rows =
                 self.update_group_state(group_values, &mut allocated)?;
+            // Decide the accumulators update mode, use scalar value to update the accumulators when all of the conditions are meet:
+            // 1) The aggregation mode is Partial or Single
+            // 2) There is not normal aggregation expressions
+            // 3) The number of affected groups is high (entries in `aggr_state` have rows need to update). Usually the high cardinality case
+            if matches!(self.mode, AggregateMode::Partial | AggregateMode::Single)
+                && normal_aggr_input_values.is_empty()
+                && normal_filter_values.is_empty()
+                && groups_with_rows.len() >= batch.num_rows() / 10
+            {
+                self.update_accumulators_using_scalar(
+                    &groups_with_rows,
+                    &row_aggr_input_values,
+                    &row_filter_values,
+                )?;
+            } else {
+                // Collect all indices + offsets based on keys in this vec
+                let mut batch_indices: UInt32Builder = UInt32Builder::with_capacity(0);
+                let mut offsets = vec![0];
+                let mut offset_so_far = 0;
+                for &group_idx in groups_with_rows.iter() {
+                    let indices = &self.aggr_state.group_states[group_idx].indices;
+                    batch_indices.append_slice(indices);
+                    offset_so_far += indices.len();
+                    offsets.push(offset_so_far);
+                }
+                let batch_indices = batch_indices.finish();
 
-            // Collect all indices + offsets based on keys in this vec
-            let mut batch_indices: UInt32Builder = UInt32Builder::with_capacity(0);
-            let mut offsets = vec![0];
-            let mut offset_so_far = 0;
-            for &group_idx in groups_with_rows.iter() {
-                let indices = &self.aggr_state.group_states[group_idx].indices;
-                batch_indices.append_slice(indices);
-                offset_so_far += indices.len();
-                offsets.push(offset_so_far);
+                let row_values = get_at_indices(&row_aggr_input_values, &batch_indices)?;
+                let normal_values =
+                    get_at_indices(&normal_aggr_input_values, &batch_indices)?;
+                let row_filter_values =
+                    get_optional_filters(&row_filter_values, &batch_indices);
+                let normal_filter_values =
+                    get_optional_filters(&normal_filter_values, &batch_indices);
+                self.update_accumulators_using_batch(
+                    &groups_with_rows,
+                    &offsets,
+                    &row_values,
+                    &normal_values,
+                    &row_filter_values,
+                    &normal_filter_values,
+                    &mut allocated,
+                )?;
             }
-            let batch_indices = batch_indices.finish();
-
-            let row_values = get_at_indices(&row_aggr_input_values, &batch_indices)?;
-            let normal_values =
-                get_at_indices(&normal_aggr_input_values, &batch_indices)?;
-            let row_filter_values =
-                get_optional_filters(&row_filter_values, &batch_indices);
-            let normal_filter_values =
-                get_optional_filters(&normal_filter_values, &batch_indices);
-            self.update_accumulators(
-                &groups_with_rows,
-                &offsets,
-                &row_values,
-                &normal_values,
-                &row_filter_values,
-                &normal_filter_values,
-                &mut allocated,
-            )?;
         }
         allocated += self
             .row_converter
@@ -792,4 +853,233 @@ fn slice_and_maybe_filter(
         None => sliced_arrays,
     };
     Ok(filtered_arrays)
+}
+
+macro_rules! typed_cast_to_scalar {
+    ($array:expr, $index:expr, $ARRAYTYPE:ident, $SCALAR:ident) => {{
+        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
+        Ok(ScalarValue::$SCALAR(Some(array.value($index).into())))
+    }};
+}
+
+macro_rules! typed_cast_tz_to_scalar {
+    ($array:expr, $index:expr, $ARRAYTYPE:ident, $SCALAR:ident, $TZ:expr) => {{
+        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
+        Ok(ScalarValue::$SCALAR(
+            Some(array.value($index).into()),
+            $TZ.clone(),
+        ))
+    }};
+}
+
+/// This method is similar to Scalar::try_from_array except for the Null handling.
+/// This method returns [ScalarValue::Null] instead of [ScalarValue::Type(None)]
+fn col_to_scalar(
+    array: &ArrayRef,
+    filter: &Option<&BooleanArray>,
+    row_index: usize,
+) -> Result<ScalarValue> {
+    if array.is_null(row_index) {
+        return Ok(ScalarValue::Null);
+    }
+    if let Some(filter) = filter {
+        if !filter.value(row_index) {
+            return Ok(ScalarValue::Null);
+        }
+    }
+    match array.data_type() {
+        DataType::Null => Ok(ScalarValue::Null),
+        DataType::Boolean => {
+            typed_cast_to_scalar!(array, row_index, BooleanArray, Boolean)
+        }
+        DataType::Int8 => typed_cast_to_scalar!(array, row_index, Int8Array, Int8),
+        DataType::Int16 => typed_cast_to_scalar!(array, row_index, Int16Array, Int16),
+        DataType::Int32 => typed_cast_to_scalar!(array, row_index, Int32Array, Int32),
+        DataType::Int64 => typed_cast_to_scalar!(array, row_index, Int64Array, Int64),
+        DataType::UInt8 => typed_cast_to_scalar!(array, row_index, UInt8Array, UInt8),
+        DataType::UInt16 => {
+            typed_cast_to_scalar!(array, row_index, UInt16Array, UInt16)
+        }
+        DataType::UInt32 => {
+            typed_cast_to_scalar!(array, row_index, UInt32Array, UInt32)
+        }
+        DataType::UInt64 => {
+            typed_cast_to_scalar!(array, row_index, UInt64Array, UInt64)
+        }
+        DataType::Float32 => {
+            typed_cast_to_scalar!(array, row_index, Float32Array, Float32)
+        }
+        DataType::Float64 => {
+            typed_cast_to_scalar!(array, row_index, Float64Array, Float64)
+        }
+        DataType::Decimal128(p, s) => {
+            let array = as_decimal128_array(array)?;
+            Ok(ScalarValue::Decimal128(
+                Some(array.value(row_index)),
+                *p,
+                *s,
+            ))
+        }
+        DataType::Binary => {
+            typed_cast_to_scalar!(array, row_index, BinaryArray, Binary)
+        }
+        DataType::LargeBinary => {
+            typed_cast_to_scalar!(array, row_index, LargeBinaryArray, LargeBinary)
+        }
+        DataType::Utf8 => typed_cast_to_scalar!(array, row_index, StringArray, Utf8),
+        DataType::LargeUtf8 => {
+            typed_cast_to_scalar!(array, row_index, LargeStringArray, LargeUtf8)
+        }
+        DataType::List(nested_type) => {
+            let list_array = as_list_array(array)?;
+
+            let nested_array = list_array.value(row_index);
+            let scalar_vec = (0..nested_array.len())
+                .map(|i| ScalarValue::try_from_array(&nested_array, i))
+                .collect::<Result<Vec<_>>>()?;
+            let value = Some(scalar_vec);
+            Ok(ScalarValue::new_list(
+                value,
+                nested_type.data_type().clone(),
+            ))
+        }
+        DataType::Date32 => {
+            typed_cast_to_scalar!(array, row_index, Date32Array, Date32)
+        }
+        DataType::Date64 => {
+            typed_cast_to_scalar!(array, row_index, Date64Array, Date64)
+        }
+        DataType::Time32(TimeUnit::Second) => {
+            typed_cast_to_scalar!(array, row_index, Time32SecondArray, Time32Second)
+        }
+        DataType::Time32(TimeUnit::Millisecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time32MillisecondArray,
+            Time32Millisecond
+        ),
+        DataType::Time64(TimeUnit::Microsecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time64MicrosecondArray,
+            Time64Microsecond
+        ),
+        DataType::Time64(TimeUnit::Nanosecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time64NanosecondArray,
+            Time64Nanosecond
+        ),
+        DataType::Timestamp(TimeUnit::Second, tz_opt) => typed_cast_tz_to_scalar!(
+            array,
+            row_index,
+            TimestampSecondArray,
+            TimestampSecond,
+            tz_opt
+        ),
+        DataType::Timestamp(TimeUnit::Millisecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampMillisecondArray,
+                TimestampMillisecond,
+                tz_opt
+            )
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampMicrosecondArray,
+                TimestampMicrosecond,
+                tz_opt
+            )
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampNanosecondArray,
+                TimestampNanosecond,
+                tz_opt
+            )
+        }
+        DataType::Dictionary(key_type, _) => {
+            let (values_array, values_index) = match key_type.as_ref() {
+                DataType::Int8 => get_dict_value::<Int8Type>(array, row_index),
+                DataType::Int16 => get_dict_value::<Int16Type>(array, row_index),
+                DataType::Int32 => get_dict_value::<Int32Type>(array, row_index),
+                DataType::Int64 => get_dict_value::<Int64Type>(array, row_index),
+                DataType::UInt8 => get_dict_value::<UInt8Type>(array, row_index),
+                DataType::UInt16 => get_dict_value::<UInt16Type>(array, row_index),
+                DataType::UInt32 => get_dict_value::<UInt32Type>(array, row_index),
+                DataType::UInt64 => get_dict_value::<UInt64Type>(array, row_index),
+                _ => unreachable!("Invalid dictionary keys type: {:?}", key_type),
+            };
+            // look up the index in the values dictionary
+            match values_index {
+                Some(values_index) => {
+                    let value = ScalarValue::try_from_array(values_array, values_index)?;
+                    Ok(ScalarValue::Dictionary(key_type.clone(), Box::new(value)))
+                }
+                // else entry was null, so return null
+                None => Ok(ScalarValue::Null),
+            }
+        }
+        DataType::Struct(fields) => {
+            let array = as_struct_array(array)?;
+            let mut field_values: Vec<ScalarValue> = Vec::new();
+            for col_index in 0..array.num_columns() {
+                let col_array = array.column(col_index);
+                let col_scalar = ScalarValue::try_from_array(col_array, row_index)?;
+                field_values.push(col_scalar);
+            }
+            Ok(ScalarValue::Struct(Some(field_values), fields.clone()))
+        }
+        DataType::FixedSizeList(nested_type, _len) => {
+            let list_array = as_fixed_size_list_array(array)?;
+            match list_array.is_null(row_index) {
+                true => Ok(ScalarValue::Null),
+                false => {
+                    let nested_array = list_array.value(row_index);
+                    let scalar_vec = (0..nested_array.len())
+                        .map(|i| ScalarValue::try_from_array(&nested_array, i))
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(ScalarValue::new_list(
+                        Some(scalar_vec),
+                        nested_type.data_type().clone(),
+                    ))
+                }
+            }
+        }
+        DataType::FixedSizeBinary(_) => {
+            let array = as_fixed_size_binary_array(array)?;
+            let size = match array.data_type() {
+                DataType::FixedSizeBinary(size) => *size,
+                _ => unreachable!(),
+            };
+            Ok(ScalarValue::FixedSizeBinary(
+                size,
+                Some(array.value(row_index).into()),
+            ))
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            typed_cast_to_scalar!(array, row_index, IntervalDayTimeArray, IntervalDayTime)
+        }
+        DataType::Interval(IntervalUnit::YearMonth) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            IntervalYearMonthArray,
+            IntervalYearMonth
+        ),
+        DataType::Interval(IntervalUnit::MonthDayNano) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            IntervalMonthDayNanoArray,
+            IntervalMonthDayNano
+        ),
+        other => Err(DataFusionError::NotImplemented(format!(
+            "Can't create a scalar from array of type \"{other:?}\""
+        ))),
+    }
 }

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -43,7 +43,15 @@ use arrow::array::*;
 use arrow::compute::{cast, filter};
 use arrow::datatypes::{DataType, Schema, UInt32Type};
 use arrow::{compute, datatypes::SchemaRef, record_batch::RecordBatch};
-use datafusion_common::cast::{as_boolean_array, as_decimal128_array};
+use arrow_array::types::{
+    Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt64Type, UInt8Type,
+};
+use arrow_schema::{IntervalUnit, TimeUnit};
+use datafusion_common::cast::{
+    as_boolean_array, as_decimal128_array, as_fixed_size_binary_array,
+    as_fixed_size_list_array, as_list_array, as_struct_array,
+};
+use datafusion_common::scalar::get_dict_value;
 use datafusion_common::utils::get_arrayref_at_indices;
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::Accumulator;
@@ -865,8 +873,17 @@ macro_rules! typed_cast_to_scalar {
     }};
 }
 
-/// This method is similar to [Scalar::try_from_array], it is used to update the Row Accumulators
-/// This method only covers the types which support the row layout and the Null handling is different.
+macro_rules! typed_cast_tz_to_scalar {
+    ($array:expr, $index:expr, $ARRAYTYPE:ident, $SCALAR:ident, $TZ:expr) => {{
+        let array = $array.as_any().downcast_ref::<$ARRAYTYPE>().unwrap();
+        Ok(ScalarValue::$SCALAR(
+            Some(array.value($index).into()),
+            $TZ.clone(),
+        ))
+    }};
+}
+
+/// This method is similar to Scalar::try_from_array except for the Null handling.
 /// This method returns [ScalarValue::Null] instead of [ScalarValue::Type(None)]
 fn col_to_scalar(
     array: &ArrayRef,
@@ -917,13 +934,161 @@ fn col_to_scalar(
         DataType::Binary => {
             typed_cast_to_scalar!(array, row_index, BinaryArray, Binary)
         }
+        DataType::LargeBinary => {
+            typed_cast_to_scalar!(array, row_index, LargeBinaryArray, LargeBinary)
+        }
         DataType::Utf8 => typed_cast_to_scalar!(array, row_index, StringArray, Utf8),
+        DataType::LargeUtf8 => {
+            typed_cast_to_scalar!(array, row_index, LargeStringArray, LargeUtf8)
+        }
+        DataType::List(nested_type) => {
+            let list_array = as_list_array(array)?;
+
+            let nested_array = list_array.value(row_index);
+            let scalar_vec = (0..nested_array.len())
+                .map(|i| ScalarValue::try_from_array(&nested_array, i))
+                .collect::<Result<Vec<_>>>()?;
+            let value = Some(scalar_vec);
+            Ok(ScalarValue::new_list(
+                value,
+                nested_type.data_type().clone(),
+            ))
+        }
         DataType::Date32 => {
             typed_cast_to_scalar!(array, row_index, Date32Array, Date32)
         }
         DataType::Date64 => {
             typed_cast_to_scalar!(array, row_index, Date64Array, Date64)
         }
+        DataType::Time32(TimeUnit::Second) => {
+            typed_cast_to_scalar!(array, row_index, Time32SecondArray, Time32Second)
+        }
+        DataType::Time32(TimeUnit::Millisecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time32MillisecondArray,
+            Time32Millisecond
+        ),
+        DataType::Time64(TimeUnit::Microsecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time64MicrosecondArray,
+            Time64Microsecond
+        ),
+        DataType::Time64(TimeUnit::Nanosecond) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            Time64NanosecondArray,
+            Time64Nanosecond
+        ),
+        DataType::Timestamp(TimeUnit::Second, tz_opt) => typed_cast_tz_to_scalar!(
+            array,
+            row_index,
+            TimestampSecondArray,
+            TimestampSecond,
+            tz_opt
+        ),
+        DataType::Timestamp(TimeUnit::Millisecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampMillisecondArray,
+                TimestampMillisecond,
+                tz_opt
+            )
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampMicrosecondArray,
+                TimestampMicrosecond,
+                tz_opt
+            )
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, tz_opt) => {
+            typed_cast_tz_to_scalar!(
+                array,
+                row_index,
+                TimestampNanosecondArray,
+                TimestampNanosecond,
+                tz_opt
+            )
+        }
+        DataType::Dictionary(key_type, _) => {
+            let (values_array, values_index) = match key_type.as_ref() {
+                DataType::Int8 => get_dict_value::<Int8Type>(array, row_index),
+                DataType::Int16 => get_dict_value::<Int16Type>(array, row_index),
+                DataType::Int32 => get_dict_value::<Int32Type>(array, row_index),
+                DataType::Int64 => get_dict_value::<Int64Type>(array, row_index),
+                DataType::UInt8 => get_dict_value::<UInt8Type>(array, row_index),
+                DataType::UInt16 => get_dict_value::<UInt16Type>(array, row_index),
+                DataType::UInt32 => get_dict_value::<UInt32Type>(array, row_index),
+                DataType::UInt64 => get_dict_value::<UInt64Type>(array, row_index),
+                _ => unreachable!("Invalid dictionary keys type: {:?}", key_type),
+            };
+            // look up the index in the values dictionary
+            match values_index {
+                Some(values_index) => {
+                    let value = ScalarValue::try_from_array(values_array, values_index)?;
+                    Ok(ScalarValue::Dictionary(key_type.clone(), Box::new(value)))
+                }
+                // else entry was null, so return null
+                None => Ok(ScalarValue::Null),
+            }
+        }
+        DataType::Struct(fields) => {
+            let array = as_struct_array(array)?;
+            let mut field_values: Vec<ScalarValue> = Vec::new();
+            for col_index in 0..array.num_columns() {
+                let col_array = array.column(col_index);
+                let col_scalar = ScalarValue::try_from_array(col_array, row_index)?;
+                field_values.push(col_scalar);
+            }
+            Ok(ScalarValue::Struct(Some(field_values), fields.clone()))
+        }
+        DataType::FixedSizeList(nested_type, _len) => {
+            let list_array = as_fixed_size_list_array(array)?;
+            match list_array.is_null(row_index) {
+                true => Ok(ScalarValue::Null),
+                false => {
+                    let nested_array = list_array.value(row_index);
+                    let scalar_vec = (0..nested_array.len())
+                        .map(|i| ScalarValue::try_from_array(&nested_array, i))
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(ScalarValue::new_list(
+                        Some(scalar_vec),
+                        nested_type.data_type().clone(),
+                    ))
+                }
+            }
+        }
+        DataType::FixedSizeBinary(_) => {
+            let array = as_fixed_size_binary_array(array)?;
+            let size = match array.data_type() {
+                DataType::FixedSizeBinary(size) => *size,
+                _ => unreachable!(),
+            };
+            Ok(ScalarValue::FixedSizeBinary(
+                size,
+                Some(array.value(row_index).into()),
+            ))
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            typed_cast_to_scalar!(array, row_index, IntervalDayTimeArray, IntervalDayTime)
+        }
+        DataType::Interval(IntervalUnit::YearMonth) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            IntervalYearMonthArray,
+            IntervalYearMonth
+        ),
+        DataType::Interval(IntervalUnit::MonthDayNano) => typed_cast_to_scalar!(
+            array,
+            row_index,
+            IntervalMonthDayNanoArray,
+            IntervalMonthDayNano
+        ),
         other => Err(DataFusionError::NotImplemented(format!(
             "GroupedHashAggregate: can't create a scalar from array of type \"{other:?}\""
         ))),

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -299,8 +299,16 @@ impl RowAccumulator for AvgRowAccumulator {
             self.state_index() + 1,
             accessor,
             &sum::sum_batch(values, &self.sum_datatype)?,
-        )?;
-        Ok(())
+        )
+    }
+
+    fn update_scalar(
+        &mut self,
+        values: &[ScalarValue],
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        let value = &values[0];
+        sum::update_avg_to_row(self.state_index(), accessor, value)
     }
 
     fn merge_batch(
@@ -315,8 +323,7 @@ impl RowAccumulator for AvgRowAccumulator {
 
         // sum
         let difference = sum::sum_batch(&states[1], &self.sum_datatype)?;
-        sum::add_to_row(self.state_index() + 1, accessor, &difference)?;
-        Ok(())
+        sum::add_to_row(self.state_index() + 1, accessor, &difference)
     }
 
     fn evaluate(&self, accessor: &RowAccessor) -> Result<ScalarValue> {

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -302,12 +302,20 @@ impl RowAccumulator for AvgRowAccumulator {
         )
     }
 
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
         accessor: &mut RowAccessor,
     ) -> Result<()> {
         let value = &values[0];
+        sum::update_avg_to_row(self.state_index(), accessor, value)
+    }
+
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
         sum::update_avg_to_row(self.state_index(), accessor, value)
     }
 

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -242,6 +242,24 @@ impl RowAccumulator for CountRowAccumulator {
         Ok(())
     }
 
+    fn update_scalar(
+        &mut self,
+        values: &[ScalarValue],
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        if values.len() == 1 {
+            match &values[0] {
+                ScalarValue::Null => {
+                    // do not update the accumulator
+                }
+                _ => accessor.add_u64(self.state_index, 1),
+            }
+        } else if !values.iter().any(|s| matches!(s, ScalarValue::Null)) {
+            accessor.add_u64(self.state_index, 1)
+        }
+        Ok(())
+    }
+
     fn merge_batch(
         &mut self,
         states: &[ArrayRef],

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -242,20 +242,27 @@ impl RowAccumulator for CountRowAccumulator {
         Ok(())
     }
 
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
         accessor: &mut RowAccessor,
     ) -> Result<()> {
-        if values.len() == 1 {
-            match &values[0] {
-                ScalarValue::Null => {
-                    // do not update the accumulator
-                }
-                _ => accessor.add_u64(self.state_index, 1),
-            }
-        } else if !values.iter().any(|s| matches!(s, ScalarValue::Null)) {
+        if !values.iter().any(|s| matches!(s, ScalarValue::Null)) {
             accessor.add_u64(self.state_index, 1)
+        }
+        Ok(())
+    }
+
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        match value {
+            ScalarValue::Null => {
+                // do not update the accumulator
+            }
+            _ => accessor.add_u64(self.state_index, 1),
         }
         Ok(())
     }

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -653,13 +653,21 @@ impl RowAccumulator for MaxRowAccumulator {
         max_row(self.index, accessor, delta)
     }
 
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
         accessor: &mut RowAccessor,
     ) -> Result<()> {
-        let values = &values[0];
-        max_row(self.index, accessor, values)
+        let value = &values[0];
+        max_row(self.index, accessor, value)
+    }
+
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        max_row(self.index, accessor, value)
     }
 
     fn merge_batch(
@@ -905,13 +913,21 @@ impl RowAccumulator for MinRowAccumulator {
         Ok(())
     }
 
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
         accessor: &mut RowAccessor,
     ) -> Result<()> {
-        let values = &values[0];
-        min_row(self.index, accessor, values)
+        let value = &values[0];
+        min_row(self.index, accessor, value)
+    }
+
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        min_row(self.index, accessor, value)
     }
 
     fn merge_batch(

--- a/datafusion/physical-expr/src/aggregate/row_accumulator.rs
+++ b/datafusion/physical-expr/src/aggregate/row_accumulator.rs
@@ -51,6 +51,13 @@ pub trait RowAccumulator: Send + Sync + Debug {
         accessor: &mut RowAccessor,
     ) -> Result<()>;
 
+    /// updates the accumulator's state from a vector of Scalar value.
+    fn update_scalar(
+        &mut self,
+        values: &[ScalarValue],
+        accessor: &mut RowAccessor,
+    ) -> Result<()>;
+
     /// updates the accumulator's state from a vector of states.
     fn merge_batch(
         &mut self,

--- a/datafusion/physical-expr/src/aggregate/row_accumulator.rs
+++ b/datafusion/physical-expr/src/aggregate/row_accumulator.rs
@@ -52,9 +52,16 @@ pub trait RowAccumulator: Send + Sync + Debug {
     ) -> Result<()>;
 
     /// updates the accumulator's state from a vector of Scalar value.
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
+        accessor: &mut RowAccessor,
+    ) -> Result<()>;
+
+    /// updates the accumulator's state from a Scalar value.
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
         accessor: &mut RowAccessor,
     ) -> Result<()>;
 

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -240,12 +240,26 @@ macro_rules! sum_row {
     }};
 }
 
+macro_rules! avg_row {
+    ($INDEX:ident, $ACC:ident, $DELTA:expr, $TYPE:ident) => {{
+        paste::item! {
+            if let Some(v) = $DELTA {
+                $ACC.add_u64($INDEX, 1);
+                $ACC.[<add_ $TYPE>]($INDEX + 1, *v)
+            }
+        }
+    }};
+}
+
 pub(crate) fn add_to_row(
     index: usize,
     accessor: &mut RowAccessor,
     s: &ScalarValue,
 ) -> Result<()> {
     match s {
+        ScalarValue::Null => {
+            // do nothing
+        }
         ScalarValue::Float64(rhs) => {
             sum_row!(index, accessor, rhs, f64)
         }
@@ -264,6 +278,39 @@ pub(crate) fn add_to_row(
         _ => {
             let msg =
                 format!("Row sum updater is not expected to receive a scalar {s:?}");
+            return Err(DataFusionError::Internal(msg));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn update_avg_to_row(
+    index: usize,
+    accessor: &mut RowAccessor,
+    s: &ScalarValue,
+) -> Result<()> {
+    match s {
+        ScalarValue::Null => {
+            // do nothing
+        }
+        ScalarValue::Float64(rhs) => {
+            avg_row!(index, accessor, rhs, f64)
+        }
+        ScalarValue::Float32(rhs) => {
+            avg_row!(index, accessor, rhs, f32)
+        }
+        ScalarValue::UInt64(rhs) => {
+            avg_row!(index, accessor, rhs, u64)
+        }
+        ScalarValue::Int64(rhs) => {
+            avg_row!(index, accessor, rhs, i64)
+        }
+        ScalarValue::Decimal128(rhs, _, _) => {
+            avg_row!(index, accessor, rhs, i128)
+        }
+        _ => {
+            let msg =
+                format!("Row avg updater is not expected to receive a scalar {s:?}");
             return Err(DataFusionError::Internal(msg));
         }
     }
@@ -331,8 +378,16 @@ impl RowAccumulator for SumRowAccumulator {
     ) -> Result<()> {
         let values = &values[0];
         let delta = sum_batch(values, &self.datatype)?;
-        add_to_row(self.index, accessor, &delta)?;
-        Ok(())
+        add_to_row(self.index, accessor, &delta)
+    }
+
+    fn update_scalar(
+        &mut self,
+        values: &[ScalarValue],
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
+        let value = &values[0];
+        add_to_row(self.index, accessor, value)
     }
 
     fn merge_batch(

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -381,12 +381,20 @@ impl RowAccumulator for SumRowAccumulator {
         add_to_row(self.index, accessor, &delta)
     }
 
-    fn update_scalar(
+    fn update_scalar_values(
         &mut self,
         values: &[ScalarValue],
         accessor: &mut RowAccessor,
     ) -> Result<()> {
         let value = &values[0];
+        add_to_row(self.index, accessor, value)
+    }
+
+    fn update_scalar(
+        &mut self,
+        value: &ScalarValue,
+        accessor: &mut RowAccessor,
+    ) -> Result<()> {
         add_to_row(self.index, accessor, value)
     }
 

--- a/datafusion/row/src/accessor.rs
+++ b/datafusion/row/src/accessor.rs
@@ -71,6 +71,7 @@ macro_rules! fn_add_idx {
     ($NATIVE: ident) => {
         paste::item! {
             /// add field at `idx` with `value`
+            #[inline(always)]
             pub fn [<add_ $NATIVE>](&mut self, idx: usize, value: $NATIVE) {
                 if self.is_valid_at(idx) {
                     self.[<set_ $NATIVE>](idx, value + self.[<get_ $NATIVE>](idx));
@@ -87,6 +88,7 @@ macro_rules! fn_max_min_idx {
     ($NATIVE: ident, $OP: ident) => {
         paste::item! {
             /// check max then update
+            #[inline(always)]
             pub fn [<$OP _ $NATIVE>](&mut self, idx: usize, value: $NATIVE) {
                 if self.is_valid_at(idx) {
                     let v = value.$OP(self.[<get_ $NATIVE>](idx));
@@ -103,6 +105,7 @@ macro_rules! fn_max_min_idx {
 macro_rules! fn_get_idx_scalar {
     ($NATIVE: ident, $SCALAR:ident) => {
         paste::item! {
+            #[inline(always)]
             pub fn [<get_ $NATIVE _scalar>](&self, idx: usize) -> ScalarValue {
                 if self.is_valid_at(idx) {
                     ScalarValue::$SCALAR(Some(self.[<get_ $NATIVE>](idx)))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6002 .

# Rationale for this change

improve the Aggregator performance when group by high cardinality columns.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

1) add `update_scalar()` method to `RowAccumulator`  trait
2) Adaptively decide the accumulators update mode


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

I had test this on my local Mac.
For TPCH-q17, there is at about 40% improvement.

Before this PR:
Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(17), debug: false, iterations: 3, partitions: 1, batch_size: 8192, path: "./parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: false, enable_scheduler: false }
Query 17 iteration 0 took 1888.9 ms and returned 1 rows
Query 17 iteration 1 took 1851.8 ms and returned 1 rows
Query 17 iteration 2 took 1853.1 ms and returned 1 rows
Query 17 avg time: 1864.61 ms


After this PR:
Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(17), debug: false, iterations: 3, partitions: 1, batch_size: 8192, path: "./parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: true, enable_scheduler: false }
Query 17 iteration 0 took 1377.0 ms and returned 1 rows
Query 17 iteration 1 took 1324.3 ms and returned 1 rows
Query 17 iteration 2 took 1317.7 ms and returned 1 rows
Query 17 avg time: 1339.68 ms.


<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->