### PR TITLE
Support equality and comparison between interval arrays and scalars

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/interval.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/interval.slt
@@ -522,5 +522,40 @@ true false false false false true
 true true false false true true
 true true false false false true
 
+### interval (array) cmp interval (array)
+query BBBBBB
+select i = i, i != i, i < i, i <= i, i > i, i >= i from t;
+----
+true false false true false true
+true false false true false true
+true false false true false true
+
+### interval (array) cmp interval (scalar)
+query BBBBBB
+select
+    (interval '1 day') = i,
+    (interval '1 day') != i,
+    i < (interval '1 day'),
+    i <= (interval '1 day'),
+    i > (interval '1 day'),
+    i >= (interval '1 day')
+from t;
+----
+false true false false true true
+true false false true false true
+false true true true false false
+
+### interval (scalar) cmp interval (scalar)
+query BBBBBB
+select
+    (interval '1 day') = (interval '1 day'),
+    (interval '1 month') != (interval '1 day'),
+    (interval '1 minute') < (interval '1 day'),
+    (interval '1 hour') <= (interval '1 day'),
+    (interval '1 year') > (interval '1 day'),
+    (interval '1 day') >= (interval '1 day');
+----
+true true true true true true
+
 statement ok
 drop table t

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1035,6 +1035,9 @@ macro_rules! binary_array_op_dyn_scalar {
             ScalarValue::TimestampMillisecond(v, _) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
             ScalarValue::TimestampMicrosecond(v, _) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
             ScalarValue::TimestampNanosecond(v, _) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
+            ScalarValue::IntervalYearMonth(v) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
+            ScalarValue::IntervalDayTime(v) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
+            ScalarValue::IntervalMonthDayNano(v) => compute_op_dyn_scalar!($LEFT, v, $OP, $OP_TYPE),
             other => Err(DataFusionError::Internal(format!(
                 "Data type {:?} not supported for scalar operation '{}' on dyn array",
                 other, stringify!($OP)))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6947.

# Rationale for this change

More complete support for operations between interval types.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Add missing cases for interval types to `binary_array_op_dyn_scalar`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Added `.slt` tests. Also added tests for the array-array and scalar-scalar cases that already work today but seem untested.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

Yes, comparing an interval array with an interval scalar now works.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->