### PR TITLE
add Eq and PartialEq to ListingTableUrl

### DIFF
--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -28,7 +28,7 @@ use url::Url;
 
 /// A parsed URL identifying files for a listing table, see [`ListingTableUrl::parse`]
 /// for more information on the supported expressions
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ListingTableUrl {
     /// A URL that identifies a file or directory to list files from
     url: Url,

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -28,7 +28,7 @@ use url::Url;
 
 /// A parsed URL identifying files for a listing table, see [`ListingTableUrl::parse`]
 /// for more information on the supported expressions
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListingTableUrl {
     /// A URL that identifies a file or directory to list files from
     url: Url,


### PR DESCRIPTION
# Which issue does this PR close?
N/A

# Rationale for this change
It would be nice to make it comparable, as right now it can't be used in structs that implement `Eq`, `Hash` and `PartialEq`

# What changes are included in this PR?
Additional traits added to `ListingTableUrl`

# Are these changes tested?
Yes

# Are there any user-facing changes?
Yes