### PR TITLE
Minor: Add one more assert to `hash_array_primitive`

### DIFF
--- a/datafusion/physical-expr/src/hash_utils.rs
+++ b/datafusion/physical-expr/src/hash_utils.rs
@@ -96,6 +96,12 @@ fn hash_array_primitive<T>(
     T: ArrowPrimitiveType,
     <T as arrow_array::ArrowPrimitiveType>::Native: HashValue,
 {
+    assert_eq!(
+        hashes_buffer.len(),
+        array.len(),
+        "hashes_buffer and array should be of equal length"
+    );
+
     if array.null_count() == 0 {
         if rehash {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/6816 from @Dandandan 

# Rationale for this change

There are some `unsafe` blocks in this function, so I would like to make it more obvious that they are ok

# What changes are included in this PR?
Add the same assert to `hash_array_primitive` as are in `hash_array`

# Are these changes tested?
existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->