### PR TITLE
feat: implement serialize/deserialize for extension logical plan

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1644,7 +1644,7 @@ impl SessionState {
         self
     }
 
-    /// Replace the extension deserializer
+    /// Replace the extension [`SerializerRegistry`]
     pub fn with_serializer_registry(
         mut self,
         registry: Arc<dyn SerializerRegistry>,

--- a/datafusion/execution/src/registry.rs
+++ b/datafusion/execution/src/registry.rs
@@ -18,7 +18,7 @@
 //! FunctionRegistry trait
 
 use datafusion_common::Result;
-use datafusion_expr::{AggregateUDF, ScalarUDF};
+use datafusion_expr::{AggregateUDF, ScalarUDF, UserDefinedLogicalNode};
 use std::{collections::HashSet, sync::Arc};
 
 /// A registry knows how to build logical expressions out of user-defined function' names
@@ -31,4 +31,22 @@ pub trait FunctionRegistry {
 
     /// Returns a reference to the udaf named `name`.
     fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>>;
+}
+
+/// Serializer and deserializer registry for extensions like [UserDefinedLogicalNode].
+pub trait SerializerRegistry: Send + Sync {
+    /// Serialize this node to a byte array. This serialization should not include
+    /// input plans.
+    fn serialize_logical_plan(
+        &self,
+        node: &dyn UserDefinedLogicalNode,
+    ) -> Result<Vec<u8>>;
+
+    /// Deserialize user defined logical plan node ([UserDefinedLogicalNode]) from
+    /// bytes.
+    fn deserialize_logical_plan(
+        &self,
+        name: &str,
+        bytes: &[u8],
+    ) -> Result<Arc<dyn UserDefinedLogicalNode>>;
 }

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -17,7 +17,7 @@
 
 //! This module defines the interface for logical nodes
 use crate::{Expr, LogicalPlan};
-use datafusion_common::{DFSchema, DFSchemaRef};
+use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError, Result};
 use std::hash::{Hash, Hasher};
 use std::{any::Any, cmp::Eq, collections::HashSet, fmt, sync::Arc};
 
@@ -164,6 +164,26 @@ pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     /// Note: [`UserDefinedLogicalNode`] is not constrained by [`Eq`]
     /// directly because it must remain object safe.
     fn dyn_eq(&self, other: &dyn UserDefinedLogicalNode) -> bool;
+
+    /// Serialize this node to a byte array. This serialization needs not to include
+    /// input plans.
+    fn serialize(&self) -> Result<Vec<u8>> {
+        Err(DataFusionError::NotImplemented(format!(
+            "Serialize is not implemented for user defined logical node {}",
+            self.name()
+        )))
+    }
+
+    /// Deserialize the node from a byte array. The inputs plan is not included in the
+    /// byte array, it will be passed later via [from_template](UserDefinedLogicalNode::from_template).
+    fn deserialize(_: &[u8]) -> Result<Arc<dyn UserDefinedLogicalNode>>
+    where
+        Self: Sized,
+    {
+        Err(DataFusionError::NotImplemented(
+            "Deserialize is not implemented for user defined logical node".to_string(),
+        ))
+    }
 }
 
 impl Hash for dyn UserDefinedLogicalNode {

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -17,7 +17,7 @@
 
 //! This module defines the interface for logical nodes
 use crate::{Expr, LogicalPlan};
-use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError, Result};
+use datafusion_common::{DFSchema, DFSchemaRef};
 use std::hash::{Hash, Hasher};
 use std::{any::Any, cmp::Eq, collections::HashSet, fmt, sync::Arc};
 
@@ -164,26 +164,6 @@ pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     /// Note: [`UserDefinedLogicalNode`] is not constrained by [`Eq`]
     /// directly because it must remain object safe.
     fn dyn_eq(&self, other: &dyn UserDefinedLogicalNode) -> bool;
-
-    /// Serialize this node to a byte array. This serialization needs not to include
-    /// input plans.
-    fn serialize(&self) -> Result<Vec<u8>> {
-        Err(DataFusionError::NotImplemented(format!(
-            "Serialize is not implemented for user defined logical node {}",
-            self.name()
-        )))
-    }
-
-    /// Deserialize the node from a byte array. The inputs plan is not included in the
-    /// byte array, it will be passed later via [from_template](UserDefinedLogicalNode::from_template).
-    fn deserialize(_: &[u8]) -> Result<Arc<dyn UserDefinedLogicalNode>>
-    where
-        Self: Sized,
-    {
-        Err(DataFusionError::NotImplemented(
-            "Deserialize is not implemented for user defined logical node".to_string(),
-        ))
-    }
 }
 
 impl Hash for dyn UserDefinedLogicalNode {

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -34,6 +34,7 @@ datafusion = { version = "24.0.0", path = "../core" }
 itertools = "0.10.5"
 object_store = "0.5.4"
 prost = "0.11"
+prost-types = "0.11"
 substrait = "0.10.0"
 tokio = "1.17"
 

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -437,7 +437,7 @@ pub async fn from_substrait_rel(
             };
             let plan = ctx
                 .state()
-                .extension_deserializer()
+                .serializer_registry()
                 .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
             Ok(LogicalPlan::Extension(Extension { node: plan }))
         }
@@ -449,7 +449,7 @@ pub async fn from_substrait_rel(
             };
             let plan = ctx
                 .state()
-                .extension_deserializer()
+                .serializer_registry()
                 .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
             let Some(input_rel) = &extension.input else {
                 return Err(DataFusionError::Substrait(
@@ -468,7 +468,7 @@ pub async fn from_substrait_rel(
             };
             let plan = ctx
                 .state()
-                .extension_deserializer()
+                .serializer_registry()
                 .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
             let mut inputs = Vec::with_capacity(extension.inputs.len());
             for input in &extension.inputs {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -430,9 +430,7 @@ pub async fn from_substrait_rel(
             )),
         },
         Some(RelType::ExtensionLeaf(extension)) => {
-            let ext_detail = if let Some(detail) = &extension.detail {
-                detail
-            } else {
+            let Some(ext_detail) = &extension.detail else {
                 return Err(DataFusionError::Substrait(
                     "Unexpected empty detail in ExtensionLeafRel".to_string(),
                 ));
@@ -444,9 +442,7 @@ pub async fn from_substrait_rel(
             Ok(LogicalPlan::Extension(Extension { node: plan }))
         }
         Some(RelType::ExtensionSingle(extension)) => {
-            let ext_detail = if let Some(detail) = &extension.detail {
-                detail
-            } else {
+            let Some(ext_detail) = &extension.detail else {
                 return Err(DataFusionError::Substrait(
                     "Unexpected empty detail in ExtensionSingleRel".to_string(),
                 ));
@@ -455,19 +451,17 @@ pub async fn from_substrait_rel(
                 .state()
                 .extension_deserializer()
                 .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
-            let input_rel = if let Some(input) = &extension.input {
-                input
-            } else {
-                return Err(DataFusionError::Substrait("ExtensionSingleRel doesn't contains input rel. Try use ExtensionLeafRel instead".to_string()));
+            let Some(input_rel) = &extension.input else {
+                return Err(DataFusionError::Substrait(
+                    "ExtensionSingleRel doesn't contains input rel. Try use ExtensionLeafRel instead".to_string()
+                ));
             };
             let input_plan = from_substrait_rel(ctx, input_rel, extensions).await?;
             let plan = plan.from_template(&plan.expressions(), &[input_plan]);
             Ok(LogicalPlan::Extension(Extension { node: plan }))
         }
         Some(RelType::ExtensionMulti(extension)) => {
-            let ext_detail = if let Some(detail) = &extension.detail {
-                detail
-            } else {
+            let Some(ext_detail) = &extension.detail else {
                 return Err(DataFusionError::Substrait(
                     "Unexpected empty detail in ExtensionSingleRel".to_string(),
                 ));

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -22,7 +22,7 @@ use datafusion::logical_expr::{
     aggregate_function, window_function::find_df_window_func, BinaryExpr, Case, Expr,
     LogicalPlan, Operator,
 };
-use datafusion::logical_expr::{build_join_schema, LogicalPlanBuilder};
+use datafusion::logical_expr::{build_join_schema, Extension, LogicalPlanBuilder};
 use datafusion::logical_expr::{expr, Cast, WindowFrameBound, WindowFrameUnits};
 use datafusion::prelude::JoinType;
 use datafusion::sql::TableReference;
@@ -429,6 +429,61 @@ pub async fn from_substrait_rel(
                 "Only NamedTable reads are supported".to_string(),
             )),
         },
+        Some(RelType::ExtensionLeaf(extension)) => {
+            let ext_detail = if let Some(detail) = &extension.detail {
+                detail
+            } else {
+                return Err(DataFusionError::Substrait(
+                    "Unexpected empty detail in ExtensionLeafRel".to_string(),
+                ));
+            };
+            let plan = ctx
+                .state()
+                .extension_deserializer()
+                .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
+            Ok(LogicalPlan::Extension(Extension { node: plan }))
+        }
+        Some(RelType::ExtensionSingle(extension)) => {
+            let ext_detail = if let Some(detail) = &extension.detail {
+                detail
+            } else {
+                return Err(DataFusionError::Substrait(
+                    "Unexpected empty detail in ExtensionSingleRel".to_string(),
+                ));
+            };
+            let plan = ctx
+                .state()
+                .extension_deserializer()
+                .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
+            let input_rel = if let Some(input) = &extension.input {
+                input
+            } else {
+                return Err(DataFusionError::Substrait("ExtensionSingleRel doesn't contains input rel. Try use ExtensionLeafRel instead".to_string()));
+            };
+            let input_plan = from_substrait_rel(ctx, input_rel, extensions).await?;
+            let plan = plan.from_template(&plan.expressions(), &[input_plan]);
+            Ok(LogicalPlan::Extension(Extension { node: plan }))
+        }
+        Some(RelType::ExtensionMulti(extension)) => {
+            let ext_detail = if let Some(detail) = &extension.detail {
+                detail
+            } else {
+                return Err(DataFusionError::Substrait(
+                    "Unexpected empty detail in ExtensionSingleRel".to_string(),
+                ));
+            };
+            let plan = ctx
+                .state()
+                .extension_deserializer()
+                .deserialize_logical_plan(&ext_detail.type_url, &ext_detail.value)?;
+            let mut inputs = Vec::with_capacity(extension.inputs.len());
+            for input in &extension.inputs {
+                let input_plan = from_substrait_rel(ctx, input, extensions).await?;
+                inputs.push(input_plan);
+            }
+            let plan = plan.from_template(&plan.expressions(), &inputs);
+            Ok(LogicalPlan::Extension(Extension { node: plan }))
+        }
         _ => Err(DataFusionError::NotImplemented(format!(
             "Unsupported RelType: {:?}",
             rel.rel_type

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -360,7 +360,8 @@ pub fn to_substrait_rel(
             }))
         }
         LogicalPlan::Extension(extension_plan) => {
-            let extension_bytes = extension_plan.node.serialize()?;
+            // let extension_bytes = extension_plan.node.serialize()?;
+            let extension_bytes = todo!();
             let detail = ProtoAny {
                 type_url: extension_plan.node.name().to_string(),
                 value: extension_bytes,

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -37,7 +37,7 @@ pub async fn serialize(sql: &str, ctx: &SessionContext, path: &str) -> Result<()
 pub async fn serialize_bytes(sql: &str, ctx: &SessionContext) -> Result<Vec<u8>> {
     let df = ctx.sql(sql).await?;
     let plan = df.into_optimized_plan()?;
-    let proto = producer::to_substrait_plan(&plan)?;
+    let proto = producer::to_substrait_plan(&plan, ctx)?;
 
     let mut protobuf_out = Vec::<u8>::new();
     proto.encode(&mut protobuf_out).map_err(|e| {

--- a/datafusion/substrait/tests/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/roundtrip_logical_plan.rs
@@ -467,7 +467,7 @@ mod tests {
             }),
         });
 
-        let proto = to_substrait_plan(&ext_plan)?;
+        let proto = to_substrait_plan(&ext_plan, &ctx)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
 
         let plan1str = format!("{ext_plan:?}");
@@ -481,7 +481,7 @@ mod tests {
         let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
-        let proto = to_substrait_plan(&plan)?;
+        let proto = to_substrait_plan(&plan, &ctx)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2 = ctx.state().optimize(&plan2)?;
         let plan2str = format!("{plan2:?}");
@@ -493,7 +493,7 @@ mod tests {
         let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan1 = df.into_optimized_plan()?;
-        let proto = to_substrait_plan(&plan1)?;
+        let proto = to_substrait_plan(&plan1, &ctx)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2 = ctx.state().optimize(&plan2)?;
 
@@ -512,11 +512,11 @@ mod tests {
         let mut ctx = create_context().await?;
 
         let df_a = ctx.sql(sql_with_alias).await?;
-        let proto_a = to_substrait_plan(&df_a.into_optimized_plan()?)?;
+        let proto_a = to_substrait_plan(&df_a.into_optimized_plan()?, &ctx)?;
         let plan_with_alias = from_substrait_plan(&mut ctx, &proto_a).await?;
 
         let df = ctx.sql(sql_no_alias).await?;
-        let proto = to_substrait_plan(&df.into_optimized_plan()?)?;
+        let proto = to_substrait_plan(&df.into_optimized_plan()?, &ctx)?;
         let plan = from_substrait_plan(&mut ctx, &proto).await?;
 
         println!("{plan_with_alias:#?}");
@@ -532,7 +532,7 @@ mod tests {
         let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
-        let proto = to_substrait_plan(&plan)?;
+        let proto = to_substrait_plan(&plan, &ctx)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2 = ctx.state().optimize(&plan2)?;
 
@@ -549,7 +549,7 @@ mod tests {
         let mut ctx = create_all_type_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
-        let proto = to_substrait_plan(&plan)?;
+        let proto = to_substrait_plan(&plan, &ctx)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2 = ctx.state().optimize(&plan2)?;
 
@@ -566,7 +566,7 @@ mod tests {
         let ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.into_optimized_plan()?;
-        let proto = to_substrait_plan(&plan)?;
+        let proto = to_substrait_plan(&plan, &ctx)?;
 
         let mut function_names: Vec<String> = vec![];
         let mut function_anchors: Vec<u32> = vec![];

--- a/datafusion/substrait/tests/serialize.rs
+++ b/datafusion/substrait/tests/serialize.rs
@@ -57,7 +57,7 @@ mod tests {
         let ctx = create_context().await?;
         let table = provider_as_source(ctx.table_provider("data").await?);
         let table_scan = LogicalPlanBuilder::scan("data", table, None)?.build()?;
-        let convert_result = producer::to_substrait_plan(&table_scan);
+        let convert_result = producer::to_substrait_plan(&table_scan, &ctx);
         assert!(convert_result.is_ok());
 
         Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/6335.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Accomplish the serialize/deserialize part for logical plan extension.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- A new field in `SessionState`: `ExtensionDeserializer`

  This is the registry (or dispatcher) of all extension's deserializer methods. In this PR only `UserDefinedLogicalPlan` is included.

- Two new methods on `UserDefinedLogicalPlan`: `serialize` and `deserialize`


# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

# Are there any user-facing changes?

Yes as described above. But both of them are non-breaking

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->