### PR TITLE
[Minor] Speedup to_array_of_size for Decimal128

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2750,11 +2750,18 @@ impl ScalarValue {
         scale: i8,
         size: usize,
     ) -> Decimal128Array {
-        std::iter::repeat(value)
-            .take(size)
-            .collect::<Decimal128Array>()
-            .with_precision_and_scale(precision, scale)
-            .unwrap()
+        match value {
+            Some(val) => Decimal128Array::from(vec![val; size])
+                .with_precision_and_scale(precision, scale)
+                .unwrap(),
+            None => {
+                let mut builder = Decimal128Array::builder(size)
+                    .with_precision_and_scale(precision, scale)
+                    .unwrap();
+                builder.append_nulls(size);
+                builder.finish()
+            }
+        }
     }
 
     /// Converts a scalar value into an array of `size` rows.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change
This came up in some profiles (mainly query 1, 16).
Benchmark results:
```
Benchmark tpch_mem.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃     main ┃ speedup_scalar_to_array_decimal ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │ 199.40ms │                        182.91ms │ +1.09x faster │
│ QQuery 2     │  34.24ms │                         33.64ms │     no change │
│ QQuery 3     │  46.25ms │                         45.73ms │     no change │
│ QQuery 4     │  36.88ms │                         37.35ms │     no change │
│ QQuery 5     │  94.34ms │                         94.33ms │     no change │
│ QQuery 6     │  10.33ms │                         10.22ms │     no change │
│ QQuery 7     │ 190.04ms │                        194.06ms │     no change │
│ QQuery 8     │  70.00ms │                         71.05ms │     no change │
│ QQuery 9     │ 134.55ms │                        138.00ms │     no change │
│ QQuery 10    │  91.41ms │                         90.04ms │     no change │
│ QQuery 11    │  40.19ms │                         39.95ms │     no change │
│ QQuery 12    │  67.83ms │                         67.38ms │     no change │
│ QQuery 13    │ 104.36ms │                        103.15ms │     no change │
│ QQuery 14    │  12.28ms │                         11.64ms │ +1.05x faster │
│ QQuery 15    │  12.64ms │                         12.81ms │     no change │
│ QQuery 16    │  40.80ms │                         36.65ms │ +1.11x faster │
│ QQuery 17    │ 111.00ms │                        112.18ms │     no change │
│ QQuery 18    │ 296.72ms │                        292.79ms │     no change │
│ QQuery 19    │  57.91ms │                         58.56ms │     no change │
│ QQuery 20    │  79.58ms │                         78.76ms │     no change │
│ QQuery 21    │ 257.55ms │                        254.48ms │     no change │
│ QQuery 22    │  27.98ms │                         28.76ms │     no change │
└──────────────┴──────────┴─────────────────────────────────┴───────────────┘
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->