### PR TITLE
use ObjectStore for dataframe writes

### DIFF
--- a/datafusion-examples/examples/dataframe-to-s3.rs
+++ b/datafusion-examples/examples/dataframe-to-s3.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::datasource::file_format::file_type::{FileType, GetExt};
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::error::Result;
+use datafusion::prelude::*;
+
+
+//use datafusion::prelude::data;
+use object_store::aws::AmazonS3Builder;
+use std::env;
+use std::sync::Arc;
+use url::Url;
+
+/// This example demonstrates executing a simple query against an Arrow data source (a directory
+/// with multiple Parquet files) and fetching results
+#[tokio::main]
+async fn main() -> Result<()> {
+    // create local execution context
+    let ctx = SessionContext::new();
+
+    let region = "us-east-1";
+    let bucket_name = "<my_s3_example_bucket>";
+
+    let s3 = AmazonS3Builder::new()
+        .with_bucket_name(bucket_name)
+        .with_region(region)
+        .with_access_key_id(env::var("AWS_ACCESS_KEY_ID").unwrap())
+        .with_secret_access_key(env::var("AWS_SECRET_ACCESS_KEY").unwrap())
+        .build()?;
+
+    let path = format!("s3://{bucket_name}");
+    let s3_url = Url::parse(&path).unwrap();
+    let arc_s3 = Arc::new(s3);
+    ctx.runtime_env()
+        .register_object_store(&s3_url, arc_s3.clone());
+
+    let path = format!("s3://{bucket_name}/test_data/");
+    let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
+    let listing_options = ListingOptions::new(Arc::new(file_format))
+        .with_file_extension(FileType::PARQUET.get_ext());
+    ctx.register_listing_table("test", &path, listing_options, None, None)
+        .await?;
+
+    // execute the query
+    let df = ctx.sql("SELECT testcode, count(1) \
+                                FROM test \
+                                group by testcode \
+                                ").await?;
+
+    let out_path = format!("s3://{bucket_name}/test_write/");
+    df.write_parquet(&out_path, None).await?;
+
+    //write as JSON to s3 instead
+    //let json_out = format!("s3://{bucket_name}/json_out");
+    //df.write_json(&json_out).await?;
+
+    //write as csv to s3 instead
+    //let csv_out = format!("s3://{bucket_name}/csv_out");
+    //df.write_csv(&csv_out).await?;
+
+    let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
+    let listing_options = ListingOptions::new(Arc::new(file_format))
+        .with_file_extension(FileType::PARQUET.get_ext());
+    ctx.register_listing_table("test2", &out_path, listing_options, None, None)
+        .await?;
+    
+    let df = ctx.sql("SELECT * \
+        FROM test2 \
+        ").await?;
+    
+    df.show_limit(20).await?;
+
+    Ok(())
+}

--- a/datafusion-examples/examples/dataframe-to-s3.rs
+++ b/datafusion-examples/examples/dataframe-to-s3.rs
@@ -21,14 +21,13 @@ use datafusion::datasource::listing::ListingOptions;
 use datafusion::error::Result;
 use datafusion::prelude::*;
 
-//use datafusion::prelude::data;
 use object_store::aws::AmazonS3Builder;
 use std::env;
 use std::sync::Arc;
 use url::Url;
 
-/// This example demonstrates executing a simple query against an Arrow data source (a directory
-/// with multiple Parquet files) and fetching results
+/// This example demonstrates querying data from AmazonS3 and writing
+/// the result of a query back to AmazonS3
 #[tokio::main]
 async fn main() -> Result<()> {
     // create local execution context

--- a/datafusion-examples/examples/dataframe-to-s3.rs
+++ b/datafusion-examples/examples/dataframe-to-s3.rs
@@ -34,8 +34,9 @@ async fn main() -> Result<()> {
     // create local execution context
     let ctx = SessionContext::new();
 
-    let region = "us-east-1";
-    let bucket_name = "rust-perf-testing";
+    //enter region and bucket to which your credentials have GET and PUT access
+    let region = "<bucket-region-here>";
+    let bucket_name = "<bucket-name-here>";
 
     let s3 = AmazonS3Builder::new()
         .with_bucket_name(bucket_name)

--- a/datafusion-examples/examples/dataframe-to-s3.rs
+++ b/datafusion-examples/examples/dataframe-to-s3.rs
@@ -21,7 +21,6 @@ use datafusion::datasource::listing::ListingOptions;
 use datafusion::error::Result;
 use datafusion::prelude::*;
 
-
 //use datafusion::prelude::data;
 use object_store::aws::AmazonS3Builder;
 use std::env;
@@ -59,10 +58,14 @@ async fn main() -> Result<()> {
         .await?;
 
     // execute the query
-    let df = ctx.sql("SELECT testcode, count(1) \
+    let df = ctx
+        .sql(
+            "SELECT testcode, count(1) \
                                 FROM test \
                                 group by testcode \
-                                ").await?;
+                                ",
+        )
+        .await?;
 
     let out_path = format!("s3://{bucket_name}/test_write/");
     df.write_parquet(&out_path, None).await?;
@@ -80,11 +83,15 @@ async fn main() -> Result<()> {
         .with_file_extension(FileType::PARQUET.get_ext());
     ctx.register_listing_table("test2", &out_path, listing_options, None, None)
         .await?;
-    
-    let df = ctx.sql("SELECT * \
+
+    let df = ctx
+        .sql(
+            "SELECT * \
         FROM test2 \
-        ").await?;
-    
+        ",
+        )
+        .await?;
+
     df.show_limit(20).await?;
 
     Ok(())

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -1031,18 +1031,20 @@ mod tests {
     #[tokio::test]
     async fn write_csv_results_error_handling() -> Result<()> {
         let ctx = SessionContext::new();
-        // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        
+        // register a local file system object store 
+        let tmp_dir = TempDir::new()?;
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
         ctx.runtime_env()
             .register_object_store(&local_url, local);
         let options = CsvReadOptions::default()
             .schema_infer_max_records(2)
             .has_header(true);
         let df = ctx.read_csv("tests/data/corrupt.csv", options).await?;
-        let tmp_dir = TempDir::new()?;
+        
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let e = df
             .write_csv(&out_dir_url)
@@ -1069,15 +1071,17 @@ mod tests {
         )
         .await?;
 
-        // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        // register a local file system object store
+        let tmp_dir = TempDir::new()?;
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
+   
         ctx.runtime_env()
             .register_object_store(&local_url, local);
 
         // execute a simple query and write the results to CSV
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let df = ctx.sql("SELECT c1, c2 FROM test").await?;
         df.write_csv(&out_dir_url).await?;

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -18,7 +18,7 @@
 //! Execution plan for reading CSV files
 
 use crate::datasource::file_format::file_type::FileCompressionType;
-use crate::datasource::listing::FileRange;
+use crate::datasource::listing::{FileRange, ListingTableUrl};
 use crate::datasource::physical_plan::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
@@ -43,10 +43,8 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::local::LocalFileSystem;
 use object_store::{GetOptions, GetResult, ObjectStore};
 use std::any::Any;
-use std::fs;
 use std::io::Cursor;
 use std::ops::Range;
-use std::path::Path;
 use std::sync::Arc;
 use std::task::Poll;
 use tokio::task::JoinSet;
@@ -566,30 +564,30 @@ pub async fn plan_to_csv(
     path: impl AsRef<str>,
 ) -> Result<()> {
     let path = path.as_ref();
-    // create directory to contain the CSV files (one per partition)
-    let fs_path = Path::new(path);
-    if let Err(e) = fs::create_dir(fs_path) {
-        return Err(DataFusionError::Execution(format!(
-            "Could not create directory {path}: {e:?}"
-        )));
-    }
-
+    let parsed =
+            ListingTableUrl::parse(path)?;
+    let object_store_url = parsed.object_store();
+    let store = task_ctx.runtime_env().object_store(&object_store_url)?;
+    let mut buffer;
     let mut join_set = JoinSet::new();
     for i in 0..plan.output_partitioning().partition_count() {
-        let plan = plan.clone();
-        let filename = format!("part-{i}.csv");
-        let path = fs_path.join(filename);
-        let file = fs::File::create(path)?;
-        let mut writer = csv::Writer::new(file);
-        let stream = plan.execute(i, task_ctx.clone())?;
+        let storeref = store.clone();
+        let plan: Arc<dyn ExecutionPlan> = plan.clone();
+        let filename = format!("{}/part-{i}.csv", parsed.prefix());
+        let file = object_store::path::Path::parse(filename)?;              
+        buffer = Vec::new();
 
+        let stream = plan.execute(i, task_ctx.clone())?;
         join_set.spawn(async move {
-            let result: Result<()> = stream
-                .map(|batch| writer.write(&batch?))
+            let mut writer = csv::Writer::new(buffer);
+            stream
+                .map(|batch| writer.write(&batch?)
+                .map_err(DataFusionError::ArrowError))
                 .try_collect()
                 .await
-                .map_err(DataFusionError::from);
-            result
+                .map_err(DataFusionError::from)?;
+            let write_bytes = Bytes::from_iter(writer.into_inner());
+            storeref.put(&file, write_bytes).await.map_err(DataFusionError::from).map(|_| ())
         });
     }
 
@@ -1033,14 +1031,21 @@ mod tests {
     #[tokio::test]
     async fn write_csv_results_error_handling() -> Result<()> {
         let ctx = SessionContext::new();
+        // register a local file system object store for /tmp directory
+        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
+        let local_url = Url::parse(&"file://tmp").unwrap();
+        ctx.runtime_env()
+            .register_object_store(&local_url, local);
         let options = CsvReadOptions::default()
             .schema_infer_max_records(2)
             .has_header(true);
         let df = ctx.read_csv("tests/data/corrupt.csv", options).await?;
         let tmp_dir = TempDir::new()?;
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
+        let out_dir_url = format!("file://{}", 
+                        &out_dir[1..]);
         let e = df
-            .write_csv(&out_dir)
+            .write_csv(&out_dir_url)
             .await
             .expect_err("should fail because input file does not match inferred schema");
         assert_eq!("Arrow error: Parser error: Error while parsing value d for column 0 at line 4", format!("{e}"));
@@ -1064,10 +1069,18 @@ mod tests {
         )
         .await?;
 
+        // register a local file system object store for /tmp directory
+        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
+        let local_url = Url::parse(&"file://tmp").unwrap();
+        ctx.runtime_env()
+            .register_object_store(&local_url, local);
+
         // execute a simple query and write the results to CSV
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
+        let out_dir_url = format!("file://{}", 
+                        &out_dir[1..]);
         let df = ctx.sql("SELECT c1, c2 FROM test").await?;
-        df.write_csv(&out_dir).await?;
+        df.write_csv(&out_dir_url).await?;
 
         // create a new context and verify that the results were saved to a partitioned csv file
         let ctx = SessionContext::new();

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -22,7 +22,6 @@ use crate::datasource::physical_plan::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
 use crate::datasource::physical_plan::FileMeta;
-use crate::datasource::physical_plan::RecordBatchMultiPartWriter;
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
@@ -44,6 +43,7 @@ use std::any::Any;
 use std::io::BufReader;
 use std::sync::Arc;
 use std::task::Poll;
+use tokio::io::AsyncWriteExt;
 use tokio::task::JoinSet;
 
 use super::FileScanConfig;
@@ -271,20 +271,20 @@ pub async fn plan_to_json(
         let file = object_store::path::Path::parse(filename)?;
 
         let mut stream = plan.execute(i, task_ctx.clone())?;
-
         join_set.spawn(async move {
-            let (_, multipart_writer) = storeref.put_multipart(&file).await?;
-            let mut multipart_rb_writer = RecordBatchMultiPartWriter::new(
-                json::LineDelimitedWriter::new,
-                multipart_writer,
-                None,
-            );
-            while let Some(next_batch) = stream.next().await {
-                let batch = next_batch?;
-                multipart_rb_writer.write_rb(batch).await?;
+            let (_, mut multipart_writer) = storeref.put_multipart(&file).await?;
+            let mut buffer = Vec::with_capacity(1024);
+            while let Some(batch) = stream.next().await.transpose()? {
+                let mut writer = json::LineDelimitedWriter::new(buffer);
+                writer.write(&batch)?;
+                buffer = writer.into_inner();
+                multipart_writer.write_all(&buffer).await?;
+                buffer.clear();
             }
-
-            multipart_rb_writer.shutdown().await
+            multipart_writer
+                .shutdown()
+                .await
+                .map_err(DataFusionError::from)
         });
     }
 

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -22,6 +22,7 @@ use crate::datasource::physical_plan::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
 use crate::datasource::physical_plan::FileMeta;
+use crate::datasource::physical_plan::RecordBatchMultiPartWriter;
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
@@ -262,29 +263,28 @@ pub async fn plan_to_json(
     let parsed = ListingTableUrl::parse(path)?;
     let object_store_url = parsed.object_store();
     let store = task_ctx.runtime_env().object_store(&object_store_url)?;
-    let mut buffer;
     let mut join_set = JoinSet::new();
     for i in 0..plan.output_partitioning().partition_count() {
         let storeref = store.clone();
         let plan: Arc<dyn ExecutionPlan> = plan.clone();
         let filename = format!("{}/part-{i}.json", parsed.prefix());
         let file = object_store::path::Path::parse(filename)?;
-        buffer = Vec::new();
 
-        let stream = plan.execute(i, task_ctx.clone())?;
+        let mut stream = plan.execute(i, task_ctx.clone())?;
+
         join_set.spawn(async move {
-            let mut writer = json::LineDelimitedWriter::new(&mut buffer);
-            stream
-                .map(|batch| writer.write(&batch?).map_err(DataFusionError::ArrowError))
-                .try_collect()
-                .await
-                .map_err(DataFusionError::from)?;
-            let write_bytes = Bytes::from_iter(buffer);
-            storeref
-                .put(&file, write_bytes)
-                .await
-                .map_err(DataFusionError::from)
-                .map(|_| ())
+            let (_, multipart_writer) = storeref.put_multipart(&file).await?;
+            let mut multipart_rb_writer = RecordBatchMultiPartWriter::new(
+                json::LineDelimitedWriter::new,
+                multipart_writer,
+                None,
+            );
+            while let Some(next_batch) = stream.next().await {
+                let batch = next_batch?;
+                multipart_rb_writer.write_rb(batch).await?;
+            }
+
+            multipart_rb_writer.shutdown().await
         });
     }
 

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -662,14 +662,14 @@ mod tests {
             .await?;
 
         // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
         ctx.runtime_env()
             .register_object_store(&local_url, local);
 
         // execute a simple query and write the results to CSV
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let df = ctx.sql("SELECT a, b FROM test").await?;
         df.write_json(&out_dir_url).await?;
@@ -731,8 +731,8 @@ mod tests {
     async fn write_json_results_error_handling() -> Result<()> {
         let ctx = SessionContext::new();
         // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
         ctx.runtime_env()
             .register_object_store(&local_url, local);
         let options = CsvReadOptions::default()
@@ -741,7 +741,7 @@ mod tests {
         let df = ctx.read_csv("tests/data/corrupt.csv", options).await?;
         let tmp_dir = TempDir::new()?;
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let e = df
             .write_json(&out_dir_url)

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -37,12 +37,14 @@ use arrow::{
     datatypes::{ArrowNativeType, DataType, Field, Schema, SchemaRef, UInt16Type},
     record_batch::{RecordBatch, RecordBatchOptions},
 };
+use arrow_array::RecordBatchWriter;
 pub use arrow_file::ArrowExec;
 pub use avro::AvroExec;
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 pub use file_stream::{FileOpenFuture, FileOpener, FileStream, OnError};
 pub(crate) use json::plan_to_json;
 pub use json::{JsonOpener, NdJsonExec};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::physical_plan::ExecutionPlan;
 use crate::{
@@ -74,6 +76,7 @@ use std::{
     cmp::min,
     collections::HashMap,
     fmt::{Debug, Formatter, Result as FmtResult},
+    io::Write,
     marker::PhantomData,
     sync::Arc,
     vec,
@@ -474,6 +477,95 @@ where
         write!(f, ", ...")?;
     }
     Ok(())
+}
+
+struct SharedBuffer {
+    /// The inner buffer for reading and writing
+    ///
+    /// The lock is used to obtain internal mutability, so no worry about the
+    /// lock contention.
+    buffer: Arc<futures::lock::Mutex<Vec<u8>>>,
+}
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut buffer = self.buffer.try_lock().unwrap();
+        Write::write(&mut *buffer, buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut buffer = self.buffer.try_lock().unwrap();
+        Write::flush(&mut *buffer)
+    }
+}
+
+//Coordinates writing a sequence of RecordBatches using a SharedBuffer
+//between a sync Arrow RecordBatchWriter and an async ObjectStore writer
+struct RecordBatchMultiPartWriter<W: RecordBatchWriter> {
+    rb_writer: W,
+    multipart_writer: Box<dyn AsyncWrite + Send + Unpin>,
+    shared_buffer: Arc<futures::lock::Mutex<Vec<u8>>>,
+    //buffer into shared buffer until we reach target_part_size_bytes
+    //then empty shared buffer / flush via multipart put to ObjectStore
+    target_part_size_bytes: usize,
+}
+
+impl<W: RecordBatchWriter> RecordBatchMultiPartWriter<W> {
+    fn new<F>(
+        rb_constructor: F,
+        multipart_writer: Box<dyn AsyncWrite + Send + Unpin>,
+        target_part_size_bytes: Option<usize>,
+    ) -> Self
+    where
+        F: Fn(SharedBuffer) -> W,
+    {
+        let target_part_size = target_part_size_bytes.unwrap_or(10485760);
+        let buffer = Arc::new(futures::lock::Mutex::new(Vec::with_capacity(
+            target_part_size * 2,
+        )));
+        let shared_buffer = SharedBuffer {
+            buffer: buffer.clone(),
+        };
+        let rb_writer = rb_constructor(shared_buffer);
+        Self {
+            rb_writer,
+            multipart_writer,
+            shared_buffer: buffer,
+            target_part_size_bytes: target_part_size,
+        }
+    }
+
+    //sends bytes in buffer to ObjectStore and clears buffer
+    async fn put_part(&mut self, last_part: bool) -> Result<(), DataFusionError> {
+        let mut buffer = self.shared_buffer.lock().await;
+        if last_part || buffer.len() >= self.target_part_size_bytes {
+            self.multipart_writer.write_all(&buffer).await?;
+            buffer.clear();
+        }
+        Ok(())
+    }
+
+    async fn write_rb(&mut self, batch: RecordBatch) -> Result<(), DataFusionError> {
+        self.rb_writer.write(&batch)?;
+        self.put_part(false).await?;
+        Ok(())
+    }
+
+    async fn flush(&mut self, last_part: bool) -> Result<(), DataFusionError> {
+        self.put_part(last_part).await?;
+        self.multipart_writer
+            .flush()
+            .await
+            .map_err(DataFusionError::from)
+    }
+
+    async fn shutdown(&mut self) -> Result<(), DataFusionError> {
+        self.flush(true).await?;
+        self.multipart_writer
+            .shutdown()
+            .await
+            .map_err(DataFusionError::from)
+    }
 }
 
 /// helper formatting array elements with a comma and a space between them

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -913,8 +913,8 @@ mod tests {
     async fn write_parquet_results_error_handling() -> Result<()> {
         let ctx = SessionContext::new();
         // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
         ctx.runtime_env()
             .register_object_store(&local_url, local);
 
@@ -924,7 +924,7 @@ mod tests {
         let df = ctx.read_csv("tests/data/corrupt.csv", options).await?;
         let tmp_dir = TempDir::new()?;
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let e = df
             .write_parquet(&out_dir_url, None)
@@ -1940,14 +1940,14 @@ mod tests {
         .await?;
 
         // register a local file system object store for /tmp directory
-        let local = Arc::new(LocalFileSystem::new_with_prefix("/tmp").unwrap());
-        let local_url = Url::parse(&"file://tmp").unwrap();
+        let local = Arc::new(LocalFileSystem::new());
+        let local_url = Url::parse(&format!("file://local")).unwrap();
         ctx.runtime_env()
             .register_object_store(&local_url, local);
 
         // execute a simple query and write the results to parquet
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://{}", 
+        let out_dir_url = format!("file://local/{}", 
                         &out_dir[1..]);
         let df = ctx.sql("SELECT c1, c2 FROM test").await?;
         df.write_parquet(&out_dir_url, None).await?;

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -17,7 +17,6 @@
 
 //! Execution plan for reading Parquet files
 
-use tokio::task::JoinSet;
 use crate::datasource::physical_plan::file_stream::{
     FileOpenFuture, FileOpener, FileStream,
 };
@@ -44,6 +43,7 @@ use std::any::Any;
 use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
+use tokio::task::JoinSet;
 
 use arrow::datatypes::{DataType, SchemaRef};
 use arrow::error::ArrowError;
@@ -634,10 +634,8 @@ pub async fn plan_to_parquet(
     path: impl AsRef<str>,
     writer_properties: Option<WriterProperties>,
 ) -> Result<()> {
-    
     let path = path.as_ref();
-    let parsed =
-            ListingTableUrl::parse(path)?;
+    let parsed = ListingTableUrl::parse(path)?;
     let object_store_url = parsed.object_store();
     let store = task_ctx.runtime_env().object_store(&object_store_url)?;
     let mut join_set = JoinSet::new();
@@ -646,7 +644,7 @@ pub async fn plan_to_parquet(
         let storeref = store.clone();
         let plan: Arc<dyn ExecutionPlan> = plan.clone();
         let filename = format!("{}/part-{i}.parquet", parsed.prefix());
-        let file = Path::parse(filename)?;              
+        let file = Path::parse(filename)?;
         buffer = Vec::new();
         let propclone = writer_properties.clone();
 
@@ -654,14 +652,17 @@ pub async fn plan_to_parquet(
         join_set.spawn(async move {
             let mut writer = ArrowWriter::try_new(&mut buffer, plan.schema(), propclone)?;
             stream
-                .map(|batch| writer.write(&batch?)
-                .map_err(DataFusionError::ParquetError))
+                .map(|batch| writer.write(&batch?).map_err(DataFusionError::ParquetError))
                 .try_collect()
                 .await
                 .map_err(DataFusionError::from)?;
             writer.close().map_err(DataFusionError::from)?;
             let write_bytes = Bytes::from_iter(buffer);
-            storeref.put(&file, write_bytes).await.map_err(DataFusionError::from).map(|_| ())
+            storeref
+                .put(&file, write_bytes)
+                .await
+                .map_err(DataFusionError::from)
+                .map(|_| ())
         });
     }
 
@@ -760,10 +761,10 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
     use object_store::ObjectMeta;
-    use url::Url;
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
+    use url::Url;
 
     struct RoundTripResult {
         /// Data that was read back from ParquetFiles
@@ -915,8 +916,7 @@ mod tests {
         // register a local file system object store for /tmp directory
         let local = Arc::new(LocalFileSystem::new());
         let local_url = Url::parse(&format!("file://local")).unwrap();
-        ctx.runtime_env()
-            .register_object_store(&local_url, local);
+        ctx.runtime_env().register_object_store(&local_url, local);
 
         let options = CsvReadOptions::default()
             .schema_infer_max_records(2)
@@ -924,8 +924,7 @@ mod tests {
         let df = ctx.read_csv("tests/data/corrupt.csv", options).await?;
         let tmp_dir = TempDir::new()?;
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://local/{}", 
-                        &out_dir[1..]);
+        let out_dir_url = format!("file://local/{}", &out_dir[1..]);
         let e = df
             .write_parquet(&out_dir_url, None)
             .await
@@ -1942,13 +1941,11 @@ mod tests {
         // register a local file system object store for /tmp directory
         let local = Arc::new(LocalFileSystem::new());
         let local_url = Url::parse(&format!("file://local")).unwrap();
-        ctx.runtime_env()
-            .register_object_store(&local_url, local);
+        ctx.runtime_env().register_object_store(&local_url, local);
 
         // execute a simple query and write the results to parquet
         let out_dir = tmp_dir.as_ref().to_str().unwrap().to_string() + "/out";
-        let out_dir_url = format!("file://local/{}", 
-                        &out_dir[1..]);
+        let out_dir_url = format!("file://local/{}", &out_dir[1..]);
         let df = ctx.sql("SELECT c1, c2 FROM test").await?;
         df.write_parquet(&out_dir_url, None).await?;
         // write_parquet(&mut ctx, "SELECT c1, c2 FROM test", &out_dir, None).await?;


### PR DESCRIPTION
# Which issue does this PR close?

Related to #1777

# Rationale for this change

Many ETL and other workflows need to persist data to an ObjectStore. Currently, DataFrame write_parquet, write_json, and write_csv only support writing to a local file system. 

# What changes are included in this PR?

DataFrame write methods (write_parquet, write_json, and write_csv) now expect a ObjectStore URL registered in the current context. Unit tests are updated to accommodate this change, and an example for writing to S3 is added.

# Are these changes tested?

Existing unit tests are updated to cover this change.

# Are there any user-facing changes?

Yes, users will now need to pass an ObjectStore url to write methods rather than a local path.
