### PR TITLE
Minor: improve error message for interval subtraction

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -327,10 +327,10 @@ select '1 month'::interval + '1980-01-01T12:00:00'::timestamp;
 
 # Exected error: interval (scalar) - date / timestamp (scalar)
 
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Date32
 select '1 month'::interval - '1980-01-01'::date;
 
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\)
 select '1 month'::interval - '1980-01-01T12:00:00'::timestamp;
 
 # interval (array) + date / timestamp (array)
@@ -349,10 +349,10 @@ select i + ts from t;
 2000-02-01T00:01:00
 
 # expected error interval (array) - date / timestamp (array)
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Date32
 select i - d from t;
 
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\)
 select i - ts from t;
 
 
@@ -372,10 +372,10 @@ select '1 month'::interval + ts from t;
 2000-03-01T00:00:00
 
 # expected error interval (scalar) - date / timestamp (array)
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Date32
 select '1 month'::interval - d from t;
 
-query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error Invalid interval subtraction: Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\)
 select '1 month'::interval - ts from t;
 
 statement ok

--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -1031,7 +1031,7 @@ SELECT '2000-01-01T00:00:00'::timestamp - '2010-01-01T00:00:00'::timestamp;
 0 years 0 mons -3653 days 0 hours 0 mins 0.000000000 secs
 
 # Interval - Timestamp => error
-statement error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: Invalid interval subtraction: Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\)
 SELECT i - ts1 from FOO;
 
 statement ok

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -197,9 +197,9 @@ pub fn coerce_types(
                 || is_interval(rhs_type) =>
         {
             if is_interval(lhs_type) && is_datetime(rhs_type) && *op == Operator::Minus {
-                return Err(DataFusionError::Plan(
-                    "interval can't subtract timestamp/date".to_string(),
-                ));
+                return Err(DataFusionError::Plan(format!(
+                    "Invalid interval subtraction: {lhs_type} - {rhs_type}"
+                )));
             }
             temporal_add_sub_coercion(lhs_type, rhs_type, op)
         }


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/arrow-datafusion/pull/6201~

# Which issue does this PR close?
Follow on from https://github.com/apache/arrow-datafusion/pull/6201

# Rationale for this change

@crepererum  noticed that the error messages could be improved when trying to subtract things from intervals -- see https://github.com/apache/arrow-datafusion/pull/6201/files#r1183584830

# What changes are included in this PR?

Improve error message 

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->