### PR TITLE
fix: from_plan generate incorrect schema when it is Aggregate

### DIFF
--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -833,14 +833,13 @@ pub fn from_plan(
             window_expr: expr[0..window_expr.len()].to_vec(),
             schema: schema.clone(),
         })),
-        LogicalPlan::Aggregate(Aggregate {
-            group_expr, schema, ..
-        }) => Ok(LogicalPlan::Aggregate(Aggregate::try_new_with_schema(
-            Arc::new(inputs[0].clone()),
-            expr[0..group_expr.len()].to_vec(),
-            expr[group_expr.len()..].to_vec(),
-            schema.clone(),
-        )?)),
+        LogicalPlan::Aggregate(Aggregate { group_expr, .. }) => {
+            Ok(LogicalPlan::Aggregate(Aggregate::try_new(
+                Arc::new(inputs[0].clone()),
+                expr[0..group_expr.len()].to_vec(),
+                expr[group_expr.len()..].to_vec(),
+            )?))
+        }
         LogicalPlan::Sort(SortPlan { fetch, .. }) => Ok(LogicalPlan::Sort(SortPlan {
             expr: expr.to_vec(),
             input: Arc::new(inputs[0].clone()),


### PR DESCRIPTION
# Rationale for this change

For the `from_plan` function, we want to generate a new logical plan with inputs and expressions replaced. When we encounter the `Aggregate` variant, the old code simply clones the old schema.  However, the new `group by expressions` may have a different schema from the old one. Therefore, we should use the `try_new` function to create a new `Aggregate`  variant with the correct schema. 


# Are these changes tested?
Yes

# Are there any user-facing changes?
No
