### PR TITLE
change the input_type parameter of the create_udaf function from DataType to Vec<DataType>

### DIFF
--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
         // the name; used to represent it in plan descriptions and in the registry, to use in SQL.
         "geo_mean",
         // the input type; DataFusion guarantees that the first entry of `values` in `update` has this type.
-        DataType::Float64,
+        vec![DataType::Float64],
         // the return type; DataFusion expects this to match the type returned by `evaluate`.
         Arc::new(DataType::Float64),
         Volatility::Immutable,

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -2248,7 +2248,7 @@ mod tests {
         // Note capitalization
         let my_avg = create_udaf(
             "MY_AVG",
-            DataType::Float64,
+            vec![DataType::Float64],
             Arc::new(DataType::Float64),
             Volatility::Immutable,
             Arc::new(|_| {

--- a/datafusion/core/src/physical_plan/windows/mod.rs
+++ b/datafusion/core/src/physical_plan/windows/mod.rs
@@ -539,7 +539,7 @@ mod tests {
 
         let my_count = create_udaf(
             "my_count",
-            DataType::Int64,
+            vec![DataType::Int64],
             Arc::new(DataType::Int64),
             Volatility::Immutable,
             Arc::new(|_| Ok(Box::new(MyCount(0)))),

--- a/datafusion/core/tests/sql/udf.rs
+++ b/datafusion/core/tests/sql/udf.rs
@@ -234,7 +234,7 @@ async fn simple_udaf() -> Result<()> {
     // define a udaf, using a DataFusion's accumulator
     let my_avg = create_udaf(
         "my_avg",
-        DataType::Float64,
+        vec![DataType::Float64],
         Arc::new(DataType::Float64),
         Volatility::Immutable,
         Arc::new(|_| {
@@ -291,7 +291,7 @@ async fn udaf_as_window_func() -> Result<()> {
 
     let my_acc = create_udaf(
         "my_acc",
-        DataType::Int32,
+        vec![DataType::Int32],
         Arc::new(DataType::Int32),
         Volatility::Immutable,
         Arc::new(|_| Ok(Box::new(MyAccumulator))),

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -801,7 +801,7 @@ pub fn create_udf(
 /// The signature and state type must match the `Accumulator's implementation`.
 pub fn create_udaf(
     name: &str,
-    input_type: DataType,
+    input_type: Vec<DataType>,
     return_type: Arc<DataType>,
     volatility: Volatility,
     accumulator: AccumulatorFactoryFunction,
@@ -811,7 +811,7 @@ pub fn create_udaf(
     let state_type: StateTypeFunction = Arc::new(move |_| Ok(state_type.clone()));
     AggregateUDF::new(
         name,
-        &Signature::exact(vec![input_type], volatility),
+        &Signature::exact(input_type, volatility),
         &return_type,
         &accumulator,
         &state_type,

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -890,7 +890,7 @@ mod test {
         let empty = empty();
         let my_avg = create_udaf(
             "MY_AVG",
-            DataType::Float64,
+            vec![DataType::Float64],
             Arc::new(DataType::Float64),
             Volatility::Immutable,
             Arc::new(|_| {

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -124,7 +124,7 @@ impl Serializeable for Expr {
             fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>> {
                 Ok(Arc::new(create_udaf(
                     name,
-                    arrow::datatypes::DataType::Null,
+                    vec![arrow::datatypes::DataType::Null],
                     Arc::new(arrow::datatypes::DataType::Null),
                     Volatility::Immutable,
                     Arc::new(|_| unimplemented!()),

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -2688,7 +2688,7 @@ mod roundtrip_tests {
             // the name; used to represent it in plan descriptions and in the registry, to use in SQL.
             "dummy_agg",
             // the input type; DataFusion guarantees that the first entry of `values` in `update` has this type.
-            DataType::Float64,
+            vec![DataType::Float64],
             // the return type; DataFusion expects this to match the type returned by `evaluate`.
             Arc::new(DataType::Float64),
             Volatility::Immutable,
@@ -2874,7 +2874,7 @@ mod roundtrip_tests {
             // the name; used to represent it in plan descriptions and in the registry, to use in SQL.
             "dummy_agg",
             // the input type; DataFusion guarantees that the first entry of `values` in `update` has this type.
-            DataType::Float64,
+            vec![DataType::Float64],
             // the return type; DataFusion expects this to match the type returned by `evaluate`.
             Arc::new(DataType::Float64),
             Volatility::Immutable,


### PR DESCRIPTION
# Which issue does this PR close?
Closes #7094 .

# Rationale for this change

For someone who is new to DataFusion and is trying to write a custom UDAF, it may be a little confusing to understand why create_udaf only takes one DataType for the input_type. Additionally, I did not find any examples demonstrating how to create a UDAF with multiple input arguments.

# What changes are included in this PR?


change `input_type: DataType` to `input_type: Vec<DataType>`
```
pub fn create_udaf(
    name: &str,
    return_type: Arc<DataType>,
    volatility: Volatility,
    accumulator: AccumulatorFactoryFunction,
    state_type: Arc<Vec<DataType>>,
) -> AggregateUDF {
```

# Are these changes tested?

Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
yes

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->