### PR TITLE
Improve grouping performance via  better vectorization in accumulate functions

### DIFF
--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/accumulate.rs
@@ -150,8 +150,8 @@ impl NullState {
             return;
         }
 
-        // have been tracking values previously, so we still need to
-        // track them here
+        // have been tracking seen values previously, so we still need
+        // to track them here
         let seen_values =
             initialize_builder(&mut self.seen_values, total_num_groups, false);
 
@@ -726,7 +726,14 @@ mod test {
             }
 
             // Validate the final buffer (one value per group)
-            let expected_null_buffer = mock.expected_null_buffer(total_num_groups);
+            let expected_null_buffer = if values.null_count() > 0 || opt_filter.is_some() {
+                mock.expected_null_buffer(total_num_groups)
+            } else {
+                // the test data doesn't always pass all group indices
+                // unlike the real hash grouper, so only build a null
+                // buffer if it would have made one
+                None
+            };
 
             let null_buffer = null_state.build();
 

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/bool_op.rs
@@ -101,7 +101,7 @@ where
     fn evaluate(&mut self) -> Result<ArrayRef> {
         let values = self.values.finish();
         let nulls = self.null_state.build();
-        let values = BooleanArray::new(values, Some(nulls));
+        let values = BooleanArray::new(values, nulls);
         Ok(Arc::new(values))
     }
 

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/prim_op.rs
@@ -115,7 +115,7 @@ where
     fn evaluate(&mut self) -> Result<ArrayRef> {
         let values = std::mem::take(&mut self.values);
         let nulls = self.null_state.build();
-        let values = PrimitiveArray::<T>::new(values.into(), Some(nulls)); // no copy
+        let values = PrimitiveArray::<T>::new(values.into(), nulls); // no copy
 
         adjust_output_array(&self.data_type, Arc::new(values))
     }

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -1407,7 +1407,7 @@ where
         let min_max = std::mem::take(&mut self.min_max);
         let nulls = self.null_state.build();
 
-        let min_max = PrimitiveArray::<T>::new(min_max.into(), Some(nulls)); // no copy
+        let min_max = PrimitiveArray::<T>::new(min_max.into(), nulls); // no copy
         let min_max = adjust_output_array(&self.data_type, Arc::new(min_max))?;
 
         Ok(Arc::new(min_max))
@@ -1418,7 +1418,7 @@ where
         let nulls = self.null_state.build();
 
         let min_max = std::mem::take(&mut self.min_max);
-        let min_max = PrimitiveArray::<T>::new(min_max.into(), Some(nulls)); // zero copy
+        let min_max = PrimitiveArray::<T>::new(min_max.into(), nulls); // zero copy
 
         let min_max = adjust_output_array(&self.data_type, Arc::new(min_max))?;
 


### PR DESCRIPTION
Draft as I am running performance tests and will clean up the code a bit if possible. 

# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/6889

This is a follow on to https://github.com/apache/arrow-datafusion/pull/6904 where some last minute changes (to track null state correctly) decreased performance slightly -- I am trying to get some back

# Rationale for this change
I am trying to help the compiler to vectorize the inner loops of the accumulators. Let's do this by doing the minimal work as possible

# What changes are included in this PR?
Update null state with a separate loop



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
covered by existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->