### PR TITLE
Minor: Update copyight date on website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Arrow DataFusion'
-copyright = '2022, Apache Software Foundation'
+copyright = '2023, Apache Software Foundation'
 author = 'Arrow DataFusion Authors'
 
 


### PR DESCRIPTION
The https://arrow.apache.org/datafusion/ website has the wrong year, so let's correct that and make sure it looks like we are keeping up to date