### PR TITLE
Fix protobuf install command for Fedora Linux.

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -76,7 +76,7 @@ On most platforms this can be installed from your system's package manager
 
 ```
 $ apt install -y protobuf-compiler
-$ dnf install -y protobuf-compiler
+$ dnf install -y protobuf-devel
 $ pacman -S protobuf
 $ brew install protobuf
 ```


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6418.

# Rationale for this change

The current command `dnf install -y protobuf-compiler` does install a real package, but it is not sufficient to be able to build DataFusion on Fedora systems.

The proposed command `dnf install -y protobuf-devel` correctly installs the protobuf compiler as well as some development resources that are required.

The proposed change improves the docs in the sense that it installs the correct dependencies for Fedora

# What changes are included in this PR?

A small code snippet in the docs.

# Are these changes tested?

No tests required for such a documentation change, at least not as far as I'm aware.

# Are there any user-facing changes?

Yes, in the sense that it changes the documentation, but the current command simply doesn't work, and ultimately this change doesn't break anything for anyone.