### PR TITLE
Substrait: Support Expr::ScalarFunction

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -782,17 +782,24 @@ pub async fn from_substrait_rex(
                 for arg in f.arguments.iter() {
                     match &arg.arg_type {
                         Some(ArgType::Value(e)) => {
-                            args.push(from_substrait_rex(e, input_schema, extensions).await?.as_ref().clone());
-                        }  
-                        e => return Err(DataFusionError::NotImplemented(format!(
-                            "Invalid arguments for scalar function: {e:?}"
-                        ))),            
+                            args.push(
+                                from_substrait_rex(e, input_schema, extensions)
+                                    .await?
+                                    .as_ref()
+                                    .clone(),
+                            );
+                        }
+                        e => {
+                            return Err(DataFusionError::NotImplemented(format!(
+                                "Invalid arguments for scalar function: {e:?}"
+                            )))
+                        }
                     }
                 }
-                
+
                 Ok(Arc::new(Expr::ScalarFunction(expr::ScalarFunction {
                     fun: fun?,
-                    args
+                    args,
                 })))
             }
         },

--- a/datafusion/substrait/tests/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/roundtrip_logical_plan.rs
@@ -279,6 +279,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn simple_scalar_function_abs() -> Result<()> {
+        roundtrip("SELECT ABS(a) FROM data").await
+    }
+
+    #[tokio::test]
     async fn case_without_base_expression() -> Result<()> {
         roundtrip(
             "SELECT (CASE WHEN a >= 0 THEN 'positive' ELSE 'negative' END) FROM data",

--- a/datafusion/substrait/tests/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/roundtrip_logical_plan.rs
@@ -284,6 +284,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn simple_scalar_function_pow() -> Result<()> {
+        roundtrip("SELECT POW(a, 2) FROM data").await
+    }
+
+    #[tokio::test]
+    async fn simple_scalar_function_substr() -> Result<()> {
+        roundtrip("SELECT * FROM data WHERE a = SUBSTR('datafusion', 0, 3)").await
+    }
+
+    #[tokio::test]
     async fn case_without_base_expression() -> Result<()> {
         roundtrip(
             "SELECT (CASE WHEN a >= 0 THEN 'positive' ELSE 'negative' END) FROM data",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6411.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Currently, we had supported Subtrait::ScalarFunction to DF::BinaryExpr when args len is 2. Now, we support Subtrait::ScalarFunction to DF::ScalarFunction for arbitrary args len. Use name to determine Operator or ScalarFunction to transform for two args cases.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Test roundtrip_logical_plan

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->