### PR TITLE
Minor: Add comments about initial value for `BitAnd` accumulator

### DIFF
--- a/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
+++ b/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
@@ -278,6 +278,9 @@ impl AggregateExpr for BitAnd {
 
     fn create_groups_accumulator(&self) -> Result<Box<dyn GroupsAccumulator>> {
         use std::ops::BitAndAssign;
+        // Note the default value for BitAnd should be all set
+        // (e.g. `0b11...111`) use MAX / -1 here to get appropriate
+        // bit pattern for each type
         match self.data_type {
             DataType::Int8 => {
                 instantiate_accumulator!(self, -1, Int8Type, |x, y| x.bitand_assign(y))


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/6957

# Rationale for this change

I didn't see a comment from @viirya  https://github.com/apache/arrow-datafusion/pull/6957#discussion_r1262797697 that had the good suggestion to explain the default value

# What changes are included in this PR?

Add doc comments to explain the code

# Are these changes tested?
N/A
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->