### PR TITLE
refactor: Expr::Exists to use a struct.

### DIFF
--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -18,7 +18,7 @@
 //! Functions for creating logical expressions
 
 use crate::expr::{
-    AggregateFunction, BinaryExpr, Cast, GroupingSet, ScalarFunction, TryCast,
+    AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, ScalarFunction, TryCast,
 };
 use crate::{
     aggregate_function, built_in_function, conditional_expressions::CaseBuilder,
@@ -307,25 +307,25 @@ pub fn approx_percentile_cont_with_weight(
 /// Create an EXISTS subquery expression
 pub fn exists(subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::Exists {
+    Expr::Exists(Exists {
         subquery: Subquery {
             subquery,
             outer_ref_columns,
         },
         negated: false,
-    }
+    })
 }
 
 /// Create a NOT EXISTS subquery expression
 pub fn not_exists(subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::Exists {
+    Expr::Exists(Exists {
         subquery: Subquery {
             subquery,
             outer_ref_columns,
         },
         negated: true,
-    }
+    })
 }
 
 /// Create an IN subquery expression

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::expr::Exists;
 ///! Logical plan types
 use crate::logical_plan::display::{GraphvizVisitor, IndentVisitor};
 use crate::logical_plan::extension::UserDefinedLogicalNode;
@@ -544,7 +545,7 @@ impl LogicalPlan {
             // recursively look for subqueries
             inspect_expr_pre(expr, |expr| {
                 match expr {
-                    Expr::Exists { subquery, .. }
+                    Expr::Exists(Exists { subquery, .. })
                     | Expr::InSubquery { subquery, .. }
                     | Expr::ScalarSubquery(subquery) => {
                         // use a synthetic plan so the collector sees a
@@ -570,7 +571,7 @@ impl LogicalPlan {
             // recursively look for subqueries
             inspect_expr_pre(expr, |expr| {
                 match expr {
-                    Expr::Exists { subquery, .. }
+                    Expr::Exists(Exists { subquery, .. })
                     | Expr::InSubquery { subquery, .. }
                     | Expr::ScalarSubquery(subquery) => {
                         // use a synthetic plan so the visitor sees a

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -20,7 +20,7 @@ use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::{Column, DFField, DFSchema, DFSchemaRef, Result};
 use datafusion_expr::expr::AggregateFunction;
 use datafusion_expr::utils::COUNT_STAR_EXPANSION;
-use datafusion_expr::Expr::{Exists, InSubquery, ScalarSubquery};
+use datafusion_expr::Expr::{InSubquery, ScalarSubquery};
 use datafusion_expr::{
     aggregate_function, count, expr, lit, window_function, Aggregate, Expr, Filter,
     LogicalPlan, Projection, Sort, Subquery, Window,
@@ -211,20 +211,20 @@ impl TreeNodeRewriter for CountWildcardRewriter {
                     negated,
                 }
             }
-            Exists { subquery, negated } => {
+            Expr::Exists(expr::Exists { subquery, negated }) => {
                 let new_plan = subquery
                     .subquery
                     .as_ref()
                     .clone()
                     .transform_down(&analyze_internal)?;
 
-                Exists {
+                Expr::Exists(expr::Exists {
                     subquery: Subquery {
                         subquery: Arc::new(new_plan),
                         outer_ref_columns: subquery.outer_ref_columns,
                     },
                     negated,
-                }
+                })
             }
             _ => old_expr,
         };

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -23,6 +23,7 @@ use crate::analyzer::AnalyzerRule;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::Result;
+use datafusion_expr::expr::Exists;
 use datafusion_expr::{
     logical_plan::LogicalPlan, Expr, Filter, LogicalPlanBuilder, TableScan,
 };
@@ -84,11 +85,11 @@ fn analyze_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
 
 fn rewrite_subquery(expr: Expr) -> Result<Transformed<Expr>> {
     match expr {
-        Expr::Exists { subquery, negated } => {
+        Expr::Exists(Exists { subquery, negated }) => {
             let plan = subquery.subquery.as_ref().clone();
             let new_plan = plan.transform_up(&analyze_internal)?;
             let subquery = subquery.with_plan(Arc::new(new_plan));
-            Ok(Transformed::Yes(Expr::Exists { subquery, negated }))
+            Ok(Transformed::Yes(Expr::Exists(Exists { subquery, negated })))
         }
         Expr::InSubquery {
             expr,

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -29,6 +29,7 @@ use crate::utils::log_plan;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{TreeNode, VisitRecursion};
 use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::expr::Exists;
 use datafusion_expr::utils::inspect_expr_pre;
 use datafusion_expr::{Expr, LogicalPlan};
 use log::debug;
@@ -119,7 +120,7 @@ fn check_plan(plan: &LogicalPlan) -> Result<()> {
         for expr in plan.expressions().iter() {
             // recursively look for subqueries
             inspect_expr_pre(expr, |expr| match expr {
-                Expr::Exists { subquery, .. }
+                Expr::Exists(Exists { subquery, .. })
                 | Expr::InSubquery { subquery, .. }
                 | Expr::ScalarSubquery(subquery) => {
                     check_subquery_expr(plan, &subquery.subquery, expr)

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -25,7 +25,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{RewriteRecursion, TreeNodeRewriter};
 use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue};
 use datafusion_expr::expr::{
-    self, Between, BinaryExpr, Case, Like, ScalarFunction, ScalarUDF, WindowFunction,
+    self, Between, BinaryExpr, Case, Exists, Like, ScalarFunction, ScalarUDF,
+    WindowFunction,
 };
 use datafusion_expr::expr_schema::cast_subquery;
 use datafusion_expr::logical_plan::Subquery;
@@ -133,15 +134,15 @@ impl TreeNodeRewriter for TypeCoercionRewriter {
                     outer_ref_columns,
                 }))
             }
-            Expr::Exists { subquery, negated } => {
+            Expr::Exists(Exists { subquery, negated }) => {
                 let new_plan = analyze_internal(&self.schema, &subquery.subquery)?;
-                Ok(Expr::Exists {
+                Ok(Expr::Exists(Exists {
                     subquery: Subquery {
                         subquery: Arc::new(new_plan),
                         outer_ref_columns: subquery.outer_ref_columns,
                     },
                     negated,
-                })
+                }))
             }
             Expr::InSubquery {
                 expr,

--- a/datafusion/optimizer/src/decorrelate_where_exists.rs
+++ b/datafusion/optimizer/src/decorrelate_where_exists.rs
@@ -21,6 +21,7 @@ use crate::utils::{
 };
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::{Column, DataFusionError, Result};
+use datafusion_expr::expr::Exists;
 use datafusion_expr::{
     logical_plan::{Distinct, Filter, JoinType, Subquery},
     Expr, LogicalPlan, LogicalPlanBuilder,
@@ -57,7 +58,7 @@ impl DecorrelateWhereExists {
         let mut others = vec![];
         for it in filters.iter() {
             match it {
-                Expr::Exists { subquery, negated } => {
+                Expr::Exists(Exists { subquery, negated }) => {
                     let subquery_plan = self
                         .try_optimize(&subquery.subquery, config)?
                         .map(Arc::new)

--- a/datafusion/sql/src/expr/subquery.rs
+++ b/datafusion/sql/src/expr/subquery.rs
@@ -17,6 +17,7 @@
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{DFSchema, Result};
+use datafusion_expr::expr::Exists;
 use datafusion_expr::{Expr, Subquery};
 use sqlparser::ast::Expr as SQLExpr;
 use sqlparser::ast::Query;
@@ -35,13 +36,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let sub_plan = self.query_to_plan(subquery, planner_context)?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
-        Ok(Expr::Exists {
+        Ok(Expr::Exists(Exists {
             subquery: Subquery {
                 subquery: Arc::new(sub_plan),
                 outer_ref_columns,
             },
             negated,
-        })
+        }))
     }
 
     pub(super) fn parse_in_subquery(


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/2175 and https://github.com/apache/arrow-datafusion/issues/3807.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Refactor Expr::Exists to a struct.

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->