### PR TITLE
refactor: optimizer shouldn't assume failed rules are internal error

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -317,11 +317,11 @@ select
 ----
 08:09:10.123456789 13:14:15.123456 13:14:15.123 13:14:15
 
-query error Cannot cast string 'not a time' to value of Time64\(Nanosecond\) type\. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+query error Cannot cast string 'not a time' to value of Time64\(Nanosecond\) type
 SELECT TIME 'not a time' as time;
 
 # invalid time
-query error Cannot cast string '24:01:02' to value of Time64\(Nanosecond\) type\. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+query error Cannot cast string '24:01:02' to value of Time64\(Nanosecond\) type
 SELECT TIME '24:01:02' as time;
 
 statement ok

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -293,7 +293,7 @@ impl Optimizer {
                             i
                         );
                     }
-                    Err(ref e) => {
+                    Err(e) => {
                         if options.optimizer.skip_failed_rules {
                             // Note to future readers: if you see this warning it signals a
                             // bug in the DataFusion optimizer. Please consider filing a ticket
@@ -304,13 +304,8 @@ impl Optimizer {
                             e
                         );
                         } else {
-                            let e = DataFusionError::Internal(format!(
-                                "Optimizer rule '{}' failed due to unexpected error: {}",
-                                rule.name(),
-                                e
-                            ));
                             return Err(DataFusionError::Context(
-                                rule.name().to_string(),
+                                format!("Optimizer rule '{}' failed", rule.name(),),
                                 Box::new(e),
                             ));
                         }

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -463,10 +463,8 @@ mod tests {
         });
         let err = opt.optimize(&plan, &config, &observe).unwrap_err();
         assert_eq!(
-            "bad rule\ncaused by\n\
-            Internal error: Optimizer rule 'bad rule' failed due to unexpected error: \
-            Error during planning: rule failed. This was likely caused by a bug in \
-            DataFusion's code and we would welcome that you file an bug report in our issue tracker",
+            "Optimizer rule 'bad rule' failed\ncaused by\n\
+            Error during planning: rule failed",
             err.to_string()
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

This does not close an issue but is related to https://github.com/apache/arrow-datafusion/issues/6108

# Rationale for this change

In IOx we use a logical planner rule to transform plans to support time series gap filling. Sometimes, a user has submitted invalid SQL that we cannot handle. In this case we want to generate a user-facing error message from the optimizer rule. It makes sense to use something besides `DataFusion::Internal` for this case.

Downstream IOx issue: https://github.com/influxdata/influxdb_iox/issues/7330

# What changes are included in this PR?

This just makes it so that when a rule invocation returns an error, it is not wrapped in `DataFusionError::Internal`.

# Are these changes tested?

I ran the existing suite of tests, and updated a SQL logic test. This is just a change to how errors are returned from  the logical planner when `skip_failed_rules` is `false`, which is not yet the default.

# Are there any user-facing changes?

These changes may be user facing in that they affect how errors are returned to users.
