### PR TITLE
RFC: Implement initial support for `COPY ... TO ... ` statement

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -31,10 +31,10 @@ use crate::{
         optimizer::PhysicalOptimizerRule,
     },
 };
-use arrow_array::{UInt64Array, ArrayRef};
+use arrow_array::{ArrayRef, UInt64Array};
 use datafusion_expr::{
     logical_plan::{DdlStatement, Statement},
-    DescribeTable, StringifiedPlan, CopyTo,
+    CopyTo, DescribeTable, StringifiedPlan,
 };
 pub use datafusion_physical_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::var_provider::is_system_variables;
@@ -397,9 +397,7 @@ impl SessionContext {
             LogicalPlan::DescribeTable(DescribeTable { schema, .. }) => {
                 self.return_describe_table_dataframe(schema).await
             }
-            LogicalPlan::CopyTo(cmd) => {
-                self.copy_to(cmd).await
-            }
+            LogicalPlan::CopyTo(cmd) => self.copy_to(cmd).await,
             plan => Ok(DataFrame::new(self.state(), plan)),
         }
     }
@@ -459,12 +457,13 @@ impl SessionContext {
 
     // Execute a COPY TO statement, returning the number of rows
     // returned.
-    async fn copy_to(
-        &self,
-        cmd: CopyTo
-    ) -> Result<DataFrame> {
-        let CopyTo { input, target, options, dummy_schema } = cmd;
-
+    async fn copy_to(&self, cmd: CopyTo) -> Result<DataFrame> {
+        let CopyTo {
+            input,
+            target,
+            options,
+            dummy_schema,
+        } = cmd;
 
         // TODO avoid clone if possible
         let input = Arc::try_unwrap(input).unwrap_or_else(|e| e.as_ref().clone());
@@ -478,11 +477,13 @@ impl SessionContext {
             physical.create_physical_plan().await?,
             target,
             props,
-        ).await?;
+        )
+        .await?;
 
-        let record_batch = RecordBatch::try_from_iter(vec![
-            ("num_row", Arc::new(UInt64Array::from_iter_values([num_rows])) as ArrayRef)
-        ])?;
+        let record_batch = RecordBatch::try_from_iter(vec![(
+            "num_row",
+            Arc::new(UInt64Array::from_iter_values([num_rows])) as ArrayRef,
+        )])?;
 
         self.read_batch(record_batch)
     }

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -31,9 +31,10 @@ use crate::{
         optimizer::PhysicalOptimizerRule,
     },
 };
+use arrow_array::{UInt64Array, ArrayRef};
 use datafusion_expr::{
     logical_plan::{DdlStatement, Statement},
-    DescribeTable, StringifiedPlan,
+    DescribeTable, StringifiedPlan, CopyTo,
 };
 pub use datafusion_physical_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::var_provider::is_system_variables;
@@ -396,7 +397,9 @@ impl SessionContext {
             LogicalPlan::DescribeTable(DescribeTable { schema, .. }) => {
                 self.return_describe_table_dataframe(schema).await
             }
-
+            LogicalPlan::CopyTo(cmd) => {
+                self.copy_to(cmd).await
+            }
             plan => Ok(DataFrame::new(self.state(), plan)),
         }
     }
@@ -451,6 +454,36 @@ impl SessionContext {
         schema: Arc<Schema>,
     ) -> Result<DataFrame> {
         let record_batch = self.return_describe_table_record_batch(schema).await?;
+        self.read_batch(record_batch)
+    }
+
+    // Execute a COPY TO statement, returning the number of rows
+    // returned.
+    async fn copy_to(
+        &self,
+        cmd: CopyTo
+    ) -> Result<DataFrame> {
+        let CopyTo { input, target, options, dummy_schema } = cmd;
+
+
+        // TODO avoid clone if possible
+        let input = Arc::try_unwrap(input).unwrap_or_else(|e| e.as_ref().clone());
+        let physical = DataFrame::new(self.state(), input);
+        let num_rows = 0;
+
+        // TODO build writer props
+        let props = None;
+        plan_to_parquet(
+            self.task_ctx(),
+            physical.create_physical_plan().await?,
+            target,
+            props,
+        ).await?;
+
+        let record_batch = RecordBatch::try_from_iter(vec![
+            ("num_row", Arc::new(UInt64Array::from_iter_values([num_rows])) as ArrayRef)
+        ])?;
+
         self.read_batch(record_batch)
     }
 

--- a/datafusion/core/src/physical_plan/copy.rs
+++ b/datafusion/core/src/physical_plan/copy.rs
@@ -1,0 +1,207 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution plan for copying data to DataSinks
+
+use super::expressions::PhysicalSortExpr;
+use super::{
+    DisplayFormatType, ExecutionPlan, Partitioning,
+    SendableRecordBatchStream, Statistics,
+};
+use crate::error::Result;
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use arrow_array::UInt64Array;
+use arrow_schema::{Schema, DataType, Field};
+use datafusion_common::DataFusionError;
+use futures::future::BoxFuture;
+use futures::{StreamExt, TryStreamExt};
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::execution::context::TaskContext;
+use crate::physical_plan::stream::RecordBatchStreamAdapter;
+use crate::physical_plan::Distribution;
+
+/// The DataSink implements writing streams of [`RecordBatch`]es to
+/// partitioned destinations
+pub trait DataSink: std::fmt::Debug + std::fmt::Display + Send + Sync {
+
+    /// How does this sink want its input distributed?
+    fn required_input_distribution(&self) -> Distribution;
+
+    /// return a future which writes a RecordBatchStream to a particular partition
+    /// and return the number of rows written
+    fn write_stream(&self, partition: usize, input: SendableRecordBatchStream) -> BoxFuture<Result<u64>>;
+
+}
+
+
+/// Execution plan for writing batches to DataSink
+///
+/// The output is a single RecordBatch with a single UInt64 column
+/// representing the total number of rows written
+#[derive(Debug)]
+pub struct CopyExec {
+    /// Input plan that produces the record batches to be written.
+    input: Arc<dyn ExecutionPlan>,
+    /// The output
+    sink: Arc<dyn DataSink>,
+    /// Schema describing the structure of the data.
+    schema: SchemaRef,
+}
+
+impl ExecutionPlan for CopyExec {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Get the schema for this execution plan
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        // single output partition
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn benefits_from_input_partitioning(&self) -> bool {
+        // don't automatically repartition this
+        false
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![self.sink.required_input_distribution()]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(CopyExec::new(
+            children[0].clone(),
+            self.sink.clone(),
+        )))
+    }
+
+    /// Execute the plan and return a stream of record batches for the specified partition.
+    /// Depending on the number of input partitions and MemTable partitions, it will choose
+    /// either a less lock acquiring or a locked implementation.
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let schema = self.schema.clone();
+        assert_eq!(partition, 0);
+
+        // Launch tasks for all input's partitions and flatten them together
+        let partition_count = self.input.output_partitioning().partition_count();
+
+        // fire up tasks that will run in parallel.
+        let sink = self.sink.clone();
+        let input = self.input.clone();
+
+        // make a future which will run all the input streams in
+        // parallel and produce a single result
+        let future = async move {
+            let mut input_futures = Vec::with_capacity(partition_count);
+            for i in 0..partition_count {
+                let input_stream = input.execute(i, context.clone())?;
+                input_futures.push(sink.write_stream(i, input_stream));
+            }
+
+            let counts: Vec<_> = futures::stream::iter(input_futures)
+            // run all the streams in parallel
+                .buffer_unordered(partition_count)
+                .try_collect()
+                .await?;
+
+            // sum them all up and make a record batch
+            let total_size = counts.iter().sum::<u64>();
+
+            let batch = RecordBatch::try_from_iter(vec![
+                ("total_rows", Arc::new(UInt64Array::from_iter_values(vec![total_size])) as _)
+            ])?;
+            Ok(batch) as Result<RecordBatch, DataFusionError>
+        };
+
+        let stream = futures::stream::once(future).boxed();
+
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(
+                    f,
+                    "CopyExec: sink={}, input_partition={}",
+                    self.sink,
+                    self.input.output_partitioning().partition_count()
+                )
+            }
+        }
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}
+
+impl CopyExec {
+    /// Create a new execution plan for reading in-memory record batches
+    /// and sending them to the DataSink
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        sink: Arc<dyn DataSink>,
+    ) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("total_rows", DataType::UInt64, false),
+        ]));
+
+        Self {
+            input,
+            sink,
+            schema,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO
+}

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -27,7 +27,7 @@ mod parquet;
 
 pub(crate) use self::csv::plan_to_csv;
 pub use self::csv::{CsvConfig, CsvExec, CsvOpener};
-pub(crate) use self::parquet::plan_to_parquet;
+pub(crate) use self::parquet::{plan_to_parquet, ParquetSink};
 pub use self::parquet::{ParquetExec, ParquetFileMetrics, ParquetFileReaderFactory};
 use arrow::{
     array::{ArrayData, ArrayRef, BufferBuilder, DictionaryArray},

--- a/datafusion/core/src/physical_plan/file_format/parquet.rs
+++ b/datafusion/core/src/physical_plan/file_format/parquet.rs
@@ -663,7 +663,7 @@ impl ParquetFileReaderFactory for DefaultParquetFileReaderFactory {
 }
 
 #[derive(Debug)]
-struct ParquetSink {
+pub struct ParquetSink {
     fs_path: PathBuf,
     writer_properties: Option<WriterProperties>,
 }
@@ -680,6 +680,7 @@ impl DataSink for ParquetSink {
         Distribution::UnspecifiedDistribution
     }
 
+    /// writes partition to a specific output partition
     fn write_stream(&self, partition: usize, input: SendableRecordBatchStream) -> BoxFuture<Result<u64>> {
         let filename = format!("part-{partition}.parquet");
         let path = self.fs_path.join(filename);
@@ -712,7 +713,7 @@ impl DataSink for ParquetSink {
 }
 
 impl ParquetSink {
-    fn try_new(
+    pub fn try_new(
         path: impl AsRef<str>,
         writer_properties: Option<WriterProperties>,
     ) -> Result<Self> {

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! TODO: rewite in terms of COPY command
 //! Execution plan for reading in-memory batches of data
 
 use super::expressions::PhysicalSortExpr;

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -658,6 +658,7 @@ pub mod analyze;
 pub mod coalesce_batches;
 pub mod coalesce_partitions;
 pub mod common;
+pub mod copy;
 pub mod display;
 pub mod empty;
 pub mod explain;

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1183,6 +1183,11 @@ impl DefaultPhysicalPlanner {
                         "Unsupported logical plan: DescribeTable must be root of the plan".to_string(),
                     ))
                 }
+                LogicalPlan::CopyTo(_) => {
+                    Err(DataFusionError::NotImplemented(
+                        format!("Physical plan not yet impelemnted for COPY statement")
+                    ))
+                }
                 LogicalPlan::Explain(_) => Err(DataFusionError::Internal(
                     "Unsupported logical plan: Explain must be root of the plan".to_string(),
                 )),

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -1184,8 +1184,10 @@ impl DefaultPhysicalPlanner {
                     ))
                 }
                 LogicalPlan::CopyTo(_) => {
+                    // There is no plan for CopyTo statements -- they
+                    // must be handled at a higher level
                     Err(DataFusionError::NotImplemented(
-                        format!("Physical plan not yet impelemnted for COPY statement")
+                        format!("Unsupported logical plan: CopyTo")
                     ))
                 }
                 LogicalPlan::Explain(_) => Err(DataFusionError::Internal(

--- a/datafusion/core/tests/sqllogictests/test_files/copy.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/copy.slt
@@ -22,19 +22,31 @@ create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 
 
 # create an external parquet file
 # TODO figure out how to use a real tempfile name
+#statement ok
+#COPY source_table to '/tmp/table.parquet';
+
+
+# create an external parquet file from a query
+# TODO figure out how to use a real tempfile name
 statement ok
-COPY source_table to '/tmp/table.parquet';
+COPY (select col2, sum(col1) from source_table group by col2 order by col2)  to '/tmp/table.parquet';
 
 # Read the data back in
 statement ok
 CREATE external table new_table STORED as PARQUET LOCATION '/tmp/table.parquet';
 
 # Read the data back in
-query
+query IT
 select * from new_table;
+----
+1 Foo
+2 Bar
 
 statement ok
 drop table new_table;
+
+
+
 
 
 

--- a/datafusion/core/tests/sqllogictests/test_files/copy.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/copy.slt
@@ -46,6 +46,10 @@ statement ok
 drop table new_table;
 
 
+# TODO error cases:
+# incomplete statement
+# pass non literal to COPY options
+
 
 
 

--- a/datafusion/core/tests/sqllogictests/test_files/copy.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/copy.slt
@@ -18,13 +18,28 @@
 # tests for copy command
 
 statement ok
-create table test_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 'Bar');
+create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 'Bar');
 
 # create an external parquet file
 # TODO figure out how to use a real tempfile name
-COPY test_table to '/tmp/test_table.parquet';
+statement ok
+COPY source_table to '/tmp/table.parquet';
+
+# Read the data back in
+statement ok
+CREATE external table new_table STORED as PARQUET LOCATION '/tmp/table.parquet';
+
+# Read the data back in
+query
+select * from new_table;
+
+statement ok
+drop table new_table;
 
 
+
+# TODO add support for reading directly for files without needing to create an external table
+# (TODO find ticket)
 
 
 
@@ -46,4 +61,4 @@ COPY test_table to '/tmp/test_table.parquet';
 
 
 statement ok
-drop table test_table;
+drop table source_table;

--- a/datafusion/core/tests/sqllogictests/test_files/copy.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/copy.slt
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# tests for copy command
+
+statement ok
+create table test_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 'Bar');
+
+# create an external parquet file
+# TODO figure out how to use a real tempfile name
+COPY test_table to '/tmp/test_table.parquet';
+
+
+
+
+
+# TODO test copying to partitioned target (directory)
+
+
+# TODO test copying with options
+
+
+
+# TODO test query source
+
+
+
+# TODO: support CSV, JSON and AVRO
+
+# TODO: document different options
+
+
+
+statement ok
+drop table test_table;

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -22,7 +22,7 @@ use std::{
     sync::Arc,
 };
 
-use datafusion_common::{DFSchemaRef, OwnedTableReference};
+use datafusion_common::{DFSchemaRef, OwnedTableReference, ScalarValue};
 
 use crate::LogicalPlan;
 
@@ -70,7 +70,7 @@ pub struct CopyTo {
     pub target: String,
 
     /// User supplied name/value pairs that are interpreted for each targe type
-    pub options: HashMap<String, String>,
+    pub options: HashMap<String, ScalarValue>,
 
     /// output schema (is empty)
     pub dummy_schema: DFSchemaRef,

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -31,7 +31,7 @@ pub use ddl::{
     CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateMemoryTable,
     CreateView, DdlStatement, DropCatalogSchema, DropTable, DropView,
 };
-pub use dml::{DmlStatement, WriteOp};
+pub use dml::{CopyTo, DmlStatement, WriteOp};
 pub use plan::{
     Aggregate, Analyze, CrossJoin, DescribeTable, Distinct, EmptyRelation, Explain,
     Extension, Filter, Join, JoinConstraint, JoinType, Limit, LogicalPlan, Partitioning,

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -340,7 +340,8 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::Extension(_)
             | LogicalPlan::Dml(_)
             | LogicalPlan::Unnest(_)
-            | LogicalPlan::Prepare(_) => {
+            | LogicalPlan::Prepare(_)
+            | LogicalPlan::CopyTo(_) => {
                 // apply the optimization to all inputs of the plan
                 utils::optimize_children(self, plan, config)?
             }
@@ -784,14 +785,14 @@ mod test {
         )?;
 
         let expected = vec![
-            (9, "(SUM(a + Int32(1)) - AVG(c)) * Int32(2)Int32(2)SUM(a + Int32(1)) - AVG(c)AVG(c)SUM(a + Int32(1))"), 
-            (7, "SUM(a + Int32(1)) - AVG(c)AVG(c)SUM(a + Int32(1))"), 
-            (4, ""), 
-            (3, "a + Int32(1)Int32(1)a"), 
-            (1, ""), 
-            (2, ""), 
-            (6, ""), 
-            (5, ""), 
+            (9, "(SUM(a + Int32(1)) - AVG(c)) * Int32(2)Int32(2)SUM(a + Int32(1)) - AVG(c)AVG(c)SUM(a + Int32(1))"),
+            (7, "SUM(a + Int32(1)) - AVG(c)AVG(c)SUM(a + Int32(1))"),
+            (4, ""),
+            (3, "a + Int32(1)Int32(1)a"),
+            (1, ""),
+            (2, ""),
+            (6, ""),
+            (5, ""),
             (8, "")
         ]
         .into_iter()

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -592,7 +592,8 @@ impl<'a> DFParser<'a> {
     }
 
     /// Parses (key value) style options, but values can only be literal strings
-    /// TODO maybe change this to be real expressions
+    /// TODO maybe change this to be real expressions rather than just strings
+    /// the reason
     fn parse_string_options(&mut self) -> Result<HashMap<String, String>, ParserError> {
         let mut options = HashMap::new();
         self.parser.expect_token(&Token::LParen)?;

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -291,7 +291,6 @@ impl<'a> DFParser<'a> {
 
     /// Parse a SQL `COPY TO` statement
     pub fn parse_copy(&mut self) -> Result<Statement, ParserError> {
-        self.parser.expect_keyword(Keyword::COPY)?;
         // parse as a query
         let source = if self.parser.consume_token(&Token::LParen) {
             let query = self.parser.parse_query()?;

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -1060,4 +1060,18 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn copy_to() -> Result<(), ParserError> {
+        // positive case
+        let sql = "COPY foo TO bar";
+        let expected = Statement::CopyTo(CopyToStatement {
+            source: CopyToSource::Relation(ObjectName(vec![Ident::new("foo")])),
+            target: "bar".to_string(),
+            options: HashMap::new(),
+        });
+        expect_parse_ok(sql, expected)?;
+
+        Ok(())
+    }
 }

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -23,6 +23,7 @@ use sqlparser::ast::TableFactor;
 mod join;
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
+    /// Create a `LogicalPlan` that scans the named relation
     fn create_relation(
         &self,
         relation: TableFactor,


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/5654
Closes https://github.com/apache/arrow-datafusion/issues/5988

# Rationale for this change

1. I would like to to make it easier to test out datafusion (both for new comers as well as when I am trying to benchmark all the things)

# What changes are included in this PR?
(I'll try and break this up into smaller pieces for easier review but I want to show it all working together)

- [x] Initial parser support for `COPY .. TO ...` statements
- [x] New `LogicalPlan::CopyTo` variant
- [x] Planing / Runtime support for copying to Parquet files 
-[ ] Parser tests
-[ ] Add end user  documentation
-[ ] Properly support writing single parquet files
-[ ] sqllogictests

I also plan to file follow on tasks (like support for other file formats, options, etc)

# Are these changes tested?
Yes

# Are there any user-facing changes?
Yes there is a new (documented) statement
