### PR TITLE
Minor: Refactor group by state machine

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -395,7 +395,7 @@ impl GroupedHashAggregateStream {
         Ok(())
     }
 
-    /// Produces the next batch of output from ExecutionState::ProductingOuptut, updating self.execution_state
+    /// Produces the next batch of output from ExecutionState::ProducingOuptut, updating self.execution_state
     /// appropriately
     fn next_output(&mut self, batch: RecordBatch) -> RecordBatch {
         assert!(matches!(


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/6932


# Rationale for this change
I was a little unhappy about the `extract_ok!` macro and @tustvold 
offered a suggestion on how to remove it:  https://github.com/apache/arrow-datafusion/pull/6932/files#r1267309181

This PR is what I came up with . I am not really sure it is better but wanted to put it up in case others had an opinion

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Pull out the state machine transition logic in group by into some new functions and remove the `extract_ok!` macro

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->