### PR TITLE
Limit the number of partition files to be displayed for FileGroupsDisplay

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -57,6 +57,7 @@ use datafusion_physical_expr::expressions::Column;
 use log::{debug, info, warn};
 use object_store::path::Path;
 use object_store::ObjectMeta;
+use std::fmt::Debug;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -119,7 +120,7 @@ pub fn get_scan_files(
 
 /// The base configurations to provide when creating a physical plan for
 /// any given file format.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FileScanConfig {
     /// Object store URL, used to get an [`ObjectStore`] instance from
     /// [`RuntimeEnv::object_store`]
@@ -234,6 +235,16 @@ impl FileScanConfig {
     }
 }
 
+impl Debug for FileScanConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "object_store_url={:?}", self.object_store_url)?;
+
+        write!(f, "statistics={:?}", self.statistics)?;
+
+        Display::fmt(self, f)
+    }
+}
+
 impl Display for FileScanConfig {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let (schema, _, ordering) = self.project();
@@ -275,7 +286,9 @@ impl<'a> Display for FileGroupsDisplay<'a> {
         let mut first_group = true;
         let groups = if self.0.len() == 1 { "group" } else { "groups" };
         write!(f, "{{{} {}: [", self.0.len(), groups)?;
-        for group in self.0 {
+        // To avoid showing too many partitions
+        let max_groups = 5;
+        for group in self.0.iter().take(max_groups) {
             if !first_group {
                 write!(f, ", ")?;
             }
@@ -296,6 +309,9 @@ impl<'a> Display for FileGroupsDisplay<'a> {
                 }
             }
             write!(f, "]")?;
+        }
+        if self.0.len() > max_groups {
+            write!(f, ", ...")?;
         }
         write!(f, "]}}")?;
         Ok(())

--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -2105,7 +2105,7 @@ mod tests {
     async fn test_with_zero_offset_plan() -> Result<()> {
         let logical_plan = test_csv_scan().await?.limit(0, None)?.build()?;
         let plan = plan(&logical_plan).await?;
-        assert!(format!("{plan:?}").contains("limit: None"));
+        assert!(!format!("{plan:?}").contains("limit="));
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6358.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When a sql needs to hit thousands of files, the content of thousands of partition files shown by the FileGroupsDisplay is too much.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Only at most 5 of them will be shown. Others will be replaced by `...`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->