### PR TITLE
Minor: Improve UX for setting `ExecutionProps::query_execution_start_time`

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -1220,7 +1220,6 @@ mod tests {
         datatypes::{DataType, Field, Schema},
     };
     use chrono::{DateTime, TimeZone, Utc};
-    use datafusion_common::alias::AliasGenerator;
     use datafusion_common::{assert_contains, cast::as_int32_array, DFField, ToDFSchema};
     use datafusion_expr::*;
     use datafusion_physical_expr::{
@@ -1314,11 +1313,8 @@ mod tests {
         expected_expr: Expr,
         date_time: &DateTime<Utc>,
     ) {
-        let execution_props = ExecutionProps {
-            query_execution_start_time: *date_time,
-            alias_generator: Arc::new(AliasGenerator::new()),
-            var_providers: None,
-        };
+        let execution_props =
+            ExecutionProps::new().with_query_execution_start_time(*date_time);
 
         let mut const_evaluator = ConstEvaluator::try_new(&execution_props).unwrap();
         let evaluated_expr = input_expr

--- a/datafusion/physical-expr/src/execution_props.rs
+++ b/datafusion/physical-expr/src/execution_props.rs
@@ -21,7 +21,7 @@ use datafusion_common::alias::AliasGenerator;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Holds per-query execution properties and data (such as statment
+/// Holds per-query execution properties and data (such as statement
 /// starting timestamps).
 ///
 /// An [`ExecutionProps`] is created each time a [`LogicalPlan`] is
@@ -57,6 +57,15 @@ impl ExecutionProps {
             alias_generator: Arc::new(AliasGenerator::new()),
             var_providers: None,
         }
+    }
+
+    /// Set the query execution start time to use
+    pub fn with_query_execution_start_time(
+        mut self,
+        query_execution_start_time: DateTime<Utc>,
+    ) -> Self {
+        self.query_execution_start_time = query_execution_start_time;
+        self
     }
 
     /// Marks the execution of query started timestamp.


### PR DESCRIPTION


# Which issue does this PR close?

N/A

# Rationale for this change
While reviewing https://github.com/apache/arrow-datafusion/pull/6706 I noticed this could be improved and figured I would make a PR

# What changes are included in this PR?
1. Add `ExecutionProps::with_query_execution_start_time`
2. Update code to use it

# Are these changes tested?
By existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
Maybe an easier to use `ExecutionProps` -- no API changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->