### PR TITLE
Minor: Log TPCH benchmark results

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -37,6 +37,7 @@ arrow = { workspace = true }
 datafusion = { path = "../datafusion/core", version = "27.0.0" }
 env_logger = "0.10"
 futures = "0.3"
+log = "^0.4"
 mimalloc = { version = "0.1", optional = true, default-features = false }
 num_cpus = "1.13.0"
 parquet = { workspace = true }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -16,7 +16,9 @@
 // under the License.
 
 //! Benchmark derived from TPC-H. This is not an official TPC-H benchmark.
+use log::info;
 
+use arrow::util::pretty::pretty_format_batches;
 use datafusion::datasource::file_format::{csv::CsvFormat, FileFormat};
 use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::error::{DataFusionError, Result};
@@ -235,6 +237,7 @@ async fn benchmark_query(
         let elapsed = start.elapsed(); //.as_secs_f64() * 1000.0;
         let ms = elapsed.as_secs_f64() * 1000.0;
         millis.push(ms);
+        info!("output:\n\n{}\n\n", pretty_format_batches(&result)?);
         let row_count = result.iter().map(|b| b.num_rows()).sum();
         println!(
             "Query {query_id} iteration {i} took {ms:.1} ms and returned {row_count} rows"


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

I wanted to validate y POC grouping code that it got the right answer when running benchmarks

# What changes are included in this PR?

the `tpch` benchmark driver now shows the output if `RUST_LOG` is enabled

## Before this PR

```shell
cargo run --profile dev --bin tpch -- benchmark datafusion --iterations 5 --format parquet -q 17 --path <data> 
...

Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(17), debug: false, iterations: 5, partitions: 2, batch_size: 8192, path: "/Users/alamb/Software/arrow-datafusion/benchmarks/data/", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: false }
Query 17 iteration 0 took 6383.7 ms and returned 1 rows
Query 17 iteration 1 took 6341.2 ms and returned 1 rows
Query 17 iteration 2 took 6337.4 ms and returned 1 rows
Query 17 iteration 3 took 6202.9 ms and returned 1 rows
Query 17 iteration 4 took 6222.3 ms and returned 1 rows
Query 17 avg time: 6297.51 ms
```

## After this PR:

```shell
 cargo run --profile dev --bin tpch -- benchmark datafusion --iterations 5 --format parquet -q 17 --path <data> 
...
Running benchmarks with the following options: DataFusionBenchmarkOpt { query: Some(17), debug: false, iterations: 5, partitions: 2, batch_size: 8192, path: "/Users/alamb/Software/arrow-datafusion/benchmarks/data/", file_format: "parquet", mem_table: false, output_path: None, disable_statistics: false }
[2023-06-30T15:33:26Z INFO  tpch] output:

    +-------------------+
    | avg_yearly        |
    +-------------------+
    | 348406.0542857143 |
    +-------------------+


Query 17 iteration 0 took 6401.7 ms and returned 1 rows
[2023-06-30T15:33:33Z INFO  tpch] output:

    +-------------------+
    | avg_yearly        |
    +-------------------+
    | 348406.0542857143 |
    +-------------------+


Query 17 iteration 1 took 6348.3 ms and returned 1 rows
...
```


# Are these changes tested?

No -- they are a debugging tool
# Are there any user-facing changes?
No -- internal debugging tool

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->