### PR TITLE
Make previous unchecked division kernel available

### DIFF
--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -47,6 +47,8 @@ pub enum Operator {
     Multiply,
     /// Division operator, like `/`
     Divide,
+    /// Same as the Division operator except divide by zero is unchecked
+    DivideUnchecked,
     /// Remainder operator, like `%`
     Modulo,
     /// Logical AND, like `&&`
@@ -96,6 +98,7 @@ impl Operator {
             | Operator::Minus
             | Operator::Multiply
             | Operator::Divide
+            | Operator::DivideUnchecked
             | Operator::Modulo
             | Operator::And
             | Operator::Or
@@ -123,6 +126,7 @@ impl Operator {
                 | Operator::Minus
                 | Operator::Multiply
                 | Operator::Divide
+                | Operator::DivideUnchecked
                 | Operator::Modulo
         )
     }
@@ -173,6 +177,7 @@ impl Operator {
             | Operator::Minus
             | Operator::Multiply
             | Operator::Divide
+            | Operator::DivideUnchecked
             | Operator::Modulo
             | Operator::And
             | Operator::Or
@@ -202,7 +207,10 @@ impl Operator {
             | Operator::Gt
             | Operator::GtEq => 20,
             Operator::Plus | Operator::Minus => 30,
-            Operator::Multiply | Operator::Divide | Operator::Modulo => 40,
+            Operator::Multiply
+            | Operator::Divide
+            | Operator::DivideUnchecked
+            | Operator::Modulo => 40,
             Operator::IsDistinctFrom
             | Operator::IsNotDistinctFrom
             | Operator::RegexMatch
@@ -232,6 +240,7 @@ impl fmt::Display for Operator {
             Operator::Minus => "-",
             Operator::Multiply => "*",
             Operator::Divide => "/",
+            Operator::DivideUnchecked => "DIVIDE BY UNCHECKED",
             Operator::Modulo => "%",
             Operator::And => "AND",
             Operator::Or => "OR",

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -953,6 +953,7 @@ mod tests {
         assert_eq!(DataType::Decimal128(20, 4), result.unwrap());
         let result =
             decimal_op_mathematics_type(&op, &left_decimal_type, &right_decimal_type);
+        assert_eq!(DataType::Decimal128(35, 24), result.unwrap());
         let op = Operator::DivideUnchecked;
         let result = coercion_decimal_mathematics_type(
             &op,

--- a/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels_arrow.rs
@@ -2277,22 +2277,19 @@ mod tests {
             right_decimal_array.data_type(),
         )
         .unwrap();
-        let result = divide_dyn_checked_decimal(
+        let result = divide_dyn_opt_decimal(
             &left_decimal_array,
             &right_decimal_array,
             &result_type,
         )?;
         let result = as_decimal128_array(&result)?;
-        assert_eq!(&expect, result);
-        let result = divide_decimal_dyn_scalar(&left_decimal_array, 10, &result_type)?;
-        let result = as_decimal128_array(&result)?;
         let expect = create_decimal_array(
             &[
                 Some(12345670000000000000000000000000000),
                 None,
-                Some(12345670000000000000000000000000000),
-                Some(12345670000000000000000000000000000),
-                Some(12345670000000000000000000000000000),
+                Some(2244667272727272727272727272727272),
+                Some(-1003713008130081300813008130081300),
+                None,
             ],
             38,
             29,

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -455,6 +455,7 @@ pub fn operator_to_name(op: Operator) -> &'static str {
         Operator::Minus => "substract",
         Operator::Multiply => "multiply",
         Operator::Divide => "divide",
+        Operator::DivideUnchecked => "divide_unchecked",
         Operator::Modulo => "mod",
         Operator::And => "and",
         Operator::Or => "or",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6967

# Rationale for this change

With #6792, now divisions check dividing by zero.
That is an API change and we are (and some other users may be) looking for an old behavior.

# What changes are included in this PR?

This PR implements `DivideUnchecked` operation that behaves like the previous Division operator (return null for dividing by zero)

# Are these changes tested?

Yes

# Are there any user-facing changes?

No, but users have a choice explicitly to use the previous division behavior.
