### PR TITLE
Minor: used named constant for the schema inference concurrency limit

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -52,6 +52,9 @@ use crate::physical_plan::{Accumulator, ExecutionPlan, Statistics};
 /// The default file extension of parquet files
 pub const DEFAULT_PARQUET_EXTENSION: &str = ".parquet";
 
+/// The number of files to read in parallel when inferring schema
+const SCHEMA_INFERENCE_CONCURRENCY: usize = 32;
+
 /// The Apache Parquet `FileFormat` implementation
 ///
 /// Note it is recommended these are instead configured on the [`ConfigOptions`]
@@ -155,7 +158,7 @@ impl FileFormat for ParquetFormat {
         let schemas: Vec<_> = futures::stream::iter(objects)
             .map(|object| fetch_schema(store.as_ref(), object, self.metadata_size_hint))
             .boxed() // Workaround https://github.com/rust-lang/rust/issues/64552
-            .buffered(32)
+            .buffered(SCHEMA_INFERENCE_CONCURRENCY)
             .try_collect()
             .await?;
 


### PR DESCRIPTION
Follow up to https://github.com/apache/arrow-datafusion/pull/6366 as suggested here https://github.com/apache/arrow-datafusion/pull/6366#r1196984754