### PR TITLE
[MINOR] Remove unnecessary api from MemTable

### DIFF
--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -169,8 +169,8 @@ impl TableProvider for MemTable {
             let inner_vec = arc_inner_vec.read().await;
             partitions.push(inner_vec.clone())
         }
-        Ok(Arc::new(MemoryExec::try_new_owned_data(
-            partitions,
+        Ok(Arc::new(MemoryExec::try_new(
+            &partitions,
             self.schema(),
             projection.cloned(),
         )?))

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -149,23 +149,6 @@ impl MemoryExec {
         })
     }
 
-    /// Create a new execution plan for reading in-memory record batches
-    /// The provided `schema` should not have the projection applied.
-    pub fn try_new_owned_data(
-        partitions: Vec<Vec<RecordBatch>>,
-        schema: SchemaRef,
-        projection: Option<Vec<usize>>,
-    ) -> Result<Self> {
-        let projected_schema = project_schema(&schema, projection.as_ref())?;
-        Ok(Self {
-            partitions,
-            schema,
-            projected_schema,
-            projection,
-            sort_information: None,
-        })
-    }
-
     /// Set sort information
     pub fn with_sort_information(
         mut self,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Refactor MemTable for unnecessary code.

# What changes are included in this PR?

Removing `try_new_owned_data`

# Are these changes tested?

Existing tests are enough.

# Are there any user-facing changes?

No