### PR TITLE
test: parquet use the byte array as the physical type to store decimal

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1181,10 +1181,13 @@ mod tests {
         let column = batches[0].column(0);
         assert_eq!(&DataType::Decimal128(13, 2), column.data_type());
 
-        // parquet use the fixed length binary as the physical type to store decimal
-        // TODO: arrow-rs don't support convert the physical type of binary to decimal
-        // https://github.com/apache/arrow-rs/pull/2160
-        // let exec = get_exec(&session_ctx, "byte_array_decimal.parquet", None, None).await?;
+        // parquet use the byte array as the physical type to store decimal
+        let exec = get_exec(&state, "byte_array_decimal.parquet", None, None).await?;
+        let batches = collect(exec, task_ctx.clone()).await?;
+        assert_eq!(1, batches.len());
+        assert_eq!(1, batches[0].num_columns());
+        let column = batches[0].column(0);
+        assert_eq!(&DataType::Decimal128(4, 2), column.data_type());
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/pull/2960

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Add one more test.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add a test for parquet use the byte array as the physical type to store decimal.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->