### PR TITLE
Switch to non-recursive on heap virtual stack when building logical plan from SQL expression

### DIFF
--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -47,4 +47,5 @@ sqlparser = "0.33"
 [dev-dependencies]
 ctor = "0.2.0"
 env_logger = "0.10"
+paste = "^1.0"
 rstest = "0.17"

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -15,21 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{DFSchema, DataFusionError, Result};
-use datafusion_expr::{BinaryExpr, Expr, Operator};
-use sqlparser::ast::{BinaryOperator, Expr as SQLExpr};
+use crate::planner::{ContextProvider, SqlToRel};
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::Operator;
+use sqlparser::ast::BinaryOperator;
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
-    pub(crate) fn parse_sql_binary_op(
-        &self,
-        left: SQLExpr,
-        op: BinaryOperator,
-        right: SQLExpr,
-        schema: &DFSchema,
-        planner_context: &mut PlannerContext,
-    ) -> Result<Expr> {
-        let operator = match op {
+    pub(crate) fn parse_sql_binary_op(&self, op: BinaryOperator) -> Result<Operator> {
+        match op {
             BinaryOperator::Gt => Ok(Operator::Gt),
             BinaryOperator::GtEq => Ok(Operator::GtEq),
             BinaryOperator::Lt => Ok(Operator::Lt),
@@ -56,12 +49,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             _ => Err(DataFusionError::NotImplemented(format!(
                 "Unsupported SQL binary operator {op:?}"
             ))),
-        }?;
-
-        Ok(Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(self.sql_expr_to_logical_expr(left, schema, planner_context)?),
-            operator,
-            Box::new(self.sql_expr_to_logical_expr(right, schema, planner_context)?),
-        )))
+        }
     }
 }

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -55,9 +55,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // This allows visiting the expr tree in a depth-first manner which
         // produces expressions in postfix notations, i.e. `a + b` => `a b +`.
         // See https://github.com/apache/arrow-datafusion/issues/1444
-        let mut stack: Box<Vec<StackEntry>> =
-            Box::new(vec![StackEntry::SQLExpr(Box::new(sql))]);
-        let mut eval_stack = Box::<Vec<Expr>>::default();
+        let mut stack = vec![StackEntry::SQLExpr(Box::new(sql))];
+        let mut eval_stack = vec![];
 
         while let Some(entry) = stack.pop() {
             match entry {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -56,7 +56,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // produces expressions in postfix notations, i.e. `a + b` => `a b +`.
         let mut stack: Box<Vec<StackEntry>> =
             Box::new(vec![StackEntry::SQLExpr(Box::new(sql))]);
-        let mut eval_stack = Box::new(vec![]);
+        let mut eval_stack = Box::<Vec<Expr>>::default();
 
         while let Some(entry) = stack.pop() {
             match entry {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -54,6 +54,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // Virtual stack machine to convert SQLExpr to Expr
         // This allows visiting the expr tree in a depth-first manner which
         // produces expressions in postfix notations, i.e. `a + b` => `a b +`.
+        // See https://github.com/apache/arrow-datafusion/issues/1444
         let mut stack: Box<Vec<StackEntry>> =
             Box::new(vec![StackEntry::SQLExpr(Box::new(sql))]);
         let mut eval_stack = Box::<Vec<Expr>>::default();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6040
Closes #1444 
Closes #1434 

# Rationale for this change

Not sure why anyone would want more than 256 expressions but I thought I would write the iterative version just for fun. Now users can write all the expressions they want (or at least until the generated `Expr` can no longer fit in the stack).

Kudos to @alamb and @houqp for suggesting this iterative version.

# What changes are included in this PR?

- Iterative version of expr logical plan builder
- Add tests verifying the number of expressions that can be handled is now larger

# Are these changes tested?

Yes. Tested by existing tests. Also added a few stack overflow tests.

# Are there any user-facing changes?

No