### PR TITLE
Add MSRV check as a GA job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -559,6 +559,7 @@ jobs:
           ./dev/update_config_docs.sh
           git diff --exit-code
 
+  # Verify MSRV for the crates which are directly used by other projects.
   msrv:
     name: Verify MSRV
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -558,3 +558,27 @@ jobs:
           # If you encounter an error, run './dev/update_config_docs.sh' and commit
           ./dev/update_config_docs.sh
           git diff --exit-code
+
+  msrv:
+    name: Verify MSRV
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Check datafusion
+        working-directory: datafusion/core
+        run: cargo msrv verify
+      - name: Check datafusion-substrait
+        working-directory: datafusion/substrait
+        run: cargo msrv verify
+      - name: Check datafusion-proto
+        working-directory: datafusion/proto
+        run: cargo msrv verify
+      - name: Check datafusion-cli
+        working-directory: datafusion-cli
+        run: cargo msrv verify

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -27,7 +27,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70"
 
 [lib]
 name = "datafusion"

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -26,7 +26,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70"
 
 # Exclude proto files so crates.io consumers don't need protoc
 exclude = ["*.proto"]

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -25,7 +25,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70"
 
 [dependencies]
 async-recursion = "1.0"


### PR DESCRIPTION
Closes #7122 

# Rationale for this change

Sometimes, `rust-version` in Cargo.toml tends to be out of sync with the actual MSRV.
So, it's nice to have a MSRV check as a CI process.

# What changes are included in this PR?
Added a MSRV check job to GA for some packages `datafusion`, `datafusion-substrait`, `datafusion-proto` and `datafusion-cli` which are intended to be published.

The following packages are also intended to be published but `datafusion` depends on them. So, this PR doesn't include MSRV check for them.

* datafusion-expr
* datafusion-optimizer
* datafusion-physical-expr
* datafusion-sql
* datafusion-execution

# Are these changes tested?

GA.

# Are there any user-facing changes?

No