### PR TITLE
Use OwnedTableReference for subquery aliases

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/ddl.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/ddl.slt
@@ -159,7 +159,7 @@ CREATE SCHEMA foo_schema;
 
 # Should be able to create view in "foo_schema".
 statement ok
-CREATE VIEW foo_schema.bar AS VALUES(1,2);
+CREATE VIEW foo_schema.bar AS (SELECT 1 as a, 2 as b);
 
 # And be able to query it.
 query II
@@ -167,7 +167,24 @@ SELECT * FROM foo_schema.bar;
 ----
 1 2
 
-# TODO: Drop schema for cleanup
+# Make sure we can query individual columns with various qualifications.
+
+query I
+SELECT a FROM foo_schema.bar;
+----
+1
+
+query I
+SELECT bar.a FROM foo_schema.bar;
+----
+1
+
+query I
+SELECT foo_schema.bar.a FROM foo_schema.bar;
+----
+1
+
+# TODO: Drop schema for cleanup, see #6027
 # statement ok
 # DROP SCHEMA foo_schema;
 

--- a/datafusion/core/tests/sqllogictests/test_files/ddl.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/ddl.slt
@@ -150,6 +150,26 @@ select * from "foo.bar.baz";
 statement ok
 drop view "foo.bar.baz"
 
+##########
+# Query views in other schemas.
+##########
+
+statement ok
+CREATE SCHEMA foo_schema;
+
+# Should be able to create view in "foo_schema".
+statement ok
+CREATE VIEW foo_schema.bar AS VALUES(1,2);
+
+# And be able to query it.
+query II
+SELECT * FROM foo_schema.bar;
+----
+1 2
+
+# TODO: Drop schema for cleanup
+# statement ok
+# DROP SCHEMA foo_schema;
 
 ##########
 # Drop view error tests

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -381,7 +381,7 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply an alias
-    pub fn alias(self, alias: impl Into<String>) -> Result<Self> {
+    pub fn alias(self, alias: impl Into<OwnedTableReference>) -> Result<Self> {
         Ok(Self::from(subquery_alias(self.plan, alias)?))
     }
 
@@ -1236,7 +1236,7 @@ pub fn project(
 /// Create a SubqueryAlias to wrap a LogicalPlan.
 pub fn subquery_alias(
     plan: LogicalPlan,
-    alias: impl Into<String>,
+    alias: impl Into<OwnedTableReference>,
 ) -> Result<LogicalPlan> {
     Ok(LogicalPlan::SubqueryAlias(SubqueryAlias::try_new(
         plan, alias,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1902,7 +1902,7 @@ mod tests {
     use crate::{col, exists, in_subquery, lit};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::tree_node::TreeNodeVisitor;
-    use datafusion_common::DFSchema;
+    use datafusion_common::{DFSchema, TableReference};
     use std::collections::HashMap;
 
     fn employee_schema() -> Schema {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -36,7 +36,7 @@ use datafusion_common::tree_node::{
 };
 use datafusion_common::{
     plan_err, Column, DFSchema, DFSchemaRef, DataFusionError, OwnedTableReference,
-    Result, ScalarValue, TableReference,
+    Result, ScalarValue,
 };
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Display, Formatter};
@@ -1304,20 +1304,20 @@ pub struct SubqueryAlias {
     /// The incoming logical plan
     pub input: Arc<LogicalPlan>,
     /// The alias for the input relation
-    pub alias: String,
+    pub alias: OwnedTableReference,
     /// The schema with qualified field names
     pub schema: DFSchemaRef,
 }
 
 impl SubqueryAlias {
-    pub fn try_new(plan: LogicalPlan, alias: impl Into<String>) -> Result<Self> {
+    pub fn try_new(
+        plan: LogicalPlan,
+        alias: impl Into<OwnedTableReference>,
+    ) -> Result<Self> {
         let alias = alias.into();
-        let table_ref = TableReference::bare(&alias);
         let schema: Schema = plan.schema().as_ref().clone().into();
-        let schema = DFSchemaRef::new(DFSchema::try_from_qualified_schema(
-            table_ref.to_owned_reference(),
-            &schema,
-        )?);
+        let schema =
+            DFSchemaRef::new(DFSchema::try_from_qualified_schema(&alias, &schema)?);
         Ok(SubqueryAlias {
             input: Arc::new(plan),
             alias,

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -64,16 +64,10 @@ fn analyze_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
             let projection_exprs = generate_projection_expr(&projection, sub_plan)?;
             let plan = LogicalPlanBuilder::from(sub_plan.clone())
                 .project(projection_exprs)?
-                // Since this This is creating a subquery like:
-                //```sql
-                // ...
-                // FROM <view definition> as "table_name"
-                // ```
-                //
-                // it doesn't make sense to have a qualified
-                // reference (e.g. "foo"."bar") -- this convert to
-                // string
-                .alias(table_name.to_string())?
+                // This will ensure that the reference to the inlined table
+                // remains the same ensuring we don't have to change any of the
+                // parent nodes that reference this table.
+                .alias(table_name)?
                 .build()?;
             Transformed::Yes(plan)
         }

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -64,9 +64,9 @@ fn analyze_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
             let projection_exprs = generate_projection_expr(&projection, sub_plan)?;
             let plan = LogicalPlanBuilder::from(sub_plan.clone())
                 .project(projection_exprs)?
-                // This will ensure that the reference to the inlined table
-                // remains the same ensuring we don't have to change any of the
-                // parent nodes that reference this table.
+                // Ensures that the reference to the inlined table remains the
+                // same, meaning we don't have to change any of the parent nodes
+                // that reference this table.
                 .alias(table_name)?
                 .build()?;
             Transformed::Yes(plan)

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -183,7 +183,7 @@ fn optimize_where_in(
 
     let right = LogicalPlanBuilder::from(subquery_input)
         .project(projection_exprs)?
-        .alias(&subquery_alias)?
+        .alias(subquery_alias.clone())?
         .build()?;
 
     // join our sub query into the main plan

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -266,7 +266,7 @@ fn optimize_scalar(
     let subqry_plan = subqry_plan
         .aggregate(group_by, aggr.aggr_expr.clone())?
         .project(proj)?
-        .alias(&subqry_alias)?
+        .alias(subqry_alias.clone())?
         .build()?;
 
     // qualify the join columns for outside the subquery

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -294,8 +294,9 @@ message SelectionExecNode {
 }
 
 message SubqueryAliasNode {
+  reserved 2; // Was string alias
   LogicalPlanNode input = 1;
-  string alias = 2;
+  OwnedTableReference alias = 3;
 }
 
 // logical expressions

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -20113,15 +20113,15 @@ impl serde::Serialize for SubqueryAliasNode {
         if self.input.is_some() {
             len += 1;
         }
-        if !self.alias.is_empty() {
+        if self.alias.is_some() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("datafusion.SubqueryAliasNode", len)?;
         if let Some(v) = self.input.as_ref() {
             struct_ser.serialize_field("input", v)?;
         }
-        if !self.alias.is_empty() {
-            struct_ser.serialize_field("alias", &self.alias)?;
+        if let Some(v) = self.alias.as_ref() {
+            struct_ser.serialize_field("alias", v)?;
         }
         struct_ser.end()
     }
@@ -20197,13 +20197,13 @@ impl<'de> serde::Deserialize<'de> for SubqueryAliasNode {
                             if alias__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("alias"));
                             }
-                            alias__ = Some(map.next_value()?);
+                            alias__ = map.next_value()?;
                         }
                     }
                 }
                 Ok(SubqueryAliasNode {
                     input: input__,
-                    alias: alias__.unwrap_or_default(),
+                    alias: alias__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -448,8 +448,8 @@ pub struct SelectionExecNode {
 pub struct SubqueryAliasNode {
     #[prost(message, optional, boxed, tag = "1")]
     pub input: ::core::option::Option<::prost::alloc::boxed::Box<LogicalPlanNode>>,
-    #[prost(string, tag = "2")]
-    pub alias: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub alias: ::core::option::Option<OwnedTableReference>,
 }
 /// logical expressions
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6016.

(Opening this to get early feedback)

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Simplest way I found for fixing the above issue. I didn't want to try to add an analyzer rule for swapping out references in parent nodes.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changes `SubqueryAlias` to hold a `OwnedTableReference` instead of just a string.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Adds sqllogictests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, this changes the public interface for `SubqueryAlias`.