### PR TITLE
Remove uneeded dependencies, add clippy lint

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -999,15 +999,12 @@ dependencies = [
  "hashbrown 0.14.0",
  "indexmap",
  "itertools 0.11.0",
- "lazy_static",
  "log",
- "num_cpus",
  "object_store",
  "parking_lot",
  "parquet",
  "percent-encoding",
  "pin-project-lite",
- "rand",
  "smallvec",
  "sqlparser",
  "tempfile",
@@ -1086,7 +1083,6 @@ name = "datafusion-optimizer"
 version = "26.0.0"
 dependencies = [
  "arrow",
- "async-trait",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -1135,7 +1131,6 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "paste",
- "rand",
 ]
 
 [[package]]

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![warn(
+    unused_crate_dependencies
+)]
+
 #![doc = include_str!("../README.md")]
 pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![warn(
+    unused_crate_dependencies
+)]
+
 use clap::Parser;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::SessionConfig;

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![warn(unused_crate_dependencies)]
 
 pub mod alias;
 pub mod cast;

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -74,16 +74,13 @@ glob = "0.3.0"
 hashbrown = { version = "0.14", features = ["raw"] }
 indexmap = "1.9.2"
 itertools = "0.11"
-lazy_static = { version = "^1.4.0" }
 log = "^0.4"
 num-traits = { version = "0.2", optional = true }
-num_cpus = "1.13.0"
 object_store = "0.6.1"
 parking_lot = "0.12"
 parquet = { workspace = true }
 percent-encoding = "2.2.0"
 pin-project-lite = "^0.2.7"
-rand = "0.8"
 smallvec = { version = "1.6", features = ["union"] }
 sqlparser = { version = "0.34", features = ["visitor"] }
 tempfile = "3"

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#![warn(missing_docs, clippy::needless_borrow)]
+#![warn(missing_docs, clippy::needless_borrow, unused_crate_dependencies)]
 
 //! [DataFusion] is an extensible query engine written in Rust that
 //! uses [Apache Arrow] as its in-memory format. DataFusion's many [use

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 //! DataFusion execution configuration and runtime structures
+#![warn(unused_crate_dependencies)]
 
 pub mod config;
 pub mod disk_manager;

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -25,6 +25,8 @@
 //!
 //! The [expr_fn] module contains functions for creating expressions.
 
+#![warn(unused_crate_dependencies)]
+
 mod accumulator;
 pub mod aggregate_function;
 pub mod array_expressions;

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -41,7 +41,6 @@ unicode_expressions = ["datafusion-physical-expr/unicode_expressions"]
 
 [dependencies]
 arrow = { workspace = true }
-async-trait = "0.1.41"
 chrono = { version = "0.4.23", default-features = false }
 datafusion-common = { path = "../common", version = "26.0.0" }
 datafusion-expr = { path = "../expr", version = "26.0.0" }

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![warn(unused_crate_dependencies)]
 
 pub mod analyzer;
 pub mod common_subexpr_eliminate;

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![warn(unused_crate_dependencies)]
 
 pub mod aggregate;
 pub mod array_expressions;

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 //! Serde code for logical plans and expressions.
+#![warn(unused_crate_dependencies)]
 
 pub mod bytes;
 pub mod common;

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -36,4 +36,3 @@ path = "src/lib.rs"
 arrow = { workspace = true }
 datafusion-common = { path = "../common", version = "26.0.0" }
 paste = "^1.0"
-rand = "0.8"

--- a/datafusion/row/src/lib.rs
+++ b/datafusion/row/src/lib.rs
@@ -30,6 +30,7 @@
 //! merging.
 //!
 //! [this paper]: https://db.in.tum.de/~kersten/vectorization_vs_compilation.pdf
+#![warn(unused_crate_dependencies)]
 
 use arrow::array::{make_builder, ArrayBuilder, ArrayRef};
 use arrow::datatypes::Schema;

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -17,6 +17,7 @@
 
 //! This module provides a SQL parser that translates SQL queries into an abstract syntax
 //! tree (AST), and a SQL query planner that creates a logical plan from the AST.
+#![warn(unused_crate_dependencies)]
 
 mod expr;
 pub mod parser;

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -36,7 +36,6 @@ object_store = "0.6.1"
 prost = "0.11"
 prost-types = "0.11"
 substrait = "0.11.0"
-tokio = "1.17"
 
 [features]
 protoc = ["substrait/protoc"]

--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![warn(unused_crate_dependencies)]
 
 pub mod logical_plan;
 pub mod physical_plan;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![warn(unused_crate_dependencies)]
+
 //! Common functions used for testing
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_int32_array;


### PR DESCRIPTION
# Which issue does this PR close?
N/A

# Rationale for this change

I noticed there were some unused dependencies in Cargo.toml 
 
# What changes are included in this PR?
1. Remove unused dependencies
2. Add clippy lint to avoid them in the future

# Are these changes tested?
Yes
# Are there any user-facing changes?

There are fewer direct dependencies in the `datafusion` crate, but I think the dependencies likely still present transitively (so this doesn't actually reduce the dependency  burden)

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->