### PR TITLE
Add partition_aware to UnionExec display

### DIFF
--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -318,7 +318,11 @@ impl ExecutionPlan for UnionExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                write!(f, "UnionExec")
+                write!(f, "UnionExec")?;
+                if self.partition_aware {
+                    write!(f, ": partition_aware=true")?;
+                }
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Draft  as it is clear we don't have plan coverage for this feature. See https://github.com/apache/arrow-datafusion/pull/6009#issuecomment-1509128673

# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/issues/5970



# Rationale for this change

As noted by @mingmwang and @crepereum on https://github.com/apache/arrow-datafusion/pull/6009, https://github.com/apache/arrow-datafusion/pull/6009#issuecomment-1508280788 there is no good way at the moment to tell if a `UnionExec` is "partition aware" and thus it is not clear to me if this mode is ever used.


# What changes are included in this PR?

Thus this PR improves the display plan to include information about partition in the display of the UnionExec. 



# Are these changes tested?

Covered by existing tests 

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->