### PR TITLE
Minor: Add more doc strings to WindowExpr

### DIFF
--- a/datafusion/physical-expr/src/window/built_in_window_function_expr.rs
+++ b/datafusion/physical-expr/src/window/built_in_window_function_expr.rs
@@ -95,10 +95,13 @@ pub trait BuiltInWindowFunctionExpr: Send + Sync + std::fmt::Debug {
         false
     }
 
-    /// Does the window function use the values from its window frame?
+    /// Does the window function use the values from the window frame,
+    /// if one is specified?
     ///
     /// If this function returns true, [`Self::create_evaluator`] must
-    /// implement [`PartitionEvaluator::evaluate_inside_range`]
+    /// implement [`PartitionEvaluator::evaluate_inside_range`]. See
+    /// details and examples on [`PartitionEvaluator::evaluate`].
+
     fn uses_window_frame(&self) -> bool {
         false
     }

--- a/datafusion/physical-expr/src/window/partition_evaluator.rs
+++ b/datafusion/physical-expr/src/window/partition_evaluator.rs
@@ -172,7 +172,7 @@ pub trait PartitionEvaluator: Debug + Send {
     /// window defined in the `OVER` clause)
     ///
     /// ```sql
-    /// lag(x, 1) OVER (ROWS BETWEEN 2 PRECEDING AND 3 FOLLOWING)
+    /// lag(x, 1) OVER (ORDER BY z ROWS BETWEEN 2 PRECEDING AND 3 FOLLOWING)
     /// ```
     ///
     /// However, `avg()` computes the average in the window and thus

--- a/datafusion/physical-expr/src/window/partition_evaluator.rs
+++ b/datafusion/physical-expr/src/window/partition_evaluator.rs
@@ -85,17 +85,19 @@ use std::ops::Range;
 /// previous batch. The previous row number is saved and restored as
 /// the state.
 ///
-/// [`BuiltInWindowFunctionExpr`]: crate::window::BuiltInWindowFunctionExpr
-/// [`BuiltInWindowFunctionExpr::create_evaluator`]: crate::window::BuiltInWindowFunctionExpr::create_evaluator
 /// When implementing a new `PartitionEvaluator`,
 /// `uses_window_frame` and `supports_bounded_execution` flags determine which evaluation method will be called
 /// during runtime. Implement corresponding evaluator according to table below.
+///
 /// |uses_window_frame|supports_bounded_execution|function_to_implement|
 /// |---|---|----|
 /// |false|false|`evaluate_all` (if we were to implement `PERCENT_RANK` it would end up in this quadrant, we cannot produce any result without seeing whole data)|
 /// |false|true|`evaluate` (optionally can also implement `evaluate_all` for more optimized implementation. However, there will be default implementation that is suboptimal) . If we were to implement `ROW_NUMBER` it will end up in this quadrant. Example `OddRowNumber` showcases this use case|
 /// |true|false|`evaluate` (I think as long as `uses_window_frame` is `true`. There is no way for `supports_bounded_execution` to be false). I couldn't come up with any example for this quadrant |
 /// |true|true|`evaluate`. If we were to implement `FIRST_VALUE`, it would end up in this quadrant|.
+///
+/// [`BuiltInWindowFunctionExpr`]: crate::window::BuiltInWindowFunctionExpr
+/// [`BuiltInWindowFunctionExpr::create_evaluator`]: crate::window::BuiltInWindowFunctionExpr::create_evaluator
 pub trait PartitionEvaluator: Debug + Send {
     /// Updates the internal state for window function
     ///


### PR DESCRIPTION
# Which issue does this PR close?

More work towards https://github.com/apache/arrow-datafusion/issues/5781 by incrementally adding docstrings to the relevant `WindowFunction` expressions

# Rationale for this change

This code needs to be well documented if we expose it and even if we don't, documenting it better will make the code easier to understand

# What changes are included in this PR?

More Docstrings that describe the differences of functions on `PartitionEvaluator` more

# Are these changes tested?
N/A
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->