### PR TITLE
Fix inserting into a table with non-nullable columns

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -729,6 +729,34 @@ impl From<Field> for DFField {
     }
 }
 
+/// DataFusion-specific extensions to [`Schema`].
+pub trait SchemaExt {
+    /// This is a specialized version of Eq that ignores differences
+    /// in nullability and metadata.
+    ///
+    /// It works the same as [`crate::DFSchema::equivalent_names_and_types`]
+    fn equivalent_names_and_types(&self, other: &Self) -> bool;
+}
+
+impl SchemaExt for Schema {
+    fn equivalent_names_and_types(&self, other: &Self) -> bool {
+        if self.fields().len() != other.fields().len() {
+            return false;
+        }
+
+        self.fields()
+            .iter()
+            .zip(other.fields().iter())
+            .all(|(f1, f2)| {
+                f1.name() == f2.name()
+                    && DFSchema::datatype_is_semantically_equal(
+                        f1.data_type(),
+                        f2.data_type(),
+                    )
+            })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::assert_contains;
@@ -995,7 +1023,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t],
             fields2: vec![&field1_i16_t],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1003,7 +1032,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t_meta],
             fields2: vec![&field1_i16_t],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1011,7 +1041,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t],
             fields2: vec![&field2_i16_t],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1019,7 +1050,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t],
             fields2: vec![&field1_i32_t],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1027,7 +1059,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t],
             fields2: vec![&field1_i16_f],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1035,7 +1068,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t],
             fields2: vec![&field1_i16_t_qualified],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: true,
         }
         .run();
 
@@ -1043,7 +1077,8 @@ mod tests {
         TestCase {
             fields1: vec![&field2_i16_t, &field1_i16_t],
             fields2: vec![&field2_i16_t, &field3_i16_t],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1051,7 +1086,8 @@ mod tests {
         TestCase {
             fields1: vec![&field1_i16_t, &field2_i16_t],
             fields2: vec![&field1_i16_t],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1059,7 +1095,8 @@ mod tests {
         TestCase {
             fields1: vec![&field_dict_t],
             fields2: vec![&field_dict_t],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1067,7 +1104,8 @@ mod tests {
         TestCase {
             fields1: vec![&field_dict_t],
             fields2: vec![&field_dict_f],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1075,7 +1113,8 @@ mod tests {
         TestCase {
             fields1: vec![&field_dict_t],
             fields2: vec![&field1_i16_t],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1083,7 +1122,8 @@ mod tests {
         TestCase {
             fields1: vec![&list_t],
             fields2: vec![&list_f],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1091,7 +1131,8 @@ mod tests {
         TestCase {
             fields1: vec![&list_t],
             fields2: vec![&list_f_name],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1099,7 +1140,8 @@ mod tests {
         TestCase {
             fields1: vec![&struct_t],
             fields2: vec![&struct_f],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1107,7 +1149,8 @@ mod tests {
         TestCase {
             fields1: vec![&struct_t],
             fields2: vec![&struct_f_meta],
-            expected: true,
+            expected_dfschema: true,
+            expected_arrow: true,
         }
         .run();
 
@@ -1115,7 +1158,8 @@ mod tests {
         TestCase {
             fields1: vec![&struct_t],
             fields2: vec![&struct_f_type],
-            expected: false,
+            expected_dfschema: false,
+            expected_arrow: false,
         }
         .run();
 
@@ -1123,7 +1167,8 @@ mod tests {
         struct TestCase<'a> {
             fields1: Vec<&'a DFField>,
             fields2: Vec<&'a DFField>,
-            expected: bool,
+            expected_dfschema: bool,
+            expected_arrow: bool,
         }
 
         impl<'a> TestCase<'a> {
@@ -1133,12 +1178,24 @@ mod tests {
                 let schema2 = to_df_schema(self.fields2);
                 assert_eq!(
                     schema1.equivalent_names_and_types(&schema2),
-                    self.expected,
+                    self.expected_dfschema,
                     "Comparison did not match expected: {}\n\n\
                      schema1:\n\n{:#?}\n\nschema2:\n\n{:#?}",
-                    self.expected,
+                    self.expected_dfschema,
                     schema1,
                     schema2
+                );
+
+                let arrow_schema1 = Schema::from(schema1);
+                let arrow_schema2 = Schema::from(schema2);
+                assert_eq!(
+                    arrow_schema1.equivalent_names_and_types(&arrow_schema2),
+                    self.expected_arrow,
+                    "Comparison did not match expected: {}\n\n\
+                     arrow schema1:\n\n{:#?}\n\n arrow schema2:\n\n{:#?}",
+                    self.expected_arrow,
+                    arrow_schema1,
+                    arrow_schema2
                 );
             }
         }

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -734,7 +734,7 @@ pub trait SchemaExt {
     /// This is a specialized version of Eq that ignores differences
     /// in nullability and metadata.
     ///
-    /// It works the same as [`crate::DFSchema::equivalent_names_and_types`]
+    /// It works the same as [`DFSchema::equivalent_names_and_types`].
     fn equivalent_names_and_types(&self, other: &Self) -> bool;
 }
 

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -36,7 +36,7 @@ pub mod tree_node;
 pub mod utils;
 
 pub use column::Column;
-pub use dfschema::{DFField, DFSchema, DFSchemaRef, ExprSchema, ToDFSchema};
+pub use dfschema::{DFField, DFSchema, DFSchemaRef, ExprSchema, SchemaExt, ToDFSchema};
 pub use error::{
     field_not_found, unqualified_field_not_found, DataFusionError, Result, SchemaError,
     SharedResult,

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -238,6 +238,7 @@ impl FileFormat for CsvFormat {
         _state: &SessionState,
         conf: FileSinkConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(CsvSink::new(
             conf,
             self.has_header,
@@ -245,7 +246,7 @@ impl FileFormat for CsvFormat {
             self.file_compression_type.clone(),
         ));
 
-        Ok(Arc::new(InsertExec::new(input, sink)) as _)
+        Ok(Arc::new(InsertExec::new(input, sink, sink_schema)) as _)
     }
 }
 

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, Field, SchemaBuilder, SchemaRef};
 use arrow_schema::Schema;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use datafusion_common::ToDFSchema;
+use datafusion_common::{SchemaExt, ToDFSchema};
 use datafusion_expr::expr::Sort;
 use datafusion_optimizer::utils::conjunction;
 use datafusion_physical_expr::{create_physical_expr, LexOrdering, PhysicalSortExpr};
@@ -42,7 +42,7 @@ use crate::datasource::{
     },
     get_statistics_with_limit,
     listing::ListingTableUrl,
-    schema_eq_ignore_nullable, TableProvider, TableType,
+    TableProvider, TableType,
 };
 use crate::logical_expr::TableProviderFilterPushDown;
 use crate::physical_plan;
@@ -776,7 +776,7 @@ impl TableProvider for ListingTable {
         input: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
-        if !schema_eq_ignore_nullable(input.schema(), self.schema()) {
+        if !self.schema().equivalent_names_and_types(&input.schema()) {
             return Err(DataFusionError::Plan(
                 // Return an error if schema of the input query does not match with the table schema.
                 "Inserting query must have the same schema with the table.".to_string(),

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -42,7 +42,7 @@ use crate::datasource::{
     },
     get_statistics_with_limit,
     listing::ListingTableUrl,
-    TableProvider, TableType,
+    schema_eq_ignore_nullable, TableProvider, TableType,
 };
 use crate::logical_expr::TableProviderFilterPushDown;
 use crate::physical_plan;
@@ -776,7 +776,7 @@ impl TableProvider for ListingTable {
         input: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
-        if !input.schema().eq(&self.schema()) {
+        if !schema_eq_ignore_nullable(input.schema(), self.schema()) {
             return Err(DataFusionError::Plan(
                 // Return an error if schema of the input query does not match with the table schema.
                 "Inserting query must have the same schema with the table.".to_string(),
@@ -816,7 +816,7 @@ impl TableProvider for ListingTable {
         let config = FileSinkConfig {
             object_store_url: self.table_paths()[0].object_store(),
             file_groups,
-            output_schema: input.schema(),
+            output_schema: self.schema(),
             table_partition_cols: self.options.table_partition_cols.clone(),
             writer_mode: crate::datasource::file_format::FileWriterMode::Append,
         };

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -43,13 +43,12 @@ use self::listing::PartitionedFile;
 pub use self::memory::MemTable;
 pub use self::provider::TableProvider;
 pub use self::view::ViewTable;
-use crate::arrow::datatypes::{Fields, Schema, SchemaRef};
+use crate::arrow::datatypes::{Schema, SchemaRef};
 use crate::error::Result;
 pub use crate::logical_expr::TableType;
 use crate::physical_plan::expressions::{MaxAccumulator, MinAccumulator};
 use crate::physical_plan::{Accumulator, ColumnStatistics, Statistics};
 use futures::StreamExt;
-use std::sync::Arc;
 
 /// Get all files as well as the file level summary statistics (no statistic for partition columns).
 /// If the optional `limit` is provided, includes only sufficient files.
@@ -199,25 +198,4 @@ fn get_col_stats(
             }
         })
         .collect()
-}
-
-fn schema_eq_ignore_nullable(
-    left: impl AsRef<Schema>,
-    right: impl AsRef<Schema>,
-) -> bool {
-    let erase_nullable = |raw: &Schema| {
-        let fields = raw
-            .fields()
-            .iter()
-            .map(|f| {
-                if f.is_nullable() {
-                    f.clone()
-                } else {
-                    Arc::new(f.as_ref().clone().with_nullable(true))
-                }
-            })
-            .collect::<Fields>();
-        Schema::new_with_metadata(fields, raw.metadata().clone())
-    };
-    erase_nullable(left.as_ref()) == erase_nullable(right.as_ref())
 }

--- a/datafusion/core/tests/sqllogictests/test_files/insert.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/insert.slt
@@ -270,3 +270,33 @@ select * from table_without_values;
 
 statement ok
 drop table table_without_values;
+
+
+# test insert with non-nullable column
+statement ok
+CREATE TABLE table_without_values(field1 BIGINT NOT NULL, field2 BIGINT NULL);
+
+query II
+insert into table_without_values values(1, 100);
+----
+1
+
+query II
+insert into table_without_values values(2, NULL);
+----
+1
+
+statement error Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
+insert into table_without_values values(NULL, 300);
+
+statement error Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
+insert into table_without_values values(3, 300), (NULL, 400);
+
+query II rowsort
+select * from table_without_values;
+----
+1 100
+2 NULL
+
+statement ok
+drop table table_without_values;


### PR DESCRIPTION
# Which issue does this PR close?
Fix the following issue:
```shell
DataFusion CLI v26.0.0
❯ create table t1(a int not null);
0 rows in set. Query took 0.028 seconds.

❯ insert into t1 values(1);
Error during planning: Inserting query must have the same schema with the table.
```
This issue is because the nullable information of the two schemas is different.
input schema: Schema { fields: [Field { name: "a", data_type: Int32, **nullable: true**, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }
table schema: Schema { fields: [Field { name: "a", data_type: Int32, **nullable: false**, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }



# Rationale for this change
Declaring the schema as nullable doesn't necessarily mean that the actual data is always NULL.
When data is NOT NULL, it should be allowed to be inserted into the table.

# What changes are included in this PR?

1. Ignore the nullable information when comparing schemas.
2. Checking NOT NULL constraint during execution.


# Are these changes tested?
YES

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
New parameter is added to `InsertExec::new()` 