### PR TITLE
removed self.all_values.len() from inside reserve

### DIFF
--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -126,7 +126,7 @@ impl Accumulator for MedianAccumulator {
         let array = &values[0];
 
         assert_eq!(array.data_type(), &self.data_type);
-        self.all_values.reserve(self.all_values.len() + array.len());
+        self.all_values.reserve(array.len());
         for index in 0..array.len() {
             self.all_values
                 .push(ScalarValue::try_from_array(array, index)?);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6674 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See #6674 

# What changes are included in this PR?
Removed self.all_values.len() from inside reserve().
I have also looked at the two other places where reserve() is used, and they don't use the same calculation.
https://github.com/apache/arrow-datafusion/blob/9dfaf4249e31e9a08953955fe4837eb287b089bf/datafusion/execution/src/memory_pool/proxy.rs#L41
https://github.com/apache/arrow-datafusion/blob/9dfaf4249e31e9a08953955fe4837eb287b089bf/datafusion/execution/src/memory_pool/proxy.rs#L83

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
No
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->