### PR TITLE
Minor: Move `include_rank` into `BuiltInWindowFunctionExpr`

### DIFF
--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -121,7 +121,7 @@ impl WindowExpr for BuiltInWindowExpr {
                 last_range = range;
             }
             ScalarValue::iter_to_array(row_wise_results.into_iter())
-        } else if evaluator.include_rank() {
+        } else if self.expr.include_rank() {
             let columns = self.sort_columns(batch)?;
             let sort_partition_points = evaluate_partition_ranges(num_rows, &columns)?;
             evaluator.evaluate_with_rank(num_rows, &sort_partition_points)
@@ -166,7 +166,7 @@ impl WindowExpr for BuiltInWindowExpr {
             // We iterate on each row to perform a running calculation.
             let record_batch = &partition_batch_state.record_batch;
             let num_rows = record_batch.num_rows();
-            let sort_partition_points = if evaluator.include_rank() {
+            let sort_partition_points = if self.expr.include_rank() {
                 let columns = self.sort_columns(record_batch)?;
                 evaluate_partition_ranges(num_rows, &columns)?
             } else {

--- a/datafusion/physical-expr/src/window/built_in_window_function_expr.rs
+++ b/datafusion/physical-expr/src/window/built_in_window_function_expr.rs
@@ -95,4 +95,12 @@ pub trait BuiltInWindowFunctionExpr: Send + Sync + std::fmt::Debug {
     fn uses_window_frame(&self) -> bool {
         false
     }
+
+    /// Can this function be evaluated with (only) rank
+    ///
+    /// If `include_rank` is true, then [`Self::create_evaluator`] must
+    /// implement [`PartitionEvaluator::evaluate_with_rank`]
+    fn include_rank(&self) -> bool {
+        false
+    }
 }

--- a/datafusion/physical-expr/src/window/cume_dist.rs
+++ b/datafusion/physical-expr/src/window/cume_dist.rs
@@ -64,16 +64,16 @@ impl BuiltInWindowFunctionExpr for CumeDist {
     fn create_evaluator(&self) -> Result<Box<dyn PartitionEvaluator>> {
         Ok(Box::new(CumeDistEvaluator {}))
     }
+
+    fn include_rank(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]
 pub(crate) struct CumeDistEvaluator;
 
 impl PartitionEvaluator for CumeDistEvaluator {
-    fn include_rank(&self) -> bool {
-        true
-    }
-
     fn evaluate_with_rank(
         &self,
         num_rows: usize,

--- a/datafusion/physical-expr/src/window/partition_evaluator.rs
+++ b/datafusion/physical-expr/src/window/partition_evaluator.rs
@@ -91,15 +91,6 @@ use std::ops::Range;
 /// [`BuiltInWindowFunctionExpr`]: crate::window::BuiltInWindowFunctionExpr
 /// [`BuiltInWindowFunctionExpr::create_evaluator`]: crate::window::BuiltInWindowFunctionExpr::create_evaluator
 pub trait PartitionEvaluator: Debug + Send {
-    /// Can this evaluator be evaluated with (only) rank
-    ///
-    /// If `include_rank` is true, then [`Self::evaluate_with_rank`]
-    /// will be called for each partition, which includes the
-    /// `rank`.
-    fn include_rank(&self) -> bool {
-        false
-    }
-
     /// Returns the internal state of the window function
     ///
     /// Only used for stateful evaluation

--- a/datafusion/physical-expr/src/window/partition_evaluator.rs
+++ b/datafusion/physical-expr/src/window/partition_evaluator.rs
@@ -182,8 +182,6 @@ pub trait PartitionEvaluator: Debug + Send {
     ///   (3,4),
     /// ]
     /// ```
-    ///
-    /// See [`Self::include_rank`] for more details
     fn evaluate_with_rank(
         &self,
         _num_rows: usize,

--- a/datafusion/physical-expr/src/window/rank.rs
+++ b/datafusion/physical-expr/src/window/rank.rs
@@ -104,6 +104,10 @@ impl BuiltInWindowFunctionExpr for Rank {
         matches!(self.rank_type, RankType::Basic | RankType::Dense)
     }
 
+    fn include_rank(&self) -> bool {
+        true
+    }
+
     fn create_evaluator(&self) -> Result<Box<dyn PartitionEvaluator>> {
         Ok(Box::new(RankEvaluator {
             state: RankState::default(),
@@ -167,10 +171,6 @@ impl PartitionEvaluator for RankEvaluator {
                 "Can not execute PERCENT_RANK in a streaming fashion".to_string(),
             )),
         }
-    }
-
-    fn include_rank(&self) -> bool {
-        true
     }
 
     fn evaluate_with_rank(


### PR DESCRIPTION
# Which issue does this PR close?
Related to #5781 

# Rationale for this change

`BuiltInWindowFunctionExpr` already contains several methods that describe how to call the corresponding `PartitionEvaluator` such as `supports_bounded_execution`. 

The `include_rank` function similarly controls how the `PartitionEvaluator`  is called, and therefore I think makes more sense to include on `BuiltInWindowFunctionExpr` as well

As we contemplate exposing `BuiltInWindowFunctionExpr` and `PartitionEvaluator` to implement window functions, making sure the interface is consistent I think is valuable

# What changes are included in this PR?
1. Move `include_rank` into `BuiltInWindowFunctionExpr`

# Are these changes tested?
Covered by existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->