### PR TITLE
Minor: Consolidate display related traits

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -44,14 +44,17 @@ pub use file_stream::{FileOpenFuture, FileOpener, FileStream, OnError};
 pub(crate) use json::plan_to_json;
 pub use json::{JsonOpener, NdJsonExec};
 
-use crate::datasource::{
-    listing::{FileRange, PartitionedFile},
-    object_store::ObjectStoreUrl,
-};
 use crate::physical_plan::ExecutionPlan;
 use crate::{
     datasource::file_format::FileWriterMode,
     physical_plan::{DisplayAs, DisplayFormatType},
+};
+use crate::{
+    datasource::{
+        listing::{FileRange, PartitionedFile},
+        object_store::ObjectStoreUrl,
+    },
+    physical_plan::display::{OutputOrderingDisplay, ProjectSchemaDisplay},
 };
 use crate::{
     error::{DataFusionError, Result},
@@ -68,7 +71,7 @@ use object_store::ObjectMeta;
 use std::{
     borrow::Cow,
     collections::HashMap,
-    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    fmt::{Debug, Formatter, Result as FmtResult},
     marker::PhantomData,
     sync::Arc,
     vec,
@@ -413,39 +416,6 @@ where
         format_element(element, f)?;
     }
     Ok(())
-}
-
-/// A wrapper to customize partitioned file display
-#[derive(Debug)]
-pub struct ProjectSchemaDisplay<'a>(pub &'a SchemaRef);
-
-impl<'a> Display for ProjectSchemaDisplay<'a> {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        let parts: Vec<_> = self
-            .0
-            .fields()
-            .iter()
-            .map(|x| x.name().to_owned())
-            .collect::<Vec<String>>();
-        write!(f, "[{}]", parts.join(", "))
-    }
-}
-
-/// A wrapper to customize output ordering display.
-#[derive(Debug)]
-pub struct OutputOrderingDisplay<'a>(pub &'a [PhysicalSortExpr]);
-
-impl<'a> Display for OutputOrderingDisplay<'a> {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "[")?;
-        for (i, e) in self.0.iter().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?
-            }
-            write!(f, "{e}")?;
-        }
-        write!(f, "]")
-    }
 }
 
 /// A utility which can adapt file-level record batches to a table schema which may have a schema

--- a/datafusion/core/src/physical_plan/streaming.rs
+++ b/datafusion/core/src/physical_plan/streaming.rs
@@ -28,7 +28,7 @@ use datafusion_common::{DataFusionError, Result, Statistics};
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 use log::debug;
 
-use crate::datasource::physical_plan::{OutputOrderingDisplay, ProjectSchemaDisplay};
+use crate::physical_plan::display::{OutputOrderingDisplay, ProjectSchemaDisplay};
 use crate::physical_plan::stream::RecordBatchStreamAdapter;
 use crate::physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream};
 use datafusion_execution::TaskContext;


### PR DESCRIPTION
# Which issue does this PR close?

Related to #1754 

# Rationale for this change

I would like to move all physical plan into its own crate eventually, thus there can't be back dependencies to core

# What changes are included in this PR?
 Move `ProjectSchemaDisplay` and `OutputOrderingDisplay` TO the display module with the other ExecutionPlan display code, most recently modified by @liurenjie1024 in https://github.com/apache/arrow-datafusion/pull/6726

# Are these changes tested?
existing CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->