### PR TITLE
minor: change error type for window expressions

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1552,7 +1552,7 @@ pub fn create_window_expr_with_name(
                 physical_input_schema,
             )
         }
-        other => Err(DataFusionError::Internal(format!(
+        other => Err(DataFusionError::Plan(format!(
             "Invalid window expression '{other:?}'"
         ))),
     }

--- a/datafusion/core/tests/sqllogictests/test_files/window.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/window.slt
@@ -920,7 +920,7 @@ drop table temp
 
 
 #fn window_frame_ranges_unbounded_preceding_err
-statement error DataFusion error: Execution error: Invalid window frame: end bound cannot be unbounded preceding
+statement error DataFusion error: Error during planning: Invalid window frame: end bound cannot be unbounded preceding
 SELECT
 SUM(c2) OVER (ORDER BY c2 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING),
 COUNT(*) OVER (ORDER BY c2 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING)
@@ -2365,3 +2365,16 @@ SELECT c9, rn1 FROM (SELECT c9,
 4216440507 3
 4144173353 4
 4076864659 5
+
+
+# invalid window frame. null as preceding
+statement error DataFusion error: Error during planning: Invalid window frame: frame offsets must be non negative integers 
+select row_number() over (rows between null preceding and current row) from (select 1 a) x
+
+# invalid window frame. null as preceding
+statement error DataFusion error: Error during planning: Invalid window frame: frame offsets must be non negative integers 
+select row_number() over (rows between null preceding and current row) from (select 1 a) x
+
+# invalid window frame. negative as following
+statement error DataFusion error: Error during planning: Invalid window frame: frame offsets must be non negative integers 
+select row_number() over (rows between current row and -1 following) from (select 1 a) x


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6207 .

# Rationale for this change
Change not user friendly `Datafusion::Internal` error messages to `Datafusion::Plan`
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
Error format will change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->