### PR TITLE
Update `arrow`, `arrow-flight` and `parquet` to `42.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,12 @@ repository = "https://github.com/apache/arrow-datafusion"
 rust-version = "1.64"
 
 [workspace.dependencies]
-arrow = { version = "41.0.0", features = ["prettyprint"] }
-arrow-flight = { version = "41.0.0", features = ["flight-sql-experimental"] }
-arrow-buffer = { version = "41.0.0", default-features = false }
-arrow-schema = { version = "41.0.0", default-features = false }
-arrow-array = { version = "41.0.0", default-features = false, features = ["chrono-tz"] }
-parquet = { version = "41.0.0", features = ["arrow", "async", "object_store"] }
+arrow = { version = "42.0.0", features = ["prettyprint"] }
+arrow-flight = { version = "42.0.0", features = ["flight-sql-experimental"] }
+arrow-buffer = { version = "42.0.0", default-features = false }
+arrow-schema = { version = "42.0.0", default-features = false }
+arrow-array = { version = "42.0.0", default-features = false, features = ["chrono-tz"] }
+parquet = { version = "42.0.0", features = ["arrow", "async", "object_store"] }
 
 [profile.release]
 codegen-units = 1

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -85,19 +85,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a46441ae78c0c5915f62aa32cad9910647c19241456dd24039646dd96d494a5"
 dependencies = [
  "ahash",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 41.0.0",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-cast 41.0.0",
+ "arrow-csv 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-ipc 41.0.0",
+ "arrow-json 41.0.0",
+ "arrow-ord 41.0.0",
+ "arrow-row 41.0.0",
+ "arrow-schema 41.0.0",
+ "arrow-select 41.0.0",
+ "arrow-string 41.0.0",
+]
+
+[[package]]
+name = "arrow"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773d18d72cd290f3f9e2149a714c8ac404b6c3fd614c684f0015449940fca899"
+dependencies = [
+ "ahash",
+ "arrow-arith 42.0.0",
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-cast 42.0.0",
+ "arrow-csv 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-ipc 42.0.0",
+ "arrow-json 42.0.0",
+ "arrow-ord 42.0.0",
+ "arrow-row 42.0.0",
+ "arrow-schema 42.0.0",
+ "arrow-select 42.0.0",
+ "arrow-string 42.0.0",
 ]
 
 [[package]]
@@ -106,10 +128,25 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350c5067470aeeb38dcfcc1f7e9c397098116409c9087e43ca99c231020635d9"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bc0da4b22ba63807fa2a74998e21209179c93c67856ae65d9218b81f3ef918"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "chrono",
  "half",
  "num",
@@ -122,13 +159,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6049e031521c4e7789b7530ea5991112c0a375430094191f3b74bdf37517c9a9"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "chrono",
+ "half",
+ "hashbrown 0.13.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9a0fd21121304cad96f307c938d861cb1e7f0c151b93047462cd9817d760fb"
+dependencies = [
+ "ahash",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "num",
 ]
 
@@ -143,18 +196,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ce342ecf5971004e23cef8b5fb3bacd2bbc48a381464144925074e1472e9eb"
+dependencies = [
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "249198411254530414805f77e88e1587b0914735ea180f906506905721f7a44a"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "arrow-select 41.0.0",
+ "chrono",
+ "lexical-core",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b94a0ce7d27abbb02e2ee4db770f593127610f57b32625b0bc6a1a90d65f085"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
+ "arrow-select 42.0.0",
  "chrono",
  "comfy-table",
+ "half",
  "lexical-core",
  "num",
 ]
@@ -165,11 +245,30 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9ee134298aa895ef9d791dc9cc557cecd839108843830bd35824fcd8d7f721"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-cast 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3be10a00a43c4bf0d243c070754ebdde17c5d576b4928d9c3efbe3005a3853"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-cast 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -184,8 +283,20 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d48dcbed83d741d4af712af17f6d952972b8f6491b24ee2415243a7e37c6438"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 41.0.0",
+ "arrow-schema 41.0.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a83dad6a53d6907765106d3bc61d6d9d313cfe1751701b3ef0948e7283dc2"
+dependencies = [
+ "arrow-buffer 42.0.0",
+ "arrow-schema 42.0.0",
  "half",
  "num",
 ]
@@ -196,11 +307,25 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8d7b138c5414aeef5dd08abacf362f87ed9b1168ea38d60a6f67590c3f7d99"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-cast 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a46da5e438a854e0386b38774da88a98782c0973c6dbc5c949ca4e02faf9b016"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-cast 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "flatbuffers",
 ]
 
@@ -210,11 +335,31 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a597fdca885a81f2e7ab0bacaa0bd2dfefb4cd6a2e5a3d1677396a68673101"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-cast 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-json"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f27a1fbc76553ad92dc1a9583e56b7058d8c418c4089b0b689f5b87e2da5e1"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-cast 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "chrono",
  "half",
  "indexmap",
@@ -230,11 +375,26 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29be2d5fadaab29e4fa6a7e527ceaa1c2cddc57dc6d86c062f7a05adcd8df71e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "arrow-select 41.0.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2373661f6c2233e18f6fa69c40999a9440231d1e8899be8bbbe73c7e24aa3b4"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
+ "arrow-select 42.0.0",
  "half",
  "num",
 ]
@@ -246,12 +406,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e0bd6ad24d56679b3317b499b0de61bca16d3142896908cce1aa943e56e981"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
  "half",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "arrow-row"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377cd5158b7de4034a175e296726c40c3236e65d71d90a5dab2fb4fab526a8f4"
+dependencies = [
+ "ahash",
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
+ "half",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -261,15 +436,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b71d8d68d0bc2e648e4e395896dc518be8b90c5f0f763c59083187c3d46184b"
 
 [[package]]
+name = "arrow-schema"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9ed245bd2d7d97ad1457cb281d4296e8b593588758b8fec6d67b2b2b0f2265"
+
+[[package]]
 name = "arrow-select"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470cb8610bdfda56554a436febd4e457e506f3c42e01e545a1ea7ecf2a4c8823"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc9bd6aebc565b1d04bae64a0f4dda3abc677190eb7d960471b1b20e1cebed0"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
  "num",
 ]
 
@@ -279,11 +473,26 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f8a2e4ff9dbbd51adbabf92098b71e3eb2ef0cfcb75236ca7c3ce087cce038"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 41.0.0",
+ "arrow-buffer 41.0.0",
+ "arrow-data 41.0.0",
+ "arrow-schema 41.0.0",
+ "arrow-select 41.0.0",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cf2baea2ef53787332050decf7d71aca836a352e188c8ad062892405955d2b"
+dependencies = [
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-schema 42.0.0",
+ "arrow-select 42.0.0",
  "regex",
  "regex-syntax",
 ]
@@ -850,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.2.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
+checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -976,9 +1185,9 @@ name = "datafusion"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 42.0.0",
+ "arrow-array 42.0.0",
+ "arrow-schema 42.0.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1022,7 +1231,7 @@ dependencies = [
 name = "datafusion-cli"
 version = "26.0.0"
 dependencies = [
- "arrow",
+ "arrow 41.0.0",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -1042,8 +1251,8 @@ dependencies = [
 name = "datafusion-common"
 version = "26.0.0"
 dependencies = [
- "arrow",
- "arrow-array",
+ "arrow 42.0.0",
+ "arrow-array 42.0.0",
  "chrono",
  "num_cpus",
  "object_store",
@@ -1072,7 +1281,7 @@ name = "datafusion-expr"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 42.0.0",
  "datafusion-common",
  "lazy_static",
  "sqlparser",
@@ -1084,7 +1293,7 @@ dependencies = [
 name = "datafusion-optimizer"
 version = "26.0.0"
 dependencies = [
- "arrow",
+ "arrow 42.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1101,10 +1310,10 @@ name = "datafusion-physical-expr"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 42.0.0",
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-schema 42.0.0",
  "blake2",
  "blake3",
  "chrono",
@@ -1131,7 +1340,7 @@ dependencies = [
 name = "datafusion-row"
 version = "26.0.0"
 dependencies = [
- "arrow",
+ "arrow 42.0.0",
  "datafusion-common",
  "paste",
  "rand",
@@ -1141,8 +1350,8 @@ dependencies = [
 name = "datafusion-sql"
 version = "26.0.0"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 42.0.0",
+ "arrow-schema 42.0.0",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -2136,25 +2345,25 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6880c32d81884ac4441d9f4b027df8561be23b54f3ac1e62086fa42753dd3faa"
+checksum = "baab9c36b1c8300b81b4d577d306a0a733f9d34021363098d3548e37757ed6c8"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 42.0.0",
+ "arrow-buffer 42.0.0",
+ "arrow-cast 42.0.0",
+ "arrow-data 42.0.0",
+ "arrow-ipc 42.0.0",
+ "arrow-schema 42.0.0",
+ "arrow-select 42.0.0",
  "base64",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "lz4",
  "num",
  "num-bigint",
@@ -3118,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -80,61 +80,24 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a46441ae78c0c5915f62aa32cad9910647c19241456dd24039646dd96d494a5"
-dependencies = [
- "ahash",
- "arrow-arith 41.0.0",
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-cast 41.0.0",
- "arrow-csv 41.0.0",
- "arrow-data 41.0.0",
- "arrow-ipc 41.0.0",
- "arrow-json 41.0.0",
- "arrow-ord 41.0.0",
- "arrow-row 41.0.0",
- "arrow-schema 41.0.0",
- "arrow-select 41.0.0",
- "arrow-string 41.0.0",
-]
-
-[[package]]
-name = "arrow"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773d18d72cd290f3f9e2149a714c8ac404b6c3fd614c684f0015449940fca899"
 dependencies = [
  "ahash",
- "arrow-arith 42.0.0",
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-cast 42.0.0",
- "arrow-csv 42.0.0",
- "arrow-data 42.0.0",
- "arrow-ipc 42.0.0",
- "arrow-json 42.0.0",
- "arrow-ord 42.0.0",
- "arrow-row 42.0.0",
- "arrow-schema 42.0.0",
- "arrow-select 42.0.0",
- "arrow-string 42.0.0",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350c5067470aeeb38dcfcc1f7e9c397098116409c9087e43ca99c231020635d9"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "chrono",
- "half",
- "num",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -143,28 +106,12 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93bc0da4b22ba63807fa2a74998e21209179c93c67856ae65d9218b81f3ef918"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6049e031521c4e7789b7530ea5991112c0a375430094191f3b74bdf37517c9a9"
-dependencies = [
- "ahash",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "chrono",
- "half",
- "hashbrown 0.13.2",
  "num",
 ]
 
@@ -175,23 +122,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9a0fd21121304cad96f307c938d861cb1e7f0c151b93047462cd9817d760fb"
 dependencies = [
  "ahash",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
  "hashbrown 0.14.0",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83450b94b9fe018b65ba268415aaab78757636f68b7f37b6bc1f2a3888af0a0"
-dependencies = [
- "half",
  "num",
 ]
 
@@ -207,31 +144,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249198411254530414805f77e88e1587b0914735ea180f906506905721f7a44a"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "arrow-select 41.0.0",
- "chrono",
- "lexical-core",
- "num",
-]
-
-[[package]]
-name = "arrow-cast"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b94a0ce7d27abbb02e2ee4db770f593127610f57b32625b0bc6a1a90d65f085"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
- "arrow-select 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "chrono",
  "comfy-table",
  "half",
@@ -241,52 +162,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9ee134298aa895ef9d791dc9cc557cecd839108843830bd35824fcd8d7f721"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-cast 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
-]
-
-[[package]]
-name = "arrow-csv"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3be10a00a43c4bf0d243c070754ebdde17c5d576b4928d9c3efbe3005a3853"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-cast 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
  "lazy_static",
  "lexical-core",
  "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d48dcbed83d741d4af712af17f6d952972b8f6491b24ee2415243a7e37c6438"
-dependencies = [
- "arrow-buffer 41.0.0",
- "arrow-schema 41.0.0",
- "half",
- "num",
 ]
 
 [[package]]
@@ -295,24 +185,10 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9a83dad6a53d6907765106d3bc61d6d9d313cfe1751701b3ef0948e7283dc2"
 dependencies = [
- "arrow-buffer 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d7b138c5414aeef5dd08abacf362f87ed9b1168ea38d60a6f67590c3f7d99"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-cast 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "flatbuffers",
 ]
 
 [[package]]
@@ -321,32 +197,12 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a46da5e438a854e0386b38774da88a98782c0973c6dbc5c949ca4e02faf9b016"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-cast 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers",
-]
-
-[[package]]
-name = "arrow-json"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a597fdca885a81f2e7ab0bacaa0bd2dfefb4cd6a2e5a3d1677396a68673101"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-cast 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "chrono",
- "half",
- "indexmap",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -355,11 +211,11 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f27a1fbc76553ad92dc1a9583e56b7058d8c418c4089b0b689f5b87e2da5e1"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-cast 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap",
@@ -371,47 +227,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29be2d5fadaab29e4fa6a7e527ceaa1c2cddc57dc6d86c062f7a05adcd8df71e"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "arrow-select 41.0.0",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-ord"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2373661f6c2233e18f6fa69c40999a9440231d1e8899be8bbbe73c7e24aa3b4"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
- "arrow-select 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-row"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e0bd6ad24d56679b3317b499b0de61bca16d3142896908cce1aa943e56e981"
-dependencies = [
- "ahash",
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "half",
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -421,19 +247,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377cd5158b7de4034a175e296726c40c3236e65d71d90a5dab2fb4fab526a8f4"
 dependencies = [
  "ahash",
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
  "hashbrown 0.14.0",
 ]
-
-[[package]]
-name = "arrow-schema"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b71d8d68d0bc2e648e4e395896dc518be8b90c5f0f763c59083187c3d46184b"
 
 [[package]]
 name = "arrow-schema"
@@ -443,43 +263,15 @@ checksum = "ba9ed245bd2d7d97ad1457cb281d4296e8b593588758b8fec6d67b2b2b0f2265"
 
 [[package]]
 name = "arrow-select"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470cb8610bdfda56554a436febd4e457e506f3c42e01e545a1ea7ecf2a4c8823"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc9bd6aebc565b1d04bae64a0f4dda3abc677190eb7d960471b1b20e1cebed0"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f8a2e4ff9dbbd51adbabf92098b71e3eb2ef0cfcb75236ca7c3ce087cce038"
-dependencies = [
- "arrow-array 41.0.0",
- "arrow-buffer 41.0.0",
- "arrow-data 41.0.0",
- "arrow-schema 41.0.0",
- "arrow-select 41.0.0",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -488,11 +280,11 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23cf2baea2ef53787332050decf7d71aca836a352e188c8ad062892405955d2b"
 dependencies = [
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-data 42.0.0",
- "arrow-schema 42.0.0",
- "arrow-select 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "regex",
  "regex-syntax",
 ]
@@ -1185,9 +977,9 @@ name = "datafusion"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow 42.0.0",
- "arrow-array 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1231,7 +1023,7 @@ dependencies = [
 name = "datafusion-cli"
 version = "26.0.0"
 dependencies = [
- "arrow 41.0.0",
+ "arrow",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -1251,8 +1043,8 @@ dependencies = [
 name = "datafusion-common"
 version = "26.0.0"
 dependencies = [
- "arrow 42.0.0",
- "arrow-array 42.0.0",
+ "arrow",
+ "arrow-array",
  "chrono",
  "num_cpus",
  "object_store",
@@ -1281,7 +1073,7 @@ name = "datafusion-expr"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow 42.0.0",
+ "arrow",
  "datafusion-common",
  "lazy_static",
  "sqlparser",
@@ -1293,7 +1085,7 @@ dependencies = [
 name = "datafusion-optimizer"
 version = "26.0.0"
 dependencies = [
- "arrow 42.0.0",
+ "arrow",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1310,10 +1102,10 @@ name = "datafusion-physical-expr"
 version = "26.0.0"
 dependencies = [
  "ahash",
- "arrow 42.0.0",
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "blake2",
  "blake3",
  "chrono",
@@ -1340,7 +1132,7 @@ dependencies = [
 name = "datafusion-row"
 version = "26.0.0"
 dependencies = [
- "arrow 42.0.0",
+ "arrow",
  "datafusion-common",
  "paste",
  "rand",
@@ -1350,8 +1142,8 @@ dependencies = [
 name = "datafusion-sql"
 version = "26.0.0"
 dependencies = [
- "arrow 42.0.0",
- "arrow-schema 42.0.0",
+ "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -1692,12 +1484,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2350,13 +2136,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baab9c36b1c8300b81b4d577d306a0a733f9d34021363098d3548e37757ed6c8"
 dependencies = [
  "ahash",
- "arrow-array 42.0.0",
- "arrow-buffer 42.0.0",
- "arrow-cast 42.0.0",
- "arrow-data 42.0.0",
- "arrow-ipc 42.0.0",
- "arrow-schema 42.0.0",
- "arrow-select 42.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64",
  "brotli",
  "bytes",

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.62"
 readme = "README.md"
 
 [dependencies]
-arrow = "41.0.0"
+arrow = "42.0.0"
 async-trait = "0.1.41"
 aws-config = "0.55"
 aws-credential-types = "0.55"

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -223,10 +223,11 @@ async fn test_interval_expressions() -> Result<()> {
         "interval '0.5 minute'",
         "0 years 0 mons 0 days 0 hours 0 mins 30.000000000 secs"
     );
-    test_expression!(
-        "interval '.5 minute'",
-        "0 years 0 mons 0 days 0 hours 0 mins 30.000000000 secs"
-    );
+    // https://github.com/apache/arrow-rs/issues/4424
+    // test_expression!(
+    //     "interval '.5 minute'",
+    //     "0 years 0 mons 0 days 0 hours 0 mins 30.000000000 secs"
+    // );
     test_expression!(
         "interval '5 minute'",
         "0 years 0 mons 0 days 0 hours 5 mins 0.000000000 secs"

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1263,7 +1263,7 @@ fn select_interval_out_of_range() {
     let sql = "SELECT INTERVAL '100000000000000000 day'";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "ArrowError(ParseError(\"Parsed interval field value out of range: 0 months 100000000000000000 days 0 nanos\"))",
+        "ArrowError(InvalidArgumentError(\"Unable to represent 100000000000000000 days in a signed 32-bit integer\"))",
         format!("{err:?}")
     );
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
Keep up to date with dependencies

# What changes are included in this PR?

Update `arrow`, `arrow-flight` and `parquet` to `42.0.0` -- https://github.com/apache/arrow-rs/issues/4422

# Are these changes tested?
Existing tests

# Are there any user-facing changes?

A slight regression in parsing intervals (`0.5 month` works, but `.5 month`, without the leading `0`, does not). Due to https://github.com/apache/arrow-rs/issues/4424
