### PR TITLE
Disable incremental compilation on CI

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -43,6 +43,11 @@ runs:
       # "1" means line tables only, which is useful for panic tracebacks.
       shell: bash
       run: echo "RUSTFLAGS=-C debuginfo=1" >> $GITHUB_ENV
+    - name: Disable incremental compilation
+      # Disable incremental compilation to save diskspace (the CI doesn't recompile modified files)
+      # https://github.com/apache/arrow-datafusion/issues/6676
+      shell: bash
+      run: echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
     - name: Enable backtraces
       shell: bash
       run: echo "RUST_BACKTRACE=1" >> $GITHUB_ENV


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/6676

# Rationale for this change

As shown on https://github.com/apache/arrow-datafusion/issues/6676#issuecomment-1593485461, disabling incremental complication saves 2GB of builder space

With incremental compilation enabled (the default):

https://github.com/apache/arrow-datafusion/actions/runs/5281745040/jobs/9555736433?pr=6678

```
Run du -s -h $GITHUB_WORKSPACE/target/debug/* || true
429M	/__w/arrow-datafusion/arrow-datafusion/target/debug/build
21G	/__w/arrow-datafusion/arrow-datafusion/target/debug/deps
4.0K	/__w/arrow-datafusion/arrow-datafusion/target/debug/examples
2.3G	/__w/arrow-datafusion/arrow-datafusion/target/debug/incremental
```

Without incremental compilation: https://github.com/apache/arrow-datafusion/actions/runs/5281960476/jobs/9556242542

```
Run du -s -h $GITHUB_WORKSPACE/target/debug/* || true
429M	/__w/arrow-datafusion/arrow-datafusion/target/debug/build
22G	/__w/arrow-datafusion/arrow-datafusion/target/debug/deps
4.0K	/__w/arrow-datafusion/arrow-datafusion/target/debug/examples
4.0K	/__w/arrow-datafusion/arrow-datafusion/target/debug/incremental
```

# Total space used on the builder's filesystem

## main (before this PR):

```
35G	/
```

## without incremental compilation (this PR):
```
33G	/
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->