### PR TITLE
Support DROP SCHEMA statements

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -26,6 +26,7 @@ pub mod parsers;
 #[cfg(feature = "pyarrow")]
 mod pyarrow;
 pub mod scalar;
+mod schema_reference;
 pub mod stats;
 mod table_reference;
 pub mod test_util;
@@ -39,6 +40,7 @@ pub use error::{
     SharedResult,
 };
 pub use scalar::{ScalarType, ScalarValue};
+pub use schema_reference::{OwnedSchemaReference, SchemaReference};
 pub use stats::{ColumnStatistics, Statistics};
 pub use table_reference::{OwnedTableReference, ResolvedTableReference, TableReference};
 

--- a/datafusion/common/src/schema_reference.rs
+++ b/datafusion/common/src/schema_reference.rs
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SchemaReference<'a> {
+    Bare {
+        schema: Cow<'a, str>,
+    },
+    Full {
+        schema: Cow<'a, str>,
+        catalog: Cow<'a, str>,
+    },
+}
+
+impl SchemaReference<'_> {
+    /// Get only the schema name that this references.
+    pub fn schema_name(&self) -> &str {
+        match self {
+            SchemaReference::Bare { schema } => schema,
+            SchemaReference::Full { schema, catalog: _ } => schema,
+        }
+    }
+}
+
+pub type OwnedSchemaReference = SchemaReference<'static>;
+
+impl std::fmt::Display for SchemaReference<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bare { schema } => write!(f, "{schema}"),
+            Self::Full { schema, catalog } => write!(f, "{catalog}.{schema}"),
+        }
+    }
+}
+
+impl<'a> From<&'a OwnedSchemaReference> for SchemaReference<'a> {
+    fn from(value: &'a OwnedSchemaReference) -> Self {
+        match value {
+            SchemaReference::Bare { schema } => SchemaReference::Bare {
+                schema: Cow::Borrowed(schema),
+            },
+            SchemaReference::Full { schema, catalog } => SchemaReference::Full {
+                schema: Cow::Borrowed(schema),
+                catalog: Cow::Borrowed(catalog),
+            },
+        }
+    }
+}

--- a/datafusion/core/tests/sqllogictests/test_files/ddl.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/ddl.slt
@@ -643,3 +643,25 @@ select * from t;
 
 statement ok
 drop table t;
+
+##########
+# Dropping schemas
+##########
+
+statement error DataFusion error: Execution error: Cannot drop schema foo_schema because other tables depend on it: bar
+DROP SCHEMA foo_schema;
+
+statement ok
+DROP SCHEMA foo_schema CASCADE;
+
+statement error DataFusion error: Execution error: Schema 'doesnt_exist' doesn't exist.
+DROP SCHEMA doesnt_exist;
+
+statement ok
+DROP SCHEMA IF EXISTS doesnt_exist;
+
+statement ok
+CREATE SCHEMA empty_schema;
+
+statement ok
+DROP SCHEMA empty_schema;

--- a/datafusion/core/tests/sqllogictests/test_files/information_schema.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/information_schema.slt
@@ -375,7 +375,7 @@ SHOW CREATE TABLE test.xyz
 ----
 datafusion test xyz CREATE VIEW test.xyz AS SELECT * FROM abc
 
-statement error DataFusion error: This feature is not implemented: Only `DROP TABLE/VIEW
+statement error DataFusion error: Execution error: Cannot drop schema test because other tables depend on it: xyz
 DROP SCHEMA test;
 
 statement ok

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -29,7 +29,7 @@ pub use builder::{
 };
 pub use ddl::{
     CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateMemoryTable,
-    CreateView, DdlStatement, DropTable, DropView,
+    CreateView, DdlStatement, DropCatalogSchema, DropTable, DropView,
 };
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1372,6 +1372,9 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::Ddl(DdlStatement::DropView(_)) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DropView",
             )),
+            LogicalPlan::Ddl(DdlStatement::DropCatalogSchema(_)) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for DropCatalogSchema",
+            )),
             LogicalPlan::Statement(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for Statement",
             )),


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6027

# Rationale for this change

Being able to drop schemas is generally just a good feature to have: exists in most databases.

# What changes are included in this PR?

- Add optional method `deregister_schema` to `CatalogProvider` trait (and an impl for it in `MemoryCatalogProvider`)
- Add a new LogicalPlan node `DropCatalogSchema`
- Modify parser to be able to parse `LogicalPlan::DropCatalogSchema`
- Implement dropping schema in the datafusion context

# Are these changes tested?
Unit tests and sql integration tests

# Are there any user-facing changes?
this is a user-facing feature but everything is backwards compatible.