### PR TITLE
feat: allow TableScan without projection

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -118,14 +118,10 @@ pub fn to_substrait_rel(
                     .collect()
             });
 
-            let projection = if let Some(struct_items) = projection {
-                Some(MaskExpression {
-                    select: Some(StructSelect { struct_items }),
-                    maintain_singular_struct: false,
-                })
-            } else {
-                None
-            };
+            let projection = projection.map(|struct_items| MaskExpression {
+                select: Some(StructSelect { struct_items }),
+                maintain_singular_struct: false,
+            });
 
             Ok(Box::new(Rel {
                 rel_type: Some(RelType::Read(Box::new(ReadRel {

--- a/datafusion/substrait/tests/serialize.rs
+++ b/datafusion/substrait/tests/serialize.rs
@@ -54,12 +54,9 @@ mod tests {
 
     #[tokio::test]
     async fn table_scan_without_projection() -> Result<()> {
-        let ctx = create_context().await.unwrap();
-        let table = provider_as_source(ctx.table_provider("data").await.unwrap());
-        let table_scan = LogicalPlanBuilder::scan("data", table, None)
-            .unwrap()
-            .build()
-            .unwrap();
+        let ctx = create_context().await?;
+        let table = provider_as_source(ctx.table_provider("data").await?);
+        let table_scan = LogicalPlanBuilder::scan("data", table, None)?.build()?;
         let convert_result = producer::to_substrait_plan(&table_scan);
         assert!(convert_result.is_ok());
 

--- a/datafusion/substrait/tests/serialize.rs
+++ b/datafusion/substrait/tests/serialize.rs
@@ -17,7 +17,10 @@
 
 #[cfg(test)]
 mod tests {
+    use datafusion::datasource::provider_as_source;
+    use datafusion::logical_expr::LogicalPlanBuilder;
     use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
+    use datafusion_substrait::logical_plan::producer;
     use datafusion_substrait::serializer;
 
     use datafusion::error::Result;
@@ -45,6 +48,20 @@ mod tests {
         assert_eq!(plan_str_ref, plan_str);
         // Delete test binary file
         fs::remove_file(path)?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn table_scan_without_projection() -> Result<()> {
+        let ctx = create_context().await.unwrap();
+        let table = provider_as_source(ctx.table_provider("data").await.unwrap());
+        let table_scan = LogicalPlanBuilder::scan("data", table, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let convert_result = producer::to_substrait_plan(&table_scan);
+        assert!(convert_result.is_ok());
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/GreptimeTeam/greptimedb/issues/1396

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow table scan without projection. It should be a constrain as the projection field in `TableScan` plan is optional:
https://github.com/apache/arrow-datafusion/blob/3ad7734a7e5b1844b02f1374d0dc1c441bef216d/datafusion/expr/src/logical_plan/plan.rs#L1396-L1403

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Don't throw error when there is no projection in `TableScan`.

# Are these changes tested?

Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

Yes but not breaking
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->