### PR TITLE
Substrait union/union all

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -474,7 +474,7 @@ pub async fn from_substrait_rel(
         Some(RelType::Set(set)) => match set_rel::SetOp::from_i32(set.op) {
             Some(set_op) => match set_op {
                 set_rel::SetOp::UnionAll => {
-                    assert!(set.inputs.len() > 0);
+                    assert!(!set.inputs.is_empty());
                     let mut union_builder = Ok(LogicalPlanBuilder::from(
                         from_substrait_rel(ctx, &set.inputs[0], extensions).await?,
                     ));

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -421,6 +421,24 @@ async fn roundtrip_ilike() -> Result<()> {
 }
 
 #[tokio::test]
+async fn roundtrip_union() -> Result<()> {
+    roundtrip("SELECT a, e FROM data UNION SELECT a, e FROM data").await
+}
+
+#[tokio::test]
+async fn roundtrip_union2() -> Result<()> {
+    roundtrip(
+        "SELECT a, b FROM data UNION SELECT a, b FROM data UNION SELECT a, b FROM data",
+    )
+    .await
+}
+
+#[tokio::test]
+async fn roundtrip_union_all() -> Result<()> {
+    roundtrip("SELECT a, e FROM data UNION ALL SELECT a, e FROM data").await
+}
+
+#[tokio::test]
 async fn simple_intersect() -> Result<()> {
     assert_expected_plan(
         "SELECT COUNT(*) FROM (SELECT data.a FROM data INTERSECT SELECT data2.a FROM data2);",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7116 .

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add support for `union` and `union all`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Producer: support for `LogicalPlan::Union`
- Consumer: support for `set_rel::SetOp::UnionAll`
  - DataFusion (v[28.0.0](https://github.com/apache/arrow-datafusion/tree/28.0.0)) represents `union` as `agg+union all` in optimized plan (`distinct+union all` in unoptimized plan). Thus, only `union all` needs support in the consumer
  - Other set operations are not yet supported
- Unit tests: `union`, `union all`, `union`s of more than 2 tables

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->