### PR TITLE
Make streaming_merge public

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/merge.rs
@@ -52,7 +52,7 @@ macro_rules! merge_helper {
 }
 
 /// Perform a streaming merge of [`SendableRecordBatchStream`]
-pub(crate) fn streaming_merge(
+pub fn streaming_merge(
     streams: Vec<SendableRecordBatchStream>,
     schema: SchemaRef,
     expressions: &[PhysicalSortExpr],

--- a/datafusion/core/src/physical_plan/sorts/merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/merge.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Merge that deals with an arbitrary size of streaming inputs.
+//! This is an order-preserving merge.
+
 use crate::physical_plan::metrics::BaselineMetrics;
 use crate::physical_plan::sorts::builder::BatchBuilder;
 use crate::physical_plan::sorts::cursor::Cursor;
@@ -51,7 +54,9 @@ macro_rules! merge_helper {
     }};
 }
 
-/// Perform a streaming merge of [`SendableRecordBatchStream`]
+/// Perform a streaming merge of [`SendableRecordBatchStream`] based on provided sort expressions
+/// while preserving order. This is a convenience wrapper for [`SortPreservingMergeStream`] and
+/// chooses a right cursor for the expressions and the data type
 pub fn streaming_merge(
     streams: Vec<SendableRecordBatchStream>,
     schema: SchemaRef,

--- a/datafusion/core/src/physical_plan/sorts/merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/merge.rs
@@ -55,8 +55,7 @@ macro_rules! merge_helper {
 }
 
 /// Perform a streaming merge of [`SendableRecordBatchStream`] based on provided sort expressions
-/// while preserving order. This is a convenience wrapper for [`SortPreservingMergeStream`] and
-/// chooses a right cursor for the expressions and the data type
+/// while preserving order.
 pub fn streaming_merge(
     streams: Vec<SendableRecordBatchStream>,
     schema: SchemaRef,

--- a/datafusion/core/src/physical_plan/sorts/mod.rs
+++ b/datafusion/core/src/physical_plan/sorts/mod.rs
@@ -20,7 +20,7 @@
 mod builder;
 mod cursor;
 mod index;
-mod merge;
+pub mod merge;
 pub mod sort;
 pub mod sort_preserving_merge;
 mod stream;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/6871

# Rationale for this change

We would like to use `streaming_merge` on its own.

# What changes are included in this PR?

Changing `physical_plan::merge::streaming_merge` to public

# Are these changes tested?

Yes, existing tests

# Are there any user-facing changes?

No
