### PR TITLE
fix: Fix panic in filter predicate

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/predicates.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/predicates.slt
@@ -347,3 +347,42 @@ drop table alltypes_plain;
 
 statement ok
 DROP TABLE test;
+
+#########
+# Predicates on memory tables / statistics generation
+# Reproducer for https://github.com/apache/arrow-datafusion/issues/7125
+#########
+
+statement ok
+CREATE TABLE t (i integer, s string, b boolean) AS VALUES
+ (1,    'One', true),
+ (2,    'Two', false),
+ (NULL, NULL,  NULL),
+ (4,    'Four', false)
+ ;
+
+query ITB
+select * from t where (b OR b) = b;
+----
+1 One true
+2 Two false
+4 Four false
+
+query ITB
+select * from t where (s LIKE 'T%') = true;
+----
+2 Two false
+
+query ITB
+select * from t where (i & 3) = 1;
+----
+1 One true
+
+
+
+
+########
+# Clean up after the test
+########
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/7125

# Rationale for this change
Panic in query isn't good

# What changes are included in this PR?

Fix the check if a predicate is supported for range analysis 

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I also verified this PR passes the IOx tests  in https://github.com/influxdata/influxdb_iox/pull/8355

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->