### PR TITLE
Fix case evaluation with NULL

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -673,6 +673,14 @@ NULL
 NULL
 4
 
+# issue: https://github.com/apache/arrow-datafusion/issues/6376
+query I
+select case when a = 0 then 123 end from (values(1), (0), (null)) as t(a);
+----
+NULL
+123
+NULL
+
 # csv_query_sum_cast() {
 
 statement ok


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6376.

# Rationale for this change


As pointed out by @richox on #6376 
> zip() does not specify the behavior of null input and it doesn't check null values in its implementation.

# What changes are included in this PR?
Call the `prep_null_mask_filter` function to eliminate NULLs.

# Are these changes tested?
Yes

# Are there any user-facing changes?
No