### PR TITLE
docs: fix broken link

### DIFF
--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -54,7 +54,7 @@ pub trait RecordBatchStream: Stream<Item = Result<RecordBatch>> {
     fn schema(&self) -> SchemaRef;
 }
 
-/// Trait for a [`Stream`] of [`RecordBatch`]es
+/// Trait for a [`Stream`](futures::stream::Stream) of [`RecordBatch`]es
 pub type SendableRecordBatchStream = Pin<Box<dyn RecordBatchStream + Send>>;
 
 /// EmptyRecordBatchStream can be used to create a RecordBatchStream


### PR DESCRIPTION
Skip the PR template as there is no code changes.

#### What does this PR do
1. Fix a broken link in the doc of `datafusion::physical_plan::SendableRecordBatchStream`