### PR TITLE
refactor: use get_result_type to replace binary_operator_data_type.

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -327,10 +327,10 @@ select '1 month'::interval + '1980-01-01T12:00:00'::timestamp;
 
 # Exected error: interval (scalar) - date / timestamp (scalar)
 
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select '1 month'::interval - '1980-01-01'::date;
 
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select '1 month'::interval - '1980-01-01T12:00:00'::timestamp;
 
 # interval (array) + date / timestamp (array)
@@ -349,10 +349,10 @@ select i + ts from t;
 2000-02-01T00:01:00
 
 # expected error interval (array) - date / timestamp (array)
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select i - d from t;
 
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select i - ts from t;
 
 
@@ -372,10 +372,10 @@ select '1 month'::interval + ts from t;
 2000-03-01T00:00:00
 
 # expected error interval (scalar) - date / timestamp (array)
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select '1 month'::interval - d from t;
 
-query error DataFusion error: Error during planning: interval can't subtract timestamp/date
+query error DataFusion error: type_coercion\ncaused by\nError during planning: interval can't subtract timestamp/date
 select '1 month'::interval - ts from t;
 
 statement ok

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -20,7 +20,7 @@ use crate::expr::{
     AggregateFunction, BinaryExpr, Cast, GetIndexedField, Sort, TryCast, WindowFunction,
 };
 use crate::field_util::get_indexed_field;
-use crate::type_coercion::binary::binary_operator_data_type;
+use crate::type_coercion::binary::get_result_type;
 use crate::type_coercion::other::get_coerce_type_for_case_expression;
 use crate::{
     aggregate_function, function, window_function, LogicalPlan, Projection, Subquery,
@@ -149,11 +149,7 @@ impl ExprSchemable for Expr {
                 ref left,
                 ref right,
                 ref op,
-            }) => binary_operator_data_type(
-                &left.get_type(schema)?,
-                op,
-                &right.get_type(schema)?,
-            ),
+            }) => get_result_type(&left.get_type(schema)?, op, &right.get_type(schema)?),
             Expr::Like { .. } | Expr::ILike { .. } | Expr::SimilarTo { .. } => {
                 Ok(DataType::Boolean)
             }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -98,7 +98,7 @@ use datafusion_common::scalar::*;
 use datafusion_common::ScalarValue;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::type_coercion::binary::{
-    binary_operator_data_type, coercion_decimal_mathematics_type,
+    coercion_decimal_mathematics_type, get_result_type,
 };
 use datafusion_expr::{ColumnarValue, Operator};
 
@@ -651,7 +651,7 @@ impl PhysicalExpr for BinaryExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        binary_operator_data_type(
+        get_result_type(
             &self.left.data_type(input_schema)?,
             &self.op,
             &self.right.data_type(input_schema)?,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

following #6221

# What changes are included in this PR?

- use get_result_type to replace binary_operator_data_type
- fix case in get_result_type
- don't use coerce_type in get_result_type

# Are these changes tested?

# Are there any user-facing changes?

N/A