### PR TITLE
minor: remove default match for function signature

### DIFF
--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -308,7 +308,7 @@ pub fn return_type(
     }
 }
 
-/// the signatures supported by the function `fun`.
+/// Return the [`Signature`] supported by the function `fun`.
 pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
     // note: the physical expression must accept the type returned by this function or the execution panics.
 
@@ -674,15 +674,46 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
             fun.volatility(),
         ),
         BuiltinScalarFunction::ArrowTypeof => Signature::any(1, fun.volatility()),
-        // math expressions expect 1 argument of type f64 or f32
-        // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
-        // return the best approximation for it (in f64).
-        // We accept f32 because in this case it is clear that the best approximation
-        // will be as good as the number of digits in the number
-        _ => Signature::uniform(
-            1,
-            vec![DataType::Float64, DataType::Float32],
-            fun.volatility(),
-        ),
+        BuiltinScalarFunction::Abs
+        | BuiltinScalarFunction::Acos
+        | BuiltinScalarFunction::Asin
+        | BuiltinScalarFunction::Atan
+        | BuiltinScalarFunction::Acosh
+        | BuiltinScalarFunction::Asinh
+        | BuiltinScalarFunction::Atanh
+        | BuiltinScalarFunction::Cbrt
+        | BuiltinScalarFunction::Ceil
+        | BuiltinScalarFunction::Cos
+        | BuiltinScalarFunction::Cosh
+        | BuiltinScalarFunction::Degrees
+        | BuiltinScalarFunction::Exp
+        | BuiltinScalarFunction::Floor
+        | BuiltinScalarFunction::Ln
+        | BuiltinScalarFunction::Log10
+        | BuiltinScalarFunction::Log2
+        | BuiltinScalarFunction::Radians
+        | BuiltinScalarFunction::Signum
+        | BuiltinScalarFunction::Sin
+        | BuiltinScalarFunction::Sinh
+        | BuiltinScalarFunction::Sqrt
+        | BuiltinScalarFunction::Tan
+        | BuiltinScalarFunction::Tanh
+        | BuiltinScalarFunction::Trunc => {
+            // math expressions expect 1 argument of type f64 or f32
+            // priority is given to f64 because e.g. `sqrt(1i32)` is in IR (real numbers) and thus we
+            // return the best approximation for it (in f64).
+            // We accept f32 because in this case it is clear that the best approximation
+            // will be as good as the number of digits in the number
+            Signature::uniform(
+                1,
+                vec![DataType::Float64, DataType::Float32],
+                fun.volatility(),
+            )
+        }
+        BuiltinScalarFunction::Now
+        | BuiltinScalarFunction::CurrentDate
+        | BuiltinScalarFunction::CurrentTime => {
+            Signature::uniform(0, vec![], fun.volatility())
+        }
     }
 }

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -60,7 +60,8 @@ pub enum TypeSignature {
     OneOf(Vec<TypeSignature>),
 }
 
-///The Signature of a function defines its supported input types as well as its volatility.
+/// The signature of a function defines the supported argument types
+/// and its volatility.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Signature {
     /// type_signature - The types that the function accepts. See [TypeSignature] for more information.


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/pull/6149

# Rationale for this change

When adding a new function, it is important to update the metadata appropriately. However, when @izveigor missed one place in https://github.com/apache/arrow-datafusion/pull/6149 the resulting runtime error was quite confusing - https://github.com/apache/arrow-datafusion/pull/6149#issuecomment-1530038460. It would be much better if the compiler told us the problem.

# What changes are included in this PR?

Replace a default match arm with all explicit patterns for clarity

# Are these changes tested?

Covered by existing tests
# Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->