### PR TITLE
Minor: show output ordering in MemoryExec

### DIFF
--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -77,7 +77,7 @@ impl DisplayAs for MemoryExec {
                     .map(|output_ordering| {
                         let order_strings: Vec<_> =
                             output_ordering.iter().map(|e| e.to_string()).collect();
-                        format!(", output_ordering: {}", order_strings.join(","))
+                        format!(", output_ordering={}", order_strings.join(","))
                     })
                     .unwrap_or_else(|| "".to_string());
 

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -68,13 +68,23 @@ impl DisplayAs for MemoryExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                let partitions: Vec<_> =
+                let partition_sizes: Vec<_> =
                     self.partitions.iter().map(|b| b.len()).collect();
+
+                let output_ordering = self
+                    .sort_information
+                    .as_ref()
+                    .map(|output_ordering| {
+                        let order_strings: Vec<_> =
+                            output_ordering.iter().map(|e| e.to_string()).collect();
+                        format!(", output_ordering: {}", order_strings.join(","))
+                    })
+                    .unwrap_or_else(|| "".to_string());
+
                 write!(
                     f,
-                    "MemoryExec: partitions={}, partition_sizes={:?}",
-                    partitions.len(),
-                    partitions
+                    "MemoryExec: partitions={}, partition_sizes={partition_sizes:?}{output_ordering}",
+                    partition_sizes.len(),
                 )
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/pull/6382

# Rationale for this change

I set the ordering on MemExec but it didn't show up on the explain plan

# What changes are included in this PR?
Show the output ordering, if present



# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->