### PR TITLE
Add analyzer output to verbose explain

### DIFF
--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -50,7 +50,8 @@ pub fn main() -> Result<()> {
     // run the analyzer with our custom rule
     let config = OptimizerContext::default().with_skip_failing_rules(false);
     let analyzer = Analyzer::with_rules(vec![Arc::new(MyAnalyzerRule {})]);
-    let analyzed_plan = analyzer.execute_and_check(&logical_plan, config.options())?;
+    let analyzed_plan =
+        analyzer.execute_and_check(&logical_plan, config.options(), |_, _| {})?;
     println!(
         "Analyzed Logical Plan:\n\n{}\n",
         analyzed_plan.display_indent()

--- a/datafusion/core/tests/sql/subqueries.rs
+++ b/datafusion/core/tests/sql/subqueries.rs
@@ -185,7 +185,7 @@ async fn invalid_scalar_subquery() -> Result<()> {
     let dataframe = ctx.sql(sql).await.expect(&msg);
     let err = dataframe.into_optimized_plan().err().unwrap();
     assert_eq!(
-        "Plan(\"Scalar subquery should only return one column\")",
+        r#"Context("check_analyzed_plan", Plan("Scalar subquery should only return one column"))"#,
         &format!("{err:?}")
     );
 
@@ -203,7 +203,7 @@ async fn subquery_not_allowed() -> Result<()> {
     let err = dataframe.into_optimized_plan().err().unwrap();
 
     assert_eq!(
-        "Plan(\"In/Exist subquery can not be used in Sort plan nodes\")",
+        r#"Context("check_analyzed_plan", Plan("In/Exist subquery can not be used in Sort plan nodes"))"#,
         &format!("{err:?}")
     );
 

--- a/datafusion/core/tests/sqllogictests/test_files/dates.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/dates.slt
@@ -85,7 +85,7 @@ g
 h
 
 ## Plan error when compare Utf8 and timestamp in where clause
-statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, Some\("\+00:00"\)\) \+ Utf8 can't be evaluated because there isn't a common type to coerce the types to
+statement error Error during planning: Timestamp\(Nanosecond, Some\("\+00:00"\)\) \+ Utf8 can't be evaluated because there isn't a common type to coerce the types to
 select i_item_desc from test
 where d3_date > now() + '5 days';
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1813,6 +1813,13 @@ pub enum Partitioning {
 pub enum PlanType {
     /// The initial LogicalPlan provided to DataFusion
     InitialLogicalPlan,
+    /// The LogicalPlan which results from applying an analyzer pass
+    AnalyzedLogicalPlan {
+        /// The name of the analyzer which produced this plan
+        analyzer_name: String,
+    },
+    /// The LogicalPlan after all analyzer passes have been applied
+    FinalAnalyzedLogicalPlan,
     /// The LogicalPlan which results from applying an optimizer pass
     OptimizedLogicalPlan {
         /// The name of the optimizer which produced this plan
@@ -1835,6 +1842,10 @@ impl Display for PlanType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             PlanType::InitialLogicalPlan => write!(f, "initial_logical_plan"),
+            PlanType::AnalyzedLogicalPlan { analyzer_name } => {
+                write!(f, "logical_plan after {analyzer_name}")
+            }
+            PlanType::FinalAnalyzedLogicalPlan => write!(f, "analyzed_logical_plan"),
             PlanType::OptimizedLogicalPlan { optimizer_name } => {
                 write!(f, "logical_plan after {optimizer_name}")
             }

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -835,7 +835,7 @@ mod test {
             .err()
             .unwrap();
         assert_eq!(
-            "Plan(\"Coercion from [Utf8] to the signature Uniform(1, [Int32]) failed.\")",
+            r#"Context("type_coercion", Plan("Coercion from [Utf8] to the signature Uniform(1, [Int32]) failed."))"#,
             &format!("{err:?}")
         );
         Ok(())
@@ -914,7 +914,7 @@ mod test {
             .err()
             .unwrap();
         assert_eq!(
-            "Plan(\"Coercion from [Utf8] to the signature Uniform(1, [Float64]) failed.\")",
+            r#"Context("type_coercion", Plan("Coercion from [Utf8] to the signature Uniform(1, [Float64]) failed."))"#,
             &format!("{err:?}")
         );
         Ok(())

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -115,7 +115,7 @@ pub fn assert_analyzed_plan_eq(
 ) -> Result<()> {
     let options = ConfigOptions::default();
     let analyzed_plan =
-        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &options)?;
+        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &options, |_, _| {})?;
     let formatted_plan = format!("{analyzed_plan:?}");
     assert_eq!(formatted_plan, expected);
 

--- a/datafusion/optimizer/tests/integration-test.rs
+++ b/datafusion/optimizer/tests/integration-test.rs
@@ -22,7 +22,7 @@ use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource};
 use datafusion_optimizer::analyzer::Analyzer;
 use datafusion_optimizer::optimizer::Optimizer;
-use datafusion_optimizer::{OptimizerConfig, OptimizerContext, OptimizerRule};
+use datafusion_optimizer::{OptimizerConfig, OptimizerContext};
 use datafusion_sql::planner::{ContextProvider, SqlToRel};
 use datafusion_sql::sqlparser::ast::Statement;
 use datafusion_sql::sqlparser::dialect::GenericDialect;
@@ -351,8 +351,8 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
     let analyzer = Analyzer::new();
     let optimizer = Optimizer::new();
     // analyze and optimize the logical plan
-    let plan = analyzer.execute_and_check(&plan, config.options())?;
-    optimizer.optimize(&plan, &config, &observe)
+    let plan = analyzer.execute_and_check(&plan, config.options(), |_, _| {})?;
+    optimizer.optimize(&plan, &config, |_, _| {})
 }
 
 #[derive(Default)]
@@ -411,8 +411,6 @@ impl ContextProvider for MySchemaProvider {
         &self.options
     }
 }
-
-fn observe(_plan: &LogicalPlan, _rule: &dyn OptimizerRule) {}
 
 struct MyTableSource {
     schema: SchemaRef,

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -926,6 +926,10 @@ message ArrowType{
 //}
 message EmptyMessage{}
 
+message AnalyzedLogicalPlanType {
+  string analyzer_name = 1;
+}
+
 message OptimizedLogicalPlanType {
   string optimizer_name = 1;
 }
@@ -937,6 +941,8 @@ message OptimizedPhysicalPlanType {
 message PlanType {
   oneof plan_type_enum {
     EmptyMessage InitialLogicalPlan = 1;
+    AnalyzedLogicalPlanType AnalyzedLogicalPlan = 7;
+    EmptyMessage FinalAnalyzedLogicalPlan = 8;
     OptimizedLogicalPlanType OptimizedLogicalPlan = 2;
     EmptyMessage FinalLogicalPlan = 3;
     EmptyMessage InitialPhysicalPlan = 4;

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -1068,6 +1068,98 @@ impl<'de> serde::Deserialize<'de> for AnalyzeNode {
         deserializer.deserialize_struct("datafusion.AnalyzeNode", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for AnalyzedLogicalPlanType {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.analyzer_name.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("datafusion.AnalyzedLogicalPlanType", len)?;
+        if !self.analyzer_name.is_empty() {
+            struct_ser.serialize_field("analyzerName", &self.analyzer_name)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for AnalyzedLogicalPlanType {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "analyzer_name",
+            "analyzerName",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AnalyzerName,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "analyzerName" | "analyzer_name" => Ok(GeneratedField::AnalyzerName),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AnalyzedLogicalPlanType;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.AnalyzedLogicalPlanType")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<AnalyzedLogicalPlanType, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut analyzer_name__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::AnalyzerName => {
+                            if analyzer_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("analyzerName"));
+                            }
+                            analyzer_name__ = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(AnalyzedLogicalPlanType {
+                    analyzer_name: analyzer_name__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.AnalyzedLogicalPlanType", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for ArrowType {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -15923,6 +16015,12 @@ impl serde::Serialize for PlanType {
                 plan_type::PlanTypeEnum::InitialLogicalPlan(v) => {
                     struct_ser.serialize_field("InitialLogicalPlan", v)?;
                 }
+                plan_type::PlanTypeEnum::AnalyzedLogicalPlan(v) => {
+                    struct_ser.serialize_field("AnalyzedLogicalPlan", v)?;
+                }
+                plan_type::PlanTypeEnum::FinalAnalyzedLogicalPlan(v) => {
+                    struct_ser.serialize_field("FinalAnalyzedLogicalPlan", v)?;
+                }
                 plan_type::PlanTypeEnum::OptimizedLogicalPlan(v) => {
                     struct_ser.serialize_field("OptimizedLogicalPlan", v)?;
                 }
@@ -15951,6 +16049,8 @@ impl<'de> serde::Deserialize<'de> for PlanType {
     {
         const FIELDS: &[&str] = &[
             "InitialLogicalPlan",
+            "AnalyzedLogicalPlan",
+            "FinalAnalyzedLogicalPlan",
             "OptimizedLogicalPlan",
             "FinalLogicalPlan",
             "InitialPhysicalPlan",
@@ -15961,6 +16061,8 @@ impl<'de> serde::Deserialize<'de> for PlanType {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InitialLogicalPlan,
+            AnalyzedLogicalPlan,
+            FinalAnalyzedLogicalPlan,
             OptimizedLogicalPlan,
             FinalLogicalPlan,
             InitialPhysicalPlan,
@@ -15988,6 +16090,8 @@ impl<'de> serde::Deserialize<'de> for PlanType {
                     {
                         match value {
                             "InitialLogicalPlan" => Ok(GeneratedField::InitialLogicalPlan),
+                            "AnalyzedLogicalPlan" => Ok(GeneratedField::AnalyzedLogicalPlan),
+                            "FinalAnalyzedLogicalPlan" => Ok(GeneratedField::FinalAnalyzedLogicalPlan),
                             "OptimizedLogicalPlan" => Ok(GeneratedField::OptimizedLogicalPlan),
                             "FinalLogicalPlan" => Ok(GeneratedField::FinalLogicalPlan),
                             "InitialPhysicalPlan" => Ok(GeneratedField::InitialPhysicalPlan),
@@ -16020,6 +16124,20 @@ impl<'de> serde::Deserialize<'de> for PlanType {
                                 return Err(serde::de::Error::duplicate_field("InitialLogicalPlan"));
                             }
                             plan_type_enum__ = map.next_value::<::std::option::Option<_>>()?.map(plan_type::PlanTypeEnum::InitialLogicalPlan)
+;
+                        }
+                        GeneratedField::AnalyzedLogicalPlan => {
+                            if plan_type_enum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("AnalyzedLogicalPlan"));
+                            }
+                            plan_type_enum__ = map.next_value::<::std::option::Option<_>>()?.map(plan_type::PlanTypeEnum::AnalyzedLogicalPlan)
+;
+                        }
+                        GeneratedField::FinalAnalyzedLogicalPlan => {
+                            if plan_type_enum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("FinalAnalyzedLogicalPlan"));
+                            }
+                            plan_type_enum__ = map.next_value::<::std::option::Option<_>>()?.map(plan_type::PlanTypeEnum::FinalAnalyzedLogicalPlan)
 ;
                         }
                         GeneratedField::OptimizedLogicalPlan => {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1245,6 +1245,12 @@ pub mod arrow_type {
 pub struct EmptyMessage {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AnalyzedLogicalPlanType {
+    #[prost(string, tag = "1")]
+    pub analyzer_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizedLogicalPlanType {
     #[prost(string, tag = "1")]
     pub optimizer_name: ::prost::alloc::string::String,
@@ -1258,7 +1264,7 @@ pub struct OptimizedPhysicalPlanType {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlanType {
-    #[prost(oneof = "plan_type::PlanTypeEnum", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "plan_type::PlanTypeEnum", tags = "1, 7, 8, 2, 3, 4, 5, 6")]
     pub plan_type_enum: ::core::option::Option<plan_type::PlanTypeEnum>,
 }
 /// Nested message and enum types in `PlanType`.
@@ -1268,6 +1274,10 @@ pub mod plan_type {
     pub enum PlanTypeEnum {
         #[prost(message, tag = "1")]
         InitialLogicalPlan(super::EmptyMessage),
+        #[prost(message, tag = "7")]
+        AnalyzedLogicalPlan(super::AnalyzedLogicalPlanType),
+        #[prost(message, tag = "8")]
+        FinalAnalyzedLogicalPlan(super::EmptyMessage),
         #[prost(message, tag = "2")]
         OptimizedLogicalPlan(super::OptimizedLogicalPlanType),
         #[prost(message, tag = "3")]

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -18,11 +18,12 @@
 use crate::protobuf::{
     self,
     plan_type::PlanTypeEnum::{
-        FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan,
+        FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan,
+        InitialPhysicalPlan, AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan,
         OptimizedLogicalPlan, OptimizedPhysicalPlan,
     },
-    CubeNode, GroupingSetNode, OptimizedLogicalPlanType, OptimizedPhysicalPlanType,
-    PlaceholderNode, RollupNode,
+    AnalyzedLogicalPlanType, CubeNode, GroupingSetNode, OptimizedLogicalPlanType,
+    OptimizedPhysicalPlanType, PlaceholderNode, RollupNode,
 };
 use arrow::datatypes::{
     DataType, Field, IntervalMonthDayNanoType, IntervalUnit, Schema, TimeUnit,
@@ -377,6 +378,12 @@ impl From<&protobuf::StringifiedPlan> for StringifiedPlan {
                     )
                 }) {
                 InitialLogicalPlan(_) => PlanType::InitialLogicalPlan,
+                AnalyzedLogicalPlan(AnalyzedLogicalPlanType { analyzer_name }) => {
+                    PlanType::AnalyzedLogicalPlan { 
+                        analyzer_name:analyzer_name.clone()
+                    }
+                }
+                FinalAnalyzedLogicalPlan(_) => PlanType::FinalAnalyzedLogicalPlan,
                 OptimizedLogicalPlan(OptimizedLogicalPlanType { optimizer_name }) => {
                     PlanType::OptimizedLogicalPlan {
                         optimizer_name: optimizer_name.clone(),

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -18,9 +18,9 @@
 use crate::protobuf::{
     self,
     plan_type::PlanTypeEnum::{
-        FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan,
-        InitialPhysicalPlan, AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan,
-        OptimizedLogicalPlan, OptimizedPhysicalPlan,
+        AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan, FinalLogicalPlan,
+        FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan, OptimizedLogicalPlan,
+        OptimizedPhysicalPlan,
     },
     AnalyzedLogicalPlanType, CubeNode, GroupingSetNode, OptimizedLogicalPlanType,
     OptimizedPhysicalPlanType, PlaceholderNode, RollupNode,
@@ -379,7 +379,7 @@ impl From<&protobuf::StringifiedPlan> for StringifiedPlan {
                 }) {
                 InitialLogicalPlan(_) => PlanType::InitialLogicalPlan,
                 AnalyzedLogicalPlan(AnalyzedLogicalPlanType { analyzer_name }) => {
-                    PlanType::AnalyzedLogicalPlan { 
+                    PlanType::AnalyzedLogicalPlan {
                         analyzer_name:analyzer_name.clone()
                     }
                 }

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -23,11 +23,12 @@ use crate::protobuf::{
     self,
     arrow_type::ArrowTypeEnum,
     plan_type::PlanTypeEnum::{
-        FinalLogicalPlan, FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan,
-        OptimizedLogicalPlan, OptimizedPhysicalPlan,
+        AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan, FinalLogicalPlan,
+        FinalPhysicalPlan, InitialLogicalPlan, InitialPhysicalPlan, OptimizedLogicalPlan,
+        OptimizedPhysicalPlan,
     },
-    CubeNode, EmptyMessage, GroupingSetNode, LogicalExprList, OptimizedLogicalPlanType,
-    OptimizedPhysicalPlanType, PlaceholderNode, RollupNode,
+    AnalyzedLogicalPlanType, CubeNode, EmptyMessage, GroupingSetNode, LogicalExprList,
+    OptimizedLogicalPlanType, OptimizedPhysicalPlanType, PlaceholderNode, RollupNode,
 };
 use arrow::datatypes::{
     DataType, Field, IntervalMonthDayNanoType, IntervalUnit, Schema, SchemaRef, TimeUnit,
@@ -317,6 +318,16 @@ impl From<&StringifiedPlan> for protobuf::StringifiedPlan {
             plan_type: match stringified_plan.clone().plan_type {
                 PlanType::InitialLogicalPlan => Some(protobuf::PlanType {
                     plan_type_enum: Some(InitialLogicalPlan(EmptyMessage {})),
+                }),
+                PlanType::AnalyzedLogicalPlan { analyzer_name } => {
+                    Some(protobuf::PlanType {
+                        plan_type_enum: Some(AnalyzedLogicalPlan(
+                            AnalyzedLogicalPlanType { analyzer_name },
+                        )),
+                    })
+                }
+                PlanType::FinalAnalyzedLogicalPlan => Some(protobuf::PlanType {
+                    plan_type_enum: Some(FinalAnalyzedLogicalPlan(EmptyMessage {})),
                 }),
                 PlanType::OptimizedLogicalPlan { optimizer_name } => {
                     Some(protobuf::PlanType {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5598

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

With new separate analyzer stage, split off from logical optimizer stage, should have output of these rules in verbose explain for debugging

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Example output now:

```
❯ explain verbose select * from part;
+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type                                                  | plan                                                                                                                                                                                                                                                                            |
+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| initial_logical_plan                                       | Projection: part.id, part.bool_col, part.tinyint_col, part.smallint_col, part.int_col, part.bigint_col, part.float_col, part.double_col, part.date_string_col, part.string_col, part.timestamp_col                                                                              |
|                                                            |   TableScan: part                                                                                                                                                                                                                                                               |
| logical_plan after inline_table_scan                       | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after type_coercion                           | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after count_wildcard_rule                     | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| analyzed_logical_plan                                      | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after unwrap_cast_in_comparison               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after replace_distinct_aggregate              | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after decorrelate_where_exists                | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after decorrelate_where_in                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after scalar_subquery_to_join                 | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after extract_equijoin_predicate              | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after merge_projection                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after rewrite_disjunctive_predicate           | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_duplicated_expr               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_filter                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_cross_join                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after common_sub_expression_eliminate         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after propagate_empty_relation                | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after filter_null_join_keys                   | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_outer_join                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_filter                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after single_distinct_aggregation_to_group_by | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after unwrap_cast_in_comparison               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after common_sub_expression_eliminate         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_projection                    | Projection: part.id, part.bool_col, part.tinyint_col, part.smallint_col, part.int_col, part.bigint_col, part.float_col, part.double_col, part.date_string_col, part.string_col, part.timestamp_col                                                                              |
|                                                            |   TableScan: part projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col]                                                                                                                  |
| logical_plan after eliminate_projection                    | TableScan: part projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col]                                                                                                                    |
| logical_plan after push_down_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after unwrap_cast_in_comparison               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after replace_distinct_aggregate              | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after decorrelate_where_exists                | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after decorrelate_where_in                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after scalar_subquery_to_join                 | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after extract_equijoin_predicate              | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after merge_projection                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after rewrite_disjunctive_predicate           | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_duplicated_expr               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_filter                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_cross_join                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after common_sub_expression_eliminate         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after propagate_empty_relation                | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after filter_null_join_keys                   | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_outer_join                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_filter                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after single_distinct_aggregation_to_group_by | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after simplify_expressions                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after unwrap_cast_in_comparison               | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after common_sub_expression_eliminate         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_projection                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after eliminate_projection                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan after push_down_limit                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| logical_plan                                               | TableScan: part projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col]                                                                                                                    |
| initial_physical_plan                                      | ParquetExec: limit=None, partitions={1 group: [[home/jeffrey/Code/arrow-datafusion/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col] |
|                                                            |                                                                                                                                                                                                                                                                                 |
| physical_plan after aggregate_statistics                   | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after join_selection                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after PipelineFixer                          | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after repartition                            | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after global_sort_selection                  | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after EnforceDistribution                    | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after EnforceSorting                         | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after CombinePartialFinalAggregate           | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after coalesce_batches                       | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan after PipelineChecker                        | SAME TEXT AS ABOVE                                                                                                                                                                                                                                                              |
| physical_plan                                              | ParquetExec: limit=None, partitions={1 group: [[home/jeffrey/Code/arrow-datafusion/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col] |
|                                                            |                                                                                                                                                                                                                                                                                 |
+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->