### PR TITLE
Adjustment of HashJoinExec APIs to Preserve Probe Side Order

### DIFF
--- a/datafusion/core/src/physical_plan/joins/hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/hash_join.rs
@@ -315,11 +315,7 @@ impl ExecutionPlan for HashJoinExec {
     }
 
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        if let Some(order) = &self.output_order {
-            Some(order)
-        } else {
-            None
-        }
+        self.output_order.as_deref()
     }
 
     // For [JoinType::Inner] and [JoinType::RightSemi] in hash joins, the probe phase initiates by

--- a/datafusion/core/src/physical_plan/joins/utils.rs
+++ b/datafusion/core/src/physical_plan/joins/utils.rs
@@ -174,7 +174,7 @@ fn adjust_right_order(
         .collect::<Result<Vec<_>>>()
 }
 
-/// Calculate the output order for Join Node
+/// Calculate the output order for hash join.
 pub fn calculate_hash_join_output_order(
     join_type: &JoinType,
     maybe_left_order: Option<&[PhysicalSortExpr]>,
@@ -185,6 +185,8 @@ pub fn calculate_hash_join_output_order(
         Some(right_order) => {
             let result = match join_type {
                 JoinType::Inner => {
+                    // We modify the indices of the right order columns because their
+                    // columns are appended to the right side of the left schema.
                     let mut adjusted_right_order =
                         adjust_right_order(right_order, left_len)?;
                     if let Some(left_order) = maybe_left_order {

--- a/datafusion/core/src/physical_plan/joins/utils.rs
+++ b/datafusion/core/src/physical_plan/joins/utils.rs
@@ -40,7 +40,7 @@ use datafusion_common::cast::as_boolean_array;
 use datafusion_common::{ScalarValue, SharedResult};
 
 use datafusion_common::tree_node::{Transformed, TreeNode};
-use datafusion_physical_expr::{EquivalentClass, PhysicalExpr};
+use datafusion_physical_expr::{EquivalentClass, PhysicalExpr, PhysicalSortExpr};
 
 use datafusion_common::JoinType;
 use datafusion_common::{DataFusionError, Result};
@@ -144,6 +144,61 @@ pub fn adjust_right_output_partitioning(
                 .collect::<Vec<_>>();
             Partitioning::Hash(new_exprs, size)
         }
+    }
+}
+
+fn adjust_right_order(
+    right_order: &[PhysicalSortExpr],
+    left_columns_len: usize,
+) -> Result<Vec<PhysicalSortExpr>> {
+    right_order
+        .iter()
+        .map(|sort_expr| {
+            let expr = sort_expr.expr.clone();
+            let adjusted = expr.transform_up(&|expr| {
+                Ok(
+                    if let Some(column) = expr.as_any().downcast_ref::<Column>() {
+                        let new_col =
+                            Column::new(column.name(), column.index() + left_columns_len);
+                        Transformed::Yes(Arc::new(new_col))
+                    } else {
+                        Transformed::No(expr)
+                    },
+                )
+            })?;
+            Ok(PhysicalSortExpr {
+                expr: adjusted,
+                options: sort_expr.options,
+            })
+        })
+        .collect::<Result<Vec<_>>>()
+}
+
+/// Calculate the output order for Join Node
+pub fn calculate_hash_join_output_order(
+    join_type: &JoinType,
+    maybe_left_order: Option<&[PhysicalSortExpr]>,
+    maybe_right_order: Option<&[PhysicalSortExpr]>,
+    left_len: usize,
+) -> Result<Option<Vec<PhysicalSortExpr>>> {
+    match maybe_right_order {
+        Some(right_order) => {
+            let result = match join_type {
+                JoinType::Inner => {
+                    let mut adjusted_right_order =
+                        adjust_right_order(right_order, left_len)?;
+                    if let Some(left_order) = maybe_left_order {
+                        adjusted_right_order.extend_from_slice(left_order);
+                    }
+                    Some(adjusted_right_order)
+                }
+                JoinType::RightAnti | JoinType::RightSemi => Some(right_order.to_vec()),
+                _ => None,
+            };
+
+            Ok(result)
+        }
+        None => Ok(None),
     }
 }
 

--- a/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
@@ -78,27 +78,34 @@ SELECT t1.a, t2.a as a2, t2.b
 
 query TT
 EXPLAIN SELECT t2.a as a2, t2.b
-            FROM annotated_data as t1
-            RIGHT SEMI JOIN annotated_data as t2
-            ON t1.d = t2.d ORDER BY a2, t2.b
-LIMIT 30
+    FROM annotated_data as t1
+    RIGHT SEMI JOIN annotated_data as t2
+    ON t1.d = t2.d AND t1.c = t2.c
+    WHERE t2.d = 3
+    ORDER BY a2, t2.b
+LIMIT 10
 ----
 logical_plan
-Limit: skip=0, fetch=30
---Sort: a2 ASC NULLS LAST, t2.b ASC NULLS LAST, fetch=30
+Limit: skip=0, fetch=10
+--Sort: a2 ASC NULLS LAST, t2.b ASC NULLS LAST, fetch=10
 ----Projection: t2.a AS a2, t2.b
-------RightSemi Join: t1.d = t2.d
+------RightSemi Join: t1.d = t2.d, t1.c = t2.c
 --------SubqueryAlias: t1
-----------TableScan: annotated_data projection=[d]
+----------TableScan: annotated_data projection=[c, d]
 --------SubqueryAlias: t2
-----------TableScan: annotated_data projection=[a, b, d]
+----------Filter: annotated_data.d = Int32(3)
+------------TableScan: annotated_data projection=[a, b, c, d], partial_filters=[annotated_data.d = Int32(3)]
 physical_plan
-GlobalLimitExec: skip=0, fetch=30
---ProjectionExec: expr=[a@0 as a2, b@1 as b]
-----CoalesceBatchesExec: target_batch_size=8192
-------HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(d@0, d@2)]
---------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[d], has_header=true
---------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, d], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
+GlobalLimitExec: skip=0, fetch=10
+--SortPreservingMergeExec: [a2@0 ASC NULLS LAST,b@1 ASC NULLS LAST], fetch=10
+----ProjectionExec: expr=[a@0 as a2, b@1 as b]
+------CoalesceBatchesExec: target_batch_size=8192
+--------HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(d@1, d@3), (c@0, c@2)]
+----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c, d], has_header=true
+----------CoalesceBatchesExec: target_batch_size=8192
+------------FilterExec: d@3 = 3
+--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+----------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, c, d], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST, c@2 ASC NULLS LAST], has_header=true
 
 # preserve_right_semi_join
 query II nosort
@@ -113,33 +120,13 @@ LIMIT 10
 0 0
 0 0
 0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
-0 0
 0 1
 0 1
 0 1
 0 1
 0 1
+1 2
+1 2
 
 # turn on repartition_joins
 statement ok

--- a/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
@@ -105,8 +105,10 @@ query II nosort
 SELECT t2.a as a2, t2.b
     FROM annotated_data as t1
     RIGHT SEMI JOIN annotated_data as t2
-    ON t1.d = t2.d ORDER BY a2, t2.b
-LIMIT 30
+    ON t1.d = t2.d AND t1.c = t2.c
+    WHERE t2.d = 3
+    ORDER BY a2, t2.b
+LIMIT 10
 ----
 0 0
 0 0

--- a/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/join_disable_repartition_joins.slt
@@ -25,6 +25,120 @@ set datafusion.optimizer.repartition_joins = false;
 
 include ./join.slt
 
+statement ok
+CREATE EXTERNAL TABLE annotated_data (
+  a0 INTEGER,
+  a INTEGER,
+  b INTEGER,
+  c INTEGER,
+  d INTEGER
+)
+STORED AS CSV
+WITH HEADER ROW
+WITH ORDER (a ASC, b ASC, c ASC)
+LOCATION 'tests/data/window_2.csv';
+
+query TT
+EXPLAIN SELECT t2.a
+ FROM annotated_data as t1
+ INNER JOIN annotated_data as t2
+ ON t1.c = t2.c ORDER BY t2.a
+ LIMIT 5
+----
+logical_plan
+Limit: skip=0, fetch=5
+--Sort: t2.a ASC NULLS LAST, fetch=5
+----Projection: t2.a
+------Inner Join: t1.c = t2.c
+--------SubqueryAlias: t1
+----------TableScan: annotated_data projection=[c]
+--------SubqueryAlias: t2
+----------TableScan: annotated_data projection=[a, c]
+physical_plan
+GlobalLimitExec: skip=0, fetch=5
+--ProjectionExec: expr=[a@1 as a]
+----CoalesceBatchesExec: target_batch_size=8192
+------HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(c@0, c@1)]
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], has_header=true
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, c], output_ordering=[a@0 ASC NULLS LAST], has_header=true
+
+# preserve_inner_join
+query III nosort
+SELECT t1.a, t2.a as a2, t2.b
+ FROM annotated_data as t1
+ INNER JOIN annotated_data as t2
+ ON t1.d = t2.d ORDER BY a2, t2.b
+ LIMIT 5
+----
+1 0 0
+1 0 0
+1 0 0
+1 0 0
+1 0 0
+
+query TT
+EXPLAIN SELECT t2.a as a2, t2.b
+            FROM annotated_data as t1
+            RIGHT SEMI JOIN annotated_data as t2
+            ON t1.d = t2.d ORDER BY a2, t2.b
+LIMIT 30
+----
+logical_plan
+Limit: skip=0, fetch=30
+--Sort: a2 ASC NULLS LAST, t2.b ASC NULLS LAST, fetch=30
+----Projection: t2.a AS a2, t2.b
+------RightSemi Join: t1.d = t2.d
+--------SubqueryAlias: t1
+----------TableScan: annotated_data projection=[d]
+--------SubqueryAlias: t2
+----------TableScan: annotated_data projection=[a, b, d]
+physical_plan
+GlobalLimitExec: skip=0, fetch=30
+--ProjectionExec: expr=[a@0 as a2, b@1 as b]
+----CoalesceBatchesExec: target_batch_size=8192
+------HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(d@0, d@2)]
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[d], has_header=true
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b, d], output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST], has_header=true
+
+# preserve_right_semi_join
+query II nosort
+SELECT t2.a as a2, t2.b
+    FROM annotated_data as t1
+    RIGHT SEMI JOIN annotated_data as t2
+    ON t1.d = t2.d ORDER BY a2, t2.b
+LIMIT 30
+----
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 0
+0 1
+0 1
+0 1
+0 1
+0 1
+
 # turn on repartition_joins
 statement ok
 set datafusion.optimizer.repartition_joins = true;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/6857

# Rationale for this change

In theory, we can maintain the order of records on the probe side of the hash join. This ordering preservation can be applied to Inner, RightSemi, and RightAnti joins.

The implementation changes in this pull request are designed to leverage this aspect of hash join operations, thereby eliminating unnecessary sort operations. Consequently, this enhancement is expected to result in improved performance, particularly in scenarios where the probe side of the hash join operation is already sorted.

# What changes are included in this PR?

1. **Adjustment of HashJoinExec APIS**: We have modified the HashJoinExec operation to preserve the order of its probe side in Inner, RightSemi, and RightAnti joins, thereby eliminating unnecessary sort operations.

2. **Bug Fix on Sort Pushdown Rule**: We have fixed a minor bug in the Sort Pushdown rule.

# Are these changes tested?

The new tests are included in the` join_disable_repartition.slt `file.

# Are there any user-facing changes?

No.

cc @Dandandan 