### PR TITLE
[doc], [minor]. Update docstring of group by rewrite.

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -562,7 +562,28 @@ fn match_window_definitions(
     Ok(())
 }
 
-/// Update group by exprs, according to functioanl dependencies
+/// Update group by exprs, according to functional dependencies
+/// The query below
+///
+/// SELECT sn, amount
+/// FROM sales_global
+/// GROUP BY sn
+///
+/// cannot be calculated, because it has a column(`amount`) which is not
+/// part of group by expression.
+/// However, if we know that, `sn` is determinant of `amount`. We can
+/// safely, determine value of `amount` for each distinct `sn`. For these cases
+/// we rewrite the query above as
+///
+/// SELECT sn, amount
+/// FROM sales_global
+/// GROUP BY sn, amount
+///
+/// Both queries, are functionally same. \[Because, (`sn`, `amount`) and (`sn`)
+/// defines the identical groups. \]
+/// This function updates group by expressions such that select expressions that are
+/// not in group by expression, are added to the group by expressions if they are dependent
+/// of the sub-set of group by expressions.
 fn get_updated_group_by_exprs(
     group_by_exprs: &[Expr],
     select_exprs: &[Expr],


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
As discussed in the [link](https://github.com/apache/arrow-datafusion/pull/7040#discussion_r1276232108), current documentation for group by rewrite is missing. And rationale for it was not clear. This PR updates the docstring of the `get_updated_group_by_exprs` function such that adds its usage, and its motivation is more clear.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->