### PR TITLE
Add linear regression aggregate functions

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
@@ -2294,157 +2294,268 @@ NULL
 
 
 #
-# regr_slope() tests
+# regr_*() tests
 #
 
-# invalid input
+# regr_*() invalid input
 statement error
 select regr_slope();
 
 statement error
-select regr_slope(*);
+select regr_intercept(*);
 
 statement error
-select regr_slope(*) from aggregate_test_100;
+select regr_count(*) from aggregate_test_100;
 
 statement error
-select regr_slope(1);
+select regr_r2(1);
 
 statement error
-select regr_slope(1,2,3);
+select regr_avgx(1,2,3);
 
 statement error
-select regr_slope(1, 'foo');
+select regr_avgy(1, 'foo');
 
 statement error
-select regr_slope('foo', 1);
+select regr_sxx('foo', 1);
 
 statement error
-select regr_slope('foo', 'bar');
+select regr_syy('foo', 'bar');
+
+statement error
+select regr_sxy(NULL, 'bar');
 
 
 
-# regr_slope() NULL result
-query R
-select regr_slope(1,1);
+# regr_*() NULL results
+query RRRRRRRRR
+select regr_slope(1,1), regr_intercept(1,1), regr_count(1,1), regr_r2(1,1), regr_avgx(1,1), regr_avgy(1,1), regr_sxx(1,1), regr_syy(1,1), regr_sxy(1,1);
 ----
-NULL
+NULL NULL 1 NULL 1 1 0 0 0
 
-query R
-select regr_slope(1, NULL);
+query RRRRRRRRR
+select regr_slope(1, NULL), regr_intercept(1, NULL), regr_count(1, NULL), regr_r2(1, NULL), regr_avgx(1, NULL), regr_avgy(1, NULL), regr_sxx(1, NULL), regr_syy(1, NULL), regr_sxy(1, NULL);
 ----
-NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
 
-query R
-select regr_slope(NULL, 1);
+query RRRRRRRRR
+select regr_slope(NULL, 1), regr_intercept(NULL, 1), regr_count(NULL, 1), regr_r2(NULL, 1), regr_avgx(NULL, 1), regr_avgy(NULL, 1), regr_sxx(NULL, 1), regr_syy(NULL, 1), regr_sxy(NULL, 1);
 ----
-NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
 
-query R
-select regr_slope(NULL, NULL);
+query RRRRRRRRR
+select regr_slope(NULL, NULL), regr_intercept(NULL, NULL), regr_count(NULL, NULL), regr_r2(NULL, NULL), regr_avgx(NULL, NULL), regr_avgy(NULL, NULL), regr_sxx(NULL, NULL), regr_syy(NULL, NULL), regr_sxy(NULL, NULL);
 ----
-NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
 
-query R
-select regr_slope(column2, column1) from (values (1,2), (1,4), (1,6));
+query RRRRRRRRR
+select regr_slope(column2, column1), regr_intercept(column2, column1), regr_count(column2, column1), regr_r2(column2, column1), regr_avgx(column2, column1), regr_avgy(column2, column1), regr_sxx(column2, column1), regr_syy(column2, column1), regr_sxy(column2, column1) from (values (1,2), (1,4), (1,6));
 ----
-NULL
+NULL NULL 3 NULL 1 4 0 8 0
 
 
 
-# regr_slope() basic tests
-query R
-select regr_slope(column2, column1) from (values (1,2), (2,4), (3,6));
+# regr_*() basic tests
+query RRRRRRRRR
+select 
+    regr_slope(column2, column1),
+    regr_intercept(column2, column1),
+    regr_count(column2, column1),
+    regr_r2(column2, column1),
+    regr_avgx(column2, column1),
+    regr_avgy(column2, column1),
+    regr_sxx(column2, column1),
+    regr_syy(column2, column1),
+    regr_sxy(column2, column1)
+from (values (1,2), (2,4), (3,6));
 ----
-2
+2 0 3 1 2 4 2 8 4
 
-query R
-select regr_slope(c12, c11) from aggregate_test_100;
+query RRRRRRRRR
+select 
+    regr_slope(c12, c11),
+    regr_intercept(c12, c11),
+    regr_count(c12, c11),
+    regr_r2(c12, c11),
+    regr_avgx(c12, c11),
+    regr_avgy(c12, c11),
+    regr_sxx(c12, c11),
+    regr_syy(c12, c11),
+    regr_sxy(c12, c11)
+from aggregate_test_100;
 ----
-0.051534002628
+0.051534002628 0.48427355347 100 0.001929150558 0.479274948239 0.508972509913 6.707779292571 9.234223721582 0.345678715695
 
 
 
-# regr_slope() ignore NULLs
-query R
-select regr_slope(column2, column1) from (values (1,NULL), (2,4), (3,6));
+# regr_*() functions ignore NULLs
+query RRRRRRRRR
+select 
+    regr_slope(column2, column1),
+    regr_intercept(column2, column1),
+    regr_count(column2, column1),
+    regr_r2(column2, column1),
+    regr_avgx(column2, column1),
+    regr_avgy(column2, column1),
+    regr_sxx(column2, column1),
+    regr_syy(column2, column1),
+    regr_sxy(column2, column1)
+from (values (1,NULL), (2,4), (3,6));
 ----
-2
+2 0 2 1 2.5 5 0.5 2 1
 
-query R
-select regr_slope(column2, column1) from (values (1,NULL), (NULL,4), (3,6));
+query RRRRRRRRR
+select 
+    regr_slope(column2, column1),
+    regr_intercept(column2, column1),
+    regr_count(column2, column1),
+    regr_r2(column2, column1),
+    regr_avgx(column2, column1),
+    regr_avgy(column2, column1),
+    regr_sxx(column2, column1),
+    regr_syy(column2, column1),
+    regr_sxy(column2, column1)
+from (values (1,NULL), (NULL,4), (3,6));
 ----
-NULL
+NULL NULL 1 NULL 3 6 0 0 0
 
-query R
-select regr_slope(column2, column1) from (values (1,NULL), (NULL,4), (NULL,NULL));
+query RRRRRRRRR
+select 
+    regr_slope(column2, column1),
+    regr_intercept(column2, column1),
+    regr_count(column2, column1),
+    regr_r2(column2, column1),
+    regr_avgx(column2, column1),
+    regr_avgy(column2, column1),
+    regr_sxx(column2, column1),
+    regr_syy(column2, column1),
+    regr_sxy(column2, column1)
+from (values (1,NULL), (NULL,4), (NULL,NULL));
 ----
-NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
 
-query TR rowsort
-select column3, regr_slope(column2, column1)
+query TRRRRRRRRR rowsort
+select 
+    column3, 
+    regr_slope(column2, column1),
+    regr_intercept(column2, column1),
+    regr_count(column2, column1),
+    regr_r2(column2, column1),
+    regr_avgx(column2, column1),
+    regr_avgy(column2, column1),
+    regr_sxx(column2, column1),
+    regr_syy(column2, column1),
+    regr_sxy(column2, column1)
 from (values (1,2,'a'), (2,4,'a'), (1,3,'b'), (3,9,'b'), (1,10,'c'), (NULL,100,'c'))
 group by column3;
 ----
-a 2
-b 3
-c NULL
+a 2 0 2 1 1.5 3 0.5 2 1
+b 3 0 2 1 2 6 2 18 6
+c NULL NULL 1 NULL 1 10 0 0 0
 
 
 
-# regr_slope() testing merge_batch() from RegrSlopeAccumulator's internal implementation
+# regr_*() testing merge_batch() from RegrAccumulator's internal implementation
 statement ok
 set datafusion.execution.batch_size = 1;
 
-query R
-select regr_slope(c12, c11) from aggregate_test_100;
+query RRRRRRRRR
+select 
+    regr_slope(c12, c11),
+    regr_intercept(c12, c11),
+    regr_count(c12, c11),
+    regr_r2(c12, c11),
+    regr_avgx(c12, c11),
+    regr_avgy(c12, c11),
+    regr_sxx(c12, c11),
+    regr_syy(c12, c11),
+    regr_sxy(c12, c11)
+from aggregate_test_100;
 ----
-0.051534002628
+0.051534002628 0.48427355347 100 0.001929150558 0.479274948239 0.508972509913 6.707779292571 9.234223721582 0.345678715695
 
 statement ok
 set datafusion.execution.batch_size = 2;
 
-query R
-select regr_slope(c12, c11) from aggregate_test_100;
+query RRRRRRRRR
+select 
+    regr_slope(c12, c11),
+    regr_intercept(c12, c11),
+    regr_count(c12, c11),
+    regr_r2(c12, c11),
+    regr_avgx(c12, c11),
+    regr_avgy(c12, c11),
+    regr_sxx(c12, c11),
+    regr_syy(c12, c11),
+    regr_sxy(c12, c11)
+from aggregate_test_100;
 ----
-0.051534002628
+0.051534002628 0.48427355347 100 0.001929150558 0.479274948239 0.508972509913 6.707779292571 9.234223721582 0.345678715695
 
 statement ok
 set datafusion.execution.batch_size = 3;
 
-query R
-select regr_slope(c12, c11) from aggregate_test_100;
+query RRRRRRRRR
+select 
+    regr_slope(c12, c11),
+    regr_intercept(c12, c11),
+    regr_count(c12, c11),
+    regr_r2(c12, c11),
+    regr_avgx(c12, c11),
+    regr_avgy(c12, c11),
+    regr_sxx(c12, c11),
+    regr_syy(c12, c11),
+    regr_sxy(c12, c11)
+from aggregate_test_100;
 ----
-0.051534002628
+0.051534002628 0.48427355347 100 0.001929150558 0.479274948239 0.508972509913 6.707779292571 9.234223721582 0.345678715695
 
 statement ok
 set datafusion.execution.batch_size = 8192;
 
 
 
-# regr_slope testing retract_batch() from RegrSlopeAccumulator's internal implementation
-query R
-select regr_slope(column2, column1)
-over (order by column1 rows between 2 preceding and current row)
-from (values (1,2), (2,4), (3,6), (4,12), (5,15), (6, 18));
+# regr_*() testing retract_batch() from RegrAccumulator's internal implementation
+query RRRRRRRRR
+SELECT
+    regr_slope(column2, column1) OVER w AS slope,
+    regr_intercept(column2, column1) OVER w AS intercept,
+    regr_count(column2, column1) OVER w AS count,
+    regr_r2(column2, column1) OVER w AS r2,
+    regr_avgx(column2, column1) OVER w AS avgx,
+    regr_avgy(column2, column1) OVER w AS avgy,
+    regr_sxx(column2, column1) OVER w AS sxx,
+    regr_syy(column2, column1) OVER w AS syy,
+    regr_sxy(column2, column1) OVER w AS sxy
+FROM (VALUES (1,2), (2,4), (3,6), (4,12), (5,15), (6,18)) AS t(column1, column2)
+WINDOW w AS (ORDER BY column1 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
 ----
-NULL
-2
-2
-4
-4.5
-3
+NULL NULL 1 NULL 1 2 0 0 0
+2 0 2 1 1.5 3 0.5 2 1
+2 0 3 1 2 4 2 8 4
+4 -4.666666666667 3 0.923076923077 3 7.333333333333 2 34.666666666667 8
+4.5 -7 3 0.964285714286 4 11 2 42 9
+3 0 3 1 5 15 2 18 6
 
-query R
-select regr_slope(column2, column1)
-over (order by column1 rows between 2 preceding and current row)
-from (values (1,2), (2,4), (3,6), (3, NULL), (4, NULL), (5,15), (6,18), (7, 21));
+query RRRRRRRRR
+SELECT
+    regr_slope(column2, column1) OVER w AS slope,
+    regr_intercept(column2, column1) OVER w AS intercept,
+    regr_count(column2, column1) OVER w AS count,
+    regr_r2(column2, column1) OVER w AS r2,
+    regr_avgx(column2, column1) OVER w AS avgx,
+    regr_avgy(column2, column1) OVER w AS avgy,
+    regr_sxx(column2, column1) OVER w AS sxx,
+    regr_syy(column2, column1) OVER w AS syy,
+    regr_sxy(column2, column1) OVER w AS sxy
+FROM (VALUES (1,2), (2,4), (3,6), (3, NULL), (4, NULL), (5,15), (6,18), (7, 21)) AS t(column1, column2)
+WINDOW w AS (ORDER BY column1 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW);
 ----
-NULL
-2
-2
-2
-NULL
-NULL
-3
-3
+NULL NULL 1 NULL 1 2 0 0 0
+2 0 2 1 1.5 3 0.5 2 1
+2 0 3 1 2 4 2 8 4
+2 0 2 1 2.5 5 0.5 2 1
+NULL NULL 1 NULL 3 6 0 0 0
+NULL NULL 1 NULL 5 15 0 0 0
+3 0 2 1 5.5 16.5 0.5 4.5 1.5
+3 0 3 1 6 18 2 18 6

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -63,6 +63,22 @@ pub enum AggregateFunction {
     Correlation,
     /// Slope from linear regression
     RegrSlope,
+    /// Intercept from linear regression
+    RegrIntercept,
+    /// Number of input rows in which both expressions are not null
+    RegrCount,
+    /// R-squared value from linear regression
+    RegrR2,
+    /// Average of the independent variable
+    RegrAvgx,
+    /// Average of the dependent variable
+    RegrAvgy,
+    /// Sum of squares of the independent variable
+    RegrSXX,
+    /// Sum of squares of the dependent variable
+    RegrSYY,
+    /// Sum of products of pairs of numbers
+    RegrSXY,
     /// Approximate continuous percentile function
     ApproxPercentileCont,
     /// Approximate continuous percentile function with weight
@@ -105,6 +121,14 @@ impl AggregateFunction {
             CovariancePop => "COVARIANCE_POP",
             Correlation => "CORRELATION",
             RegrSlope => "REGR_SLOPE",
+            RegrIntercept => "REGR_INTERCEPT",
+            RegrCount => "REGR_COUNT",
+            RegrR2 => "REGR_R2",
+            RegrAvgx => "REGR_AVGX",
+            RegrAvgy => "REGR_AVGY",
+            RegrSXX => "REGR_SXX",
+            RegrSYY => "REGR_SYY",
+            RegrSXY => "REGR_SXY",
             ApproxPercentileCont => "APPROX_PERCENTILE_CONT",
             ApproxPercentileContWithWeight => "APPROX_PERCENTILE_CONT_WITH_WEIGHT",
             ApproxMedian => "APPROX_MEDIAN",
@@ -156,6 +180,14 @@ impl FromStr for AggregateFunction {
             "var_pop" => AggregateFunction::VariancePop,
             "var_samp" => AggregateFunction::Variance,
             "regr_slope" => AggregateFunction::RegrSlope,
+            "regr_intercept" => AggregateFunction::RegrIntercept,
+            "regr_count" => AggregateFunction::RegrCount,
+            "regr_r2" => AggregateFunction::RegrR2,
+            "regr_avgx" => AggregateFunction::RegrAvgx,
+            "regr_avgy" => AggregateFunction::RegrAvgy,
+            "regr_sxx" => AggregateFunction::RegrSXX,
+            "regr_syy" => AggregateFunction::RegrSYY,
+            "regr_sxy" => AggregateFunction::RegrSXY,
             // approximate
             "approx_distinct" => AggregateFunction::ApproxDistinct,
             "approx_median" => AggregateFunction::ApproxMedian,
@@ -230,7 +262,15 @@ impl AggregateFunction {
             }
             AggregateFunction::Stddev => stddev_return_type(&coerced_data_types[0]),
             AggregateFunction::StddevPop => stddev_return_type(&coerced_data_types[0]),
-            AggregateFunction::RegrSlope => Ok(DataType::Float64),
+            AggregateFunction::RegrSlope
+            | AggregateFunction::RegrIntercept
+            | AggregateFunction::RegrCount
+            | AggregateFunction::RegrR2
+            | AggregateFunction::RegrAvgx
+            | AggregateFunction::RegrAvgy
+            | AggregateFunction::RegrSXX
+            | AggregateFunction::RegrSYY
+            | AggregateFunction::RegrSXY => Ok(DataType::Float64),
             AggregateFunction::Avg => avg_return_type(&coerced_data_types[0]),
             AggregateFunction::ArrayAgg => Ok(DataType::List(Arc::new(Field::new(
                 "item",
@@ -317,7 +357,15 @@ impl AggregateFunction {
             AggregateFunction::Covariance
             | AggregateFunction::CovariancePop
             | AggregateFunction::Correlation
-            | AggregateFunction::RegrSlope => {
+            | AggregateFunction::RegrSlope
+            | AggregateFunction::RegrIntercept
+            | AggregateFunction::RegrCount
+            | AggregateFunction::RegrR2
+            | AggregateFunction::RegrAvgx
+            | AggregateFunction::RegrAvgy
+            | AggregateFunction::RegrSXX
+            | AggregateFunction::RegrSYY
+            | AggregateFunction::RegrSXY => {
                 Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable)
             }
             AggregateFunction::ApproxPercentileCont => {

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -192,7 +192,15 @@ pub fn coerce_types(
             }
             Ok(input_types.to_vec())
         }
-        AggregateFunction::RegrSlope => {
+        AggregateFunction::RegrSlope
+        | AggregateFunction::RegrIntercept
+        | AggregateFunction::RegrCount
+        | AggregateFunction::RegrR2
+        | AggregateFunction::RegrAvgx
+        | AggregateFunction::RegrAvgy
+        | AggregateFunction::RegrSXX
+        | AggregateFunction::RegrSYY
+        | AggregateFunction::RegrSXY => {
             let valid_types = [NUMERICS.to_vec(), vec![DataType::Null]].concat();
             let input_types_valid = // number of input already checked before
                 valid_types.contains(&input_types[0]) && valid_types.contains(&input_types[1]);

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -26,6 +26,7 @@
 //! * Signature: see `Signature`
 //! * Return type: a function `(arg_types) -> return_type`. E.g. for min, ([f32]) -> f32, ([f64]) -> f64.
 
+use crate::aggregate::regr::RegrType;
 use crate::{expressions, AggregateExpr, PhysicalExpr, PhysicalSortExpr};
 use arrow::datatypes::Schema;
 use datafusion_common::{DataFusionError, Result};
@@ -248,16 +249,85 @@ pub fn create_aggregate_expr(
                 "CORR(DISTINCT) aggregations are not available".to_string(),
             ));
         }
-        (AggregateFunction::RegrSlope, false) => Arc::new(expressions::RegrSlope::new(
+        (AggregateFunction::RegrSlope, false) => Arc::new(expressions::Regr::new(
             input_phy_exprs[0].clone(),
             input_phy_exprs[1].clone(),
             name,
+            RegrType::Slope,
             rt_type,
         )),
-        (AggregateFunction::RegrSlope, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "REGR_SLOPE(DISTINCT) aggregations are not available".to_string(),
-            ));
+        (AggregateFunction::RegrIntercept, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::Intercept,
+            rt_type,
+        )),
+        (AggregateFunction::RegrCount, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::Count,
+            rt_type,
+        )),
+        (AggregateFunction::RegrR2, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::R2,
+            rt_type,
+        )),
+        (AggregateFunction::RegrAvgx, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::AvgX,
+            rt_type,
+        )),
+        (AggregateFunction::RegrAvgy, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::AvgY,
+            rt_type,
+        )),
+        (AggregateFunction::RegrSXX, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::SXX,
+            rt_type,
+        )),
+        (AggregateFunction::RegrSYY, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::SYY,
+            rt_type,
+        )),
+        (AggregateFunction::RegrSXY, false) => Arc::new(expressions::Regr::new(
+            input_phy_exprs[0].clone(),
+            input_phy_exprs[1].clone(),
+            name,
+            RegrType::SXY,
+            rt_type,
+        )),
+        (
+            AggregateFunction::RegrSlope
+            | AggregateFunction::RegrIntercept
+            | AggregateFunction::RegrCount
+            | AggregateFunction::RegrR2
+            | AggregateFunction::RegrAvgx
+            | AggregateFunction::RegrAvgy
+            | AggregateFunction::RegrSXX
+            | AggregateFunction::RegrSYY
+            | AggregateFunction::RegrSXY,
+            true,
+        ) => {
+            return Err(DataFusionError::NotImplemented(format!(
+                "{}(DISTINCT) aggregations are not available",
+                fun
+            )));
         }
         (AggregateFunction::ApproxPercentileCont, false) => {
             if input_phy_exprs.len() == 2 {

--- a/datafusion/physical-expr/src/aggregate/mod.rs
+++ b/datafusion/physical-expr/src/aggregate/mod.rs
@@ -49,7 +49,7 @@ pub mod build_in;
 pub(crate) mod groups_accumulator;
 mod hyperloglog;
 pub mod moving_min_max;
-pub(crate) mod regr_slope;
+pub(crate) mod regr;
 pub(crate) mod stats;
 pub(crate) mod stddev;
 pub(crate) mod sum;

--- a/datafusion/physical-expr/src/aggregate/regr.rs
+++ b/datafusion/physical-expr/src/aggregate/regr.rs
@@ -35,35 +35,77 @@ use datafusion_expr::Accumulator;
 use crate::aggregate::utils::down_cast_any_ref;
 use crate::expressions::format_state_name;
 
-/// regr_slope aggregate expression
-/// Returns the slope of the linear regression line for non-null pairs in aggregate columns
-/// Given input column Y and X: regr_slope(Y, X) returns the slope (k in Y = k*X + b) using minimal
-/// RSS fitting.
 #[derive(Debug)]
-pub struct RegrSlope {
+pub struct Regr {
     name: String,
+    regr_type: RegrType,
     expr_y: Arc<dyn PhysicalExpr>,
     expr_x: Arc<dyn PhysicalExpr>,
 }
 
-impl RegrSlope {
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum RegrType {
+    /// Variant for `regr_slope` aggregate expression
+    /// Returns the slope of the linear regression line for non-null pairs in aggregate columns.
+    /// Given input column Y and X: `regr_slope(Y, X)` returns the slope (k in Y = k*X + b) using minimal
+    /// RSS (Residual Sum of Squares) fitting.
+    Slope,
+    /// Variant for `regr_intercept` aggregate expression
+    /// Returns the intercept of the linear regression line for non-null pairs in aggregate columns.
+    /// Given input column Y and X: `regr_intercept(Y, X)` returns the intercept (b in Y = k*X + b) using minimal
+    /// RSS fitting.
+    Intercept,
+    /// Variant for `regr_count` aggregate expression
+    /// Returns the number of input rows for which both expressions are not null.
+    /// Given input column Y and X: `regr_count(Y, X)` returns the count of non-null pairs.
+    Count,
+    /// Variant for `regr_r2` aggregate expression
+    /// Returns the coefficient of determination (R-squared value) of the linear regression line for non-null pairs in aggregate columns.
+    /// The R-squared value represents the proportion of variance in Y that is predictable from X.
+    R2,
+    /// Variant for `regr_avgx` aggregate expression
+    /// Returns the average of the independent variable for non-null pairs in aggregate columns.
+    /// Given input column X: `regr_avgx(Y, X)` returns the average of X values.
+    AvgX,
+    /// Variant for `regr_avgy` aggregate expression
+    /// Returns the average of the dependent variable for non-null pairs in aggregate columns.
+    /// Given input column Y: `regr_avgy(Y, X)` returns the average of Y values.
+    AvgY,
+    /// Variant for `regr_sxx` aggregate expression
+    /// Returns the sum of squares of the independent variable for non-null pairs in aggregate columns.
+    /// Given input column X: `regr_sxx(Y, X)` returns the sum of squares of deviations of X from its mean.
+    SXX,
+    /// Variant for `regr_syy` aggregate expression
+    /// Returns the sum of squares of the dependent variable for non-null pairs in aggregate columns.
+    /// Given input column Y: `regr_syy(Y, X)` returns the sum of squares of deviations of Y from its mean.
+    SYY,
+    /// Variant for `regr_sxy` aggregate expression
+    /// Returns the sum of products of pairs of numbers for non-null pairs in aggregate columns.
+    /// Given input column Y and X: `regr_sxy(Y, X)` returns the sum of products of the deviations of Y and X from their respective means.
+    SXY,
+}
+
+impl Regr {
     pub fn new(
         expr_y: Arc<dyn PhysicalExpr>,
         expr_x: Arc<dyn PhysicalExpr>,
         name: impl Into<String>,
+        regr_type: RegrType,
         return_type: DataType,
     ) -> Self {
         // the result of regr_slope only support FLOAT64 data type.
         assert!(matches!(return_type, DataType::Float64));
         Self {
             name: name.into(),
+            regr_type,
             expr_y,
             expr_x,
         }
     }
 }
 
-impl AggregateExpr for RegrSlope {
+impl AggregateExpr for Regr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -73,11 +115,11 @@ impl AggregateExpr for RegrSlope {
     }
 
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(RegrSlopeAccumulator::try_new()?))
+        Ok(Box::new(RegrAccumulator::try_new(&self.regr_type)?))
     }
 
     fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(RegrSlopeAccumulator::try_new()?))
+        Ok(Box::new(RegrAccumulator::try_new(&self.regr_type)?))
     }
 
     fn state_fields(&self) -> Result<Vec<Field>> {
@@ -103,6 +145,11 @@ impl AggregateExpr for RegrSlope {
                 true,
             ),
             Field::new(
+                format_state_name(&self.name, "m2_y"),
+                DataType::Float64,
+                true,
+            ),
+            Field::new(
                 format_state_name(&self.name, "algo_const"),
                 DataType::Float64,
                 true,
@@ -119,7 +166,7 @@ impl AggregateExpr for RegrSlope {
     }
 }
 
-impl PartialEq<dyn Any> for RegrSlope {
+impl PartialEq<dyn Any> for Regr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -132,38 +179,79 @@ impl PartialEq<dyn Any> for RegrSlope {
     }
 }
 
-// regr_slope(y, x) is calculated using cov_pop(x, y)/var_pop(x)
-// Reference of online algorithms for calculationg variance:
-// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+/// `RegrAccumulator` is used to compute linear regression aggregate functions
+/// by maintaining statistics needed to compute them in an online fashion.
+///
+/// This struct uses Welford's online algorithm for calculating variance and covariance:
+/// <https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm>
+///
+/// Given the statistics, the following aggregate functions can be calculated:
+///
+/// - `regr_slope(y, x)`: Slope of the linear regression line, calculated as:
+///   cov_pop(x, y) / var_pop(x).
+///   It represents the expected change in Y for a one-unit change in X.
+///
+/// - `regr_intercept(y, x)`: Intercept of the linear regression line, calculated as:
+///   mean_y - (regr_slope(y, x) * mean_x).
+///   It represents the expected value of Y when X is 0.
+///
+/// - `regr_count(y, x)`: Count of the non-null(both x and y) input rows.
+///
+/// - `regr_r2(y, x)`: R-squared value (coefficient of determination), calculated as:
+///   (cov_pop(x, y) ^ 2) / (var_pop(x) * var_pop(y)).
+///   It provides a measure of how well the model's predictions match the observed data.
+///
+/// - `regr_avgx(y, x)`: Average of the independent variable X, calculated as: mean_x.
+///
+/// - `regr_avgy(y, x)`: Average of the dependent variable Y, calculated as: mean_y.
+///
+/// - `regr_sxx(y, x)`: Sum of squares of the independent variable X, calculated as:
+///   m2_x.
+///
+/// - `regr_syy(y, x)`: Sum of squares of the dependent variable Y, calculated as:
+///   m2_y.
+///
+/// - `regr_sxy(y, x)`: Sum of products of paired values, calculated as:
+///   algo_const.
+///
+/// Here's how the statistics maintained in this struct are calculated:
+/// - `cov_pop(x, y)`: algo_const / count.
+/// - `var_pop(x)`: m2_x / count.
+/// - `var_pop(y)`: m2_y / count.
 #[derive(Debug)]
-pub struct RegrSlopeAccumulator {
+pub struct RegrAccumulator {
     count: u64,
     mean_x: f64,
     mean_y: f64,
     m2_x: f64,
+    m2_y: f64,
     algo_const: f64,
+    regr_type: RegrType,
 }
 
-impl RegrSlopeAccumulator {
-    /// Creates a new `RegrSlopeAccumulator`
-    pub fn try_new() -> Result<Self> {
+impl RegrAccumulator {
+    /// Creates a new `RegrAccumulator`
+    pub fn try_new(regr_type: &RegrType) -> Result<Self> {
         Ok(Self {
             count: 0_u64,
             mean_x: 0_f64,
             mean_y: 0_f64,
             m2_x: 0_f64,
+            m2_y: 0_f64,
             algo_const: 0_f64,
+            regr_type: regr_type.clone(),
         })
     }
 }
 
-impl Accumulator for RegrSlopeAccumulator {
+impl Accumulator for RegrAccumulator {
     fn state(&self) -> Result<Vec<ScalarValue>> {
         Ok(vec![
             ScalarValue::from(self.count),
             ScalarValue::from(self.mean_x),
             ScalarValue::from(self.mean_y),
             ScalarValue::from(self.m2_x),
+            ScalarValue::from(self.m2_y),
             ScalarValue::from(self.algo_const),
         ])
     }
@@ -200,9 +288,11 @@ impl Accumulator for RegrSlopeAccumulator {
             let delta_x = value_x - self.mean_x;
             let delta_y = value_y - self.mean_y;
             self.mean_x += delta_x / self.count as f64;
-            let delta_x_2 = value_x - self.mean_x;
-            self.m2_x += delta_x * delta_x_2;
             self.mean_y += delta_y / self.count as f64;
+            let delta_x_2 = value_x - self.mean_x;
+            let delta_y_2 = value_y - self.mean_y;
+            self.m2_x += delta_x * delta_x_2;
+            self.m2_y += delta_y * delta_y_2;
             self.algo_const += delta_x * (value_y - self.mean_y);
         }
 
@@ -241,14 +331,17 @@ impl Accumulator for RegrSlopeAccumulator {
                 let delta_x = value_x - self.mean_x;
                 let delta_y = value_y - self.mean_y;
                 self.mean_x -= delta_x / self.count as f64;
-                let delta_x_2 = value_x - self.mean_x;
-                self.m2_x -= delta_x * delta_x_2;
                 self.mean_y -= delta_y / self.count as f64;
+                let delta_x_2 = value_x - self.mean_x;
+                let delta_y_2 = value_y - self.mean_y;
+                self.m2_x -= delta_x * delta_x_2;
+                self.m2_y -= delta_y * delta_y_2;
                 self.algo_const -= delta_x * (value_y - self.mean_y);
             } else {
                 self.count = 0;
                 self.mean_x = 0.0;
                 self.m2_x = 0.0;
+                self.m2_y = 0.0;
                 self.mean_y = 0.0;
                 self.algo_const = 0.0;
             }
@@ -262,25 +355,28 @@ impl Accumulator for RegrSlopeAccumulator {
         let mean_x_arr = downcast_value!(states[1], Float64Array);
         let mean_y_arr = downcast_value!(states[2], Float64Array);
         let m2_x_arr = downcast_value!(states[3], Float64Array);
-        let algo_const_arr = downcast_value!(states[4], Float64Array);
+        let m2_y_arr = downcast_value!(states[4], Float64Array);
+        let algo_const_arr = downcast_value!(states[5], Float64Array);
 
         for i in 0..count_arr.len() {
             let count_b = count_arr.value(i);
             if count_b == 0_u64 {
                 continue;
             }
-            let (count_a, mean_x_a, mean_y_a, m2_x_a, algo_const_a) = (
+            let (count_a, mean_x_a, mean_y_a, m2_x_a, m2_y_a, algo_const_a) = (
                 self.count,
                 self.mean_x,
                 self.mean_y,
                 self.m2_x,
+                self.m2_y,
                 self.algo_const,
             );
-            let (count_b, mean_x_b, mean_y_b, m2_x_b, algo_const_b) = (
+            let (count_b, mean_x_b, mean_y_b, m2_x_b, m2_y_b, algo_const_b) = (
                 count_b,
                 mean_x_arr.value(i),
                 mean_y_arr.value(i),
                 m2_x_arr.value(i),
+                m2_y_arr.value(i),
                 algo_const_arr.value(i),
             );
 
@@ -300,6 +396,8 @@ impl Accumulator for RegrSlopeAccumulator {
             let mean_y_ab = mean_y_a + d_y * count_b / count_ab as f64;
             let m2_x_ab =
                 m2_x_a + m2_x_b + d_x * d_x * count_a * count_b / count_ab as f64;
+            let m2_y_ab =
+                m2_y_a + m2_y_b + d_y * d_y * count_a * count_b / count_ab as f64;
             let algo_const_ab = algo_const_a
                 + algo_const_b
                 + d_x * d_y * count_a * count_b / count_ab as f64;
@@ -308,6 +406,7 @@ impl Accumulator for RegrSlopeAccumulator {
             self.mean_x = mean_x_ab;
             self.mean_y = mean_y_ab;
             self.m2_x = m2_x_ab;
+            self.m2_y = m2_y_ab;
             self.algo_const = algo_const_ab;
         }
         Ok(())
@@ -316,12 +415,42 @@ impl Accumulator for RegrSlopeAccumulator {
     fn evaluate(&self) -> Result<ScalarValue> {
         let cov_pop_x_y = self.algo_const / self.count as f64;
         let var_pop_x = self.m2_x / self.count as f64;
+        let var_pop_y = self.m2_y / self.count as f64;
 
-        // Only 0/1 point or slope is infinite
-        if self.count <= 1 || var_pop_x == 0.0 {
-            Ok(ScalarValue::Float64(None))
-        } else {
-            Ok(ScalarValue::Float64(Some(cov_pop_x_y / var_pop_x)))
+        let nullif_or_stat = |cond: bool, stat: f64| {
+            if cond {
+                Ok(ScalarValue::Float64(None))
+            } else {
+                Ok(ScalarValue::Float64(Some(stat)))
+            }
+        };
+
+        match self.regr_type {
+            RegrType::Slope => {
+                // Only 0/1 point or slope is infinite
+                let nullif_cond = self.count <= 1 || var_pop_x == 0.0;
+                nullif_or_stat(nullif_cond, cov_pop_x_y / var_pop_x)
+            }
+            RegrType::Intercept => {
+                let slope = cov_pop_x_y / var_pop_x;
+                // Only 0/1 point or slope is infinite
+                let nullif_cond = self.count <= 1 || var_pop_x == 0.0;
+                nullif_or_stat(nullif_cond, self.mean_y - slope * self.mean_x)
+            }
+            RegrType::Count => Ok(ScalarValue::Float64(Some(self.count as f64))),
+            RegrType::R2 => {
+                // Only 0/1 point or all x(or y) is the same
+                let nullif_cond = self.count <= 1 || var_pop_x == 0.0 || var_pop_y == 0.0;
+                nullif_or_stat(
+                    nullif_cond,
+                    (cov_pop_x_y * cov_pop_x_y) / (var_pop_x * var_pop_y),
+                )
+            }
+            RegrType::AvgX => nullif_or_stat(self.count < 1, self.mean_x),
+            RegrType::AvgY => nullif_or_stat(self.count < 1, self.mean_y),
+            RegrType::SXX => nullif_or_stat(self.count < 1, self.m2_x),
+            RegrType::SYY => nullif_or_stat(self.count < 1, self.m2_y),
+            RegrType::SXY => nullif_or_stat(self.count < 1, self.algo_const),
         }
     }
 

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -60,7 +60,7 @@ pub use crate::aggregate::grouping::Grouping;
 pub use crate::aggregate::median::Median;
 pub use crate::aggregate::min_max::{Max, Min};
 pub use crate::aggregate::min_max::{MaxAccumulator, MinAccumulator};
-pub use crate::aggregate::regr_slope::RegrSlope;
+pub use crate::aggregate::regr::Regr;
 pub use crate::aggregate::stats::StatsType;
 pub use crate::aggregate::stddev::{Stddev, StddevPop};
 pub use crate::aggregate::sum::Sum;

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -617,6 +617,14 @@ enum AggregateFunction {
   FIRST_VALUE_AGG = 24;
   LAST_VALUE_AGG = 25;
   REGR_SLOPE = 26;
+  REGR_INTERCEPT = 27;
+  REGR_COUNT = 28;
+  REGR_R2 = 29;
+  REGR_AVGX = 30;
+  REGR_AVGY = 31;
+  REGR_SXX = 32;
+  REGR_SYY = 33;
+  REGR_SXY = 34;
 }
 
 message AggregateExprNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -466,6 +466,14 @@ impl serde::Serialize for AggregateFunction {
             Self::FirstValueAgg => "FIRST_VALUE_AGG",
             Self::LastValueAgg => "LAST_VALUE_AGG",
             Self::RegrSlope => "REGR_SLOPE",
+            Self::RegrIntercept => "REGR_INTERCEPT",
+            Self::RegrCount => "REGR_COUNT",
+            Self::RegrR2 => "REGR_R2",
+            Self::RegrAvgx => "REGR_AVGX",
+            Self::RegrAvgy => "REGR_AVGY",
+            Self::RegrSxx => "REGR_SXX",
+            Self::RegrSyy => "REGR_SYY",
+            Self::RegrSxy => "REGR_SXY",
         };
         serializer.serialize_str(variant)
     }
@@ -504,6 +512,14 @@ impl<'de> serde::Deserialize<'de> for AggregateFunction {
             "FIRST_VALUE_AGG",
             "LAST_VALUE_AGG",
             "REGR_SLOPE",
+            "REGR_INTERCEPT",
+            "REGR_COUNT",
+            "REGR_R2",
+            "REGR_AVGX",
+            "REGR_AVGY",
+            "REGR_SXX",
+            "REGR_SYY",
+            "REGR_SXY",
         ];
 
         struct GeneratedVisitor;
@@ -573,6 +589,14 @@ impl<'de> serde::Deserialize<'de> for AggregateFunction {
                     "FIRST_VALUE_AGG" => Ok(AggregateFunction::FirstValueAgg),
                     "LAST_VALUE_AGG" => Ok(AggregateFunction::LastValueAgg),
                     "REGR_SLOPE" => Ok(AggregateFunction::RegrSlope),
+                    "REGR_INTERCEPT" => Ok(AggregateFunction::RegrIntercept),
+                    "REGR_COUNT" => Ok(AggregateFunction::RegrCount),
+                    "REGR_R2" => Ok(AggregateFunction::RegrR2),
+                    "REGR_AVGX" => Ok(AggregateFunction::RegrAvgx),
+                    "REGR_AVGY" => Ok(AggregateFunction::RegrAvgy),
+                    "REGR_SXX" => Ok(AggregateFunction::RegrSxx),
+                    "REGR_SYY" => Ok(AggregateFunction::RegrSyy),
+                    "REGR_SXY" => Ok(AggregateFunction::RegrSxy),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2587,6 +2587,14 @@ pub enum AggregateFunction {
     FirstValueAgg = 24,
     LastValueAgg = 25,
     RegrSlope = 26,
+    RegrIntercept = 27,
+    RegrCount = 28,
+    RegrR2 = 29,
+    RegrAvgx = 30,
+    RegrAvgy = 31,
+    RegrSxx = 32,
+    RegrSyy = 33,
+    RegrSxy = 34,
 }
 impl AggregateFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2624,6 +2632,14 @@ impl AggregateFunction {
             AggregateFunction::FirstValueAgg => "FIRST_VALUE_AGG",
             AggregateFunction::LastValueAgg => "LAST_VALUE_AGG",
             AggregateFunction::RegrSlope => "REGR_SLOPE",
+            AggregateFunction::RegrIntercept => "REGR_INTERCEPT",
+            AggregateFunction::RegrCount => "REGR_COUNT",
+            AggregateFunction::RegrR2 => "REGR_R2",
+            AggregateFunction::RegrAvgx => "REGR_AVGX",
+            AggregateFunction::RegrAvgy => "REGR_AVGY",
+            AggregateFunction::RegrSxx => "REGR_SXX",
+            AggregateFunction::RegrSyy => "REGR_SYY",
+            AggregateFunction::RegrSxy => "REGR_SXY",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2658,6 +2674,14 @@ impl AggregateFunction {
             "FIRST_VALUE_AGG" => Some(Self::FirstValueAgg),
             "LAST_VALUE_AGG" => Some(Self::LastValueAgg),
             "REGR_SLOPE" => Some(Self::RegrSlope),
+            "REGR_INTERCEPT" => Some(Self::RegrIntercept),
+            "REGR_COUNT" => Some(Self::RegrCount),
+            "REGR_R2" => Some(Self::RegrR2),
+            "REGR_AVGX" => Some(Self::RegrAvgx),
+            "REGR_AVGY" => Some(Self::RegrAvgy),
+            "REGR_SXX" => Some(Self::RegrSxx),
+            "REGR_SYY" => Some(Self::RegrSyy),
+            "REGR_SXY" => Some(Self::RegrSxy),
             _ => None,
         }
     }

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -552,6 +552,14 @@ impl From<protobuf::AggregateFunction> for AggregateFunction {
             protobuf::AggregateFunction::StddevPop => Self::StddevPop,
             protobuf::AggregateFunction::Correlation => Self::Correlation,
             protobuf::AggregateFunction::RegrSlope => Self::RegrSlope,
+            protobuf::AggregateFunction::RegrIntercept => Self::RegrIntercept,
+            protobuf::AggregateFunction::RegrCount => Self::RegrCount,
+            protobuf::AggregateFunction::RegrR2 => Self::RegrR2,
+            protobuf::AggregateFunction::RegrAvgx => Self::RegrAvgx,
+            protobuf::AggregateFunction::RegrAvgy => Self::RegrAvgy,
+            protobuf::AggregateFunction::RegrSxx => Self::RegrSXX,
+            protobuf::AggregateFunction::RegrSyy => Self::RegrSYY,
+            protobuf::AggregateFunction::RegrSxy => Self::RegrSXY,
             protobuf::AggregateFunction::ApproxPercentileCont => {
                 Self::ApproxPercentileCont
             }

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -385,6 +385,14 @@ impl From<&AggregateFunction> for protobuf::AggregateFunction {
             AggregateFunction::StddevPop => Self::StddevPop,
             AggregateFunction::Correlation => Self::Correlation,
             AggregateFunction::RegrSlope => Self::RegrSlope,
+            AggregateFunction::RegrIntercept => Self::RegrIntercept,
+            AggregateFunction::RegrCount => Self::RegrCount,
+            AggregateFunction::RegrR2 => Self::RegrR2,
+            AggregateFunction::RegrAvgx => Self::RegrAvgx,
+            AggregateFunction::RegrAvgy => Self::RegrAvgy,
+            AggregateFunction::RegrSXX => Self::RegrSxx,
+            AggregateFunction::RegrSYY => Self::RegrSyy,
+            AggregateFunction::RegrSXY => Self::RegrSxy,
             AggregateFunction::ApproxPercentileCont => Self::ApproxPercentileCont,
             AggregateFunction::ApproxPercentileContWithWeight => {
                 Self::ApproxPercentileContWithWeight
@@ -679,6 +687,18 @@ impl TryFrom<&Expr> for protobuf::LogicalExprNode {
                     AggregateFunction::RegrSlope => {
                         protobuf::AggregateFunction::RegrSlope
                     }
+                    AggregateFunction::RegrIntercept => {
+                        protobuf::AggregateFunction::RegrIntercept
+                    }
+                    AggregateFunction::RegrR2 => protobuf::AggregateFunction::RegrR2,
+                    AggregateFunction::RegrAvgx => protobuf::AggregateFunction::RegrAvgx,
+                    AggregateFunction::RegrAvgy => protobuf::AggregateFunction::RegrAvgy,
+                    AggregateFunction::RegrCount => {
+                        protobuf::AggregateFunction::RegrCount
+                    }
+                    AggregateFunction::RegrSXX => protobuf::AggregateFunction::RegrSxx,
+                    AggregateFunction::RegrSYY => protobuf::AggregateFunction::RegrSyy,
+                    AggregateFunction::RegrSXY => protobuf::AggregateFunction::RegrSxy,
                     AggregateFunction::ApproxMedian => {
                         protobuf::AggregateFunction::ApproxMedian
                     }

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -245,7 +245,15 @@ last_value(expression [ORDER BY expression])
 - [var](#var)
 - [var_pop](#var_pop)
 - [var_samp](#var_samp)
+- [regr_avgx](#regr_avgx)
+- [regr_avgy](#regr_avgy)
+- [regr_count](#regr_count)
+- [regr_intercept](#regr_intercept)
+- [regr_r2](#regr_r2)
 - [regr_slope](#regr_slope)
+- [regr_sxx](#regr_sxx)
+- [regr_syy](#regr_syy)
+- [regr_sxy](#regr_sxy)
 
 ### `corr`
 
@@ -396,9 +404,129 @@ regr_slope(expression1, expression2)
 
 #### Arguments
 
-- **expression1**: Expression to operate on.
+- **expression_y**: Expression to operate on.
   Can be a constant, column, or function, and any combination of arithmetic operators.
-- **expression2**: Expression to operate on.
+- **expression_x**: Expression to operate on.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_avgx`
+
+Computes the average of the independent variable (input) `expression_x` for the non-null paired data points.
+
+```
+regr_avgx(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_avgy`
+
+Computes the average of the dependent variable (output) `expression_y` for the non-null paired data points.
+
+```
+regr_avgy(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_count`
+
+Counts the number of non-null paired data points.
+
+```
+regr_count(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_intercept`
+
+Computes the y-intercept of the linear regression line. For the equation \(y = kx + b\), this function returns `b`.
+
+```
+regr_intercept(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_r2`
+
+Computes the square of the correlation coefficient between the independent and dependent variables.
+
+```
+regr_r2(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_sxx`
+
+Computes the sum of squares of the independent variable.
+
+```
+regr_sxx(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_syy`
+
+Computes the sum of squares of the dependent variable.
+
+```
+regr_syy(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+
+### `regr_sxy`
+
+Computes the sum of products of paired data points.
+
+```
+regr_sxy(expression_y, expression_x)
+```
+
+#### Arguments
+
+- **expression_y**: Dependent variable.
+  Can be a constant, column, or function, and any combination of arithmetic operators.
+- **expression_x**: Independent variable.
   Can be a constant, column, or function, and any combination of arithmetic operators.
 
 ## Approximate


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

NA

## Rationale for this change

A previous PR first implemented `regr_slope(y, x)` linear regression aggregate function https://github.com/apache/arrow-datafusion/pull/7135
This PR wants to extend the previous one to implement all PostgreSQL's linear regression aggregate functions like `regr_intercept(y, x)`
https://www.postgresql.org/docs/9.4/functions-aggregate.html
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Extend `RegrAccumulator` to support other `regr_*(y, x)` aggregate functions
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

All end-to-end tests have the same result compared to PostgreSQL
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->