### PR TITLE
Minor: Further Increase stack_size to prevent roundtrip_deeply_nested test stack overflow

### DIFF
--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -455,7 +455,7 @@ mod test {
     #[test]
     fn roundtrip_deeply_nested() {
         // we need more stack space so this doesn't overflow in dev builds
-        std::thread::Builder::new().stack_size(10_000_000).spawn(|| {
+        std::thread::Builder::new().stack_size(100_000_000).spawn(|| {
             // don't know what "too much" is, so let's slowly try to increase complexity
             let n_max = 100;
 

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -455,7 +455,7 @@ mod test {
     #[test]
     fn roundtrip_deeply_nested() {
         // we need more stack space so this doesn't overflow in dev builds
-        std::thread::Builder::new().stack_size(100_000_000).spawn(|| {
+        std::thread::Builder::new().stack_size(20_000_000).spawn(|| {
             // don't know what "too much" is, so let's slowly try to increase complexity
             let n_max = 100;
 


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

On my local dev machine, `cargo test roundtrip_deeply_nested` aborts with a stack overflow error. Increasing the `stack_size` value in the test fixes the problem. It is unclear to me why this is required for me locally, but does not affect the CI pipeline (or presumably other devs).

## What changes are included in this PR?

Increase stack_size to 20_000_000 from previous value of 10_000_000.

## Are these changes tested?

N/A

## Are there any user-facing changes?

No.