### PR TITLE
Skip casting result array for binary numerical operators result between array and scalar if possible

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1061,24 +1061,22 @@ fn to_result_type_array(
 ) -> Result<ArrayRef> {
     if array.data_type() == result_type {
         Ok(array)
-    } else {
-        if op.is_numerical_operators() {
-            match array.data_type() {
-                DataType::Dictionary(_, value_type) => {
-                    if value_type.as_ref() == result_type {
-                        Ok(cast(&array, result_type)?)
-                    } else {
-                        Err(DataFusionError::Internal(format!(
+    } else if op.is_numerical_operators() {
+        match array.data_type() {
+            DataType::Dictionary(_, value_type) => {
+                if value_type.as_ref() == result_type {
+                    Ok(cast(&array, result_type)?)
+                } else {
+                    Err(DataFusionError::Internal(format!(
                             "Incompatible Dictionary value type {:?} with result type {:?} of Binary operator {:?}",
                             value_type, result_type, op
                         )))
-                    }
                 }
-                _ => Ok(array),
             }
-        } else {
-            Ok(array)
+            _ => Ok(array),
         }
+    } else {
+        Ok(array)
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1059,22 +1059,26 @@ fn to_result_type_array(
     array: ArrayRef,
     result_type: &DataType,
 ) -> Result<ArrayRef> {
-    if op.is_numerical_operators() {
-        match array.data_type() {
-            DataType::Dictionary(_, value_type) => {
-                if value_type.as_ref() == result_type {
-                    Ok(cast(&array, result_type)?)
-                } else {
-                    Err(DataFusionError::Internal(format!(
-                        "Incompatible Dictionary value type {:?} with result type {:?} of Binary operator {:?}",
-                        value_type, result_type, op
-                    )))
-                }
-            }
-            _ => Ok(array),
-        }
-    } else {
+    if array.data_type() == result_type {
         Ok(array)
+    } else {
+        if op.is_numerical_operators() {
+            match array.data_type() {
+                DataType::Dictionary(_, value_type) => {
+                    if value_type.as_ref() == result_type {
+                        Ok(cast(&array, result_type)?)
+                    } else {
+                        Err(DataFusionError::Internal(format!(
+                            "Incompatible Dictionary value type {:?} with result type {:?} of Binary operator {:?}",
+                            value_type, result_type, op
+                        )))
+                    }
+                }
+                _ => Ok(array),
+            }
+        } else {
+            Ok(array)
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is a follow up to #6269.

As we try on upgrading to latest DataFusion 25.0.0 internally, just found this issue. In DataFusion, for numerical operators between Dictionary array (lhs) and literal (rhs), the type of rhs literal will be coerced to Scalar::Dictionary. Although the operation is still between array and literal, the result datatype can be aligned with the operation between array and array.

That's why #6269 is proposed to convert the result between array and literal to match the one between array and array.

But in our case, we don't rely on query analysis and optimization of DataFusion but directly go for physical execution, our query doesn't go through the coercion phase. So the operation is between Dictionary array and original literal (without coerced to Scalar::Dictionary). This leads to different result type as Dictionary array. In such case, we don't need to cast the result array. We can skip casting for the result array if its datatype is already same as binary operator's result type.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Tested internally. This is not the case that DataFusion queries could hit actually.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->