### PR TITLE
minor: Remove mac m1 compilation for size_of_scalar test

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -4633,6 +4633,7 @@ mod tests {
         assert_eq!(expected, data_type.try_into().unwrap())
     }
 
+    // this test fails on aarch  so don't run it there
     #[cfg(not(target_arch = "aarch64"))]
     #[test]
     fn size_of_scalar() {

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -4633,6 +4633,7 @@ mod tests {
         assert_eq!(expected, data_type.try_into().unwrap())
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     #[test]
     fn size_of_scalar() {
         // Since ScalarValues are used in a non trivial number of places,

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -4633,7 +4633,7 @@ mod tests {
         assert_eq!(expected, data_type.try_into().unwrap())
     }
 
-    // this test fails on aarch  so don't run it there
+    // this test fails on aarch, so don't run it there
     #[cfg(not(target_arch = "aarch64"))]
     #[test]
     fn size_of_scalar() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes [#7089](https://github.com/apache/arrow-datafusion/issues/7089).

# Rationale for this change
`size_of_scalar` test seems to be failing in M1 machines. This PR removes this test when target architecture is arm64.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->