### PR TITLE
Support `interval '1 month' + date/timestamp`: Handle binary op interval in logical AST builder  

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -138,6 +138,53 @@ select interval '1' + '1' month
 ----
 0 years 2 mons 0 days 0 hours 0 mins 0.000000000 secs
 
+# Interval with nested string literal addition
+query ?
+select interval '1 month' + '1 month' + '1 month'
+----
+0 years 3 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# Interval with nested string literal addition and leading field
+query ?
+select interval '1' + '1' + '1' month
+----
+0 years 3 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# Interval mega nested string literal addition
+query ?
+select interval '1 year' + '1 month' + '1 day' + '1 hour' + '1 minute' + '1 second' + '1 millisecond' + '1 microsecond' + '1 nanosecond'
+----
+0 years 13 mons 1 days 1 hours 1 mins 1.001001001 secs
+
+# Interval with nested string literal substraction
+query ?
+select interval '1 month' - '1 day'
+----
+0 years 1 mons -1 days 0 hours 0 mins 0.000000000 secs
+
+# Interval with nested string literal substraction and leading field
+query ?
+select interval '10' - '1' month;
+----
+0 years 9 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# Interval mega nested string literal substraction
+query ?
+select interval '1 year' - '1 month' - '1 day' - '1 hour' - '1 minute' - '1 second' - '1 millisecond' - '1 microsecond' - '1 nanosecond'
+----
+0 years 11 mons -1 days -1 hours -1 mins -1.001001001 secs
+
+# Interval string literal + date
+query D
+select interval '1 month' + '1 day' + '2012-01-01'::date;
+----
+2012-02-02
+
+# Interval string literal parenthesized + date
+query D
+select ( interval '1 month' + '1 day' ) + '2012-01-01'::date;
+----
+2012-02-02
 
 
 

--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -378,5 +378,11 @@ select '1 month'::interval - d from t;
 query error DataFusion error: type_coercion\ncaused by\nError during planning: Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\) can't be evaluated because there isn't a common type to coerce the types to
 select '1 month'::interval - ts from t;
 
+# interval + date
+query D
+select interval '1 month' + '2012-01-01'::date;
+----
+2012-02-01
+
 statement ok
 drop table t

--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -126,6 +126,17 @@ select interval '5' nanoseconds
 ----
 0 years 0 mons 0 days 0 hours 0 mins 0.000000005 secs
 
+# Interval with string literal addition
+query ?
+select interval '1 month' + '1 month'
+----
+0 years 2 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# Interval with string literal addition and leading field
+query ?
+select interval '1' + '1' month
+----
+0 years 2 mons 0 days 0 hours 0 mins 0.000000000 secs
 
 
 

--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -156,19 +156,31 @@ select interval '1 year' + '1 month' + '1 day' + '1 hour' + '1 minute' + '1 seco
 ----
 0 years 13 mons 1 days 1 hours 1 mins 1.001001001 secs
 
-# Interval with nested string literal substraction
+# Interval with string literal subtraction
 query ?
-select interval '1 month' - '1 day'
+select interval '1 month' - '1 day';
 ----
 0 years 1 mons -1 days 0 hours 0 mins 0.000000000 secs
 
-# Interval with nested string literal substraction and leading field
+# Interval with string literal subtraction and leading field
 query ?
-select interval '10' - '1' month;
+select interval '5' - '1' - '2' year;
 ----
-0 years 9 mons 0 days 0 hours 0 mins 0.000000000 secs
+0 years 24 mons 0 days 0 hours 0 mins 0.000000000 secs
 
-# Interval mega nested string literal substraction
+# Interval with nested string literal subtraction
+query ?
+select interval '1 month' - '1 day' - '1 hour';
+----
+0 years 1 mons -1 days -1 hours 0 mins 0.000000000 secs
+
+# Interval with nested string literal subtraction and leading field
+query ?
+select interval '10' - '1' - '1' month;
+----
+0 years 8 mons 0 days 0 hours 0 mins 0.000000000 secs
+
+# Interval mega nested string literal subtraction
 query ?
 select interval '1 year' - '1 month' - '1 day' - '1 hour' - '1 minute' - '1 second' - '1 millisecond' - '1 microsecond' - '1 nanosecond'
 ----
@@ -186,6 +198,17 @@ select ( interval '1 month' + '1 day' ) + '2012-01-01'::date;
 ----
 2012-02-02
 
+# Interval nested string literal + date
+query D
+select interval '1 year' + '1 month' + '1 day' + '2012-01-01'::date
+----
+2013-02-02
+
+# Interval nested string literal subtraction + date
+query D
+select interval '1 year' - '1 month' + '1 day' + '2012-01-01'::date
+----
+2012-12-02
 
 
 

--- a/datafusion/core/tests/sqllogictests/test_files/type_coercion.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/type_coercion.slt
@@ -44,10 +44,10 @@ SELECT '2023-05-01 12:30:00'::timestamp - interval '1 month';
 
 # TODO: https://github.com/apache/arrow-datafusion/issues/6180
 # interval - date
-query error DataFusion error: This feature is not implemented: Unsupported interval argument\. Expected string literal, got: BinaryOp \{ left: Value\(SingleQuotedString\("1 month"\)\), op: Minus, right: Cast \{ expr: Value\(SingleQuotedString\("2023\-05\-01"\)\), data_type: Date \} \}
+query error DataFusion error: type_coercion
 select interval '1 month' - '2023-05-01'::date;
 
 # TODO: https://github.com/apache/arrow-datafusion/issues/6180
 # interval - timestamp
-query error DataFusion error: This feature is not implemented: Unsupported interval argument\. Expected string literal, got: BinaryOp \{ left: Value\(SingleQuotedString\("1 month"\)\), op: Minus, right: Cast \{ expr: Value\(SingleQuotedString\("2023\-05\-01 12:30:00"\)\), data_type: Timestamp\(None, None\) \} \}
+query error DataFusion error: type_coercion
 SELECT interval '1 month' - '2023-05-01 12:30:00'::timestamp;

--- a/datafusion/core/tests/sqllogictests/test_files/type_coercion.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/type_coercion.slt
@@ -42,12 +42,10 @@ SELECT '2023-05-01 12:30:00'::timestamp - interval '1 month';
 ----
 2023-04-01T12:30:00
 
-# TODO: https://github.com/apache/arrow-datafusion/issues/6180
 # interval - date
 query error DataFusion error: type_coercion
 select interval '1 month' - '2023-05-01'::date;
 
-# TODO: https://github.com/apache/arrow-datafusion/issues/6180
 # interval - timestamp
 query error DataFusion error: type_coercion
 SELECT interval '1 month' - '2023-05-01 12:30:00'::timestamp;

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -138,6 +138,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 fractional_seconds_precision,
             } => self.sql_interval_to_expr(
                 *value,
+                schema,
+                planner_context,
                 leading_field,
                 leading_precision,
                 last_field,

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -211,7 +211,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     }
                 };
                 match (leading_field, left.as_ref(), right.as_ref()) {
-                    (_, SQLExpr::Value(_), SQLExpr::Value(_)) => {
+                    (_, _, SQLExpr::Value(_)) => {
                         let left_expr = self.sql_interval_to_expr(
                             *left,
                             schema,
@@ -239,8 +239,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // In this case, the left node is part of the interval
                     // expr and the right node is an independent expr.
                     //
-                    // Leading field is not supported when either the left or
-                    // right is not a value.
+                    // Leading field is not supported when the right operand
+                    // is not a value.
                     (None, _, _) => {
                         let left_expr = self.sql_interval_to_expr(
                             *left,

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -165,7 +165,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// expression
     ///
     /// Waiting for this issue to be resolved:
-    /// https://github.com/sqlparser-rs/sqlparser-rs/issues/869
+    /// `<https://github.com/sqlparser-rs/sqlparser-rs/issues/869>`
     #[allow(clippy::too_many_arguments)]
     pub(super) fn sql_interval_to_expr(
         &self,

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -200,15 +200,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLExpr::Value(
                 Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
             ) => s,
-            // Support expressions like `interval '1 month' + date/timestamp`. 
-            // Such expressions are parsed like this by sqlparser-rs 
-            // 
+            // Support expressions like `interval '1 month' + date/timestamp`.
+            // Such expressions are parsed like this by sqlparser-rs
+            //
             // Interval
-            // BinaryOp
-            //   Value(StringLiteral)
-            //   Cast
+            //   BinaryOp
             //     Value(StringLiteral)
-            // 
+            //     Cast
+            //       Value(StringLiteral)
+            //
             // This code rewrites them to the following:
             //
             // BinaryOp

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -200,6 +200,22 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLExpr::Value(
                 Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
             ) => s,
+            // Support expressions like `interval '1 month' + date/timestamp`. 
+            // Such expressions are parsed like this by sqlparser-rs 
+            // 
+            // Interval
+            // BinaryOp
+            //   Value(StringLiteral)
+            //   Cast
+            //     Value(StringLiteral)
+            // 
+            // This code rewrites them to the following:
+            //
+            // BinaryOp
+            //   Interval
+            //     Value(StringLiteral)
+            //   Cast
+            //      Value(StringLiteral)
             SQLExpr::BinaryOp { left, op, right } => {
                 let df_op = match op {
                     BinaryOperator::Plus => Operator::Plus,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6205.

# Rationale for this change

Due to sqlparser lack of semantic, we need to rewrite the AST in datafusion.

For example, this is valid in sqlparser:

```
SELECT INTERVAL `1 month` + `1 month`
```

This is also valid:

```
SELECT INTERVAL '1 month' + '2012-01-01'::date;
```

Both generates structurally similar interval expression with BinaryOp +.

The first statement generates the following AST (SELECT omitted):

```
Interval
  BinaryOp
     Value(StringLiteral)
     Value(StringLiteral)
```

The second statement generates the following AST (SELECT omitted):

```
Interval
  BinaryOp
     Value(StringLiteral)
     Cast
       Value(StringLiteral)
```

I don't think this can be handled in sqlparser because sqlparser doesn't have the semantic to understand which BinaryOp + cast is and isn't allowed.

This PR transforms the 2nd AST (or any AST with non string literal value in right operand) into:

```
BinaryOp
  Interval
    Value(StringLiteral)
  Cast
     Value(StringLiteral)
```

# What changes are included in this PR?

- Modify parser to allow for interval + date in a select statement.
- Add some test cases

# Are these changes tested?

Yes

# Are there any user-facing changes?

No