### PR TITLE
(WIP) Add some way to observe sizes of RecordBatches flowing through the system

### DIFF
--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -671,6 +671,7 @@ pub mod planner;
 pub mod projection;
 pub mod repartition;
 pub mod sorts;
+pub mod stats;
 pub mod stream;
 pub mod streaming;
 pub mod tree_node;
@@ -679,8 +680,6 @@ pub mod union;
 pub mod unnest;
 pub mod values;
 pub mod windows;
-pub mod stats;
-
 
 use crate::execution::context::TaskContext;
 use crate::physical_plan::common::AbortOnDropSingle;

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -679,6 +679,8 @@ pub mod union;
 pub mod unnest;
 pub mod values;
 pub mod windows;
+pub mod stats;
+
 
 use crate::execution::context::TaskContext;
 use crate::physical_plan::common::AbortOnDropSingle;

--- a/datafusion/core/src/physical_plan/sorts/builder.rs
+++ b/datafusion/core/src/physical_plan/sorts/builder.rs
@@ -19,6 +19,7 @@ use crate::common::Result;
 use arrow::compute::interleave;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion_execution::memory_pool::MemoryReservation;
 
 #[derive(Debug, Copy, Clone, Default)]
 struct BatchCursor {
@@ -37,6 +38,9 @@ pub struct BatchBuilder {
     /// Maintain a list of [`RecordBatch`] and their corresponding stream
     batches: Vec<(usize, RecordBatch)>,
 
+    /// Accounts for memory used by buffered batches
+    reservation: MemoryReservation,
+
     /// The current [`BatchCursor`] for each stream
     cursors: Vec<BatchCursor>,
 
@@ -47,23 +51,31 @@ pub struct BatchBuilder {
 
 impl BatchBuilder {
     /// Create a new [`BatchBuilder`] with the provided `stream_count` and `batch_size`
-    pub fn new(schema: SchemaRef, stream_count: usize, batch_size: usize) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        stream_count: usize,
+        batch_size: usize,
+        reservation: MemoryReservation,
+    ) -> Self {
         Self {
             schema,
             batches: Vec::with_capacity(stream_count * 2),
             cursors: vec![BatchCursor::default(); stream_count],
             indices: Vec::with_capacity(batch_size),
+            reservation,
         }
     }
 
     /// Append a new batch in `stream_idx`
-    pub fn push_batch(&mut self, stream_idx: usize, batch: RecordBatch) {
+    pub fn push_batch(&mut self, stream_idx: usize, batch: RecordBatch) -> Result<()> {
+        self.reservation.try_grow(batch.get_array_memory_size())?;
         let batch_idx = self.batches.len();
         self.batches.push((stream_idx, batch));
         self.cursors[stream_idx] = BatchCursor {
             batch_idx,
             row_idx: 0,
-        }
+        };
+        Ok(())
     }
 
     /// Append the next row from `stream_idx`
@@ -119,14 +131,17 @@ impl BatchBuilder {
         // We can therefore drop all but the last batch for each stream
         let mut batch_idx = 0;
         let mut retained = 0;
-        self.batches.retain(|(stream_idx, _)| {
+        self.batches.retain(|(stream_idx, batch)| {
             let stream_cursor = &mut self.cursors[*stream_idx];
             let retain = stream_cursor.batch_idx == batch_idx;
             batch_idx += 1;
 
-            if retain {
-                stream_cursor.batch_idx = retained;
-                retained += 1;
+            match retain {
+                true => {
+                    stream_cursor.batch_idx = retained;
+                    retained += 1;
+                }
+                false => self.reservation.shrink(batch.get_array_memory_size()),
             }
             retain
         });

--- a/datafusion/core/src/physical_plan/sorts/cursor.rs
+++ b/datafusion/core/src/physical_plan/sorts/cursor.rs
@@ -21,6 +21,7 @@ use arrow::datatypes::ArrowNativeTypeOp;
 use arrow::row::{Row, Rows};
 use arrow_array::types::ByteArrayType;
 use arrow_array::{Array, ArrowPrimitiveType, GenericByteArray, PrimitiveArray};
+use datafusion_execution::memory_pool::MemoryReservation;
 use std::cmp::Ordering;
 
 /// A [`Cursor`] for [`Rows`]
@@ -29,6 +30,9 @@ pub struct RowCursor {
     num_rows: usize,
 
     rows: Rows,
+
+    #[allow(dead_code)]
+    reservation: MemoryReservation,
 }
 
 impl std::fmt::Debug for RowCursor {
@@ -41,12 +45,13 @@ impl std::fmt::Debug for RowCursor {
 }
 
 impl RowCursor {
-    /// Create a new SortKeyCursor
-    pub fn new(rows: Rows) -> Self {
+    /// Create a new SortKeyCursor from `rows` and the associated `reservation`
+    pub fn new(rows: Rows, reservation: MemoryReservation) -> Self {
         Self {
             cur_row: 0,
             num_rows: rows.num_rows(),
             rows,
+            reservation,
         }
     }
 

--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -738,7 +738,8 @@ mod tests {
     #[tokio::test]
     async fn test_sort_spill() -> Result<()> {
         // trigger spill there will be 4 batches with 5.5KB for each
-        let config = RuntimeConfig::new().with_memory_limit(12288, 1.0);
+        let config = RuntimeConfig::new()
+            .with_memory_limit(EXTERNAL_SORTER_MERGE_RESERVATION + 12288, 1.0);
         let runtime = Arc::new(RuntimeEnv::new(config)?);
         let session_ctx = SessionContext::with_config_rt(SessionConfig::new(), runtime);
 

--- a/datafusion/core/src/physical_plan/sorts/stream.rs
+++ b/datafusion/core/src/physical_plan/sorts/stream.rs
@@ -23,6 +23,7 @@ use arrow::array::Array;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use arrow::row::{RowConverter, SortField};
+use datafusion_execution::memory_pool::MemoryReservation;
 use futures::stream::{Fuse, StreamExt};
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -84,6 +85,8 @@ pub struct RowCursorStream {
     column_expressions: Vec<Arc<dyn PhysicalExpr>>,
     /// Input streams
     streams: FusedStreams,
+    /// Tracks the memory used by `converter`
+    reservation: MemoryReservation,
 }
 
 impl RowCursorStream {
@@ -91,6 +94,7 @@ impl RowCursorStream {
         schema: &Schema,
         expressions: &[PhysicalSortExpr],
         streams: Vec<SendableRecordBatchStream>,
+        reservation: MemoryReservation,
     ) -> Result<Self> {
         let sort_fields = expressions
             .iter()
@@ -104,6 +108,7 @@ impl RowCursorStream {
         let converter = RowConverter::new(sort_fields)?;
         Ok(Self {
             converter,
+            reservation,
             column_expressions: expressions.iter().map(|x| x.expr.clone()).collect(),
             streams: FusedStreams(streams),
         })
@@ -117,7 +122,11 @@ impl RowCursorStream {
             .collect::<Result<Vec<_>>>()?;
 
         let rows = self.converter.convert_columns(&cols)?;
-        Ok(RowCursor::new(rows))
+        self.reservation.try_resize(self.converter.size())?;
+
+        let mut reservation = self.reservation.split_empty();
+        reservation.try_grow(rows.size())?;
+        Ok(RowCursor::new(rows, reservation))
     }
 }
 

--- a/datafusion/core/src/physical_plan/stats.rs
+++ b/datafusion/core/src/physical_plan/stats.rs
@@ -1,11 +1,22 @@
-use arrow::array::Array;
+use arrow::{
+    array::{Array, AsArray},
+    datatypes::{
+        Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type,
+        UInt8Type,
+    },
+};
 use arrow_array::RecordBatch;
+use arrow_schema::DataType;
 use datafusion_common::Statistics;
-
 
 /// This is a debugging function
 ///
 /// This calculates statistics about a stream of record batches for debugging purposes
+///
+/// Potential future improvments:
+/// 1. User defined observers
+/// 2. aggregating statistics
+/// 3. TBD
 #[derive(Debug)]
 pub struct StatisticsStream {
     // Map column name --> Statistics
@@ -19,7 +30,6 @@ impl StatisticsStream {
 
     // Record statistics for this batch
     pub fn observe_batch(&self, batch: &RecordBatch) {
-
         println!("---------------------");
         for (f, array) in batch.schema().fields().iter().zip(batch.columns().iter()) {
             let col_name = f.name();
@@ -28,8 +38,6 @@ impl StatisticsStream {
         }
     }
 }
-
-
 
 #[derive(Debug)]
 enum ArrayStatistics {
@@ -41,25 +49,132 @@ enum ArrayStatistics {
     Primitive(Statistics),
 }
 
-
 impl ArrayStatistics {
     // TODO make this `impl Display`
     fn summary(&self) -> String {
-        match self
-        {
-            ArrayStatistics::Dictionary { keys, values } => todo!(),
-            ArrayStatistics::Primitive(_) => todo!(),
+        match self {
+            ArrayStatistics::Dictionary { keys, values } => {
+                let overall = combine_stats(keys, values);
+                // TODO add overall stats (and then breakdown)
+                format!(
+                    "{:<16}{}\n{:<16}{}{:<16}\n{}",
+                    "DictionaryArray:",
+                    stat_summary(&overall),
+                    "  Keys:",
+                    stat_summary(keys),
+                    "  Values:",
+                    stat_summary(values)
+                )
+            }
+            ArrayStatistics::Primitive(stats) => {
+                format!("PrimitiveArray: {}", stat_summary(stats))
+            }
         }
     }
 }
 
+//fn overall_dict_stats(
+
+// TODO make this impl display
+//
+fn stat_summary(stats: &Statistics) -> String {
+    let num_rows = match stats.num_rows.as_ref() {
+        Some(num_rows) => format!("{num_rows:>6} rows "),
+        None => "".to_string(),
+    };
+
+    let total_byte_size = match stats.total_byte_size.as_ref() {
+        Some(total_byte_size) => format!("{total_byte_size:>20} bytes "),
+        None => "".to_string(),
+    };
+
+    let is_exact = if stats.is_exact { "(Exact)" } else { "" };
+
+    // TODO column statistics, etc
+
+    format!("{num_rows}{total_byte_size}{is_exact}")
+}
+
 impl From<&dyn Array> for ArrayStatistics {
     fn from(value: &dyn Array) -> Self {
-        todo!()
+        match value.data_type() {
+            DataType::Dictionary(key_type, _) => {
+                let (keys, values) = match key_type.as_ref() {
+                    DataType::Int8 => {
+                        let dict = value.as_dictionary::<Int8Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::Int16 => {
+                        let dict = value.as_dictionary::<Int16Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::Int32 => {
+                        let dict = value.as_dictionary::<Int32Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::Int64 => {
+                        let dict = value.as_dictionary::<Int64Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::UInt8 => {
+                        let dict = value.as_dictionary::<UInt8Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::UInt16 => {
+                        let dict = value.as_dictionary::<UInt16Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::UInt32 => {
+                        let dict = value.as_dictionary::<UInt32Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    DataType::UInt64 => {
+                        let dict = value.as_dictionary::<UInt64Type>();
+                        (dict.keys() as &dyn Array, dict.values() as &dyn Array)
+                    }
+                    _ => {
+                        // todo real error
+                        unreachable!("unsupported key type")
+                    }
+                };
+                ArrayStatistics::Dictionary {
+                    keys: make_stats(keys),
+                    values: make_stats(values),
+                }
+            }
+            _ => ArrayStatistics::Primitive(make_stats(value)),
+        }
     }
 }
 
+/// create the lower level statistics from an array
+/// (TODO can put this into memory exec, or something)
+fn make_stats(array: &dyn Array) -> Statistics {
+    Statistics {
+        num_rows: Some(array.len()),
+        total_byte_size: Some(array.get_array_memory_size()),
+        column_statistics: None,
+        is_exact: true,
+    }
+}
 
+fn combine_stats(l: &Statistics, r: &Statistics) -> Statistics {
+    Statistics {
+        num_rows: add_opts(l.num_rows, r.num_rows),
+        total_byte_size: add_opts(l.total_byte_size, r.total_byte_size),
+        column_statistics: None,
+        is_exact: true,
+    }
+}
+
+fn add_opts(l: Option<usize>, r: Option<usize>) -> Option<usize> {
+    match (l, r) {
+        (Some(l), Some(r)) => Some(l + r),
+        (Some(l), None) => Some(l),
+        (None, Some(r)) => Some(r),
+        (None, None) => None,
+    }
+}
 
 // TODO make this a sendable record batchs stream so it can be connected to input/output
 
@@ -67,27 +182,38 @@ impl From<&dyn Array> for ArrayStatistics {
 mod test {
     use super::*;
     use arrow::datatypes::Int32Type;
-    use arrow_array::{Int32Array, DictionaryArray};
+    use arrow_array::{DictionaryArray, Int32Array};
 
     use super::ArrayStatistics;
-
 
     #[test]
     fn ints() {
         let ints = Int32Array::from(vec![Some(1), None, Some(3)]);
         let stats = ArrayStatistics::from(&ints as &dyn Array);
 
-        assert_eq!("foo", stats.summary())
+        assert_eq!(
+            "PrimitiveArray:      3 rows                  224 bytes (Exact)",
+            stats.summary()
+        )
     }
 
     #[test]
     fn dictionary() {
-        let d1: DictionaryArray<Int32Type> = vec![Some("one"), None, Some("three")].into_iter().collect();
+        let d1: DictionaryArray<Int32Type> =
+            vec![Some("one"), None, Some("three")].into_iter().collect();
 
         let stats = ArrayStatistics::from(&d1 as &dyn Array);
 
-        assert_eq!("foo", stats.summary())
+        let expected = vec![
+            "DictionaryArray:",
+            "  Keys:      3 rows                  224 bytes (Exact)",
+            "  Values:      2 rows                 2232 bytes (Exact)",
+        ];
+
+        let actual: Vec<_> = stats.summary().split("\n").map(|s| s.to_string()).collect();
+        assert_eq!(
+            expected, actual,
+            "\n\nexpected: {expected:#?}\n\nactual: {actual:#?}"
+        )
     }
-
-
 }

--- a/datafusion/core/src/physical_plan/stats.rs
+++ b/datafusion/core/src/physical_plan/stats.rs
@@ -57,7 +57,7 @@ impl ArrayStatistics {
                 let overall = combine_stats(keys, values);
                 // TODO add overall stats (and then breakdown)
                 format!(
-                    "{:<16}{}\n{:<16}{}{:<16}\n{}",
+                    "{:<16}{}\n{:<16}{}\n{:<16}{}",
                     "DictionaryArray:",
                     stat_summary(&overall),
                     "  Keys:",
@@ -205,9 +205,9 @@ mod test {
         let stats = ArrayStatistics::from(&d1 as &dyn Array);
 
         let expected = vec![
-            "DictionaryArray:",
-            "  Keys:      3 rows                  224 bytes (Exact)",
-            "  Values:      2 rows                 2232 bytes (Exact)",
+            "DictionaryArray:     5 rows                 2456 bytes (Exact)",
+            "  Keys:              3 rows                  224 bytes (Exact)",
+            "  Values:            2 rows                 2232 bytes (Exact)",
         ];
 
         let actual: Vec<_> = stats.summary().split("\n").map(|s| s.to_string()).collect();

--- a/datafusion/core/src/physical_plan/stats.rs
+++ b/datafusion/core/src/physical_plan/stats.rs
@@ -1,0 +1,93 @@
+use arrow::array::Array;
+use arrow_array::RecordBatch;
+use datafusion_common::Statistics;
+
+
+/// This is a debugging function
+///
+/// This calculates statistics about a stream of record batches for debugging purposes
+#[derive(Debug)]
+pub struct StatisticsStream {
+    // Map column name --> Statistics
+    //cols: BTreeMap<String, ArrayStatistics>
+}
+
+impl StatisticsStream {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    // Record statistics for this batch
+    pub fn observe_batch(&self, batch: &RecordBatch) {
+
+        println!("---------------------");
+        for (f, array) in batch.schema().fields().iter().zip(batch.columns().iter()) {
+            let col_name = f.name();
+            let stats = ArrayStatistics::from(array.as_ref());
+            println!("Statistics for {col_name}: {}", stats.summary());
+        }
+    }
+}
+
+
+
+#[derive(Debug)]
+enum ArrayStatistics {
+    /// statistics for a dictionaryarray
+    Dictionary {
+        keys: Statistics,
+        values: Statistics,
+    },
+    Primitive(Statistics),
+}
+
+
+impl ArrayStatistics {
+    // TODO make this `impl Display`
+    fn summary(&self) -> String {
+        match self
+        {
+            ArrayStatistics::Dictionary { keys, values } => todo!(),
+            ArrayStatistics::Primitive(_) => todo!(),
+        }
+    }
+}
+
+impl From<&dyn Array> for ArrayStatistics {
+    fn from(value: &dyn Array) -> Self {
+        todo!()
+    }
+}
+
+
+
+// TODO make this a sendable record batchs stream so it can be connected to input/output
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::datatypes::Int32Type;
+    use arrow_array::{Int32Array, DictionaryArray};
+
+    use super::ArrayStatistics;
+
+
+    #[test]
+    fn ints() {
+        let ints = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let stats = ArrayStatistics::from(&ints as &dyn Array);
+
+        assert_eq!("foo", stats.summary())
+    }
+
+    #[test]
+    fn dictionary() {
+        let d1: DictionaryArray<Int32Type> = vec![Some("one"), None, Some("three")].into_iter().collect();
+
+        let stats = ArrayStatistics::from(&d1 as &dyn Array);
+
+        assert_eq!("foo", stats.summary())
+    }
+
+
+}

--- a/datafusion/core/tests/order_spill_fuzz.rs
+++ b/datafusion/core/tests/order_spill_fuzz.rs
@@ -22,13 +22,13 @@ use arrow::{
     compute::SortOptions,
     record_batch::RecordBatch,
 };
-use datafusion::execution::memory_pool::GreedyMemoryPool;
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::physical_plan::expressions::{col, PhysicalSortExpr};
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{collect, ExecutionPlan};
 use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_execution::memory_pool::GreedyMemoryPool;
 use rand::Rng;
 use std::sync::Arc;
 use test_utils::{batches_to_vec, partitions_to_sorted_vec};
@@ -76,6 +76,9 @@ async fn run_sort(pool_size: usize, size_spill: Vec<(usize, bool)>) {
         let exec = MemoryExec::try_new(&input, schema, None).unwrap();
         let sort = Arc::new(SortExec::new(sort, Arc::new(exec)));
 
+        // Add IN_MEMORY_SORT_THRESHOLD from sort.rs
+        let pool_size = pool_size.saturating_add(10 * 1024 * 1024);
+
         let runtime_config = RuntimeConfig::new()
             .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size)));
         let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
@@ -88,9 +91,17 @@ async fn run_sort(pool_size: usize, size_spill: Vec<(usize, bool)>) {
         let actual = batches_to_vec(&collected);
 
         if spill {
-            assert_ne!(sort.metrics().unwrap().spill_count().unwrap(), 0);
+            assert_ne!(
+                sort.metrics().unwrap().spill_count().unwrap(),
+                0,
+                "{pool_size} {size}"
+            );
         } else {
-            assert_eq!(sort.metrics().unwrap().spill_count().unwrap(), 0);
+            assert_eq!(
+                sort.metrics().unwrap().spill_count().unwrap(),
+                0,
+                "{pool_size} {size}"
+            );
         }
 
         assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

Not yet filed

# Rationale for this change

We are working on debugging memory usage in IOx

I want to know something about the sizes of batches being created by intermediate operations (SortPreservingMerge in this case)

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->