### PR TITLE
Fix date_trunc signature

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -16,6 +16,38 @@
 # under the License.
 
 ##########
+## Common timestamp data
+#
+# ts_data:        Int64 nanosecods
+# ts_data_nanos:  Timestamp(Nanosecond, None)
+# ts_data_micros: Timestamp(Microsecond, None)
+# ts_data_millis: Timestamp(Millisecond, None)
+# ts_data_secs:   Timestamp(Second, None)
+##########
+
+# Create timestamp tables with different precisions but the same logical values
+
+statement ok
+create table ts_data(ts bigint, value int) as values
+  (1599572549190855000, 1),
+  (1599568949190855000, 2),
+  (1599565349190855000, 3);
+
+statement ok
+create table ts_data_nanos as select arrow_cast(ts, 'Timestamp(Nanosecond, None)') as ts, value from ts_data;
+
+statement ok
+create table ts_data_micros as select arrow_cast(ts / 1000, 'Timestamp(Microsecond, None)') as ts, value from ts_data;
+
+statement ok
+create table ts_data_millis as select arrow_cast(ts / 1000000, 'Timestamp(Millisecond, None)') as ts, value from ts_data;
+
+statement ok
+create table ts_data_secs as select arrow_cast(ts / 1000000000, 'Timestamp(Second, None)') as ts, value from ts_data;
+
+
+
+##########
 ## Timestamp Handling Tests
 ##########
 
@@ -104,29 +136,6 @@ SELECT to_timestamp_seconds(ts / 1000) FROM t1 LIMIT 3
 2009-03-01T00:00:00
 2009-03-01T00:01:00
 2009-04-01T00:00:00
-
-statement error DataFusion error: Execution error: Table 'ts' doesn't exist\.
-drop table ts;
-
-# Create timestamp tables with different precisions but the same logical values
-
-statement ok
-create table ts_data(ts bigint, value int) as values
-  (1599572549190855000, 1),
-  (1599568949190855000, 2),
-  (1599565349190855000, 3);
-
-statement ok
-create table ts_data_nanos as select arrow_cast(ts, 'Timestamp(Nanosecond, None)') as ts, value from ts_data;
-
-statement ok
-create table ts_data_micros as select arrow_cast(ts / 1000, 'Timestamp(Microsecond, None)') as ts, value from ts_data;
-
-statement ok
-create table ts_data_millis as select arrow_cast(ts / 1000000, 'Timestamp(Millisecond, None)') as ts, value from ts_data;
-
-statement ok
-create table ts_data_secs as select arrow_cast(ts / 1000000000, 'Timestamp(Second, None)') as ts, value from ts_data;
 
 
 
@@ -376,21 +385,6 @@ query P
 select to_timestamp_seconds(cast (1 as int));
 ----
 1970-01-01T00:00:01
-
-statement ok
-drop table ts_data
-
-statement ok
-drop table ts_data_nanos
-
-statement ok
-drop table ts_data_micros
-
-statement ok
-drop table ts_data_millis
-
-statement ok
-drop table ts_data_secs
 
 ##########
 ## test date_bin function
@@ -913,6 +907,31 @@ SELECT DATE_TRUNC('SECOND', TIMESTAMP '2022-08-03 14:38:50Z');
 ----
 2022-08-03T14:38:50
 
+# Test date trunc on different timestamp types
+query TP rowsort
+SELECT 'ts_data_nanos', DATE_TRUNC('day', ts) FROM ts_data_nanos
+ UNION ALL
+SELECT 'ts_data_micros', DATE_TRUNC('day', ts) FROM ts_data_micros
+ UNION ALL
+SELECT 'ts_data_millis', DATE_TRUNC('day', ts) FROM ts_data_millis
+ UNION ALL
+SELECT 'ts_data_secs', DATE_TRUNC('day', ts) FROM ts_data_secs
+----
+ts_data_micros 2020-09-08T00:00:00
+ts_data_micros 2020-09-08T00:00:00
+ts_data_micros 2020-09-08T00:00:00
+ts_data_millis 2020-09-08T00:00:00
+ts_data_millis 2020-09-08T00:00:00
+ts_data_millis 2020-09-08T00:00:00
+ts_data_nanos 2020-09-08T00:00:00
+ts_data_nanos 2020-09-08T00:00:00
+ts_data_nanos 2020-09-08T00:00:00
+ts_data_secs 2020-09-08T00:00:00
+ts_data_secs 2020-09-08T00:00:00
+ts_data_secs 2020-09-08T00:00:00
+
+
+
 
 # Demonstrate that strings are automatically coerced to timestamps (don't use TIMESTAMP)
 
@@ -1078,3 +1097,24 @@ SELECT
 ;
 ----
 true false true true
+
+
+
+##########
+## Common timestamp data
+##########
+
+statement ok
+drop table ts_data
+
+statement ok
+drop table ts_data_nanos
+
+statement ok
+drop table ts_data_micros
+
+statement ok
+drop table ts_data_millis
+
+statement ok
+drop table ts_data_secs

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -218,7 +218,9 @@ pub fn return_type(
         BuiltinScalarFunction::Concat => Ok(DataType::Utf8),
         BuiltinScalarFunction::ConcatWithSeparator => Ok(DataType::Utf8),
         BuiltinScalarFunction::DatePart => Ok(DataType::Float64),
-        BuiltinScalarFunction::DateTrunc | BuiltinScalarFunction::DateBin => {
+        // DateTrunc always makes nanosecond timestamps
+        BuiltinScalarFunction::DateTrunc => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        BuiltinScalarFunction::DateBin => {
             match input_expr_types[1] {
                 DataType::Timestamp(TimeUnit::Nanosecond, _) | DataType::Utf8 => {
                     Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/6623


# Rationale for this change

The declared output type for `date_trunc` is wrong -- it is always `Timestamp(Nanosecond)` but it was declared to return the same type as its input

# What changes are included in this PR?
Make signature match the actual output type

# Are these changes tested?
Yes, 


# Are there any user-facing changes?
(fewer queries will error with a bug)
