### PR TITLE
tweak: demote heading levels in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Which issue does this PR close?
+## Which issue does this PR close?
 
 <!--
 We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
@@ -6,20 +6,20 @@ We generally require a GitHub issue to be filed for all bug fixes and enhancemen
 
 Closes #.
 
-# Rationale for this change
+## Rationale for this change
 
 <!--
  Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
  Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
 -->
 
-# What changes are included in this PR?
+## What changes are included in this PR?
 
 <!--
 There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
 -->
 
-# Are these changes tested?
+## Are these changes tested?
 
 <!--
 We typically require tests for all PRs in order to:
@@ -29,7 +29,7 @@ We typically require tests for all PRs in order to:
 If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
 -->
 
-# Are there any user-facing changes?
+## Are there any user-facing changes?
 
 <!--
 If there are user-facing changes then we may require documentation to be updated before approving the PR.


### PR DESCRIPTION
The PR title is an `<h1>`, so headings in
the PR description should start at `<h2>`.