### PR TITLE
Minor: consolidate `GroupByOrderMode::None`

### DIFF
--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -252,12 +252,12 @@ impl AggregationOrdering {
 
     /// return true if this is GroupByOrderMode::None
     pub(crate) fn is_none(&self) -> bool {
-        return matches!(&self.mode, GroupByOrderMode::None);
+        matches!(&self.mode, GroupByOrderMode::None);
     }
 
     /// return true if there is some aggregation ordering
     pub(crate) fn is_some(&self) -> bool {
-        return !self.is_none();
+        !self.is_none();
     }
 
     /// What order is the output?

--- a/datafusion/core/src/physical_plan/aggregates/row_hash.rs
+++ b/datafusion/core/src/physical_plan/aggregates/row_hash.rs
@@ -228,15 +228,8 @@ impl GroupedHashAggregateStream {
         let name = format!("GroupedHashAggregateStream[{partition}]");
         let reservation = MemoryConsumer::new(name).register(context.memory_pool());
 
-        let group_ordering = agg
-            .aggregation_ordering
-            .as_ref()
-            .map(|aggregation_ordering| {
-                GroupOrdering::try_new(&group_schema, aggregation_ordering)
-            })
-            // return error if any
-            .transpose()?
-            .unwrap_or(GroupOrdering::None);
+        let group_ordering =
+            GroupOrdering::try_new(&group_schema, &agg.aggregation_ordering)?;
 
         let group_values = new_group_values(group_schema)?;
         timer.done();


### PR DESCRIPTION
# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/pull/7129

# Rationale for this change
Inspired by @mustafasrepo 's  comment https://github.com/apache/arrow-datafusion/pull/7129/files#r1278576304 about `Option<GroupByOrderMode>` being redundant with `GroupByOrderMode::None` here I tried the alternate approach to see what it would look like 

 I am not sure which I prefer but figured I would put it up for review in case other people liked this

# What changes are included in this PR?

1. Change `Option<GroupByOrderMode>` to `GroupByOrderMode`

# Are these changes tested?
Covered by existing tests

# Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->