### PR TITLE
Test: Use unchecked group_value access in group hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,10 @@ rpath = false
 
 
 [patch.crates-io]
-arrow = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-arrow-array = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-arrow-buffer = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-arrow-flight = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-arrow-schema = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-arrow-cast = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
-parquet = {  git = "https://github.com/alamb/arrow-rs.git",branch="alamb/peephole" }
+arrow = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+arrow-array = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+arrow-buffer = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+arrow-flight = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+arrow-schema = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+arrow-cast = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }
+parquet = {  git = "https://github.com/alamb/arrow-rs.git", rev="661caf3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,13 @@ opt-level = 3
 overflow-checks = false
 panic = 'unwind'
 rpath = false
+
+
+[patch.crates-io]
+arrow = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+arrow-array = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+arrow-buffer = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+arrow-flight = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+arrow-schema = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+arrow-cast = {  git = "https://github.com/alamb/arrow-rs.git", branch="alamb/peephole" }
+parquet = {  git = "https://github.com/alamb/arrow-rs.git",branch="alamb/peephole" }

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -423,8 +423,10 @@ impl GroupedHashAggregateStream {
                 // verify that a group that we are inserting with hash is
                 // actually the same key value as the group in
                 // existing_idx  (aka group_values @ row)
-                group_rows.row_unchecked(row)
-                    == self.group_values.row_unchecked(*group_idx)
+                unsafe {
+                    group_rows.row_unchecked(row)
+                        == self.group_values.row_unchecked(*group_idx)
+                }
             });
 
             let group_idx = match entry {
@@ -434,7 +436,9 @@ impl GroupedHashAggregateStream {
                 None => {
                     // Add new entry to aggr_state and save newly created index
                     let group_idx = self.group_values.num_rows();
-                    self.group_values.push(group_rows.row_unchecked(row));
+                    unsafe {
+                        self.group_values.push(group_rows.row_unchecked(row));
+                    }
 
                     // for hasher function, use precomputed hash value
                     self.map.insert_accounted(

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -423,7 +423,8 @@ impl GroupedHashAggregateStream {
                 // verify that a group that we are inserting with hash is
                 // actually the same key value as the group in
                 // existing_idx  (aka group_values @ row)
-                group_rows.row(row) == self.group_values.row(*group_idx)
+                group_rows.row_unchecked(row)
+                    == self.group_values.row_unchecked(*group_idx)
             });
 
             let group_idx = match entry {
@@ -433,7 +434,7 @@ impl GroupedHashAggregateStream {
                 None => {
                     // Add new entry to aggr_state and save newly created index
                     let group_idx = self.group_values.num_rows();
-                    self.group_values.push(group_rows.row(row));
+                    self.group_values.push(group_rows.row_unchecked(row));
 
                     // for hasher function, use precomputed hash value
                     self.map.insert_accounted(


### PR DESCRIPTION
Related to https://github.com/apache/arrow-datafusion/issues/6969

Inspired by the @yahoNanJing 's work in https://github.com/apache/arrow-rs/pull/4524#issuecomment-1637417030  I am seeing how much extra performance there is to be gained via inlining and unchecked access in group keys: https://github.com/apache/arrow-rs/pull/4539

I think there is still substantial performance to be had by avoiding the row format entirely for single column groups, but I will explore that theory later