### PR TITLE
Minor: remove some uses of unwrap

### DIFF
--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -258,7 +258,7 @@ fn date_trunc_single(granularity: &str, value: i64) -> Result<i64> {
             )));
         }
     };
-    // `with_x(0)` are infalible because `0` are always a valid
+    // `with_x(0)` are infallible because `0` are always a valid
     Ok(value.unwrap().timestamp_nanos())
 }
 
@@ -284,18 +284,11 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(v, tz_opt)) => {
             let nano = (f)(*v)?;
 
-            if nano.is_none() {
-                return Ok(ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
-                    None,
-                    tz_opt.clone(),
-                )));
-            }
-
             match granularity.as_str() {
                 "minute" => {
                     // trunc to minute
                     let second = ScalarValue::TimestampNanosecond(
-                        Some(nano.unwrap() / 1_000_000_000 * 1_000_000_000),
+                        nano.map(|nano| nano / 1_000_000_000 * 1_000_000_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(second)
@@ -303,7 +296,7 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 "second" => {
                     // trunc to second
                     let mill = ScalarValue::TimestampNanosecond(
-                        Some(nano.unwrap() / 1_000_000 * 1_000_000),
+                        nano.map(|nano| nano / 1_000_000 * 1_000_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(mill)
@@ -311,17 +304,14 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 "millisecond" => {
                     // trunc to microsecond
                     let micro = ScalarValue::TimestampNanosecond(
-                        Some(nano.unwrap() / 1_000 * 1_000),
+                        nano.map(|nano| nano / 1_000 * 1_000),
                         tz_opt.clone(),
                     );
                     ColumnarValue::Scalar(micro)
                 }
                 _ => {
                     // trunc to nanosecond
-                    let nano = ScalarValue::TimestampNanosecond(
-                        Some(nano.unwrap()),
-                        tz_opt.clone(),
-                    );
+                    let nano = ScalarValue::TimestampNanosecond(nano, tz_opt.clone());
                     ColumnarValue::Scalar(nano)
                 }
             }


### PR DESCRIPTION
# Which issue does this PR close?
Minor follow on to https://github.com/apache/arrow-datafusion/pull/6723 

# Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/6723 (thanks @BryanEmond !) I noticed it would be possible to do so with a little less code using `Option::map` so I coded it up

# What changes are included in this PR?

Refactor some code to avoid `unwrap`

# Are these changes tested?
Covered by existing tests added in https://github.com/apache/arrow-datafusion/pull/6723

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->