### PR TITLE
Improve error message for wrong built-in scalar function signatures.

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/errors.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/errors.slt
@@ -38,7 +38,7 @@ WITH HEADER ROW
 LOCATION '../../testing/data/csv/aggregate_test_100.csv'
 
 # csv_query_error
-statement error Error during planning: Coercion from \[Utf8\] to the signature Uniform\(1, \[Float64, Float32\]\) failed\.
+statement error DataFusion error: Error during planning: No function matches the given name and argument types 'sin\(Utf8\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tsin\(Float64/Float32\)
 SELECT sin(c1) FROM aggregate_test_100
 
 # cast_expressions_error

--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -1222,10 +1222,10 @@ SELECT nullif(1);
 statement error Error during planning: No function matches the given name and argument types 'pi\(Float64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tpi\(\)
 SELECT pi(3.14);
 
-# error message for wrong function signature (Any: fixed number of args of arbitary types)
+# error message for wrong function signature (Any: fixed number of args of arbitrary types)
 statement error Error during planning: No function matches the given name and argument types 'arrowtypeof\(Int64, Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tarrowtypeof\(Any\)
 SELECT arrow_typeof(1, 1);
 
-# error message for wrong function signature (OneOf: fixed number of args of arbitary types)
+# error message for wrong function signature (OneOf: fixed number of args of arbitrary types)
 statement error Error during planning: No function matches the given name and argument types 'power\(Int64, Int64, Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tpower\(Int64, Int64\)\n\tpower\(Float64, Float64\)
 SELECT power(1, 2, 3);

--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -1209,3 +1209,23 @@ NULL NULL NULL NULL 8 15.625
 
 statement ok
 drop table test
+
+# error message for wrong function signature (Variadic: arbitrary number of args all from some common types)
+statement error Error during planning: No function matches the given name and argument types 'concat\(\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tconcat\(Utf8, ..\)
+SELECT concat();
+
+# error message for wrong function signature (Uniform: t args all from some common types)
+statement error Error during planning: No function matches the given name and argument types 'nullif\(Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tnullif\(Boolean/UInt8/UInt16/UInt32/UInt64/Int8/Int16/Int32/Int64/Float32/Float64/Utf8/LargeUtf8, Boolean/UInt8/UInt16/UInt32/UInt64/Int8/Int16/Int32/Int64/Float32/Float64/Utf8/LargeUtf8\)
+SELECT nullif(1);
+
+# error message for wrong function signature (Exact: exact number of args of an exact type)
+statement error Error during planning: No function matches the given name and argument types 'pi\(Float64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tpi\(\)
+SELECT pi(3.14);
+
+# error message for wrong function signature (Any: fixed number of args of arbitary types)
+statement error Error during planning: No function matches the given name and argument types 'arrowtypeof\(Int64, Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tarrowtypeof\(Any\)
+SELECT arrow_typeof(1, 1);
+
+# error message for wrong function signature (OneOf: fixed number of args of arbitary types)
+statement error Error during planning: No function matches the given name and argument types 'power\(Int64, Int64, Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tpower\(Int64, Int64\)\n\tpower\(Float64, Float64\)
+SELECT power(1, 2, 3);

--- a/datafusion/expr/src/function_err.rs
+++ b/datafusion/expr/src/function_err.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Function_err module enhances frontend error messages for unresolved functions due to incorrect parameters,
+//! by providing the correct function signatures.
+//!
+//! For example, a query like `select round(3.14, 1.1);` would yield:
+//! ```text
+//! Error during planning: No function matches 'round(Float64, Float64)'. You might need to add explicit type casts.
+//!     Candidate functions:
+//!     round(Float64, Int64)
+//!     round(Float32, Int64)
+//!     round(Float64)
+//!     round(Float32)
+//! ```
+
+use crate::function::signature;
+use crate::{BuiltinScalarFunction, TypeSignature};
+use arrow::datatypes::DataType;
+
+impl TypeSignature {
+    fn to_string_repr(&self) -> Vec<String> {
+        match self {
+            TypeSignature::Variadic(types) => {
+                vec![format!("{}, ..", join_types(types, "/"))]
+            }
+            TypeSignature::Uniform(arg_count, valid_types) => {
+                vec![std::iter::repeat(join_types(valid_types, "/"))
+                    .take(*arg_count)
+                    .collect::<Vec<String>>()
+                    .join(", ")]
+            }
+            TypeSignature::Exact(types) => {
+                vec![join_types(types, ", ")]
+            }
+            TypeSignature::Any(arg_count) => {
+                vec![std::iter::repeat("Any")
+                    .take(*arg_count)
+                    .collect::<Vec<&str>>()
+                    .join(", ")]
+            }
+            TypeSignature::VariadicEqual => vec!["T, .., T".to_string()],
+            TypeSignature::VariadicAny => vec!["Any, .., Any".to_string()],
+            TypeSignature::OneOf(sigs) => {
+                sigs.iter().flat_map(|s| s.to_string_repr()).collect()
+            }
+        }
+    }
+}
+
+/// Helper function to join types with specified delimiter.
+fn join_types<T: std::fmt::Debug>(types: &[T], delimiter: &str) -> String {
+    types
+        .iter()
+        .map(|t| format!("{:?}", t))
+        .collect::<Vec<String>>()
+        .join(delimiter)
+}
+
+/// Creates a detailed error message for a function with wrong signature.
+pub fn generate_signature_error_msg(
+    fun: &BuiltinScalarFunction,
+    input_expr_types: &[DataType],
+) -> String {
+    let candidate_signatures = signature(fun)
+        .type_signature
+        .to_string_repr()
+        .iter()
+        .map(|args_str| format!("\t{}({})", fun, args_str))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    format!(
+        "No function matches the given name and argument types '{}({})'. You might need to add explicit type casts.\n\tCandidate functions:\n{}",
+        fun, join_types(input_expr_types, ", "), candidate_signatures
+    )
+}

--- a/datafusion/expr/src/function_err.rs
+++ b/datafusion/expr/src/function_err.rs
@@ -63,10 +63,10 @@ impl TypeSignature {
 }
 
 /// Helper function to join types with specified delimiter.
-fn join_types<T: std::fmt::Debug>(types: &[T], delimiter: &str) -> String {
+fn join_types<T: std::fmt::Display>(types: &[T], delimiter: &str) -> String {
     types
         .iter()
-        .map(|t| format!("{:?}", t))
+        .map(|t| t.to_string())
         .collect::<Vec<String>>()
         .join(delimiter)
 }

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -37,6 +37,7 @@ pub mod expr_rewriter;
 pub mod expr_schema;
 pub mod field_util;
 pub mod function;
+mod function_err;
 mod literal;
 pub mod logical_plan;
 mod nullif;

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -2750,11 +2750,10 @@ mod tests {
                         "Builtin scalar function {fun} does not support empty arguments"
                     )));
                 }
-                Err(DataFusionError::Internal(err)) => {
-                    if err
-                        != format!(
-                        "Builtin scalar function {fun} does not support empty arguments"
-                    ) {
+                Err(DataFusionError::Plan(err)) => {
+                    if !err
+                        .contains("No function matches the given name and argument types")
+                    {
                         return Err(DataFusionError::Internal(format!(
                             "Builtin scalar function {fun} didn't got the right error message with empty arguments")));
                     }


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

https://github.com/apache/arrow-datafusion/issues/6396

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently, the error message for the built-in scalar function signature mismatch is not straightforward.
The error message before and after this change is shown below:
(There are 5 different function signature types(variadic, exact...) from internal implementation, 1 function is chosen from each type)
```
[BEFORE]DataFusion CLI v25.0.0
❯ select concat();
Internal error: Builtin scalar function concat does not support empty arguments. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
❯ SELECT nullif(1);
Error during planning: Coercion from [Int64] to the signature Uniform(2, [Boolean, UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64, Utf8, LargeUtf8]) failed.
❯ SELECT pi(3.14);
Error during planning: Coercion from [Float64] to the signature Exact([]) failed.
❯ SELECT arrow_typeof(1, 1);
Error during planning: The function expected 1 arguments but received 2
❯ SELECT power('1', '2');
Error during planning: Coercion from [Utf8, Utf8] to the signature OneOf([Exact([Int64, Int64]), Exact([Float64, Float64])]) failed.
```
```
[AFTER]DataFusion CLI v25.0.0
❯ select concat();
Error during planning: No function matches the given name and argument types 'concat()'. You might need to add explicit type casts.
        Candidate functions:
        concat(Utf8, ..)
❯ SELECT nullif(1);
Error during planning: No function matches the given name and argument types 'nullif(Int64)'. You might need to add explicit type casts.
        Candidate functions:
        nullif(Boolean/UInt8/UInt16/UInt32/UInt64/Int8/Int16/Int32/Int64/Float32/Float64/Utf8/LargeUtf8, Boolean/UInt8/UInt16/UInt32/UInt64/Int8/Int16/Int32/Int64/Float32/Float64/Utf8/LargeUtf8)
❯ SELECT pi(3.14);
Error during planning: No function matches the given name and argument types 'pi(Float64)'. You might need to add explicit type casts.
        Candidate functions:
        pi()
❯ SELECT arrow_typeof(1, 1);
Error during planning: No function matches the given name and argument types 'arrowtypeof(Int64, Int64)'. You might need to add explicit type casts.
        Candidate functions:
        arrowtypeof(Any)
❯ SELECT power('1', '2');
Error during planning: No function matches the given name and argument types 'power(Utf8, Utf8)'. You might need to add explicit type casts.
        Candidate functions:
        power(Int64, Int64)
        power(Float64, Float64)

```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1.  Add a `function_err.rs` to generate error messages by providing candidate function signatures if input function arguments are not valid.
2. Before this change, if functions have wrong number of args or input args can't be coerced into valid signatures, it will return different error messages, now they'll all report the error in this way.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
There are 5 function signature types from [internal implementation ](https://github.com/apache/arrow-datafusion/blob/dd3a003c1ca4e2109f33277d13f2b0b2fa500337/datafusion/expr/src/signature.rs#L41), remaining 2 of them are not used when defining built-in scalar functions.
1 of each signature type has an end-to-end sqllogictest for the error message.

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->