### PR TITLE
[MINOR] Improve performance of `create_hashes`

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -330,13 +330,13 @@ impl GroupedHashAggregateStream {
         } = &mut self.aggr_state;
 
         for (row, hash) in batch_hashes.into_iter().enumerate() {
-            let entry = map.get_mut(hash, |(hash2, group_idx)| {
+            let entry = map.get_mut(hash, |(_hash, group_idx)| {
                 // verify that a group that we are inserting with hash is
                 // actually the same key value as the group in
                 // existing_idx  (aka group_values @ row)
                 let group_state = &group_states[*group_idx];
 
-                hash == *hash2 && group_rows.row(row) == group_state.group_by_values.row()
+                group_rows.row(row) == group_state.group_by_values.row()
             });
 
             match entry {

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -330,12 +330,13 @@ impl GroupedHashAggregateStream {
         } = &mut self.aggr_state;
 
         for (row, hash) in batch_hashes.into_iter().enumerate() {
-            let entry = map.get_mut(hash, |(_hash, group_idx)| {
+            let entry = map.get_mut(hash, |(hash2, group_idx)| {
                 // verify that a group that we are inserting with hash is
                 // actually the same key value as the group in
                 // existing_idx  (aka group_values @ row)
                 let group_state = &group_states[*group_idx];
-                group_rows.row(row) == group_state.group_by_values.row()
+
+                hash == *hash2 && group_rows.row(row) == group_state.group_by_values.row()
             });
 
             match entry {

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -135,7 +135,11 @@ fn hash_array<T>(
     T: ArrayAccessor,
     T::Item: HashValue,
 {
-    assert_eq!(hashes_buffer.len(), array.len(), "hashes_buffer and array should be of equal length");
+    assert_eq!(
+        hashes_buffer.len(),
+        array.len(),
+        "hashes_buffer and array should be of equal length"
+    );
 
     if array.null_count() == 0 {
         if rehash {

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -266,11 +266,11 @@ pub fn create_hashes<'a>(
             }
             DataType::Decimal128(_, _) => {
                 let array = as_primitive_array::<Decimal128Type>(array)?;
-                hash_array_primitve(array, random_state, hashes_buffer, rehash)
+                hash_array_primitive(array, random_state, hashes_buffer, rehash)
             }
             DataType::Decimal256(_, _) => {
                 let array = as_primitive_array::<Decimal256Type>(array)?;
-                hash_array_primitve(array, random_state, hashes_buffer, rehash)
+                hash_array_primitive(array, random_state, hashes_buffer, rehash)
             }
             DataType::Dictionary(_, _) => downcast_dictionary_array! {
                 array => hash_dictionary(array, random_state, hashes_buffer, rehash)?,

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -84,6 +84,9 @@ macro_rules! hash_float_value {
 }
 hash_float_value!((half::f16, u16), (f32, u32), (f64, u64));
 
+/// Builds hash values of PrimitiveArray and writes them into `hashes_buffer`
+/// If `rehash==true` this combines the previous hash value in the buffer
+/// with the new hash using `combine_hashes`
 fn hash_array_primitive<T>(
     array: &PrimitiveArray<T>,
     random_state: &RandomState,
@@ -120,6 +123,9 @@ fn hash_array_primitive<T>(
     }
 }
 
+/// Hashes one array into the `hashes_buffer`
+/// If `rehash==true` this combines the previous hash value in the buffer
+/// with the new hash using `combine_hashes`
 fn hash_array<T>(
     array: T,
     random_state: &RandomState,
@@ -129,6 +135,8 @@ fn hash_array<T>(
     T: ArrayAccessor,
     T::Item: HashValue,
 {
+    assert_eq!(hashes_buffer.len(), array.len(), "hashes_buffer and array should be of equal length");
+
     if array.null_count() == 0 {
         if rehash {
             for (i, hash) in hashes_buffer.iter_mut().enumerate() {

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -106,14 +106,14 @@ fn hash_array_primitve<T>(
     } else if rehash {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                let value = unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         }
     } else {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                let value = unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = value.hash_one(random_state);
             }
         }
@@ -132,26 +132,26 @@ fn hash_array<T>(
     if array.null_count() == 0 {
         if rehash {
             for (i, hash) in hashes_buffer.iter_mut().enumerate() {
-                let value = unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         } else {
             for (i, hash) in hashes_buffer.iter_mut().enumerate() {
-                let value= unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = value.hash_one(random_state);
             }
         }
     } else if rehash {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                let value= unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         }
     } else {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                let value= unsafe {array.value_unchecked(i)};
+                let value = unsafe { array.value_unchecked(i) };
                 *hash = value.hash_one(random_state);
             }
         }

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -84,7 +84,7 @@ macro_rules! hash_float_value {
 }
 hash_float_value!((half::f16, u16), (f32, u32), (f64, u64));
 
-fn hash_array_primitve<T>(
+fn hash_array_primitive<T>(
     array: &PrimitiveArray<T>,
     random_state: &RandomState,
     hashes_buffer: &mut [u64],
@@ -253,7 +253,7 @@ pub fn create_hashes<'a>(
         // combine hashes with `combine_hashes` for all columns besides the first
         let rehash = i >= 1;
         downcast_primitive_array! {
-            array => hash_array_primitve(array, random_state, hashes_buffer, rehash),
+            array => hash_array_primitive(array, random_state, hashes_buffer, rehash),
             DataType::Null => hash_null(random_state, hashes_buffer, rehash),
             DataType::Boolean => hash_array(as_boolean_array(array)?, random_state, hashes_buffer, rehash),
             DataType::Utf8 => hash_array(as_string_array(array)?, random_state, hashes_buffer, rehash),

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -100,7 +100,7 @@ fn hash_array_primitive<T>(
             }
         } else {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
-                *hash = value.hash_one(&random_state);
+                *hash = value.hash_one(random_state);
             }
         }
     } else if rehash {

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -84,35 +84,75 @@ macro_rules! hash_float_value {
 }
 hash_float_value!((half::f16, u16), (f32, u32), (f64, u64));
 
-fn hash_array<T>(
-    array: T,
+fn hash_array_primitve<T>(
+    array: &PrimitiveArray<T>,
     random_state: &RandomState,
     hashes_buffer: &mut [u64],
-    multi_col: bool,
+    rehash: bool,
 ) where
-    T: ArrayAccessor,
-    T::Item: HashValue,
+    T: ArrowPrimitiveType,
+    <T as arrow_array::ArrowPrimitiveType>::Native: HashValue,
 {
     if array.null_count() == 0 {
-        if multi_col {
-            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
-                *hash = combine_hashes(array.value(i).hash_one(random_state), *hash);
+        if rehash {
+            for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
+                *hash = combine_hashes(value.hash_one(&random_state), *hash);
             }
         } else {
-            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
-                *hash = array.value(i).hash_one(random_state);
+            for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
+                *hash = value.hash_one(&random_state);
             }
         }
-    } else if multi_col {
+    } else if rehash {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                *hash = combine_hashes(array.value(i).hash_one(random_state), *hash);
+                let value = unsafe {array.value_unchecked(i)};
+                *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         }
     } else {
         for (i, hash) in hashes_buffer.iter_mut().enumerate() {
             if !array.is_null(i) {
-                *hash = array.value(i).hash_one(random_state);
+                let value = unsafe {array.value_unchecked(i)};
+                *hash = value.hash_one(random_state);
+            }
+        }
+    }
+}
+
+fn hash_array<T>(
+    array: T,
+    random_state: &RandomState,
+    hashes_buffer: &mut [u64],
+    rehash: bool,
+) where
+    T: ArrayAccessor,
+    T::Item: HashValue,
+{
+    if array.null_count() == 0 {
+        if rehash {
+            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+                let value = unsafe {array.value_unchecked(i)};
+                *hash = combine_hashes(value.hash_one(random_state), *hash);
+            }
+        } else {
+            for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+                let value= unsafe {array.value_unchecked(i)};
+                *hash = value.hash_one(random_state);
+            }
+        }
+    } else if rehash {
+        for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+            if !array.is_null(i) {
+                let value= unsafe {array.value_unchecked(i)};
+                *hash = combine_hashes(value.hash_one(random_state), *hash);
+            }
+        }
+    } else {
+        for (i, hash) in hashes_buffer.iter_mut().enumerate() {
+            if !array.is_null(i) {
+                let value= unsafe {array.value_unchecked(i)};
+                *hash = value.hash_one(random_state);
             }
         }
     }
@@ -208,34 +248,32 @@ pub fn create_hashes<'a>(
     random_state: &RandomState,
     hashes_buffer: &'a mut Vec<u64>,
 ) -> Result<&'a mut Vec<u64>> {
-    // combine hashes with `combine_hashes` if we have more than 1 column
-
-    let multi_col = arrays.len() > 1;
-
-    for col in arrays {
+    for (i, col) in arrays.iter().enumerate() {
         let array = col.as_ref();
+        // combine hashes with `combine_hashes` for all columns besides the first
+        let rehash = i >= 1;
         downcast_primitive_array! {
-            array => hash_array(array, random_state, hashes_buffer, multi_col),
-            DataType::Null => hash_null(random_state, hashes_buffer, multi_col),
-            DataType::Boolean => hash_array(as_boolean_array(array)?, random_state, hashes_buffer, multi_col),
-            DataType::Utf8 => hash_array(as_string_array(array)?, random_state, hashes_buffer, multi_col),
-            DataType::LargeUtf8 => hash_array(as_largestring_array(array), random_state, hashes_buffer, multi_col),
-            DataType::Binary => hash_array(as_generic_binary_array::<i32>(array)?, random_state, hashes_buffer, multi_col),
-            DataType::LargeBinary => hash_array(as_generic_binary_array::<i64>(array)?, random_state, hashes_buffer, multi_col),
+            array => hash_array_primitve(array, random_state, hashes_buffer, rehash),
+            DataType::Null => hash_null(random_state, hashes_buffer, rehash),
+            DataType::Boolean => hash_array(as_boolean_array(array)?, random_state, hashes_buffer, rehash),
+            DataType::Utf8 => hash_array(as_string_array(array)?, random_state, hashes_buffer, rehash),
+            DataType::LargeUtf8 => hash_array(as_largestring_array(array), random_state, hashes_buffer, rehash),
+            DataType::Binary => hash_array(as_generic_binary_array::<i32>(array)?, random_state, hashes_buffer, rehash),
+            DataType::LargeBinary => hash_array(as_generic_binary_array::<i64>(array)?, random_state, hashes_buffer, rehash),
             DataType::FixedSizeBinary(_) => {
                 let array: &FixedSizeBinaryArray = array.as_any().downcast_ref().unwrap();
-                hash_array(array, random_state, hashes_buffer, multi_col)
+                hash_array(array, random_state, hashes_buffer, rehash)
             }
             DataType::Decimal128(_, _) => {
                 let array = as_primitive_array::<Decimal128Type>(array)?;
-                hash_array(array, random_state, hashes_buffer, multi_col)
+                hash_array_primitve(array, random_state, hashes_buffer, rehash)
             }
             DataType::Decimal256(_, _) => {
                 let array = as_primitive_array::<Decimal256Type>(array)?;
-                hash_array(array, random_state, hashes_buffer, multi_col)
+                hash_array_primitve(array, random_state, hashes_buffer, rehash)
             }
             DataType::Dictionary(_, _) => downcast_dictionary_array! {
-                array => hash_dictionary(array, random_state, hashes_buffer, multi_col)?,
+                array => hash_dictionary(array, random_state, hashes_buffer, rehash)?,
                 _ => unreachable!()
             }
             _ => {

--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -96,7 +96,7 @@ fn hash_array_primitve<T>(
     if array.null_count() == 0 {
         if rehash {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
-                *hash = combine_hashes(value.hash_one(&random_state), *hash);
+                *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         } else {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

`create_hashes` is not super critical to performance but shows up in profiles.
There are some tweaks we can do:

* Don't rehash the first array if we need to hash multiple columns
* Directly iterate over values for primitive / non null arrays 
* Use `value_unchecked`

Overall this is a little bit faster:
```
┃ Query        ┃     main ┃ create_hashes_primitive ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │ 189.57ms │                186.99ms │     no change │
│ QQuery 2     │  58.37ms │                 56.41ms │     no change │
│ QQuery 3     │  50.00ms │                 47.19ms │ +1.06x faster │
│ QQuery 4     │  39.27ms │                 37.18ms │ +1.06x faster │
│ QQuery 5     │  95.93ms │                 91.49ms │     no change │
│ QQuery 6     │  10.27ms │                 10.27ms │     no change │
│ QQuery 7     │ 198.99ms │                197.05ms │     no change │
│ QQuery 8     │  73.58ms │                 70.10ms │     no change │
│ QQuery 9     │ 141.44ms │                137.33ms │     no change │
│ QQuery 10    │  97.62ms │                 98.02ms │     no change │
│ QQuery 11    │  45.01ms │                 45.78ms │     no change │
│ QQuery 12    │  67.86ms │                 67.33ms │     no change │
│ QQuery 13    │ 177.16ms │                173.97ms │     no change │
│ QQuery 14    │  12.44ms │                 11.56ms │ +1.08x faster │
│ QQuery 15    │  23.23ms │                 22.73ms │     no change │
│ QQuery 16    │  46.84ms │                 47.63ms │     no change │
│ QQuery 17    │ 680.77ms │                669.99ms │     no change │
│ QQuery 18    │ 521.03ms │                509.00ms │     no change │
│ QQuery 19    │  58.23ms │                 57.57ms │     no change │
│ QQuery 20    │ 204.74ms │                211.60ms │     no change │
│ QQuery 21    │ 263.20ms │                251.50ms │     no change │
│ QQuery 22    │  28.34ms │                 27.72ms │     no change │
└──────────────┴──────────┴─────────────────────────┴───────────────┘
```


# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Covered by existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->