### PR TITLE
Update rust_lint.sh to include newly added `cargo doc` check

### DIFF
--- a/ci/scripts/rust_docs.sh
+++ b/ci/scripts/rust_docs.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,16 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This script runs all the Rust lints locally the same way the
-# DataFusion CI does
-
-set -e
-if ! command -v cargo-tomlfmt &> /dev/null; then
-    echo "Installing cargo-tomlfmt using cargo"
-    cargo install cargo-tomlfmt
-fi
-
-ci/scripts/rust_fmt.sh
-ci/scripts/rust_clippy.sh
-ci/scripts/rust_toml_fmt.sh
-ci/scripts/rust_docs.sh
+set -ex
+export RUSTDOCFLAGS="-D warnings -A rustdoc::private-intra-doc-links"
+cargo doc --document-private-items --no-deps --workspace


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/6042. Follow on to https://github.com/apache/arrow-datafusion/pull/6044 

# Rationale for this change

I often use `rust_lint.sh` to ensure my PR will pass CI. 

# What changes are included in this PR?

Add a `rust_docs.sh` script so that `./dev/rust_lint.sh` also runs the newly added check in https://github.com/apache/arrow-datafusion/pull/6044 

# Are these changes tested?
I tested them manually

# Are there any user-facing changes?
No
