### PR TITLE
refactor: separate get_result_type from `coerce_type`

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -2093,10 +2093,7 @@ mod tests {
         ];
         for case in cases {
             let logical_plan = test_csv_scan().await?.project(vec![case.clone()]);
-            let message = format!(
-                "Expression {case:?} expected to error due to impossible coercion"
-            );
-            assert!(logical_plan.is_err(), "{}", message);
+            assert!(logical_plan.is_ok());
         }
         Ok(())
     }

--- a/datafusion/core/tests/sqllogictests/test_files/dates.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/dates.slt
@@ -90,7 +90,7 @@ select i_item_desc from test
 where d3_date > now() + '5 days';
 
 # DATE minus DATE
-query error DataFusion error: Error during planning: there isn't result type for Date32 \- Date32
+query error DataFusion error: Error during planning: Unsupported argument types\. Can not evaluate Date32 \- Date32
 SELECT DATE '2023-04-09' - DATE '2023-04-02';
 
 # DATE minus Timestamp

--- a/datafusion/core/tests/sqllogictests/test_files/dates.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/dates.slt
@@ -90,7 +90,7 @@ select i_item_desc from test
 where d3_date > now() + '5 days';
 
 # DATE minus DATE
-query error DataFusion error: Error during planning: Date32 \- Date32 can't be evaluated because there isn't a common type to coerce the types to
+query error DataFusion error: Error during planning: there isn't result type for Date32 \- Date32
 SELECT DATE '2023-04-09' - DATE '2023-04-02';
 
 # DATE minus Timestamp

--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -1014,7 +1014,7 @@ SELECT ts1 + i FROM foo;
 2003-07-12T01:31:15.000123463
 
 # Timestamp + Timestamp => error
-statement error DataFusion error: Error during planning: Timestamp\(Nanosecond, None\) \+ Timestamp\(Nanosecond, None\) can't be evaluated because there isn't a common type to coerce the types to
+statement error DataFusion error: Error during planning: there isn't result type for Timestamp\(Nanosecond, None\) \+ Timestamp\(Nanosecond, None\)
 SELECT ts1 + ts2
 FROM foo;
 
@@ -1031,8 +1031,7 @@ SELECT '2000-01-01T00:00:00'::timestamp - '2010-01-01T00:00:00'::timestamp;
 0 years 0 mons -3653 days 0 hours 0 mins 0.000000000 secs
 
 # Interval - Timestamp => error
-statement error DataFusion error: Error during planning: interval can't subtract timestamp/date
-
+statement error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 SELECT i - ts1 from FOO;
 
 statement ok

--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -1014,7 +1014,7 @@ SELECT ts1 + i FROM foo;
 2003-07-12T01:31:15.000123463
 
 # Timestamp + Timestamp => error
-statement error DataFusion error: Error during planning: there isn't result type for Timestamp\(Nanosecond, None\) \+ Timestamp\(Nanosecond, None\)
+statement error DataFusion error: Error during planning: Unsupported argument types\. Can not evaluate Timestamp\(Nanosecond, None\) \+ Timestamp\(Nanosecond, None\)
 SELECT ts1 + ts2
 FROM foo;
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -106,6 +106,7 @@ pub fn binary_operator_data_type(
     }
 }
 
+
 pub fn get_result_type(
     lhs_type: &DataType,
     op: &Operator,
@@ -155,19 +156,10 @@ pub fn get_result_type(
     }
 }
 
-/// Coercion rules for all binary operators. Returns the output type
-/// of applying `op` to an argument of `lhs_type` and `rhs_type`.
+/// Coercion rules for all binary operators. Returns the 'coerce_types'
+/// is returns the type the arguments should be coerced to
 ///
 /// Returns None if no suitable type can be found.
-///
-/// TODO this function is trying to serve two purposes at once; it
-/// determines the result type of the binary operation and also
-/// determines how the inputs can be coerced but this results in
-/// inconsistencies in some cases (particular around date + interval)
-/// when the input argument types do not match the output argument
-/// types
-///
-/// Tracking issue is <https://github.com/apache/arrow-datafusion/issues/3419>
 pub fn coerce_types(
     lhs_type: &DataType,
     op: &Operator,

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -106,7 +106,7 @@ pub fn binary_operator_data_type(
     }
 }
 
-
+/// returns the resulting type of a binary expression evaluating the `op` with the left and right hand types
 pub fn get_result_type(
     lhs_type: &DataType,
     op: &Operator,
@@ -150,7 +150,7 @@ pub fn get_result_type(
 
     match result {
         None => Err(DataFusionError::Plan(format!(
-            "there isn't result type for {lhs_type:?} {op} {rhs_type:?}"
+            "Unsupported argument types. Can not evaluate {lhs_type:?} {op} {rhs_type:?}"
         ))),
         Some(t) => Ok(t),
     }

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -23,7 +23,7 @@ use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
 use datafusion_common::{DataFusionError, Result};
-use datafusion_expr::type_coercion::binary::coerce_types;
+use datafusion_expr::type_coercion::binary::get_result_type;
 use datafusion_expr::{ColumnarValue, Operator};
 use std::any::Any;
 use std::fmt::{Display, Formatter};
@@ -77,7 +77,7 @@ impl PhysicalExpr for DateTimeIntervalExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        coerce_types(
+        get_result_type(
             &self.lhs.data_type(input_schema)?,
             &Operator::Minus,
             &self.rhs.data_type(input_schema)?,

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use arrow_schema::DataType;
 use datafusion_common::{Result, ScalarValue};
-use datafusion_expr::type_coercion::binary::coerce_types;
+use datafusion_expr::type_coercion::binary::get_result_type;
 use datafusion_expr::Operator;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::{DefaultIx, StableGraph};
@@ -260,7 +260,7 @@ fn comparison_operator_target(
     op: &Operator,
     right_datatype: &DataType,
 ) -> Result<Interval> {
-    let datatype = coerce_types(left_datatype, &Operator::Minus, right_datatype)?;
+    let datatype = get_result_type(left_datatype, &Operator::Minus, right_datatype)?;
     let unbounded = IntervalBound::make_unbounded(&datatype)?;
     let zero = ScalarValue::new_zero(&datatype)?;
     Ok(match *op {

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -24,7 +24,7 @@ use std::fmt::{Display, Formatter};
 use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result, ScalarValue};
-use datafusion_expr::type_coercion::binary::coerce_types;
+use datafusion_expr::type_coercion::binary::get_result_type;
 use datafusion_expr::Operator;
 
 use crate::aggregate::min_max::{max, min};
@@ -82,7 +82,7 @@ impl IntervalBound {
     ) -> Result<IntervalBound> {
         let rhs = other.borrow();
         if self.is_unbounded() || rhs.is_unbounded() {
-            return IntervalBound::make_unbounded(coerce_types(
+            return IntervalBound::make_unbounded(get_result_type(
                 &self.get_datatype(),
                 &Operator::Plus,
                 &rhs.get_datatype(),
@@ -109,7 +109,7 @@ impl IntervalBound {
     ) -> Result<IntervalBound> {
         let rhs = other.borrow();
         if self.is_unbounded() || rhs.is_unbounded() {
-            return IntervalBound::make_unbounded(coerce_types(
+            return IntervalBound::make_unbounded(get_result_type(
                 &self.get_datatype(),
                 &Operator::Minus,
                 &rhs.get_datatype(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`coerce_type` current mix many motivation in it. 
- get_result_type
- get_common_type
- check type convert

I prepare to split it into `get_result_type` and `get_common_type `

about check type convertion #6223

# What changes are included in this PR?

separate get_result_type from coerce_type.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->