### PR TITLE
Minor: remove left over println

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -180,7 +180,6 @@ fn anchored_literal_to_expr(v: &[Hir]) -> Option<Expr> {
 }
 
 fn lower_simple(mode: &OperatorMode, left: &Expr, hir: &Hir) -> Option<Expr> {
-    println!("Considering hir kind: mode {mode:?} hir: {hir:?}");
     match hir.kind() {
         HirKind::Empty => {
             return Some(mode.expr(Box::new(left.clone()), "%".to_owned()));


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

I noticed this while reviewing https://github.com/apache/arrow-datafusion/pull/6369 from @wolffcm 

# What changes are included in this PR?

Remove `println!`

# Are these changes tested?

N/A

# Are there any user-facing changes?

Less random console spew