### PR TITLE
Add support for ClickBench in bench.sh

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -373,7 +373,7 @@ data_clickbench_partitioned() {
     echo -n "Checking hits_partitioned..."
     OUTPUT_SIZE=`wc -c * 2>/dev/null | tail -n 1  | awk '{print $1}' || true`
     if test "${OUTPUT_SIZE}" = "14737666736"; then
-        echo -n "... found ${OUTPUT_SIZE} KB ..."
+        echo -n "... found ${OUTPUT_SIZE} bytes ..."
     else
         echo -n " downloading with ${MAX_CONCURRENT_DOWNLOADS} parallel workers"
         seq 0 99 | xargs -P${MAX_CONCURRENT_DOWNLOADS} -I{} bash -c 'wget -q --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet && echo -n "."'


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/6994

# Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/6994

> The ClickBench benchmarks are both widely used in the industry and focus on grouping / aggregation / filtering: https://github.com/ClickHouse/ClickBench/tree/main/datafusion

# What changes are included in this PR?

Add support in bench.sh for downloading the ClickBench dataset (both single file as well as partitioned)

You can download it now via:

```shell
./bench.sh data clickbench_1 # single parquet file
./bench.sh data clickbench_partitioned # 100 parquet file partitioned dataset
```

Example

```shell
./bench.sh data clickbench_partitioned
***************************
DataFusion Benchmark Runner and Data Generator
COMMAND: data
BENCHMARK: clickbench_partitioned
DATA_DIR: /home/alamb/arrow-datafusion/benchmarks/data
CARGO_COMMAND: cargo run --profile release-nonlto
***************************
Checking hits_partitioned... downloading with 10 parallel workers.................................................................................................... Done
```

I also plan to update the runner so it can run the clickbench queries, but will do so as a follow on PR

```shell
./bench.sh run clickbench_1 # single parquet file
./bench.sh run clickbench_partitioned # 100 parquet file partitioned dataset
```


# Are these changes tested?
Tested manually

# Are there any user-facing changes?
No, this is a development tool 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->