### PR TITLE
Do not run avro sqllogictests tests unless the avro feature is enabled

### DIFF
--- a/datafusion/core/tests/sqllogictests/src/main.rs
+++ b/datafusion/core/tests/sqllogictests/src/main.rs
@@ -84,7 +84,10 @@ async fn run_test_file(
     relative_path: PathBuf,
 ) -> Result<(), Box<dyn Error>> {
     info!("Running with DataFusion runner: {}", path.display());
-    let test_ctx = context_for_test_file(&relative_path).await;
+    let Some(test_ctx) = context_for_test_file(&relative_path).await else {
+        info!("Skipping: {}", path.display());
+        return Ok(())
+    };
     let ctx = test_ctx.session_ctx().clone();
     let mut runner = sqllogictest::Runner::new(DataFusion::new(ctx, relative_path));
     runner.with_column_validator(strict_column_validator);
@@ -112,7 +115,10 @@ async fn run_complete_file(
 
     info!("Using complete mode to complete: {}", path.display());
 
-    let test_ctx = context_for_test_file(&relative_path).await;
+    let Some(test_ctx) = context_for_test_file(&relative_path).await else {
+        info!("Skipping: {}", path.display());
+        return Ok(())
+    };
     let ctx = test_ctx.session_ctx().clone();
     let mut runner = sqllogictest::Runner::new(DataFusion::new(ctx, relative_path));
     let col_separator = " ";
@@ -162,15 +168,20 @@ fn read_dir_recursive<P: AsRef<Path>>(path: P) -> Box<dyn Iterator<Item = PathBu
     )
 }
 
-/// Create a SessionContext, configured for the specific test
-async fn context_for_test_file(relative_path: &Path) -> TestContext {
+/// Create a SessionContext, configured for the specific test, if
+/// possible.
+///
+/// If `None` is returned (e.g. because some needed feature is not
+/// enabled), the file should be skipped
+async fn context_for_test_file(relative_path: &Path) -> Option<TestContext> {
     let config = SessionConfig::new()
         // hardcode target partitions so plans are deterministic
         .with_target_partitions(4);
 
-    let mut test_ctx = TestContext::new(SessionContext::with_config(config));
+    let test_ctx = TestContext::new(SessionContext::with_config(config));
 
-    match relative_path.file_name().unwrap().to_str().unwrap() {
+    let file_name = relative_path.file_name().unwrap().to_str().unwrap();
+    match file_name {
         "aggregate.slt" => {
             info!("Registering aggregate tables");
             setup::register_aggregate_tables(test_ctx.session_ctx()).await;
@@ -180,14 +191,24 @@ async fn context_for_test_file(relative_path: &Path) -> TestContext {
             setup::register_scalar_tables(test_ctx.session_ctx()).await;
         }
         "avro.slt" => {
-            info!("Registering avro tables");
-            setup::register_avro_tables(&mut test_ctx).await;
+            #[cfg(feature = "avro")]
+            {
+                let mut test_ctx = test_ctx;
+                info!("Registering avro tables");
+                setup::register_avro_tables(&mut test_ctx).await;
+                return Some(test_ctx);
+            }
+            #[cfg(not(feature = "avro"))]
+            {
+                info!("Skipping {file_name} because avro feature is not enabled");
+                return None;
+            }
         }
         _ => {
             info!("Using default SessionContext");
         }
     };
-    test_ctx
+    Some(test_ctx)
 }
 
 /// Context for running tests
@@ -199,7 +220,7 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    fn new(ctx: SessionContext) -> Self {
+    pub fn new(ctx: SessionContext) -> Self {
         Self {
             ctx,
             test_dir: None,
@@ -208,7 +229,7 @@ impl TestContext {
 
     /// Enables the test directory feature. If not enabled,
     /// calling `testdir_path` will result in a panic.
-    fn enable_testdir(&mut self) {
+    pub fn enable_testdir(&mut self) {
         if self.test_dir.is_none() {
             self.test_dir = Some(TempDir::new().expect("failed to create testdir"));
         }
@@ -216,7 +237,7 @@ impl TestContext {
 
     /// Returns the path to the test directory. Panics if the test
     /// directory feature is not enabled via `enable_testdir`.
-    fn testdir_path(&self) -> &Path {
+    pub fn testdir_path(&self) -> &Path {
         self.test_dir.as_ref().expect("testdir not enabled").path()
     }
 

--- a/datafusion/core/tests/sqllogictests/src/setup.rs
+++ b/datafusion/core/tests/sqllogictests/src/setup.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::prelude::AvroReadOptions;
 use datafusion::{
     arrow::{
         array::{
@@ -31,13 +30,12 @@ use datafusion::{
 };
 use std::sync::Arc;
 
-use crate::{utils, TestContext};
+use crate::utils;
 
-pub async fn register_avro_tables(ctx: &mut TestContext) {
-    register_avro_test_data(ctx).await;
-}
+#[cfg(feature = "avro")]
+pub async fn register_avro_tables(ctx: &mut crate::TestContext) {
+    use datafusion::prelude::AvroReadOptions;
 
-async fn register_avro_test_data(ctx: &mut TestContext) {
     ctx.enable_testdir();
 
     let table_path = ctx.testdir_path().join("avro");


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/6399

# Rationale for this change

If a feature is not enabled, we should not fail tests . This test was newly added in https://github.com/apache/arrow-datafusion/pull/6362 by @e1ijah1 👋 ❤️  but has the unfortunate property that running `cargo test -p datafusion` now fails because `avro.slt` will only pass if the `avro` feature is enabled

# What changes are included in this PR?
Change sqllogictest so that it does not run avro.sql if the `avro` feature is not available

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes

# Are there any user-facing changes?
You can now do:

```shell
RUST_LOG=debug cargo test -p datafusion --test sqllogictests -- avro
```

And it will pass
```
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running tests/sqllogictests/src/main.rs (/Users/alamb/Software/target-df/debug/deps/sqllogictests-ef50afea7db0aec6)
[2023-05-23T10:59:09Z INFO  sqllogictests] Running with DataFusion runner: tests/sqllogictests/test_files/avro.slt
[2023-05-23T10:59:09Z INFO  sqllogictests] Skipping avro.slt because avro feature is not enabled
[2023-05-23T10:59:09Z INFO  sqllogictests] Skipping: tests/sqllogictests/test_files/avro.slt
```