### PR TITLE
Return correct scalar types for date_trunc

### DIFF
--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -712,7 +712,7 @@ async fn test_arrow_typeof() -> Result<()> {
         "+--------------------------------------------------------------------------+",
         "| arrow_typeof(date_trunc(Utf8(\"minute\"),to_timestamp_seconds(Int64(61)))) |",
         "+--------------------------------------------------------------------------+",
-        "| Timestamp(Second, None)                                                  |",
+        "| Timestamp(Nanosecond, None)                                              |",
         "+--------------------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
@@ -723,7 +723,7 @@ async fn test_arrow_typeof() -> Result<()> {
         "+-------------------------------------------------------------------------+",
         "| arrow_typeof(date_trunc(Utf8(\"second\"),to_timestamp_millis(Int64(61)))) |",
         "+-------------------------------------------------------------------------+",
-        "| Timestamp(Millisecond, None)                                            |",
+        "| Timestamp(Nanosecond, None)                                             |",
         "+-------------------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);
@@ -734,7 +734,7 @@ async fn test_arrow_typeof() -> Result<()> {
         "+------------------------------------------------------------------------------+",
         "| arrow_typeof(date_trunc(Utf8(\"millisecond\"),to_timestamp_micros(Int64(61)))) |",
         "+------------------------------------------------------------------------------+",
-        "| Timestamp(Microsecond, None)                                                 |",
+        "| Timestamp(Nanosecond, None)                                                  |",
         "+------------------------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected, &actual);

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -285,31 +285,31 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             let nano = (f)(*v)?;
             match granularity.as_str() {
                 "minute" => {
-                    // cast to second
-                    let second = ScalarValue::TimestampSecond(
-                        Some(nano.unwrap() / 1_000_000_000),
+                    // trunc to minute
+                    let second = ScalarValue::TimestampNanosecond(
+                        Some(nano.unwrap() / 1_000_000_000 * 1_000_000_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(second)
                 }
                 "second" => {
-                    // cast to millisecond
-                    let mill = ScalarValue::TimestampMillisecond(
-                        Some(nano.unwrap() / 1_000_000),
+                    // trunc to second
+                    let mill = ScalarValue::TimestampNanosecond(
+                        Some(nano.unwrap() / 1_000_000 * 1_000_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(mill)
                 }
                 "millisecond" => {
-                    // cast to microsecond
-                    let micro = ScalarValue::TimestampMicrosecond(
-                        Some(nano.unwrap() / 1_000),
+                    // trunc to microsecond
+                    let micro = ScalarValue::TimestampNanosecond(
+                        Some(nano.unwrap() / 1_000 * 1_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(micro)
                 }
                 _ => {
-                    // cast to nanosecond
+                    // trunc to nanosecond
                     let nano = ScalarValue::TimestampNanosecond(
                         Some(nano.unwrap()),
                         tz_opt.clone(),
@@ -329,7 +329,7 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         }
         _ => {
             return Err(DataFusionError::Execution(
-                "array of `date_trunc` must be non-null scalar Utf8".to_string(),
+                "second argument of `date_trunc` must be nanosecond timestamp scalar or array".to_string(),
             ));
         }
     })


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is inspired when I review #6632 and read the date_trunc implementation. Based on its signature, date_trunc always returns nanosecond timestamp, but for scalar case, it actually returns second/millisecond/microsecond scalar values. This patch fixes the mismatched scalar types.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->