### PR TITLE
Support array concatenation for arrays with different dimensions

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/array.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/array.slt
@@ -365,26 +365,25 @@ select array_concat(make_array(), make_array(2, 3));
 ----
 [2, 3]
 
-# array_concat with different dimensions
-# 2D + 1D
+# array_concat with different dimensions #1 (2D + 1D)
 query ?
 select array_concat(make_array([1,2], [3,4]), make_array(5, 6))
 ----
 [[1, 2], [3, 4], [5, 6]]
 
-# 1D + 2D
+# array_concat with different dimensions #2 (1D + 2D)
 query ?
 select array_concat(make_array(5, 6), make_array([1,2], [3,4]))
 ----
 [[5, 6], [1, 2], [3, 4]]
 
-# 2D + 1D + 1D
+# array_concat with different dimensions #3 (2D + 1D + 1D)
 query ?
 select array_concat(make_array([1,2], [3,4]), make_array(5, 6), make_array(7,8))
 ----
 [[1, 2], [3, 4], [5, 6], [7, 8]]
 
-# 1D + 2D + 3D
+# array_concat with different dimensions #4 (1D + 2D + 3D)
 query ?
 select array_concat(make_array(10, 20), make_array([30, 40]), make_array([[50, 60]]))
 ----

--- a/datafusion/core/tests/sqllogictests/test_files/array.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/array.slt
@@ -365,6 +365,31 @@ select array_concat(make_array(), make_array(2, 3));
 ----
 [2, 3]
 
+# array_concat with different dimensions
+# 2D + 1D
+query ?
+select array_concat(make_array([1,2], [3,4]), make_array(5, 6))
+----
+[[1, 2], [3, 4], [5, 6]]
+
+# 1D + 2D
+query ?
+select array_concat(make_array(5, 6), make_array([1,2], [3,4]))
+----
+[[5, 6], [1, 2], [3, 4]]
+
+# 2D + 1D + 1D
+query ?
+select array_concat(make_array([1,2], [3,4]), make_array(5, 6), make_array(7,8))
+----
+[[1, 2], [3, 4], [5, 6], [7, 8]]
+
+# 1D + 2D + 3D
+query ?
+select array_concat(make_array(10, 20), make_array([30, 40]), make_array([[50, 60]]))
+----
+[[[10, 20]], [[30, 40]], [[50, 60]]]
+
 ## array_position
 
 # array_position scalar function #1

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -400,15 +400,14 @@ fn compute_array_ndims(arg: u8, arr: ArrayRef) -> Result<u8> {
 }
 
 fn align_array_dimensions(args: Vec<ArrayRef>) -> Result<Vec<ArrayRef>> {
-    // Compute the number of dimensions for each array
-    let args_ndim: Result<Vec<u8>> = args
+    // Find the maximum number of dimensions
+    let max_ndim: u8 = *args
         .iter()
         .map(|arr| compute_array_ndims(0, arr.clone()))
-        .collect();
-    let args_ndim = args_ndim?;
-
-    // Find the maximum number of dimensions
-    let max_ndim = *args_ndim.iter().max().unwrap();
+        .collect::<Result<Vec<u8>>>()?
+        .iter()
+        .max()
+        .unwrap();
 
     // Align the dimensions of the arrays
     let aligned_args: Result<Vec<ArrayRef>> = args


### PR DESCRIPTION
# Which issue does this PR close?



<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ref #6849

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Calculate dims for each array in concat(), find the max one, and wrap each array to the same dims.

Note that this change does not restrict that each array dimension should be diff by 1 as mentioned in the issue, but I think it is fine not to restrict that, If we need to ensure that, we just need additional error handling.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->