### PR TITLE
minor: Move shift_date tests to be with code

### DIFF
--- a/datafusion/common/src/delta.rs
+++ b/datafusion/common/src/delta.rs
@@ -290,4 +290,46 @@ mod tests {
         assert_eq!(shift_months(base, 1).time(), o_clock);
         assert_eq!(shift_months(base, 2).time(), o_clock);
     }
+
+    #[test]
+    fn add_11_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, 11);
+        assert_eq!(format!("{actual:?}").as_str(), "2000-12-01");
+    }
+
+    #[test]
+    fn add_12_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, 12);
+        assert_eq!(format!("{actual:?}").as_str(), "2001-01-01");
+    }
+
+    #[test]
+    fn add_13_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, 13);
+        assert_eq!(format!("{actual:?}").as_str(), "2001-02-01");
+    }
+
+    #[test]
+    fn sub_11_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, -11);
+        assert_eq!(format!("{actual:?}").as_str(), "1999-02-01");
+    }
+
+    #[test]
+    fn sub_12_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, -12);
+        assert_eq!(format!("{actual:?}").as_str(), "1999-01-01");
+    }
+
+    #[test]
+    fn sub_13_months() {
+        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let actual = shift_months(prior, -13);
+        assert_eq!(format!("{actual:?}").as_str(), "1998-12-01");
+    }
 }

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -235,48 +235,6 @@ mod tests {
     use std::ops::Add;
 
     #[test]
-    fn add_11_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, 11);
-        assert_eq!(format!("{actual:?}").as_str(), "2000-12-01");
-    }
-
-    #[test]
-    fn add_12_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, 12);
-        assert_eq!(format!("{actual:?}").as_str(), "2001-01-01");
-    }
-
-    #[test]
-    fn add_13_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, 13);
-        assert_eq!(format!("{actual:?}").as_str(), "2001-02-01");
-    }
-
-    #[test]
-    fn sub_11_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, -11);
-        assert_eq!(format!("{actual:?}").as_str(), "1999-02-01");
-    }
-
-    #[test]
-    fn sub_12_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, -12);
-        assert_eq!(format!("{actual:?}").as_str(), "1999-01-01");
-    }
-
-    #[test]
-    fn sub_13_months() {
-        let prior = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
-        let actual = shift_months(prior, -13);
-        assert_eq!(format!("{actual:?}").as_str(), "1998-12-01");
-    }
-
-    #[test]
     fn add_32_day_time() -> Result<()> {
         // setup
         let dt = Expr::Literal(ScalarValue::Date32(Some(0)));

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -229,7 +229,6 @@ mod tests {
     use arrow::datatypes::*;
     use arrow_array::IntervalMonthDayNanoArray;
     use chrono::{Duration, NaiveDate};
-    use datafusion_common::delta::shift_months;
     use datafusion_common::{Column, Result, ScalarValue, ToDFSchema};
     use datafusion_expr::Expr;
     use std::ops::Add;


### PR DESCRIPTION
# Which issue does this PR close?
Noticed while reviewing https://github.com/apache/arrow-datafusion/pull/6196

# Rationale for this change

These tests are for a function in another file

# What changes are included in this PR?

Move the tests to be with the code they are testing

# Are these changes tested?
only tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->