### PR TITLE
Docs: add more PR guidance in contributing guide (smaller PRs)

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -49,7 +49,7 @@ We recommend splitting your contributions into smaller PRs rather than large PRs
 2. The PR discussions tend to be more focused and less likely to get lost among several different threads.
 3. It is often easier to accept and act on feedback when it comes early on in a small change, before a particular approach has been polished too much.
 
-If you are concerned that a larger design will be lost in a string of small PRs, creating a large draft PR that shows how they all work together chan help.
+If you are concerned that a larger design will be lost in a string of small PRs, creating a large draft PR that shows how they all work together can help.
 
 # Reviewing Pull Requests
 

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -41,10 +41,28 @@ DataFusion is a very active fast-moving project and we try to review and merge P
 
 Review bandwidth is currently our most limited resource, and we highly encourage reviews by the broader community. If you are waiting for your PR to be reviewed, consider helping review other PRs that are waiting. Such review both helps the reviewer to learn the codebase and become more expert, as well as helps identify issues in the PR (such as lack of test coverage), that can be addressed and make future reviews faster and more efficient.
 
-Things to help look for in a PR:
+## Creating Pull Requests
+
+We recommend splitting your contributions into smaller PRs rather than large PRs (500+ lines) because:
+
+1. The PR is more likely to be reviewed quickly -- our reviewers struggle to find the contiguous time needed to review large PRs.
+2. The PR discussions tend to be more focused and less likely to get lost among several different threads.
+3. It is often easier to accept and act on feedback when it comes early on in a small change, before a particular approach has been polished too much.
+
+If you are concerned that a larger design will be lost in a string of small PRs, creating a large draft PR that shows how they all work together chan help.
+
+# Reviewing Pull Requests
+
+When reviewing PRs, please remember our primary goal is to improve DataFusion and its community together. PR feedback should be constructive with the aim to help improve the code as well as the understanding of the contributor.
+
+Please ensure any issues you raise contains a rationale and suggested alternative -- it is frustrating to be told "don't do it this way" without any clear reason or alternate provided.
+
+Some things to specifically check:
 
 1. Is the feature or fix covered sufficiently with tests (see `Test Organization` below)?
 2. Is the code clear, and fits the style of the existing codebase?
+
+## "Major" and "Minor" PRs
 
 Since we are a worldwide community, we have contributors in many timezones who review and comment. To ensure anyone who wishes has an opportunity to review a PR, our committers try to ensure that at least 24 hours passes between when a "major" PR is approved and when it is merged.
 
@@ -54,6 +72,8 @@ A "major" PR means there is a substantial change in design or a change in the AP
 2. Small bug fixes
 3. Non-controversial build-related changes (clippy, version upgrades etc.)
 4. Smaller non-controversial feature additions
+
+The good thing about open code and open development is that any issues in one change can almost always be fixed with a follow on PR.
 
 ## Getting Started
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
I have had PR size discussions with various people over time and I wanted to write down suggestions so that 
1. We could agree as a community on the guidance (so it was consistent)
2. It can be clearly documented and we don't have to repeat it on a case by case basis

Most recently this came up with @izveigor on https://github.com/apache/arrow-datafusion/pull/6384 but I have had similar exchanges with @ozankabak  and likely others
  
# What changes are included in this PR?

Add a suggestion in the contributor section of the docs

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A

# Are there any user-facing changes?
Docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->