### PR TITLE
Refactor: Expr::InSubquery to use a struct

### DIFF
--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -90,7 +90,7 @@ pub fn expr_applicable_for_cols(col_names: &[String], expr: &Expr) -> bool {
             | Expr::SimilarTo { .. }
             | Expr::InList { .. }
             | Expr::Exists { .. }
-            | Expr::InSubquery { .. }
+            | Expr::InSubquery(_)
             | Expr::ScalarSubquery(_)
             | Expr::GetIndexedField { .. }
             | Expr::GroupingSet(_)

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -258,7 +258,7 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
         Expr::Exists { .. } => Err(DataFusionError::NotImplemented(
             "EXISTS is not yet supported in the physical plan".to_string(),
         )),
-        Expr::InSubquery { .. } => Err(DataFusionError::NotImplemented(
+        Expr::InSubquery(_) => Err(DataFusionError::NotImplemented(
             "IN subquery is not yet supported in the physical plan".to_string(),
         )),
         Expr::ScalarSubquery(_) => Err(DataFusionError::NotImplemented(

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -18,8 +18,8 @@
 //! Functions for creating logical expressions
 
 use crate::expr::{
-    AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, InList, ScalarFunction,
-    TryCast,
+    AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, InList, InSubquery,
+    ScalarFunction, TryCast,
 };
 use crate::{
     aggregate_function, built_in_function, conditional_expressions::CaseBuilder,
@@ -328,27 +328,27 @@ pub fn not_exists(subquery: Arc<LogicalPlan>) -> Expr {
 /// Create an IN subquery expression
 pub fn in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::InSubquery {
-        expr: Box::new(expr),
-        subquery: Subquery {
+    Expr::InSubquery(InSubquery::new(
+        Box::new(expr),
+        Subquery {
             subquery,
             outer_ref_columns,
         },
-        negated: false,
-    }
+        false,
+    ))
 }
 
 /// Create a NOT IN subquery expression
 pub fn not_in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::InSubquery {
-        expr: Box::new(expr),
-        subquery: Subquery {
+    Expr::InSubquery(InSubquery::new(
+        Box::new(expr),
+        Subquery {
             subquery,
             outer_ref_columns,
         },
-        negated: true,
-    }
+        true,
+    ))
 }
 
 /// Create a scalar subquery expression

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -18,7 +18,7 @@
 use super::{Between, Expr, Like};
 use crate::expr::{
     AggregateFunction, AggregateUDF, BinaryExpr, Cast, GetIndexedField, InList,
-    ScalarFunction, ScalarUDF, Sort, TryCast, WindowFunction,
+    InSubquery, ScalarFunction, ScalarUDF, Sort, TryCast, WindowFunction,
 };
 use crate::field_util::get_indexed_field;
 use crate::type_coercion::binary::get_result_type;
@@ -133,7 +133,7 @@ impl ExprSchemable for Expr {
             Expr::Not(_)
             | Expr::IsNull(_)
             | Expr::Exists { .. }
-            | Expr::InSubquery { .. }
+            | Expr::InSubquery(_)
             | Expr::Between { .. }
             | Expr::InList { .. }
             | Expr::IsNotNull(_)
@@ -232,7 +232,7 @@ impl ExprSchemable for Expr {
             | Expr::IsNotUnknown(_)
             | Expr::Exists { .. }
             | Expr::Placeholder { .. } => Ok(true),
-            Expr::InSubquery { expr, .. } => expr.nullable(input_schema),
+            Expr::InSubquery(InSubquery { expr, .. }) => expr.nullable(input_schema),
             Expr::ScalarSubquery(subquery) => {
                 Ok(subquery.subquery.schema().field(0).is_nullable())
             }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::expr::Exists;
+use crate::expr::InSubquery;
 ///! Logical plan types
 use crate::logical_plan::display::{GraphvizVisitor, IndentVisitor};
 use crate::logical_plan::extension::UserDefinedLogicalNode;
@@ -546,7 +547,7 @@ impl LogicalPlan {
             inspect_expr_pre(expr, |expr| {
                 match expr {
                     Expr::Exists(Exists { subquery, .. })
-                    | Expr::InSubquery { subquery, .. }
+                    | Expr::InSubquery(InSubquery { subquery, .. })
                     | Expr::ScalarSubquery(subquery) => {
                         // use a synthetic plan so the collector sees a
                         // LogicalPlan::Subquery (even though it is
@@ -572,7 +573,7 @@ impl LogicalPlan {
             inspect_expr_pre(expr, |expr| {
                 match expr {
                     Expr::Exists(Exists { subquery, .. })
-                    | Expr::InSubquery { subquery, .. }
+                    | Expr::InSubquery(InSubquery { subquery, .. })
                     | Expr::ScalarSubquery(subquery) => {
                         // use a synthetic plan so the visitor sees a
                         // LogicalPlan::Subquery (even though it is

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -303,7 +303,7 @@ pub fn expr_to_columns(expr: &Expr, accum: &mut HashSet<Column>) -> Result<()> {
             | Expr::AggregateUDF { .. }
             | Expr::InList { .. }
             | Expr::Exists { .. }
-            | Expr::InSubquery { .. }
+            | Expr::InSubquery(_)
             | Expr::ScalarSubquery(_)
             | Expr::Wildcard
             | Expr::QualifiedWildcard { .. }
@@ -704,7 +704,7 @@ pub fn from_plan(
                     match expr {
                         Expr::Exists { .. }
                         | Expr::ScalarSubquery(_)
-                        | Expr::InSubquery { .. } => {
+                        | Expr::InSubquery(_) => {
                             // subqueries could contain aliases so we don't recurse into those
                             Ok(RewriteRecursion::Stop)
                         }

--- a/datafusion/optimizer/README.md
+++ b/datafusion/optimizer/README.md
@@ -201,7 +201,7 @@ fn extract_subquery_filters(expression: &Expr, extracted: &mut Vec<Expr>) -> Res
 
     impl ExpressionVisitor for InSubqueryVisitor<'_> {
         fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>> {
-            if let Expr::InSubquery { .. } = expr {
+            if let Expr::InSubquery(_) = expr {
                 self.accum.push(expr.to_owned());
             }
             Ok(Recursion::Continue(self))

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -18,9 +18,9 @@
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::{Column, DFField, DFSchema, DFSchemaRef, Result};
-use datafusion_expr::expr::AggregateFunction;
+use datafusion_expr::expr::{AggregateFunction, InSubquery};
 use datafusion_expr::utils::COUNT_STAR_EXPANSION;
-use datafusion_expr::Expr::{InSubquery, ScalarSubquery};
+use datafusion_expr::Expr::ScalarSubquery;
 use datafusion_expr::{
     aggregate_function, count, expr, lit, window_function, Aggregate, Expr, Filter,
     LogicalPlan, Projection, Sort, Subquery, Window,
@@ -191,25 +191,25 @@ impl TreeNodeRewriter for CountWildcardRewriter {
                     outer_ref_columns,
                 })
             }
-            InSubquery {
+            Expr::InSubquery(InSubquery {
                 expr,
                 subquery,
                 negated,
-            } => {
+            }) => {
                 let new_plan = subquery
                     .subquery
                     .as_ref()
                     .clone()
                     .transform_down(&analyze_internal)?;
 
-                InSubquery {
+                Expr::InSubquery(InSubquery::new(
                     expr,
-                    subquery: Subquery {
+                    Subquery {
                         subquery: Arc::new(new_plan),
                         outer_ref_columns: subquery.outer_ref_columns,
                     },
                     negated,
-                }
+                ))
             }
             Expr::Exists(expr::Exists { subquery, negated }) => {
                 let new_plan = subquery

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -24,6 +24,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::Result;
 use datafusion_expr::expr::Exists;
+use datafusion_expr::expr::InSubquery;
 use datafusion_expr::{
     logical_plan::LogicalPlan, Expr, Filter, LogicalPlanBuilder, TableScan,
 };
@@ -91,19 +92,17 @@ fn rewrite_subquery(expr: Expr) -> Result<Transformed<Expr>> {
             let subquery = subquery.with_plan(Arc::new(new_plan));
             Ok(Transformed::Yes(Expr::Exists(Exists { subquery, negated })))
         }
-        Expr::InSubquery {
+        Expr::InSubquery(InSubquery {
             expr,
             subquery,
             negated,
-        } => {
+        }) => {
             let plan = subquery.subquery.as_ref().clone();
             let new_plan = plan.transform_up(&analyze_internal)?;
             let subquery = subquery.with_plan(Arc::new(new_plan));
-            Ok(Transformed::Yes(Expr::InSubquery {
-                expr,
-                subquery,
-                negated,
-            }))
+            Ok(Transformed::Yes(Expr::InSubquery(InSubquery::new(
+                expr, subquery, negated,
+            ))))
         }
         Expr::ScalarSubquery(subquery) => {
             let plan = subquery.subquery.as_ref().clone();

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -30,6 +30,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{TreeNode, VisitRecursion};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::expr::Exists;
+use datafusion_expr::expr::InSubquery;
 use datafusion_expr::utils::inspect_expr_pre;
 use datafusion_expr::{Expr, LogicalPlan};
 use log::debug;
@@ -121,7 +122,7 @@ fn check_plan(plan: &LogicalPlan) -> Result<()> {
             // recursively look for subqueries
             inspect_expr_pre(expr, |expr| match expr {
                 Expr::Exists(Exists { subquery, .. })
-                | Expr::InSubquery { subquery, .. }
+                | Expr::InSubquery(InSubquery { subquery, .. })
                 | Expr::ScalarSubquery(subquery) => {
                     check_subquery_expr(plan, &subquery.subquery, expr)
                 }

--- a/datafusion/optimizer/src/decorrelate_where_in.rs
+++ b/datafusion/optimizer/src/decorrelate_where_in.rs
@@ -23,6 +23,7 @@ use crate::utils::{
 };
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::{context, Column, Result};
+use datafusion_expr::expr::InSubquery;
 use datafusion_expr::expr_rewriter::unnormalize_col;
 use datafusion_expr::logical_plan::{JoinType, Projection, Subquery};
 use datafusion_expr::{Expr, Filter, LogicalPlan, LogicalPlanBuilder};
@@ -59,11 +60,11 @@ impl DecorrelateWhereIn {
         let mut others = vec![];
         for it in filters.iter() {
             match it {
-                Expr::InSubquery {
+                Expr::InSubquery(InSubquery {
                     expr,
                     subquery,
                     negated,
-                } => {
+                }) => {
                     let subquery_plan = self
                         .try_optimize(&subquery.subquery, config)?
                         .map(Arc::new)

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -157,7 +157,7 @@ fn can_evaluate_as_join_condition(predicate: &Expr) -> Result<bool> {
         | Expr::Placeholder { .. }
         | Expr::ScalarVariable(_, _) => Ok(VisitRecursion::Skip),
         Expr::Exists { .. }
-        | Expr::InSubquery { .. }
+        | Expr::InSubquery(_)
         | Expr::ScalarSubquery(_)
         | Expr::OuterReferenceColumn(_, _)
         | Expr::ScalarUDF(..) => {

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -895,12 +895,12 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
                 expr_type: Some(ExprType::Wildcard(true)),
             },
             Expr::ScalarSubquery(_)
-            | Expr::InSubquery { .. }
+            | Expr::InSubquery(_)
             | Expr::Exists { .. }
             | Expr::OuterReferenceColumn { .. } => {
                 // we would need to add logical plan operators to datafusion.proto to support this
                 // see discussion in https://github.com/apache/arrow-datafusion/issues/2565
-                return Err(Error::General("Proto serialization error: Expr::ScalarSubquery(_) | Expr::InSubquery { .. } | Expr::Exists { .. } | Exp:OuterReferenceColumn not supported".to_string()));
+                return Err(Error::General("Proto serialization error: Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists { .. } | Exp:OuterReferenceColumn not supported".to_string()));
             }
             Expr::GetIndexedField(GetIndexedField { key, expr }) => Self {
                 expr_type: Some(ExprType::GetIndexedField(Box::new(

--- a/datafusion/sql/src/expr/subquery.rs
+++ b/datafusion/sql/src/expr/subquery.rs
@@ -18,6 +18,7 @@
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{DFSchema, Result};
 use datafusion_expr::expr::Exists;
+use datafusion_expr::expr::InSubquery;
 use datafusion_expr::{Expr, Subquery};
 use sqlparser::ast::Expr as SQLExpr;
 use sqlparser::ast::Query;
@@ -59,14 +60,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
         let expr = Box::new(self.sql_to_expr(expr, input_schema, planner_context)?);
-        Ok(Expr::InSubquery {
+        Ok(Expr::InSubquery(InSubquery::new(
             expr,
-            subquery: Subquery {
+            Subquery {
                 subquery: Arc::new(sub_plan),
                 outer_ref_columns,
             },
             negated,
-        })
+        )))
     }
 
     pub(super) fn parse_scalar_subquery(

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -23,7 +23,7 @@ use sqlparser::ast::Ident;
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::expr::{
     AggregateFunction, AggregateUDF, Between, BinaryExpr, Case, GetIndexedField,
-    GroupingSet, InList, Like, ScalarFunction, ScalarUDF, WindowFunction,
+    GroupingSet, InList, InSubquery, Like, ScalarFunction, ScalarUDF, WindowFunction,
 };
 use datafusion_expr::expr::{Cast, Sort};
 use datafusion_expr::utils::{expr_as_column_expr, find_column_exprs};
@@ -368,15 +368,15 @@ where
             | Expr::ScalarVariable(_, _)
             | Expr::Exists { .. }
             | Expr::ScalarSubquery(_) => Ok(expr.clone()),
-            Expr::InSubquery {
+            Expr::InSubquery(InSubquery {
                 expr: nested_expr,
                 subquery,
                 negated,
-            } => Ok(Expr::InSubquery {
-                expr: Box::new(clone_with_replacement(nested_expr, replacement_fn)?),
-                subquery: subquery.clone(),
-                negated: *negated,
-            }),
+            }) => Ok(Expr::InSubquery(InSubquery::new(
+                Box::new(clone_with_replacement(nested_expr, replacement_fn)?),
+                subquery.clone(),
+                *negated,
+            ))),
             Expr::Wildcard => Ok(Expr::Wildcard),
             Expr::QualifiedWildcard { .. } => Ok(expr.clone()),
             Expr::GetIndexedField(GetIndexedField { key, expr }) => {


### PR DESCRIPTION
# Which issue does this PR close?

Related to #2175 and #3807.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Refactor Expr::InSubquery to use a struct.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->