### PR TITLE
Substrait: Handle multiple select with the same table/columns in INTERSECT

### DIFF
--- a/datafusion/substrait/tests/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/roundtrip_logical_plan.rs
@@ -251,6 +251,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn simple_intersect_table_reuse() -> Result<()> {
+        assert_expected_plan(
+            "SELECT COUNT(*) FROM (SELECT data.a FROM data INTERSECT SELECT data.a FROM data);",
+            "Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
+            \n  LeftSemi Join: data.a = data.a\
+            \n    Aggregate: groupBy=[[data.a]], aggr=[[]]\
+            \n      TableScan: data projection=[a]\
+            \n    TableScan: data projection=[a]",
+        )
+        .await
+    }
+
+    #[tokio::test]
     async fn simple_window_function() -> Result<()> {
         roundtrip("SELECT RANK() OVER (PARTITION BY a ORDER BY b), d, SUM(b) OVER (PARTITION BY a) FROM data;").await
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6058.

# Rationale for this change

Please refer to related [issue](https://github.com/apache/arrow-datafusion/issues/6058).

# What changes are included in this PR?
- Producer: handle duplicate qualified fields by returning the join's output schema
- Consumer: handle duplicate qualified fields by returning the join's output schema
- Test: add test with `INTERSECT` with table/column reuse

# Are these changes tested?

Yes

# Are there any user-facing changes?

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->