### PR TITLE
Minor: remove dead code with decimal datatypes from `in_list`

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -34,9 +34,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::bit_iterator::BitIndexIterator;
 use arrow::{downcast_dictionary_array, downcast_primitive_array};
 use datafusion_common::{
-    cast::{
-        as_boolean_array, as_generic_binary_array, as_primitive_array, as_string_array,
-    },
+    cast::{as_boolean_array, as_generic_binary_array, as_string_array},
     DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::ColumnarValue;
@@ -179,14 +177,6 @@ fn make_set(array: &dyn Array) -> Result<Arc<dyn Set>> {
             let array = as_boolean_array(array)?;
             Arc::new(ArraySet::new(array, make_hash_set(array)))
         },
-        DataType::Decimal128(_, _) => {
-            let array = as_primitive_array::<Decimal128Type>(array)?;
-            Arc::new(ArraySet::new(array, make_hash_set(array)))
-        }
-        DataType::Decimal256(_, _) => {
-            let array = as_primitive_array::<Decimal256Type>(array)?;
-            Arc::new(ArraySet::new(array, make_hash_set(array)))
-        }
         DataType::Utf8 => {
             let array = as_string_array(array)?;
             Arc::new(ArraySet::new(array, make_hash_set(array)))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
As `Decimal128` and `Decimal256` data types became primitive types they are automatically converted by `downcast_primitive_array` macros.

I think the dead code should be removed.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->