### PR TITLE
Fix column mapping in output_ordering() and output_partitioning() for ProjectionExec and AggregateExec

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -1355,14 +1355,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_aa() -> Result<()> {
-        let aa = vec!["aa".to_string(), "bb".to_string()];
-        let aa_ref: &[String] = &aa;
-        let bb = aa_ref.iter().map(|s| s.to_uppercase()).collect::<Vec<_>>();
-        println!("bb {:?}", bb);
-
-        Ok(())
-    }
 }

--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -50,7 +50,7 @@ pub use datafusion_expr::AggregateFunction;
 use datafusion_physical_expr::aggregate::row_accumulator::RowAccumulator;
 use datafusion_physical_expr::equivalence::project_equivalence_properties;
 pub use datafusion_physical_expr::expressions::create_aggregate_expr;
-use datafusion_physical_expr::normalize_out_expr_with_alias_schema;
+use datafusion_physical_expr::normalize_out_expr_with_columns_map;
 
 /// Hash aggregate modes
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -203,9 +203,9 @@ pub struct AggregateExec {
     /// same as input.schema() but for the final aggregate it will be the same as the input
     /// to the partial aggregate
     pub(crate) input_schema: SchemaRef,
-    /// The alias map used to normalize out expressions like Partitioning and PhysicalSortExpr
+    /// The columns map used to normalize out expressions like Partitioning and PhysicalSortExpr
     /// The key is the column from the input schema and the values are the columns from the output schema
-    alias_map: HashMap<Column, Vec<Column>>,
+    columns_map: HashMap<Column, Vec<Column>>,
     /// Execution Metrics
     metrics: ExecutionPlanMetricsSet,
 }
@@ -230,15 +230,13 @@ impl AggregateExec {
 
         let schema = Arc::new(schema);
 
-        let mut alias_map: HashMap<Column, Vec<Column>> = HashMap::new();
+        // construct a map from the input columns to the output columns of the Aggregation
+        let mut columns_map: HashMap<Column, Vec<Column>> = HashMap::new();
         for (expression, name) in group_by.expr.iter() {
             if let Some(column) = expression.as_any().downcast_ref::<Column>() {
                 let new_col_idx = schema.index_of(name)?;
-                // When the column name is the same, but index does not equal, treat it as Alias
-                if (column.name() != name) || (column.index() != new_col_idx) {
-                    let entry = alias_map.entry(column.clone()).or_insert_with(Vec::new);
-                    entry.push(Column::new(name, new_col_idx));
-                }
+                let entry = columns_map.entry(column.clone()).or_insert_with(Vec::new);
+                entry.push(Column::new(name, new_col_idx));
             };
         }
 
@@ -250,7 +248,7 @@ impl AggregateExec {
             input,
             schema,
             input_schema,
-            alias_map,
+            columns_map,
             metrics: ExecutionPlanMetricsSet::new(),
         })
     }
@@ -358,10 +356,9 @@ impl ExecutionPlan for AggregateExec {
                         let normalized_exprs = exprs
                             .into_iter()
                             .map(|expr| {
-                                normalize_out_expr_with_alias_schema(
+                                normalize_out_expr_with_columns_map(
                                     expr,
-                                    &self.alias_map,
-                                    &self.schema,
+                                    &self.columns_map,
                                 )
                             })
                             .collect::<Vec<_>>();
@@ -408,7 +405,7 @@ impl ExecutionPlan for AggregateExec {
         let mut new_properties = EquivalenceProperties::new(self.schema());
         project_equivalence_properties(
             self.input.equivalence_properties(),
-            &self.alias_map,
+            &self.columns_map,
             &mut new_properties,
         );
         new_properties
@@ -1355,6 +1352,16 @@ mod tests {
         assert_is_pending(&mut fut);
         drop(fut);
         assert_strong_count_converges_to_zero(refs).await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_aa() -> Result<()> {
+        let aa = vec!["aa".to_string(), "bb".to_string()];
+        let aa_ref: &[String] = &aa;
+        let bb = aa_ref.iter().map(|s| s.to_uppercase()).collect::<Vec<_>>();
+        println!("bb {:?}", bb);
 
         Ok(())
     }

--- a/datafusion/core/tests/sqllogictests/test_files/groupby.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/groupby.slt
@@ -1477,13 +1477,10 @@ SELECT + cor0.col0 AS col2 FROM tab1 AS cor0 GROUP BY cor0.col0
 28
 82
 
-# TODO: WRONG
 # https://github.com/apache/arrow-datafusion/issues/6099
 query I rowsort
 SELECT DISTINCT + 45 col0 FROM tab1 AS cor0 GROUP BY col0
 ----
-45
-45
 45
 
 query I rowsort label-211
@@ -1914,12 +1911,10 @@ SELECT ALL - ( 30 ) * + cor0.col1 AS col2 FROM tab2 AS cor0 GROUP BY cor0.col1
 -1770
 -1830
 
-# TODO: WRONG
 # https://github.com/apache/arrow-datafusion/issues/6099
 query I rowsort
 SELECT DISTINCT 94 AS col1 FROM tab0 AS cor0 GROUP BY cor0.col1
 ----
-94
 94
 
 query I rowsort

--- a/datafusion/core/tests/sqllogictests/test_files/groupby.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/groupby.slt
@@ -1477,7 +1477,6 @@ SELECT + cor0.col0 AS col2 FROM tab1 AS cor0 GROUP BY cor0.col0
 28
 82
 
-# https://github.com/apache/arrow-datafusion/issues/6099
 query I rowsort
 SELECT DISTINCT + 45 col0 FROM tab1 AS cor0 GROUP BY col0
 ----
@@ -1911,7 +1910,6 @@ SELECT ALL - ( 30 ) * + cor0.col1 AS col2 FROM tab2 AS cor0 GROUP BY cor0.col1
 -1770
 -1830
 
-# https://github.com/apache/arrow-datafusion/issues/6099
 query I rowsort
 SELECT DISTINCT 94 AS col1 FROM tab0 AS cor0 GROUP BY cor0.col1
 ----

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -56,7 +56,7 @@ pub use scalar_function::ScalarFunctionExpr;
 pub use sort_expr::{PhysicalSortExpr, PhysicalSortRequirement};
 pub use utils::{
     expr_list_eq_any_order, expr_list_eq_strict_order,
-    normalize_expr_with_equivalence_properties, normalize_out_expr_with_alias_schema,
+    normalize_expr_with_equivalence_properties, normalize_out_expr_with_columns_map,
     normalize_sort_expr_with_equivalence_properties, sort_expr_list_eq_strict_order,
     split_conjunction,
 };


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6099
Closes #6112

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->