### PR TITLE
Improve median performance.

### DIFF
--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -225,11 +225,11 @@ impl Accumulator for MedianAccumulator {
     }
 
     fn size(&self) -> usize {
-        let batches_size: usize = self.arrays.iter().map(|a| a.len()).sum();
+        let arrays_size: usize = self.arrays.iter().map(|a| a.len()).sum();
 
         std::mem::size_of_val(self)
             + ScalarValue::size_of_vec(&self.all_values)
-            + batches_size
+            + arrays_size
             - std::mem::size_of_val(&self.all_values)
             + self.data_type.size()
             - std::mem::size_of_val(&self.data_type)

--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -236,7 +236,8 @@ impl Accumulator for MedianAccumulator {
     fn size(&self) -> usize {
         let batches_size: usize = self.batches.iter().map(|a| a.len()).sum();
 
-        std::mem::size_of_val(self) + ScalarValue::size_of_vec(&self.all_values)
+        std::mem::size_of_val(self)
+            + ScalarValue::size_of_vec(&self.all_values)
             + batches_size
             - std::mem::size_of_val(&self.all_values)
             + self.data_type.size()


### PR DESCRIPTION
# Which issue does this PR close?

Related to discussion in #4973.

# Rationale for this change

This PR improves the median aggregator by reducing the number of allocations. 

For this example I am using one year of data from the [nyctaxi](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) dataset, running  a group by `payment_type` and computing the `total_amount` median, with the current version it takes ~22secs:

```
$ time ./target/release/datafusion-median
+--------------+--------------+----------+
| payment_type | total_amount | n        |
+--------------+--------------+----------+
| 5            | 5.275        | 6        |
| 3            | 7.7          | 194323   |
| 4            | -6.8         | 244364   |
| 0            | 23.0         | 1368303  |
| 2            | 13.3         | 7763339  |
| 1            | 16.56        | 30085763 |
+--------------+--------------+----------+

real    0m22.861s
user    1m54.033s
sys     0m2.872s
```

with the changes introduced in this PR we get the same result in ~2secs:

```
$ time ./target/release/datafusion-median
+--------------+--------------+----------+
| payment_type | total_amount | n        |
+--------------+--------------+----------+
| 5            | 5.275        | 6        |
| 3            | 7.7          | 194323   |
| 4            | -6.8         | 244364   |
| 0            | 23.0         | 1368303  |
| 2            | 13.3         | 7763339  |
| 1            | 16.56        | 30085763 |
+--------------+--------------+----------+

real    0m2.514s
user    0m4.725s
sys     0m1.765s
```


# What changes are included in this PR?

Reduce number of allocations.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Run tests locally they all passed.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->