### PR TITLE
RFC: Distinguish between argument coercion and output type

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -125,11 +125,7 @@ impl Coercion {
     // creates a new coercion where the argument types and result
     // types are the same
     pub fn new_uniform(output_type: DataType) -> Self {
-        Coercion::new(
-            output_type.clone(),
-            output_type.clone(),
-            output_type,
-        )
+        Coercion::new(output_type.clone(), output_type.clone(), output_type)
     }
 }
 
@@ -148,8 +144,9 @@ pub fn binary_coerce(
         | Operator::BitwiseOr
         | Operator::BitwiseXor
         | Operator::BitwiseShiftRight
-        | Operator::BitwiseShiftLeft => bitwise_coercion(lhs_type, rhs_type)
-            .map(Coercion::new_uniform),
+        | Operator::BitwiseShiftLeft => {
+            bitwise_coercion(lhs_type, rhs_type).map(Coercion::new_uniform)
+        }
         Operator::And | Operator::Or => {
             match (lhs_type, rhs_type) {
                 // logical binary boolean operators can only be evaluated in bools or nulls
@@ -170,8 +167,9 @@ pub fn binary_coerce(
         | Operator::GtEq
         | Operator::LtEq
         | Operator::IsDistinctFrom
-        | Operator::IsNotDistinctFrom => comparison_coercion(lhs_type, rhs_type)
-            .map(Coercion::new_uniform),
+        | Operator::IsNotDistinctFrom => {
+            comparison_coercion(lhs_type, rhs_type).map(Coercion::new_uniform)
+        }
         // interval - timestamp is an erroneous case, cannot coerce a type
         Operator::Plus | Operator::Minus
             if is_datetime(lhs_type)
@@ -205,8 +203,9 @@ pub fn binary_coerce(
         | Operator::RegexNotIMatch => regex_coercion(lhs_type, rhs_type)
             .map(|result_type| Coercion::new_uniform(result_type)),
         // "||" operator has its own rules, and always return a string type
-        Operator::StringConcat => string_concat_coercion(lhs_type, rhs_type)
-            .map(Coercion::new_uniform),
+        Operator::StringConcat => {
+            string_concat_coercion(lhs_type, rhs_type).map(Coercion::new_uniform)
+        }
     }
 }
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -128,7 +128,7 @@ impl Coercion {
         Coercion::new(
             output_type.clone(),
             output_type.clone(),
-            output_type.clone(),
+            output_type,
         )
     }
 }
@@ -149,7 +149,7 @@ pub fn binary_coerce(
         | Operator::BitwiseXor
         | Operator::BitwiseShiftRight
         | Operator::BitwiseShiftLeft => bitwise_coercion(lhs_type, rhs_type)
-            .map(|result_type| Coercion::new_uniform(result_type)),
+            .map(Coercion::new_uniform),
         Operator::And | Operator::Or => {
             match (lhs_type, rhs_type) {
                 // logical binary boolean operators can only be evaluated in bools or nulls
@@ -171,7 +171,7 @@ pub fn binary_coerce(
         | Operator::LtEq
         | Operator::IsDistinctFrom
         | Operator::IsNotDistinctFrom => comparison_coercion(lhs_type, rhs_type)
-            .map(|result_type| Coercion::new_uniform(result_type)),
+            .map(Coercion::new_uniform),
         // interval - timestamp is an erroneous case, cannot coerce a type
         Operator::Plus | Operator::Minus
             if is_datetime(lhs_type)
@@ -206,7 +206,7 @@ pub fn binary_coerce(
             .map(|result_type| Coercion::new_uniform(result_type)),
         // "||" operator has its own rules, and always return a string type
         Operator::StringConcat => string_concat_coercion(lhs_type, rhs_type)
-            .map(|result_type| Coercion::new_uniform(result_type)),
+            .map(Coercion::new_uniform),
     }
 }
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -200,8 +200,9 @@ pub fn binary_coerce(
         Operator::RegexMatch
         | Operator::RegexIMatch
         | Operator::RegexNotMatch
-        | Operator::RegexNotIMatch => regex_coercion(lhs_type, rhs_type)
-            .map(|result_type| Coercion::new_uniform(result_type)),
+        | Operator::RegexNotIMatch => {
+            regex_coercion(lhs_type, rhs_type).map(Coercion::new_uniform)
+        }
         // "||" operator has its own rules, and always return a string type
         Operator::StringConcat => {
             string_concat_coercion(lhs_type, rhs_type).map(Coercion::new_uniform)


### PR DESCRIPTION
I am trying to collect some feedback on this approach before pushing along with it

# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/3419

# Rationale for this change

Every time I see the type coercion and binary.rs I am saddened -- it is overly complicated for what it is doing (which is already complicated). Since I spent a while this morning loading in the context into my head to review https://github.com/apache/arrow-datafusion/pull/6196 and related code, I figured I would start trying to clean this up.

# What changes are included in this PR?

1. Introduce a structure `Coercion` to represent what coercion is needed for given argument operands and operator


# Are these changes tested?

Existing tests

# Are there any user-facing changes?

As I have it now, there is no user facing API change, but I would like to press on and remove the old API eventually