### PR TITLE
chore(deps): update regex and regex-syntax requirement from 0.6.28 to 0.7.1

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byteorder"
@@ -811,7 +811,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "itertools",
  "log",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -49,7 +49,7 @@ datafusion-physical-expr = { path = "../physical-expr", version = "23.0.0", defa
 hashbrown = { version = "0.13", features = ["raw"] }
 itertools = "0.10"
 log = "^0.4"
-regex-syntax = "0.6.28"
+regex-syntax = "0.7.1"
 
 [dev-dependencies]
 ctor = "0.2.0"

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -103,7 +103,7 @@ fn collect_concat_to_like_string(parts: &[Hir]) -> Option<String> {
 
     for sub in parts {
         if let HirKind::Literal(l) = sub.kind() {
-            s.extend(str_from_literal(l)?.chars());
+            s.push_str(str_from_literal(l)?);
         } else {
             return None;
         }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -63,7 +63,7 @@ md-5 = { version = "^0.10.0", optional = true }
 paste = "^1.0"
 petgraph = "0.6.2"
 rand = "0.8"
-regex = { version = "^1.4.3", optional = true }
+regex = { version = "1.8", optional = true }
 sha2 = { version = "^0.10.1", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "^1.2", features = ["v4"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/pull/6092

# Rationale for this change

Keep up with dependencies

# What changes are included in this PR?

See title

# Are these changes tested?

Existing tests

# Are there any user-facing changes?

No