### PR TITLE
Make `FileStream` error handling configurable

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -749,6 +749,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn on_error_scanning_fail() -> Result<()> {
+        let result = FileStreamTest::new()
+            .with_records(vec![make_partition(3), make_partition(2)])
+            .with_num_files(2)
+            .with_on_error(OnError::Fail)
+            .with_scan_errors(vec![1])
+            .result()
+            .await;
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn on_error_opening_fail() -> Result<()> {
+        let result = FileStreamTest::new()
+            .with_records(vec![make_partition(3), make_partition(2)])
+            .with_num_files(2)
+            .with_on_error(OnError::Fail)
+            .with_open_errors(vec![1])
+            .result()
+            .await;
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn on_error_scanning() -> Result<()> {
         let batches = FileStreamTest::new()
             .with_records(vec![make_partition(3), make_partition(2)])

--- a/datafusion/core/src/physical_plan/file_format/file_stream.rs
+++ b/datafusion/core/src/physical_plan/file_format/file_stream.rs
@@ -273,7 +273,7 @@ impl<F: FileOpener> FileStream<F> {
 
     /// Specify the behavior when an error occurs opening or scanning a file
     ///
-    /// If `OnError::Skip` the stream will skip files which encounter and error and continue
+    /// If `OnError::Skip` the stream will skip files which encounter an error and continue
     /// If `OnError:Fail` (default) the stream will fail and stop processing when an error occurs
     pub fn with_on_error(mut self, on_error: OnError) -> Self {
         self.on_error = on_error;

--- a/datafusion/core/src/physical_plan/file_format/mod.rs
+++ b/datafusion/core/src/physical_plan/file_format/mod.rs
@@ -39,7 +39,7 @@ use arrow::{
 pub use arrow_file::ArrowExec;
 pub use avro::AvroExec;
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
-pub use file_stream::{FileOpenFuture, FileOpener, FileStream};
+pub use file_stream::{FileOpenFuture, FileOpener, FileStream, OnError};
 pub(crate) use json::plan_to_json;
 pub use json::{JsonOpener, NdJsonExec};
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6476 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In some cases it useful to skip files during scan if they are not readable (because they have been deleted or corrupted, etc) without failing the entire query

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`FileStream` can now have an `OnError` config set. When `OnError::Fail` (default) the behavior is unchanged from what exists now and any error opening or scanning a fail will terminate the stream. If `OnError::Skip`, then the stream will skip the error'd file and continue scanning any other files in the queue. 

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No