### PR TITLE
Preserve field metadata across expressions in logical plans

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -581,6 +581,9 @@ pub trait ExprSchema: std::fmt::Debug {
 
     /// What is the datatype of this column?
     fn data_type(&self, col: &Column) -> Result<&DataType>;
+
+    /// Returns the column's optional metadata.
+    fn metadata(&self, col: &Column) -> Result<&HashMap<String, String>>;
 }
 
 // Implement `ExprSchema` for `Arc<DFSchema>`
@@ -592,6 +595,10 @@ impl<P: AsRef<DFSchema> + std::fmt::Debug> ExprSchema for P {
     fn data_type(&self, col: &Column) -> Result<&DataType> {
         self.as_ref().data_type(col)
     }
+
+    fn metadata(&self, col: &Column) -> Result<&HashMap<String, String>> {
+        ExprSchema::metadata(&self, col)
+    }
 }
 
 impl ExprSchema for DFSchema {
@@ -601,6 +608,10 @@ impl ExprSchema for DFSchema {
 
     fn data_type(&self, col: &Column) -> Result<&DataType> {
         Ok(self.field_from_column(col)?.data_type())
+    }
+
+    fn metadata(&self, col: &Column) -> Result<&HashMap<String, String>> {
+        Ok(self.field_from_column(col)?.metadata())
     }
 }
 
@@ -661,6 +672,10 @@ impl DFField {
         self.field.is_nullable()
     }
 
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        self.field.metadata()
+    }
+
     /// Returns a string to the `DFField`'s qualified name
     pub fn qualified_name(&self) -> String {
         if let Some(qualifier) = &self.qualifier {
@@ -705,6 +720,13 @@ impl DFField {
     /// Return field with nullable specified
     pub fn with_nullable(mut self, nullable: bool) -> Self {
         let f = self.field().as_ref().clone().with_nullable(nullable);
+        self.field = f.into();
+        self
+    }
+
+    /// Return field with new metadata
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        let f = self.field().as_ref().clone().with_metadata(metadata);
         self.field = f.into();
         self
     }

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -597,7 +597,7 @@ impl<P: AsRef<DFSchema> + std::fmt::Debug> ExprSchema for P {
     }
 
     fn metadata(&self, col: &Column) -> Result<&HashMap<String, String>> {
-        ExprSchema::metadata(&self, col)
+        ExprSchema::metadata(self.as_ref(), col)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6886.

# Rationale for this change

This change improves support for extension types by allowing access to field metadata at the logical planning stage.

# What changes are included in this PR?

- Added `ExprSchemable::metadata` method.
  - Forwards metadata for column and alias expressions
  - All other expressions return empty metadata
- Updated `ExprSchemable::to_field` to populate field metadata.
- Added metadata utility methods `metadata` and `with_metadata` to `DFField` to match `Field` methods in `arrow-rs`.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No