### PR TITLE
avoid copying listarray in unset exec

### DIFF
--- a/datafusion/core/src/physical_plan/unnest.rs
+++ b/datafusion/core/src/physical_plan/unnest.rs
@@ -444,17 +444,6 @@ where
     T: ArrayAccessor<Item = ArrayRef>,
     P: ArrowPrimitiveType,
 {
-    let _elem_type = match list_array.data_type() {
-        DataType::List(f) | DataType::FixedSizeList(f, _) | DataType::LargeList(f) => {
-            f.data_type()
-        }
-        dt => {
-            return Err(DataFusionError::Execution(format!(
-                "Cannot unnest array of type {dt}"
-            )))
-        }
-    };
-
     if list_array.null_count() > 0 {
         let capacity = list_array_values.len() + list_array.null_count();
         let take_indices = create_unnest_take_indices(list_lengths, capacity);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6961.

# Rationale for this change

To avoid unnecessary copying of arrays, improving performance. 

Tbh, I'm not sure these changes make this perform better (can work on some benchmarks), in the end we need the copied/modified array to create the unnested recordbatch and the take indices were already not using the copied data.   

There's also the extra optimization mentioned in the comments regarding the case when `list_array` has no null values. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

UnnestExec is changed such that it uses the take kernel instead of copying values manually + using concat. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

I've added a unit test to verify calculating the new take indices (specific to list_array and not the other columns in the recordbatch)
The rest should be covered by existing physical plan tests for unnest. 

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
Nope
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->