### PR TITLE
Improve `compare.py` output to use `min` times and better column titles

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -25,8 +25,6 @@ from typing import Dict, List, Any
 from pathlib import Path
 from argparse import ArgumentParser
 
-import os
-
 try:
     from rich.console import Console
     from rich.table import Table

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -20,11 +20,12 @@
 from __future__ import annotations
 
 import json
-import statistics
 from dataclasses import dataclass
 from typing import Dict, List, Any
 from pathlib import Path
 from argparse import ArgumentParser
+
+import os
 
 try:
     from rich.console import Console
@@ -32,8 +33,6 @@ try:
 except ImportError:
     print("Try `pip install rich` for using this script.")
     raise
-
-MEAN_THRESHOLD = 5
 
 
 @dataclass
@@ -64,14 +63,9 @@ class QueryRun:
     def execution_time(self) -> float:
         assert len(self.iterations) >= 1
 
-        # If we don't have enough samples, median() is probably
-        # going to be a worse measure than just an average.
-        if len(self.iterations) < MEAN_THRESHOLD:
-            method = statistics.mean
-        else:
-            method = statistics.median
-
-        return method(iteration.elapsed for iteration in self.iterations)
+        # Use minimum execution time to account for variations / other
+        # things the system was doing
+        return min(iteration.elapsed for iteration in self.iterations)
 
 
 @dataclass
@@ -81,7 +75,6 @@ class Context:
     num_cpus: int
     start_time: int
     arguments: List[str]
-    branch: str
 
     @classmethod
     def load_from(cls, data: Dict[str, Any]) -> Context:
@@ -91,7 +84,6 @@ class Context:
             num_cpus=data["num_cpus"],
             start_time=data["start_time"],
             arguments=data["arguments"],
-            branch=data["arguments"][9]
         )
 
 
@@ -119,17 +111,19 @@ def compare(
     noise_threshold: float,
 ) -> None:
     baseline = BenchmarkRun.load_from_file(baseline_path)
-    baselineBranch = baseline.context.branch
 
     comparison = BenchmarkRun.load_from_file(comparison_path)
-    comparisonBranch = comparison.context.branch
 
     console = Console()
 
+    # use basename as the column names
+    baseline_header = baseline_path.stem
+    comparison_header = comparison_path.stem
+
     table = Table(show_header=True, header_style="bold magenta")
     table.add_column("Query", style="dim", width=12)
-    table.add_column(baselineBranch, justify="right", style="dim", width=12)
-    table.add_column(comparisonBranch, justify="right", style="dim", width=12)
+    table.add_column(baseline_header, justify="right", style="dim")
+    table.add_column(comparison_header, justify="right", style="dim")
     table.add_column("Change", justify="right", style="dim")
 
     for baseline_result, comparison_result in zip(baseline.queries, comparison.queries):


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/6127

# Rationale for this change
I want to be able to easily understand what is being compared and reported. Currently the reporting from `compare.py` is somewhat opaque: 
1. It averages benchmark run timings (which increases the variance)
2. The header columns are non sensical

# What changes are included in this PR?
1. Use `min` of the iteration times to report the benchmark results -- I think this minimizes run to run variance and is the fairest way to asses performance
2. Use the filename as the column header

# Are these changes tested?
No, it is a tool only change

# Are there any user-facing changes?
Not really

# Example output Before this PR

(note the bad headers)

```shell
python3 compare.py results/alamb_bench/tpch.json results/alamb_bench/tpch_mem.json
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ /Users/alam… ┃           -o ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │     794.64ms │     559.37ms │ +1.42x faster │
│ QQuery 2     │     239.12ms │     171.29ms │ +1.40x faster │
│ QQuery 3     │     254.99ms │      99.33ms │ +2.57x faster │
│ QQuery 4     │     147.85ms │      66.65ms │ +2.22x faster │
│ QQuery 5     │     322.94ms │     258.98ms │ +1.25x faster │
│ QQuery 6     │     130.89ms │      24.24ms │ +5.40x faster │
│ QQuery 7     │     629.42ms │     645.68ms │     no change │
│ QQuery 8     │     375.57ms │     140.26ms │ +2.68x faster │
│ QQuery 9     │     597.65ms │     334.59ms │ +1.79x faster │
│ QQuery 10    │     397.16ms │     197.59ms │ +2.01x faster │
│ QQuery 11    │     182.41ms │     167.33ms │ +1.09x faster │
│ QQuery 12    │     228.44ms │      99.10ms │ +2.31x faster │
│ QQuery 13    │     736.21ms │     438.47ms │ +1.68x faster │
│ QQuery 14    │     195.68ms │      31.99ms │ +6.12x faster │
│ QQuery 15    │     175.08ms │      57.62ms │ +3.04x faster │
│ QQuery 16    │     175.67ms │     144.90ms │ +1.21x faster │
│ QQuery 17    │    1953.59ms │    1925.39ms │     no change │
│ QQuery 18    │    2133.06ms │    1968.85ms │ +1.08x faster │
│ QQuery 19    │     371.82ms │     107.44ms │ +3.46x faster │
│ QQuery 20    │     680.02ms │     567.75ms │ +1.20x faster │
│ QQuery 21    │     987.36ms │     857.87ms │ +1.15x faster │
│ QQuery 22    │     105.31ms │      77.25ms │ +1.36x faster │
└──────────────┴──────────────┴──────────────┴───────────────┘
```

# Output after this PR

```bash
python3 compare.py results/alamb_bench/tpch.json results/alamb_bench/tpch_mem.json
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      tpch ┃  tpch_mem ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  762.35ms │  548.16ms │ +1.39x faster │
│ QQuery 2     │  210.23ms │  164.26ms │ +1.28x faster │
│ QQuery 3     │  239.37ms │   96.47ms │ +2.48x faster │
│ QQuery 4     │  147.01ms │   59.81ms │ +2.46x faster │
│ QQuery 5     │  317.68ms │  251.01ms │ +1.27x faster │
│ QQuery 6     │  129.40ms │   22.86ms │ +5.66x faster │
│ QQuery 7     │  603.09ms │  629.24ms │     no change │
│ QQuery 8     │  359.94ms │  138.52ms │ +2.60x faster │
│ QQuery 9     │  578.71ms │  329.58ms │ +1.76x faster │
│ QQuery 10    │  378.17ms │  188.56ms │ +2.01x faster │
│ QQuery 11    │  180.20ms │  159.49ms │ +1.13x faster │
│ QQuery 12    │  219.37ms │   94.54ms │ +2.32x faster │
│ QQuery 13    │  732.80ms │  425.82ms │ +1.72x faster │
│ QQuery 14    │  190.55ms │   30.99ms │ +6.15x faster │
│ QQuery 15    │  173.51ms │   54.58ms │ +3.18x faster │
│ QQuery 16    │  163.33ms │  130.02ms │ +1.26x faster │
│ QQuery 17    │ 1866.25ms │ 1855.35ms │     no change │
│ QQuery 18    │ 2063.31ms │ 1916.26ms │ +1.08x faster │
│ QQuery 19    │  363.00ms │  102.86ms │ +3.53x faster │
│ QQuery 20    │  639.92ms │  530.65ms │ +1.21x faster │
│ QQuery 21    │  946.66ms │  815.83ms │ +1.16x faster │
│ QQuery 22    │  103.37ms │   73.07ms │ +1.41x faster │
└──────────────┴───────────┴───────────┴───────────────┘
```