### PR TITLE
Support IsDistinctFrom and IsNotDistinctFrom on interval types

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -489,5 +489,20 @@ select interval '1 month' + '2012-01-01'::date;
 ----
 2012-02-01
 
+# is (not) distinct from
+query BBBBBB
+select
+    i is distinct from null,
+    i is distinct from (interval '1 month'),
+    i is distinct from i,
+    i is not distinct from null,
+    i is not distinct from (interval '1 day'),
+    i is not distinct from i
+from t;
+----
+true false false false false true
+true true false false true true
+true true false false false true
+
 statement ok
 drop table t

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -554,6 +554,15 @@ macro_rules! binary_array_op {
             DataType::Time64(TimeUnit::Nanosecond) => {
                 compute_op!($LEFT, $RIGHT, $OP, Time64NanosecondArray)
             }
+            DataType::Interval(IntervalUnit::YearMonth) => {
+                compute_op!($LEFT, $RIGHT, $OP, IntervalYearMonthArray)
+            }
+            DataType::Interval(IntervalUnit::DayTime) => {
+                compute_op!($LEFT, $RIGHT, $OP, IntervalDayTimeArray)
+            }
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                compute_op!($LEFT, $RIGHT, $OP, IntervalMonthDayNanoArray)
+            }
             DataType::Boolean => compute_bool_op!($LEFT, $RIGHT, $OP, BooleanArray),
             other => Err(DataFusionError::Internal(format!(
                 "Data type {:?} not supported for binary operation '{}' on dyn arrays",

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -99,7 +99,7 @@ pub(crate) fn is_distinct_from<T>(
     right: &PrimitiveArray<T>,
 ) -> Result<BooleanArray>
 where
-    T: ArrowNumericType,
+    T: ArrowPrimitiveType,
 {
     distinct(
         left,
@@ -140,7 +140,7 @@ fn distinct<
     mut op: F,
 ) -> Result<BooleanArray>
 where
-    T: ArrowNumericType,
+    T: ArrowPrimitiveType,
 {
     let left_values = left.values();
     let right_values = right.values();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6774.

# Rationale for this change

`Eq` and `NotEq` work fine on intervals. This PR extends support to `IsDistinctFrom` and `IsNotDistinctFrom`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Changed the kernels to work on `ArrowPrimitiveType` instead of `ArrowNumericType`.
 - Added interval types to the `binary_array_op` macro.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Tested in `interval.slt`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, `IsDistinctFrom` and `IsNotDistinctFrom` work on interval types.