### PR TITLE
Add support for scientific notation (remove old unimplemented() for scientific notation)

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -820,3 +820,40 @@ drop table test_boolean
 
 statement ok
 drop table test_int32
+
+# scientific notation (0s)
+query RRRR
+SELECT 0e0 AS c1, 0.e-0 AS c2, -.0e+0 AS c3, 00.00e-00 AS c4
+----
+0 0 0 0
+
+# scientific notation (integer)
+query RRRR
+SELECT -1e-1, 0e100, 10E-2, 1E+0;
+----
+-0.1 0 0.1 1
+
+# scientific notation (decimal)
+query RRRR
+SELECT -1.5e-1, 00.0e1, 150.0E-3, 0.015E+2;
+----
+-0.15 0 0.15 1.5
+
+# scientific notation (integer or decimal part only)
+query RRRR
+SELECT -2.e-1, 0.e0, .0002E+3, .02E+2;
+----
+-0.2 0 0.2 2
+
+# scientific notation (overflows)
+# FLOAT64 range: -1.79E+308 to -2.22E-308, or from 2.22E-308 to 1.79E+308
+query RRRR
+SELECT -1.79e309, -2.22e-309, 2.22E-309, 1.79E+309;
+----
+-Infinity 0 0 Infinity
+
+# scientific notation (other edgecases)
+query IRRR
+SELECT 1ea, 1e-2a, 1E-2-2, 1E-1e2;
+----
+1 0.01 -1.99 0.1

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -47,14 +47,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     /// Parse number in sql string, convert to Expr::Literal
     fn parse_sql_number(&self, n: &str) -> Result<Expr> {
-        if n.find('E').is_some() {
-            // not implemented yet
-            // https://github.com/apache/arrow-datafusion/issues/3448
-            Err(DataFusionError::NotImplemented(
-                "sql numeric literals in scientific notation are not supported"
-                    .to_string(),
-            ))
-        } else if let Ok(n) = n.parse::<i64>() {
+        if let Ok(n) = n.parse::<i64>() {
             Ok(lit(n))
         } else if self.options.parse_float_as_decimal {
             // remove leading zeroes


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This issue reply https://github.com/apache/arrow-datafusion/issues/3448#issuecomment-1368607406 mentioned after a fix in sqlparser-rs, now datafusion should support scientific notations.

# Rationale for this change
1. Remove old `unimplemented()` code for scientific notations
2. Add tests for scientific notations
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
Yes, now values in scientific notations should be supported
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->