### PR TITLE
fix: error instead of panic when date_bin interval is 0

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -397,13 +397,13 @@ drop table ts_data_secs
 ##########
 
 # not support interval 0
-statement error Execution error: DATE_BIN stride must be non-zero and positive
+statement error Execution error: DATE_BIN stride must be non-zero
 SELECT DATE_BIN(INTERVAL '0 second', TIMESTAMP '2022-08-03 14:38:50.000000006Z', TIMESTAMP '1970-01-01T00:00:00Z')
 
-statement error Execution error: DATE_BIN stride must be non-zero and positive
+statement error Execution error: DATE_BIN stride must be non-zero
 SELECT DATE_BIN(INTERVAL '0 month', TIMESTAMP '2022-08-03 14:38:50.000000006Z')
 
-statement error Execution error: DATE_BIN stride must be non-zero and positive
+statement error Execution error: DATE_BIN stride must be non-zero
 SELECT
   DATE_BIN(INTERVAL '0' minute, time) AS time,
   count(val)

--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -392,11 +392,28 @@ drop table ts_data_millis
 statement ok
 drop table ts_data_secs
 
-
-
 ##########
 ## test date_bin function
 ##########
+
+# not support interval 0
+statement error Execution error: DATE_BIN stride must be non-zero and positive
+SELECT DATE_BIN(INTERVAL '0 second', TIMESTAMP '2022-08-03 14:38:50.000000006Z', TIMESTAMP '1970-01-01T00:00:00Z')
+
+statement error Execution error: DATE_BIN stride must be non-zero and positive
+SELECT DATE_BIN(INTERVAL '0 month', TIMESTAMP '2022-08-03 14:38:50.000000006Z')
+
+statement error Execution error: DATE_BIN stride must be non-zero and positive
+SELECT
+  DATE_BIN(INTERVAL '0' minute, time) AS time,
+  count(val)
+FROM (
+  VALUES
+    (TIMESTAMP '2021-06-10 17:05:00Z', 0.5),
+    (TIMESTAMP '2021-06-10 17:19:10Z', 0.3)
+  ) as t (time, val)
+group by time;
+
 query P
 SELECT DATE_BIN(INTERVAL '15 minutes', TIMESTAMP '2022-08-03 14:38:50Z', TIMESTAMP '1970-01-01T00:00:00Z')
 ----

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -525,7 +525,7 @@ fn date_bin_impl(
     // Return error if stride is 0
     if stride == 0 {
         return Err(DataFusionError::Execution(
-            "DATE_BIN stride must be non-zero and positive".to_string(),
+            "DATE_BIN stride must be non-zero".to_string(),
         ));
     }
 
@@ -1044,7 +1044,7 @@ mod tests {
         ]);
         assert_eq!(
             res.err().unwrap().to_string(),
-            "Execution error: DATE_BIN stride must be non-zero and positive"
+            "Execution error: DATE_BIN stride must be non-zero"
         );
 
         // stride: overflow of day-time interval

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -522,6 +522,13 @@ fn date_bin_impl(
 
     let (stride, stride_fn) = stride.bin_fn();
 
+    // Return error if stride is 0
+    if stride == 0 {
+        return Err(DataFusionError::Execution(
+            "DATE_BIN stride must be non-zero and positive".to_string(),
+        ));
+    }
+
     let f_nanos = |x: Option<i64>| x.map(|x| stride_fn(stride, x, origin));
     let f_micros = |x: Option<i64>| {
         let scale = 1_000;
@@ -1027,6 +1034,17 @@ mod tests {
         assert_eq!(
             res.err().unwrap().to_string(),
             "Execution error: DATE_BIN expects stride argument to be an INTERVAL but got Interval(YearMonth)"
+        );
+
+        // stride: invalid value
+        let res = date_bin(&[
+            ColumnarValue::Scalar(ScalarValue::IntervalDayTime(Some(0))),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+        ]);
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Execution error: DATE_BIN stride must be non-zero and positive"
         );
 
         // stride: overflow of day-time interval


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #https://github.com/apache/arrow-datafusion/issues/6517

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Instead of panic when the stride of date_bin is 0, let us just make it an error message

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Check if the stride is 0 and error out

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

# Are there any user-facing changes?

User will see a proper error message `Execution error: DATE_BIN stride must be non-zero and positive` instead of 
`thread 'main' panicked at 'attempt to calculate the remainder with a divisor of zero',  /arrow-datafusion/datafusion/physical-expr/src/datetime_expressions.rs:354:34
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->