### PR TITLE
refine decimal multiply, avoid cast to wider type

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -514,7 +514,7 @@ pub fn coercion_decimal_mathematics_type(
                 left_decimal_type,
                 right_decimal_type,
             ),
-            Operator::Multiply | Operator::Divide | Operator::Modulo => {
+            Operator::Divide | Operator::Modulo => {
                 get_wider_decimal_type(left_decimal_type, right_decimal_type)
             }
             _ => None,
@@ -946,7 +946,7 @@ mod tests {
             &left_decimal_type,
             &right_decimal_type,
         );
-        assert_eq!(DataType::Decimal128(20, 4), result.unwrap());
+        assert_eq!(None, result);
         let result =
             decimal_op_mathematics_type(&op, &left_decimal_type, &right_decimal_type);
         assert_eq!(DataType::Decimal128(31, 7), result.unwrap());
@@ -1232,7 +1232,7 @@ mod tests {
         mathematics_op: Operator,
         expected_lhs_type: Option<DataType>,
         expected_rhs_type: Option<DataType>,
-        expected_coerced_type: DataType,
+        expected_coerced_type: Option<DataType>,
         expected_output_type: DataType,
     ) {
         // The coerced types for lhs and rhs, if any of them is not decimal
@@ -1245,8 +1245,7 @@ mod tests {
 
         // The coerced type of decimal math expression, applied during expression evaluation
         let coerced_type =
-            coercion_decimal_mathematics_type(&mathematics_op, &lhs_type, &rhs_type)
-                .unwrap();
+            coercion_decimal_mathematics_type(&mathematics_op, &lhs_type, &rhs_type);
         assert_eq!(coerced_type, expected_coerced_type);
 
         // The output type of decimal math expression
@@ -1263,7 +1262,7 @@ mod tests {
             Operator::Plus,
             None,
             None,
-            DataType::Decimal128(11, 2),
+            Some(DataType::Decimal128(11, 2)),
             DataType::Decimal128(11, 2),
         );
 
@@ -1273,7 +1272,7 @@ mod tests {
             Operator::Plus,
             Some(DataType::Decimal128(10, 0)),
             None,
-            DataType::Decimal128(13, 2),
+            Some(DataType::Decimal128(13, 2)),
             DataType::Decimal128(13, 2),
         );
 
@@ -1283,7 +1282,7 @@ mod tests {
             Operator::Minus,
             Some(DataType::Decimal128(10, 0)),
             None,
-            DataType::Decimal128(13, 2),
+            Some(DataType::Decimal128(13, 2)),
             DataType::Decimal128(13, 2),
         );
 
@@ -1293,7 +1292,7 @@ mod tests {
             Operator::Multiply,
             Some(DataType::Decimal128(10, 0)),
             None,
-            DataType::Decimal128(12, 2),
+            None,
             DataType::Decimal128(21, 2),
         );
 
@@ -1303,7 +1302,7 @@ mod tests {
             Operator::Divide,
             Some(DataType::Decimal128(10, 0)),
             None,
-            DataType::Decimal128(12, 2),
+            Some(DataType::Decimal128(12, 2)),
             DataType::Decimal128(23, 11),
         );
 
@@ -1313,7 +1312,7 @@ mod tests {
             Operator::Modulo,
             Some(DataType::Decimal128(10, 0)),
             None,
-            DataType::Decimal128(12, 2),
+            Some(DataType::Decimal128(12, 2)),
             DataType::Decimal128(10, 2),
         );
 

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -684,9 +684,9 @@ pub(crate) fn modulus_decimal_dyn_scalar(
 
 #[cfg(test)]
 mod tests {
-    use datafusion_expr::Operator;
     use super::*;
     use datafusion_expr::type_coercion::binary::decimal_op_mathematics_type;
+    use datafusion_expr::Operator;
 
     fn create_decimal_array(
         array: &[Option<i128>],

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -469,24 +469,8 @@ pub(crate) fn multiply_decimal_dyn_scalar(
     result_type: &DataType,
 ) -> Result<ArrayRef> {
     let (precision, scale) = get_precision_scale(result_type)?;
-
-    let op_type = decimal_op_mathematics_type(
-        &Operator::Multiply,
-        left.data_type(),
-        left.data_type(),
-    )
-    .unwrap();
-    let (_, op_scale) = get_precision_scale(&op_type)?;
-
     let array = multiply_scalar_dyn::<Decimal128Type>(left, right)?;
-
-    if op_scale > scale {
-        let div = 10_i128.pow((op_scale - scale) as u32);
-        let array = divide_scalar_dyn::<Decimal128Type>(&array, div)?;
-        decimal_array_with_precision_scale(array, precision, scale)
-    } else {
-        decimal_array_with_precision_scale(array, precision, scale)
-    }
+    decimal_array_with_precision_scale(array, precision, scale)
 }
 
 pub(crate) fn divide_decimal_dyn_scalar(

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -35,9 +35,7 @@ use arrow_schema::DataType;
 use datafusion_common::cast::{as_date32_array, as_date64_array, as_decimal128_array};
 use datafusion_common::scalar::{date32_add, date64_add};
 use datafusion_common::{DataFusionError, Result, ScalarValue};
-use datafusion_expr::type_coercion::binary::decimal_op_mathematics_type;
 use datafusion_expr::ColumnarValue;
-use datafusion_expr::Operator;
 use std::cmp::min;
 use std::sync::Arc;
 
@@ -686,7 +684,9 @@ pub(crate) fn modulus_decimal_dyn_scalar(
 
 #[cfg(test)]
 mod tests {
+    use datafusion_expr::Operator;
     use super::*;
+    use datafusion_expr::type_coercion::binary::decimal_op_mathematics_type;
 
     fn create_decimal_array(
         array: &[Option<i128>],


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6278, bring the performance back.

# Rationale for this change

For decimal multiply,  avoid casting to the wider type, decimals can multiply decimals directly.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Main branch:

Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(1), debug: false, iterations: 3, partitions: 1, batch_size: 8192, path: "./parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: true }
Query 1 iteration 0 took 1716.3 ms and returned 4 rows
Query 1 iteration 1 took 1697.0 ms and returned 4 rows
Query 1 iteration 2 took 1694.3 ms and returned 4 rows
Query 1 avg time: 1702.52 ms

Branch 23 (Tag 23.0.0):

Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(1), debug: false, iterations: 3, partitions: 1, batch_size: 8192, path: "./parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: true, enable_scheduler: false }
Query 1 iteration 0 took 864.2 ms and returned 4 rows
Query 1 iteration 1 took 842.0 ms and returned 4 rows
Query 1 iteration 2 took 838.7 ms and returned 4 rows
Query 1 avg time: 848.29 ms

This PR:

Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(1), debug: false, iterations: 3, partitions: 1, batch_size: 8192, path: "./parquet_data", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: true }
Query 1 iteration 0 took 539.1 ms and returned 4 rows
Query 1 iteration 1 took 514.7 ms and returned 4 rows
Query 1 iteration 2 took 511.1 ms and returned 4 rows
Query 1 avg time: 521.61 ms


<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->