### PR TITLE
Make the struct function return the correct data type.

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/functions.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/functions.slt
@@ -458,3 +458,25 @@ SELECT v1, v2, ROWNUMBER() OVER(ORDER BY v1) from test;
 
 statement ok
 drop table test
+
+# Scalar function struct
+statement ok
+create table simple_struct_test (
+    c1 boolean,
+    c2 INT,
+    c3 FLOAT,
+    c4 DOUBLE,
+    a VARCHAR,
+    b TEXT
+) as select *
+from (values
+  (true, 1,3.1,3.14,'str','text')
+);
+
+query ?
+SELECT struct(c1,c2,c3,c4,a,b) from simple_struct_test
+----
+{c0: 1, c1: 1, c2: 3.1, c3: 3.14, c4: str, c5: text}
+
+statement ok
+drop table simple_struct_test

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -352,7 +352,14 @@ pub fn return_type(
             _ => Ok(DataType::Float64),
         },
 
-        BuiltinScalarFunction::Struct => Ok(DataType::Struct(Fields::empty())),
+        BuiltinScalarFunction::Struct => {
+            let return_fields = input_expr_types
+                .iter()
+                .enumerate()
+                .map(|(pos, dt)| Field::new(format!("c{pos}"), dt.clone(), true))
+                .collect::<Vec<Field>>();
+            Ok(DataType::Struct(Fields::from(return_fields)))
+        }
 
         BuiltinScalarFunction::Atan2 => match &input_expr_types[0] {
             DataType::Float32 => Ok(DataType::Float32),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

```
use datafusion::prelude::*;
use datafusion_expr::BuiltinScalarFunction;
​
#[tokio::main]
async fn main() -> datafusion::error::Result<()> {
    let ctx = SessionContext::new();
    ctx.register_csv("example", "tests/data/example.csv", CsvReadOptions::new()).await?;
​
    let df = ctx.table("example").await?;
​
    let f = Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction {
        fun: BuiltinScalarFunction::Struct,
        args: vec![col("a"), col("b")],
    });
​
    let df2 = df.select(vec![f])?;
    df2.show().await?;
    Ok(())
}

```

Error: ArrowError(InvalidArgumentError("column types must match schema types, expected Struct([]) but found Struct([Field { name: \"c0\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"c1\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]) at column index 0"))

Closes #6597.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->