### PR TITLE
Re-export modules individually to fix rustdocs

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -430,11 +430,13 @@ pub mod prelude;
 pub mod scalar;
 pub mod variable;
 
-// re-export dependencies from arrow-rs to minimise version maintenance for crate users
+// re-export dependencies from arrow-rs to minimize version maintenance for crate users
 pub use arrow;
 pub use parquet;
 
-// re-export DataFusion crates
+// re-export DataFusion sub-crates at the top level. Use `pub use *`
+// so that the contents of the subcrates appears in rustdocs
+// for details, see https://github.com/apache/arrow-datafusion/issues/6648
 
 /// re-export of [`datafusion_common`] crate
 pub mod common {

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -435,14 +435,40 @@ pub use arrow;
 pub use parquet;
 
 // re-export DataFusion crates
-pub use datafusion_common as common;
-pub use datafusion_common::config;
-pub use datafusion_execution;
-pub use datafusion_expr as logical_expr;
-pub use datafusion_optimizer as optimizer;
-pub use datafusion_physical_expr as physical_expr;
-pub use datafusion_row as row;
-pub use datafusion_sql as sql;
+
+/// re-export of [`datafusion_common`] crate
+pub mod common {
+    pub use datafusion_common::*;
+}
+
+// Backwards compatibility
+pub use common::config;
+
+// NB datafusion execution is re-exported in the `execution` module
+/// re-export of [`datafusion_expr`] crate
+pub mod logical_expr {
+    pub use datafusion_expr::*;
+}
+
+/// re-export of [`datafusion_optimizer`] crate
+pub mod optimizer {
+    pub use datafusion_optimizer::*;
+}
+
+/// re-export of [`datafusion_physical_expr`] crate
+pub mod physical_expr {
+    pub use datafusion_physical_expr::*;
+}
+
+/// re-export of [`datafusion_row`] crate
+pub mod row {
+    pub use datafusion_row::*;
+}
+
+/// re-export of [`datafusion_sql`] crate
+pub mod sql {
+    pub use datafusion_sql::*;
+}
 
 #[cfg(test)]
 pub mod test;

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -445,6 +445,7 @@ pub mod common {
 pub use common::config;
 
 // NB datafusion execution is re-exported in the `execution` module
+
 /// re-export of [`datafusion_expr`] crate
 pub mod logical_expr {
     pub use datafusion_expr::*;


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/6648

# Rationale for this change

When I am trying to use rustdocs to find certain classes it often fails to do so (see https://github.com/apache/arrow-datafusion/issues/6648 for more details)

# What changes are included in this PR?
1. Directly `pub use` the content of submodules rather than just the modules themselves

This means that rustdoc can now find all the classes directly:

<img width="1262" alt="Screenshot 2023-06-23 at 3 17 25 PM" src="https://github.com/apache/arrow-datafusion/assets/490673/7747d1e5-da02-49f4-b9b3-0a652d05a3af">

# Are these changes tested?
Existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
Better rust docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->