### PR TITLE
Minor: add sqllogictests for binary data type

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/binary.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/binary.slt
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#############
+## Tests for binary data types
+#############
+
+# Basic literals encoded as hex
+query ?T
+SELECT X'FF01', arrow_typeof(X'FF01');
+----
+ff01 Binary
+
+# Invaid hex values
+query error DataFusion error: Error during planning: Invalid HexStringLiteral 'Z'
+SELECT X'Z'
+
+# Insert binary data into tables
+statement ok
+CREATE TABLE t
+AS VALUES
+  ('FF01', X'FF01'),
+  ('ABC', X'ABC'),
+  ('000', X'000');
+
+query T?TT
+SELECT column1, column2, arrow_typeof(column1), arrow_typeof(column2)
+FROM t;
+----
+FF01 ff01 Utf8 Binary
+ABC 0abc Utf8 Binary
+000 0000 Utf8 Binary
+
+# predicates
+query T?
+SELECT column1, column2
+FROM t
+WHERE column2 > X'123';
+----
+FF01 ff01
+ABC 0abc
+
+# order by
+query T?
+SELECT *
+FROM t
+ORDER BY column2;
+----
+000 0000
+ABC 0abc
+FF01 ff01
+
+# group by
+query I
+SELECT count(*)
+FROM t
+GROUP BY column1;
+----
+1
+1
+1

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -96,6 +96,9 @@ For example, to cast the output of `now()` to a `Timestamp` with second precisio
 | ------------ | :------------- |
 | `BYTEA`      | `Binary`       |
 
+You can create binary literals using a hex string literal such as
+`X'1234` to create a `Binary` value of two bytes, `0x12` and `0x34`.
+
 ## Unsupported SQL Types
 
 | SQL Data Type | Arrow DataType      |


### PR DESCRIPTION

# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/issues/6764

# Rationale for this change

Some tests for https://github.com/apache/arrow-datafusion/pull/6767

# What changes are included in this PR?
1. Add `binary.slt` tests for `Binary` data type to add some end to end coverage 
2. Add note about using `X'` style strings to docs

# Are these changes tested?

Yes, all tests

# Are there any user-facing changes?
No