### PR TITLE
Minor: Split `DmlStatement` into its own module

### DIFF
--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    fmt::{self, Display},
+    sync::Arc,
+};
+
+use datafusion_common::{DFSchemaRef, OwnedTableReference};
+
+use crate::LogicalPlan;
+
+/// The operator that modifies the content of a database (adapted from
+/// substrait WriteRel)
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct DmlStatement {
+    /// The table name
+    pub table_name: OwnedTableReference,
+    /// The schema of the table (must align with Rel input)
+    pub table_schema: DFSchemaRef,
+    /// The type of operation to perform
+    pub op: WriteOp,
+    /// The relation that determines the tuples to add/remove/modify the schema must match with table_schema
+    pub input: Arc<LogicalPlan>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum WriteOp {
+    Insert,
+    Delete,
+    Update,
+    Ctas,
+}
+
+impl Display for WriteOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WriteOp::Insert => write!(f, "Insert"),
+            WriteOp::Delete => write!(f, "Delete"),
+            WriteOp::Update => write!(f, "Update"),
+            WriteOp::Ctas => write!(f, "Ctas"),
+        }
+    }
+}

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -17,11 +17,13 @@
 
 pub mod builder;
 pub mod display;
+mod dml;
 mod extension;
 mod plan;
 mod statement;
 
 pub use builder::{table_scan, LogicalPlanBuilder};
+pub use dml::{DmlStatement, WriteOp};
 pub use plan::{
     Aggregate, Analyze, CreateCatalog, CreateCatalogSchema, CreateExternalTable,
     CreateMemoryTable, CreateView, CrossJoin, DescribeTable, Distinct, DropTable,
@@ -31,8 +33,8 @@ pub use plan::{
     Unnest, Values, Window,
 };
 pub use statement::{
-    DmlStatement, SetVariable, Statement, TransactionAccessMode, TransactionConclusion,
-    TransactionEnd, TransactionIsolationLevel, TransactionStart, WriteOp,
+    SetVariable, Statement, TransactionAccessMode, TransactionConclusion, TransactionEnd,
+    TransactionIsolationLevel, TransactionStart,
 };
 
 pub use display::display_schema;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -18,7 +18,7 @@
 ///! Logical plan types
 use crate::logical_plan::display::{GraphvizVisitor, IndentVisitor};
 use crate::logical_plan::extension::UserDefinedLogicalNode;
-use crate::logical_plan::statement::{DmlStatement, Statement};
+use crate::logical_plan::{DmlStatement, Statement};
 
 use crate::logical_plan::plan;
 use crate::utils::{

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -15,14 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{
-    fmt::{self, Display},
-    sync::Arc,
-};
+use std::fmt::{self, Display};
 
-use datafusion_common::{DFSchemaRef, OwnedTableReference};
-
-use crate::LogicalPlan;
+use datafusion_common::DFSchemaRef;
 
 /// Various types of Statements.
 ///
@@ -94,39 +89,6 @@ impl Statement {
             }
         }
         Wrapper(self)
-    }
-}
-
-/// The operator that modifies the content of a database (adapted from
-/// substrait WriteRel)
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct DmlStatement {
-    /// The table name
-    pub table_name: OwnedTableReference,
-    /// The schema of the table (must align with Rel input)
-    pub table_schema: DFSchemaRef,
-    /// The type of operation to perform
-    pub op: WriteOp,
-    /// The relation that determines the tuples to add/remove/modify the schema must match with table_schema
-    pub input: Arc<LogicalPlan>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum WriteOp {
-    Insert,
-    Delete,
-    Update,
-    Ctas,
-}
-
-impl Display for WriteOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WriteOp::Insert => write!(f, "Insert"),
-            WriteOp::Delete => write!(f, "Delete"),
-            WriteOp::Update => write!(f, "Update"),
-            WriteOp::Ctas => write!(f, "Ctas"),
-        }
     }
 }
 

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -60,7 +60,7 @@ impl Statement {
     /// description of this LogicalPlan node per node, not including
     /// children.
     ///
-    /// See [LogicalPlan::display] for an example
+    /// See [crate::LogicalPlan::display] for an example
     pub fn display(&self) -> impl fmt::Display + '_ {
         struct Wrapper<'a>(&'a Statement);
         impl<'a> Display for Wrapper<'a> {


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/1281

# Rationale for this change

I am trying to improve the organization of `LogicalPlan` and would like the code to mirror the structure


# What changes are included in this PR?

extract DML related plan structures into a new module

# Are these changes tested?

Covered by existing tests 
# Are there any user-facing changes?

No, the imports are updated so there should be no API changes