### PR TITLE
minor feat: impl FromStr for JoinType enum

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -41,6 +41,7 @@ use datafusion_common::{
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 use std::sync::Arc;
 
 /// A LogicalPlan represents the different types of relational
@@ -1159,6 +1160,28 @@ impl Display for JoinType {
         write!(f, "{join_type}")
     }
 }
+
+impl FromStr for JoinType {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let s = s.to_uppercase();
+        match s.as_str() {
+            "INNER" => Ok(JoinType::Inner),
+            "LEFT" => Ok(JoinType::Left),
+            "RIGHT" => Ok(JoinType::Right),
+            "FULL" => Ok(JoinType::Full),
+            "LEFTSEMI" => Ok(JoinType::LeftSemi),
+            "RIGHTSEMI" => Ok(JoinType::RightSemi),
+            "LEFTANTI" => Ok(JoinType::LeftAnti),
+            "RIGHTANTI" => Ok(JoinType::RightAnti),
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "The join type {s} does not exist or is not implemented"
+            )))
+        }
+    }
+}
+
 
 /// Join constraint
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1177,7 +1177,7 @@ impl FromStr for JoinType {
             "RIGHTANTI" => Ok(JoinType::RightAnti),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "The join type {s} does not exist or is not implemented"
-            )))
+            ))),
         }
     }
 }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1182,7 +1182,6 @@ impl FromStr for JoinType {
     }
 }
 
-
 /// Join constraint
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum JoinConstraint {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Adding Python bindings for `join_on` (https://github.com/apache/arrow-datafusion-python/pull/324) causing some code duplication when matching join type. @Jimexist suggested this trait should be implemented instead.

# What changes are included in this PR?

FromStr interface for enum JoinType

# Are these changes tested?

# Are there any user-facing changes?
