### PR TITLE
Remove `avro_to_arrow::reader::Reader::next` in favor of `Iterator` implementation.

### DIFF
--- a/datafusion/core/src/avro_to_arrow/reader.rs
+++ b/datafusion/core/src/avro_to_arrow/reader.rs
@@ -151,28 +151,15 @@ impl<'a, R: Read> Reader<'a, R> {
     pub fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
-
-    /// Returns the next batch of results (defined by `self.batch_size`), or `None` if there
-    /// are no more results.
-    //
-    // TODO(clippy): The clippy `allow` could be removed by renaming this method to `next_batch`.
-    // This would also make the intent of the method clearer.
-    //
-    // Another option could be to rework `AvroArrowArrayReader::next_batch` so it returns an
-    // `Option<ArrowResult<RecordBatch>>` instead of a  `ArrowResult<Option<RecordBatch>>`.
-    // This would make it possible to remove this method entirely and move its body into the
-    // `Iterator` implementation.
-    #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
-        self.array_reader.next_batch(self.batch_size)
-    }
 }
 
 impl<'a, R: Read> Iterator for Reader<'a, R> {
     type Item = ArrowResult<RecordBatch>;
 
+    /// Returns the next batch of results (defined by `self.batch_size`), or `None` if there
+    /// are no more results.
     fn next(&mut self) -> Option<Self::Item> {
-        self.next().transpose()
+        self.array_reader.next_batch(self.batch_size)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6537.

# Rationale for this change
Explained in the linked issue

# What changes are included in this PR?
Reworked `AvroArrowArrayReader::next_batch`, removed `avro_to_arrow::reader::Reader::next`, and reworked `avro_to_arrow::reader::Reader`'s `Iterator` implementation.

# Are these changes tested?
No change in behavior, so existing tests should be sufficient.

# Are there any user-facing changes?
I think so? I'm not sure because `avro_to_arrow::reader::Reader` doesn't appear in the documentation, but it's public AFAICT?

Anyways, if `Reader` is indeed public, then users will have to import the `Iterator` trait to use the `next` method.