### PR TITLE
feat: add pattern for simplifying exprs like `str ~ '^foo$'`

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -2434,6 +2434,21 @@ mod tests {
         // single word
         assert_change(regex_match(col("c1"), lit("foo")), like(col("c1"), "%foo%"));
 
+        // regular expressions that match an exact literal
+        assert_change(regex_match(col("c1"), lit("^$")), col("c1").eq(lit("")));
+        assert_change(
+            regex_not_match(col("c1"), lit("^$")),
+            col("c1").not_eq(lit("")),
+        );
+        assert_change(
+            regex_match(col("c1"), lit("^foo$")),
+            col("c1").eq(lit("foo")),
+        );
+        assert_change(
+            regex_not_match(col("c1"), lit("^foo$")),
+            col("c1").not_eq(lit("foo")),
+        );
+
         // OR-chain
         assert_change(
             regex_match(col("c1"), lit("foo|bar|baz")),

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use datafusion_common::{DataFusionError, Result, ScalarValue};
-use datafusion_expr::{BinaryExpr, Expr, Like, Operator};
-use regex_syntax::hir::{Hir, HirKind, Literal};
+use datafusion_expr::{lit, BinaryExpr, Expr, Like, Operator};
+use regex_syntax::hir::{Hir, HirKind, Literal, Look};
 
 /// Maximum number of regex alternations (`foo|bar|...`) that will be expanded into multiple `LIKE` expressions.
 const MAX_REGEX_ALTERNATIONS_EXPANSION: usize = 4;
@@ -95,6 +95,15 @@ impl OperatorMode {
             Expr::Like(like)
         }
     }
+
+    fn expr_matches_literal(&self, left: Box<Expr>, right: Box<Expr>) -> Expr {
+        let op = if self.not {
+            Operator::NotEq
+        } else {
+            Operator::Eq
+        };
+        Expr::BinaryExpr(BinaryExpr { left, op, right })
+    }
 }
 
 fn collect_concat_to_like_string(parts: &[Hir]) -> Option<String> {
@@ -130,6 +139,46 @@ fn is_safe_for_like(c: char) -> bool {
     (c != '%') && (c != '_')
 }
 
+/// returns true if the elements in a `Concat` pattern are:
+/// - `[Look::Start, Look::End]`
+/// - `[Look::Start, Literal(_), Look::End]`
+fn is_anchored_literal(v: &[Hir]) -> bool {
+    match v.len() {
+        2..=3 => (),
+        _ => return false,
+    };
+
+    let first_last = (
+        v.first().expect("length checked"),
+        v.last().expect("length checked"),
+    );
+    if !matches!(first_last,
+    (s, e) if s.kind() == &HirKind::Look(Look::Start)
+        && e.kind() == &HirKind::Look(Look::End)
+         )
+    {
+        return false;
+    }
+
+    v.iter()
+        .skip(1)
+        .take(v.len() - 2)
+        .all(|h| matches!(h.kind(), HirKind::Literal(_)))
+}
+
+/// extracts a string literal expression assuming that `is_anchored_literal()`
+/// returned true.
+fn anchored_literal_to_expr(v: &[Hir]) -> Option<Expr> {
+    match v.len() {
+        2 => Some(lit("")),
+        3 => {
+            let HirKind::Literal(l) = v[1].kind() else { return None };
+            str_from_literal(l).map(lit)
+        }
+        _ => None,
+    }
+}
+
 fn lower_simple(mode: &OperatorMode, left: &Expr, hir: &Hir) -> Option<Expr> {
     println!("Considering hir kind: mode {mode:?} hir: {hir:?}");
     match hir.kind() {
@@ -139,6 +188,12 @@ fn lower_simple(mode: &OperatorMode, left: &Expr, hir: &Hir) -> Option<Expr> {
         HirKind::Literal(l) => {
             let s = str_from_literal(l)?;
             return Some(mode.expr(Box::new(left.clone()), format!("%{s}%")));
+        }
+        HirKind::Concat(inner) if is_anchored_literal(inner) => {
+            let right = anchored_literal_to_expr(inner)?;
+            return Some(
+                mode.expr_matches_literal(Box::new(left.clone()), Box::new(right)),
+            );
         }
         HirKind::Concat(inner) => {
             if let Some(pattern) = collect_concat_to_like_string(inner) {

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -166,7 +166,7 @@ fn is_anchored_literal(v: &[Hir]) -> bool {
         .all(|h| matches!(h.kind(), HirKind::Literal(_)))
 }
 
-/// extracts a string literal expression assuming that `is_anchored_literal()`
+/// extracts a string literal expression assuming that [`is_anchored_literal`]
 /// returned true.
 fn anchored_literal_to_expr(v: &[Hir]) -> Option<Expr> {
     match v.len() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6367.

# Rationale for this change

This should be a performance improvement for queries that contain this pattern, and it may also be easier to push down predicates that use `=` or `!=` rather than regexes.

It will also make it easier to find predicates that are looking for the empty string (an important case for [IOx's InfluxQL support](https://github.com/influxdata/influxdb_iox/issues/6902)).

# What changes are included in this PR?

This adds a pattern to `ExprSimplifier` to find regexes of the form `^foo$` and uses them to compare with a string literal instead of doing regex matching.

# Are these changes tested?

I included unit tests with the other regex simplifications that are performed. I also tested manually with `datafusion-cli`.

# Are there any user-facing changes?

No.