### PR TITLE
fix: incorrect nullability of `Like` expressions

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3802,7 +3802,7 @@ impl fmt::Debug for ScalarValue {
     }
 }
 
-/// Trait used to map a NativeTime to a ScalarType.
+/// Trait used to map a NativeType to a ScalarValue
 pub trait ScalarType<T: ArrowNativeType> {
     /// returns a scalar from an optional T
     fn scalar(r: Option<T>) -> ScalarValue;


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

The nullability of the `Like` expressions can also depend on the pattern expression.
```shell
DataFusion CLI v27.0.0
❯ select 'foo' like null is null;
+--------------------------------+
| Utf8("foo") LIKE NULL  IS NULL |
+--------------------------------+
| true                           |
+--------------------------------+
```

# What changes are included in this PR?
- fix nullability of `Like` expressions
- improve the documentation for `ScalarType`

# Are these changes tested?
Yes

# Are there any user-facing changes?
No