### PR TITLE
Reduce code / allocations when printing Exprs

### DIFF
--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -290,6 +290,31 @@ pub fn longest_consecutive_prefix<T: Borrow<usize>>(
     count
 }
 
+/// formats the Iterator of Display'ble items as a comma separated
+/// list
+///
+/// TODO an example:
+/// ```
+/// let data = vec!["foo", "bar"];
+/// fmt_iterator(DDD);
+/// ```
+pub fn fmt_iterator<'a>(
+    iter: impl IntoIterator<Item = &'a dyn std::fmt::Display>,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    let iter = iter.into_iter();
+    let mut first = true;
+    for expr in iter {
+        if !first {
+            write!(f, ", ")?;
+        } else {
+            first = false;
+        }
+        write!(f, "{expr}")?;
+    }
+    Ok(())
+}
+
 /// An extension trait for smart pointers. Provides an interface to get a
 /// raw pointer to the data (with metadata stripped away).
 ///

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -27,6 +27,7 @@ use crate::window_frame;
 use crate::window_function;
 use crate::Operator;
 use arrow::datatypes::DataType;
+use datafusion_common::utils::fmt_iterator;
 use datafusion_common::{plan_err, Column, DataFusionError, Result, ScalarValue};
 use std::collections::HashSet;
 use std::fmt;
@@ -900,24 +901,16 @@ impl Expr {
 
 /// Returns a struct that can display the `Vec` of [`Expr`]s as a
 /// comma separated display list, without allocating
-pub(crate) fn expr_vec_fmt<'a>(v: &'a [Expr]) -> CommaListExprFormatter<'a> {
+pub fn expr_vec_fmt<'a>(v: &'a [Expr]) -> CommaListExprFormatter<'a> {
     CommaListExprFormatter(v)
 }
 
-pub(crate) struct CommaListExprFormatter<'a>(&'a [Expr]);
+/// See [`expr_vec_fmt`]
+pub struct CommaListExprFormatter<'a>(&'a [Expr]);
 
 impl<'a> Display for CommaListExprFormatter<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut first = true;
-        for expr in self.0.iter() {
-            if !first {
-                write!(f, ", ")?;
-            } else {
-                first = false;
-            }
-            write!(f, "{expr}")?;
-        }
-        Ok(())
+        fmt_iterator(self.0.iter().map(|e| e as &dyn Display), f)
     }
 }
 
@@ -927,20 +920,12 @@ pub(crate) fn expr_vec_ref_fmt<'a>(v: &'a [&'a Expr]) -> CommaListExprRefFormatt
     CommaListExprRefFormatter(v)
 }
 
+/// See [`expr_vec_ref_fmt`]
 pub(crate) struct CommaListExprRefFormatter<'a>(&'a [&'a Expr]);
 
 impl<'a> Display for CommaListExprRefFormatter<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut first = true;
-        for expr in self.0.iter() {
-            if !first {
-                write!(f, ", ")?;
-            } else {
-                first = false;
-            }
-            write!(f, "{expr}")?;
-        }
-        Ok(())
+        fmt_iterator(self.0.iter().map(|e| e as &dyn Display), f)
     }
 }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -17,9 +17,8 @@
 
 //! Logical plan types
 
-use crate::expr::{Exists, InSubquery, Placeholder};
+use crate::expr::{expr_vec_fmt, expr_vec_ref_fmt, Exists, InSubquery, Placeholder};
 use crate::expr_rewriter::create_col_from_scalar_expr;
-use crate::expr_vec_fmt;
 use crate::logical_plan::display::{GraphvizVisitor, IndentVisitor};
 use crate::logical_plan::extension::UserDefinedLogicalNode;
 use crate::logical_plan::{DmlStatement, Statement};
@@ -1003,7 +1002,7 @@ impl LogicalPlan {
                                 source.supports_filters_pushdown(&filters)
                             {
                                 filters.iter().zip(results.iter()).for_each(
-                                    |(x, res)| match res {
+                                    |(&x, res)| match res {
                                         TableProviderFilterPushDown::Exact => {
                                             full_filter.push(x)
                                         }
@@ -1021,21 +1020,21 @@ impl LogicalPlan {
                                 write!(
                                     f,
                                     ", full_filters=[{}]",
-                                    expr_vec_fmt!(full_filter)
+                                    expr_vec_ref_fmt(&full_filter)
                                 )?;
                             };
                             if !partial_filter.is_empty() {
                                 write!(
                                     f,
                                     ", partial_filters=[{}]",
-                                    expr_vec_fmt!(partial_filter)
+                                    expr_vec_ref_fmt(&partial_filter)
                                 )?;
                             }
                             if !unsupported_filters.is_empty() {
                                 write!(
                                     f,
                                     ", unsupported_filters=[{}]",
-                                    expr_vec_fmt!(unsupported_filters)
+                                    expr_vec_ref_fmt(&unsupported_filters)
                                 )?;
                             }
                         }
@@ -1072,7 +1071,7 @@ impl LogicalPlan {
                         write!(
                             f,
                             "WindowAggr: windowExpr=[[{}]]",
-                            expr_vec_fmt!(window_expr)
+                            expr_vec_fmt(window_expr)
                         )
                     }
                     LogicalPlan::Aggregate(Aggregate {
@@ -1082,8 +1081,8 @@ impl LogicalPlan {
                     }) => write!(
                         f,
                         "Aggregate: groupBy=[[{}]], aggr=[[{}]]",
-                        expr_vec_fmt!(group_expr),
-                        expr_vec_fmt!(aggr_expr)
+                        expr_vec_fmt(group_expr),
+                        expr_vec_fmt(aggr_expr)
                     ),
                     LogicalPlan::Sort(Sort { expr, fetch, .. }) => {
                         write!(f, "Sort: ")?;

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1291,10 +1291,10 @@ pub fn find_valid_equijoin_key_pair(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr_vec_fmt;
     use crate::{
-        col, cube, expr, grouping_set, rollup, AggregateFunction, WindowFrame,
-        WindowFunction,
+        col, cube,
+        expr::{self, expr_vec_fmt},
+        grouping_set, rollup, AggregateFunction, WindowFrame, WindowFunction,
     };
 
     #[test]
@@ -1497,22 +1497,22 @@ mod tests {
 
         // 1. col
         let sets = enumerate_grouping_sets(vec![simple_col.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!("[simple_col]", &result);
 
         // 2. cube
         let sets = enumerate_grouping_sets(vec![cube.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!("[CUBE (col1, col2, col3)]", &result);
 
         // 3. rollup
         let sets = enumerate_grouping_sets(vec![rollup.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!("[ROLLUP (col1, col2, col3)]", &result);
 
         // 4. col + cube
         let sets = enumerate_grouping_sets(vec![simple_col.clone(), cube.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!(
             "[GROUPING SETS (\
             (simple_col), \
@@ -1528,7 +1528,7 @@ mod tests {
 
         // 5. col + rollup
         let sets = enumerate_grouping_sets(vec![simple_col.clone(), rollup.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!(
             "[GROUPING SETS (\
             (simple_col), \
@@ -1541,7 +1541,7 @@ mod tests {
         // 6. col + grouping_set
         let sets =
             enumerate_grouping_sets(vec![simple_col.clone(), grouping_set.clone()])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!(
             "[GROUPING SETS (\
             (simple_col, col1, col2, col3))]",
@@ -1554,7 +1554,7 @@ mod tests {
             grouping_set,
             rollup.clone(),
         ])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!(
             "[GROUPING SETS (\
             (simple_col, col1, col2, col3), \
@@ -1566,7 +1566,7 @@ mod tests {
 
         // 8. col + cube + rollup
         let sets = enumerate_grouping_sets(vec![simple_col, cube, rollup])?;
-        let result = format!("[{}]", expr_vec_fmt!(sets));
+        let result = format!("[{}]", expr_vec_fmt(&sets));
         assert_eq!(
             "[GROUPING SETS (\
             (simple_col), \

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -34,14 +34,14 @@ use crate::utils::expr_list_eq_strict_order;
 use crate::PhysicalExpr;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion_common::utils::fmt_iterator;
 use datafusion_common::Result;
-use datafusion_expr::expr_vec_fmt;
 use datafusion_expr::BuiltinScalarFunction;
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::ScalarFunctionImplementation;
 use std::any::Any;
-use std::fmt::Debug;
 use std::fmt::{self, Formatter};
+use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -103,7 +103,9 @@ impl ScalarFunctionExpr {
 
 impl fmt::Display for ScalarFunctionExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}({})", self.name, expr_vec_fmt!(self.args))
+        write!(f, "{}(", self.name)?;
+        fmt_iterator(self.args.iter().map(|v| v as &dyn Display), f)?;
+        write!(f, ")")
     }
 }
 

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -22,12 +22,11 @@ use sqlparser::ast::Ident;
 
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::expr::{
-    AggregateFunction, AggregateUDF, Between, BinaryExpr, Case, GetIndexedField,
-    GroupingSet, InList, InSubquery, Like, Placeholder, ScalarFunction, ScalarUDF,
-    WindowFunction,
+    expr_vec_fmt, AggregateFunction, AggregateUDF, Between, BinaryExpr, Case,
+    GetIndexedField, GroupingSet, InList, InSubquery, Like, Placeholder, ScalarFunction,
+    ScalarUDF, WindowFunction,
 };
 use datafusion_expr::expr::{Cast, Sort};
-use datafusion_expr::expr_vec_fmt;
 use datafusion_expr::utils::{expr_as_column_expr, find_column_exprs};
 use datafusion_expr::{Expr, LogicalPlan, TryCast};
 use std::collections::HashMap;
@@ -125,7 +124,7 @@ fn check_column_satisfies_expr(
             "{}: Expression {} could not be resolved from available columns: {}",
             message_prefix,
             expr,
-            expr_vec_fmt!(columns)
+            expr_vec_fmt(columns)
         )));
     }
     Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/6677 

# Rationale for this change

Using a macro to format Vec's of Exprs adds more code and it does a bunch of allocations (both `String` and `Vec`) that we can avoid. 

See  https://github.com/apache/arrow-datafusion/pull/6708#discussion_r1236829200 for more context



# What changes are included in this PR?

Change macro to functions and `impl Display` 

cc @parkma99 

# Are these changes tested?
Yes, by existing tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->