### PR TITLE
Insert supports specifying column names in any order

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/insert.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/insert.slt
@@ -238,32 +238,35 @@ drop table table_without_values;
 
 # test insert with column names
 statement ok
-CREATE TABLE table_without_values(field1 BIGINT NULL, field2 BIGINT NULL);
+CREATE TABLE table_without_values(id BIGINT, name varchar);
 
-query II
-insert into table_without_values(field1, field2) values(1, 2);
+query IT
+insert into table_without_values(id, name) values(1, 'foo');
 ----
 1
 
-query II
-insert into table_without_values(field2, field1) values(4, 3);
+query IT
+insert into table_without_values(name, id) values('bar', 2);
 ----
 1
 
-statement error Error during planning: Column 'field1' specified more than once
-insert into table_without_values(field1, field1) values(5, 6);
+statement error Schema error: Schema contains duplicate unqualified field name id
+insert into table_without_values(id, id) values(3, 3);
+
+statement error Arrow error: Cast error: Cannot cast string 'zoo' to value of Int64 type
+insert into table_without_values(name, id) values(4, 'zoo');
 
 statement error Error during planning: Column count doesn't match insert query!
-insert into table_without_values(field1) values(7, 8);
+insert into table_without_values(id) values(4, 'zoo');
 
 statement error Error during planning: Inserting query must have the same schema with the table.
-insert into table_without_values(field1) values(9);
+insert into table_without_values(id) values(4);
 
-query II rowsort
+query IT rowsort
 select * from table_without_values;
 ----
-1 2
-3 4
+1 foo
+2 bar
 
 statement ok
 drop table table_without_values;

--- a/datafusion/core/tests/sqllogictests/test_files/insert.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/insert.slt
@@ -234,3 +234,36 @@ select count(*) from table_without_values;
 
 statement ok
 drop table table_without_values;
+
+
+# test insert with column names
+statement ok
+CREATE TABLE table_without_values(field1 BIGINT NULL, field2 BIGINT NULL);
+
+query II
+insert into table_without_values(field1, field2) values(1, 2);
+----
+1
+
+query II
+insert into table_without_values(field2, field1) values(4, 3);
+----
+1
+
+statement error Error during planning: Column 'field1' specified more than once
+insert into table_without_values(field1, field1) values(5, 6);
+
+statement error Error during planning: Column count doesn't match insert query!
+insert into table_without_values(field1) values(7, 8);
+
+statement error Error during planning: Inserting query must have the same schema with the table.
+insert into table_without_values(field1) values(9);
+
+query II rowsort
+select * from table_without_values;
+----
+1 2
+3 4
+
+statement ok
+drop table table_without_values;

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1002,10 +1002,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .index_of_column_by_name(None, &c)?
                         .ok_or_else(|| unqualified_field_not_found(&c, &table_schema))?;
                     if mapping[column_index].is_some() {
-                        return Err(DataFusionError::Plan(format!(
-                            "Column '{}' specified more than once",
-                            c
-                        )));
+                        return Err(DataFusionError::SchemaError(
+                            datafusion_common::SchemaError::DuplicateUnqualifiedField {
+                                name: c,
+                            },
+                        ));
                     } else {
                         mapping[column_index] = Some(i);
                     }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -26,8 +26,8 @@ use crate::utils::normalize_ident;
 use arrow_schema::DataType;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
-    Column, DFField, DFSchema, DFSchemaRef, DataFusionError, ExprSchema,
-    OwnedTableReference, Result, SchemaReference, TableReference, ToDFSchema,
+    unqualified_field_not_found, Column, DFField, DFSchema, DFSchemaRef, DataFusionError,
+    ExprSchema, OwnedTableReference, Result, SchemaReference, TableReference, ToDFSchema,
 };
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::builder::project;
@@ -981,24 +981,38 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let arrow_schema = (*provider.schema()).clone();
         let table_schema = DFSchema::try_from(arrow_schema)?;
 
-        let fields = if columns.is_empty() {
+        // Get insert fields and index_mapping
+        // The i-th field of the table is `fields[index_mapping[i]]`
+        let (fields, index_mapping) = if columns.is_empty() {
             // Empty means we're inserting into all columns of the table
-            table_schema.fields().clone()
+            (
+                table_schema.fields().clone(),
+                (0..table_schema.fields().len())
+                    .map(Some)
+                    .collect::<Vec<_>>(),
+            )
         } else {
+            let mut mapping = vec![None; table_schema.fields().len()];
             let fields = columns
-                .iter()
-                .map(|c| {
-                    Ok(table_schema
-                        .field_with_unqualified_name(
-                            &self.normalizer.normalize(c.clone()),
-                        )?
-                        .clone())
+                .into_iter()
+                .map(|c| self.normalizer.normalize(c))
+                .enumerate()
+                .map(|(i, c)| {
+                    let column_index = table_schema
+                        .index_of_column_by_name(None, &c)?
+                        .ok_or_else(|| unqualified_field_not_found(&c, &table_schema))?;
+                    if mapping[column_index].is_some() {
+                        return Err(DataFusionError::Plan(format!(
+                            "Column '{}' specified more than once",
+                            c
+                        )));
+                    } else {
+                        mapping[column_index] = Some(i);
+                    }
+                    Ok(table_schema.field(column_index).clone())
                 })
                 .collect::<Result<Vec<DFField>>>()?;
-            // Validate no duplicate fields
-            let table_schema =
-                DFSchema::new_with_metadata(fields, table_schema.metadata().clone())?;
-            table_schema.fields().clone()
+            (fields, mapping)
         };
 
         // infer types for Values clause... other types should be resolvable the regular way
@@ -1036,10 +1050,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 "Column count doesn't match insert query!".to_owned(),
             ))?;
         }
-        let exprs = fields
-            .iter()
-            .zip(source.schema().fields().iter())
-            .map(|(target_field, source_field)| {
+
+        let exprs = index_mapping
+            .into_iter()
+            .flatten()
+            .map(|i| {
+                let target_field = &fields[i];
+                let source_field = source.schema().field(i);
                 let expr =
                     datafusion_expr::Expr::Column(source_field.unqualified_column())
                         .cast_to(target_field.data_type(), source.schema())?


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Currently, the order of the specified column names for INSERT must match the order of the column names in the table.

For example, the following statement cannot be executed successfully
```shell
DataFusion CLI v26.0.0
❯ create table t(a int, b int);
0 rows in set. Query took 0.028 seconds.
❯ insert into t(b,a) values(2,1);
Error during planning: Inserting query must have the same schema with the table.
```
To address this issue, we can rearrange the order of the INSERT fields so that they align with the table fields.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes

# Are there any user-facing changes?
No