### PR TITLE
Fix (another) logical conflict

### DIFF
--- a/datafusion/core/src/physical_plan/streaming.rs
+++ b/datafusion/core/src/physical_plan/streaming.rs
@@ -28,11 +28,12 @@ use datafusion_common::{DataFusionError, Result, Statistics};
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 use log::debug;
 
+use crate::datasource::physical_plan::{OutputOrderingDisplay, ProjectSchemaDisplay};
 use crate::physical_plan::stream::RecordBatchStreamAdapter;
 use crate::physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream};
 use datafusion_execution::TaskContext;
 
-use super::DisplayAs;
+use super::{DisplayAs, DisplayFormatType};
 
 /// A partition that can be converted into a [`SendableRecordBatchStream`]
 pub trait PartitionStream: Send + Sync {


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change

Fix a logical conflict from https://github.com/apache/arrow-datafusion/pull/6726

Ci is failing on main like this: https://github.com/apache/arrow-datafusion/actions/runs/5486691970/jobs/9997114358

```
rror[E0433]: failed to resolve: use of undeclared type `DisplayFormatType`
   --> datafusion/core/src/physical_plan/streaming.rs:105:13
    |
105 |             DisplayFormatType::Default | DisplayFormatType::Verbose => {
    |             ^^^^^^^^^^^^^^^^^ use of undeclared type `DisplayFormatType`

error[E0433]: failed to resolve: use of undeclared type `DisplayFormatType`
   --> datafusion/core/src/physical_plan/streaming.rs:105:42
    |
105 |             DisplayFormatType::Default | DisplayFormatType::Verbose => {
    |                                          ^^^^^^^^^^^^^^^^^ use of undeclared type `DisplayFormatType`

error[E0412]: cannot find type `DisplayFormatType` in this scope
   --> datafusion/core/src/physical_plan/streaming.rs:101:12
    |
101 |         t: DisplayFormatType,
    |            ^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this enum
    |
20  + use crate::physical_plan::DisplayFormatType;
    |

error[E0425]: cannot find function, tuple struct or tuple variant `ProjectSchemaDisplay` in this scope
   --> datafusion/core/src/physical_plan/streaming.rs:115:25
    |
115 |                         ProjectSchemaDisplay(&self.projected_schema)
    |                         ^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this tuple struct
    |
20  + use crate::datasource::physical_plan::ProjectSchemaDisplay;
    |

error[E0425]: cannot find function, tuple struct or tuple variant `OutputOrderingDisplay` in this scope
   --> datafusion/core/src/physical_plan/streaming.rs:129:33
    |
129 | ...                   OutputOrderingDisplay(ordering)
    |                       ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this tuple struct
    |
20  + use crate::datasource::physical_plan::OutputOrderingDisplay;
    |
```

# What changes are included in this PR?

Add necessary includes 

# Are these changes tested?
CI

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->