### PR TITLE
Extend insert into support to include Json backed tables

### DIFF
--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -274,6 +274,12 @@ impl FileFormat for CsvFormat {
                 "Overwrites are not implemented yet for CSV".into(),
             ));
         }
+
+        if self.file_compression_type != FileCompressionType::UNCOMPRESSED{
+            return Err(DataFusionError::NotImplemented(
+                "Inserting compressed CSV is not implemented yet.".into()
+            ))
+        }
         let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(CsvSink::new(
             conf,

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -592,9 +592,9 @@ impl DataSink for CsvSink {
                 ))
             }
             FileWriterMode::PutMultipart => {
-                //currently assuming only 1 partition path (i.e. not hive style partitioning on a column)
+                // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)
                 let base_path = &self.config.table_paths[0];
-                //uniquely identify this batch of files with a random string, to prevent collisions overwriting files
+                // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
                 let write_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
                 for part_idx in 0..num_partitions {
                     let header = true;

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -36,9 +36,9 @@ use bytes::{Buf, Bytes};
 use futures::stream::BoxStream;
 use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
 use object_store::{delimited::newline_delimited_stream, ObjectMeta, ObjectStore};
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::AsyncWrite;
 
-use super::FileFormat;
+use super::{stateless_serialize_and_write_files, FileFormat};
 use crate::datasource::file_format::file_type::FileCompressionType;
 use crate::datasource::file_format::FileWriterMode;
 use crate::datasource::file_format::{
@@ -445,28 +445,6 @@ impl BatchSerializer for CsvSerializer {
     }
 }
 
-async fn check_for_errors<T, W: AsyncWrite + Unpin + Send>(
-    result: Result<T>,
-    writers: &mut [AbortableWrite<W>],
-) -> Result<T> {
-    match result {
-        Ok(value) => Ok(value),
-        Err(e) => {
-            // Abort all writers before returning the error:
-            for writer in writers {
-                let mut abort_future = writer.abort_writer();
-                if let Ok(abort_future) = &mut abort_future {
-                    let _ = abort_future.await;
-                }
-                // Ignore errors that occur during abortion,
-                // We do try to abort all writers before returning error.
-            }
-            // After aborting writers return original error.
-            Err(e)
-        }
-    }
-}
-
 /// Implements [`DataSink`] for writing to a CSV file.
 struct CsvSink {
     /// Config options for writing data
@@ -572,7 +550,7 @@ impl CsvSink {
 impl DataSink for CsvSink {
     async fn write_all(
         &self,
-        mut data: Vec<SendableRecordBatchStream>,
+        data: Vec<SendableRecordBatchStream>,
         context: &Arc<TaskContext>,
     ) -> Result<u64> {
         let num_partitions = data.len();
@@ -582,7 +560,7 @@ impl DataSink for CsvSink {
             .object_store(&self.config.object_store_url)?;
 
         // Construct serializer and writer for each file group
-        let mut serializers = vec![];
+        let mut serializers: Vec<Box<dyn BatchSerializer>> = vec![];
         let mut writers = vec![];
         match self.config.writer_mode {
             FileWriterMode::Append => {
@@ -596,7 +574,7 @@ impl DataSink for CsvSink {
                     let serializer = CsvSerializer::new()
                         .with_builder(builder)
                         .with_header(header);
-                    serializers.push(serializer);
+                    serializers.push(Box::new(serializer));
 
                     let file = file_group.clone();
                     let writer = self
@@ -624,7 +602,7 @@ impl DataSink for CsvSink {
                     let serializer = CsvSerializer::new()
                         .with_builder(builder)
                         .with_header(header);
-                    serializers.push(serializer);
+                    serializers.push(Box::new(serializer));
                     let file_path = base_path
                         .prefix()
                         .child(format!("/{}_{}.csv", write_id, part_idx));
@@ -642,39 +620,7 @@ impl DataSink for CsvSink {
             }
         }
 
-        let mut row_count = 0;
-        // Map errors to DatafusionError.
-        let err_converter =
-            |_| DataFusionError::Internal("Unexpected FileSink Error".to_string());
-        // TODO parallelize serialization accross partitions and batches within partitions
-        // see: https://github.com/apache/arrow-datafusion/issues/7079
-        for idx in 0..num_partitions {
-            while let Some(maybe_batch) = data[idx].next().await {
-                // Write data to files in a round robin fashion:
-                let serializer = &mut serializers[idx];
-                let batch = check_for_errors(maybe_batch, &mut writers).await?;
-                row_count += batch.num_rows();
-                let bytes =
-                    check_for_errors(serializer.serialize(batch).await, &mut writers)
-                        .await?;
-                let writer = &mut writers[idx];
-                check_for_errors(
-                    writer.write_all(&bytes).await.map_err(err_converter),
-                    &mut writers,
-                )
-                .await?;
-            }
-        }
-        // Perform cleanup:
-        let n_writers = writers.len();
-        for idx in 0..n_writers {
-            check_for_errors(
-                writers[idx].shutdown().await.map_err(err_converter),
-                &mut writers,
-            )
-            .await?;
-        }
-        Ok(row_count as u64)
+        stateless_serialize_and_write_files(data, serializers, writers).await
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -275,10 +275,10 @@ impl FileFormat for CsvFormat {
             ));
         }
 
-        if self.file_compression_type != FileCompressionType::UNCOMPRESSED{
+        if self.file_compression_type != FileCompressionType::UNCOMPRESSED {
             return Err(DataFusionError::NotImplemented(
-                "Inserting compressed CSV is not implemented yet.".into()
-            ))
+                "Inserting compressed CSV is not implemented yet.".into(),
+            ));
         }
         let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(CsvSink::new(

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -356,9 +356,9 @@ impl DataSink for JsonSink {
                 ))
             }
             FileWriterMode::PutMultipart => {
-                //currently assuming only 1 partition path (i.e. not hive style partitioning on a column)
+                // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)
                 let base_path = &self.config.table_paths[0];
-                //uniquely identify this batch of files with a random string, to prevent collisions overwriting files
+                // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
                 let write_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
                 for part_idx in 0..num_partitions {
                     let serializer = JsonSerializer::new();

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -39,7 +39,7 @@ use crate::arrow::datatypes::SchemaRef;
 use crate::datasource::physical_plan::{FileScanConfig, FileSinkConfig};
 use crate::error::Result;
 use crate::execution::context::SessionState;
-use crate::physical_plan::{ExecutionPlan, Statistics};
+use crate::physical_plan::{ExecutionPlan, SendableRecordBatchStream, Statistics};
 
 use arrow_array::RecordBatch;
 use datafusion_common::DataFusionError;
@@ -48,11 +48,11 @@ use datafusion_physical_expr::PhysicalExpr;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::ready;
 use futures::FutureExt;
+use futures::{ready, StreamExt};
 use object_store::path::Path;
 use object_store::{MultipartId, ObjectMeta, ObjectStore};
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 /// This trait abstracts all the file format specific implementations
 /// from the [`TableProvider`]. This helps code re-utilization across
 /// providers that support the the same file formats.
@@ -311,6 +311,73 @@ pub enum FileWriterMode {
 pub trait BatchSerializer: Unpin + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
     async fn serialize(&mut self, batch: RecordBatch) -> Result<Bytes>;
+}
+
+async fn check_for_errors<T, W: AsyncWrite + Unpin + Send>(
+    result: Result<T>,
+    writers: &mut [AbortableWrite<W>],
+) -> Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            // Abort all writers before returning the error:
+            for writer in writers {
+                let mut abort_future = writer.abort_writer();
+                if let Ok(abort_future) = &mut abort_future {
+                    let _ = abort_future.await;
+                }
+                // Ignore errors that occur during abortion,
+                // We do try to abort all writers before returning error.
+            }
+            // After aborting writers return original error.
+            Err(e)
+        }
+    }
+}
+
+/// Contains the common logic for serializing RecordBatches and
+/// writing the resulting bytes to an ObjectStore.
+/// Serialization is assumed to be stateless, i.e.
+/// each RecordBatch can be serialized without any
+/// dependency on the RecordBatches before or after.
+async fn stateless_serialize_and_write_files(
+    mut data: Vec<SendableRecordBatchStream>,
+    mut serializers: Vec<Box<dyn BatchSerializer>>,
+    mut writers: Vec<AbortableWrite<Box<dyn AsyncWrite + Send + Unpin>>>,
+) -> Result<u64> {
+    let num_partitions = data.len();
+    let mut row_count = 0;
+    // Map errors to DatafusionError.
+    let err_converter =
+        |_| DataFusionError::Internal("Unexpected FileSink Error".to_string());
+    // TODO parallelize serialization accross partitions and batches within partitions
+    // see: https://github.com/apache/arrow-datafusion/issues/7079
+    for idx in 0..num_partitions {
+        while let Some(maybe_batch) = data[idx].next().await {
+            // Write data to files in a round robin fashion:
+            let serializer = &mut serializers[idx];
+            let batch = check_for_errors(maybe_batch, &mut writers).await?;
+            row_count += batch.num_rows();
+            let bytes =
+                check_for_errors(serializer.serialize(batch).await, &mut writers).await?;
+            let writer = &mut writers[idx];
+            check_for_errors(
+                writer.write_all(&bytes).await.map_err(err_converter),
+                &mut writers,
+            )
+            .await?;
+        }
+    }
+    // Perform cleanup:
+    let n_writers = writers.len();
+    for idx in 0..n_writers {
+        check_for_errors(
+            writers[idx].shutdown().await.map_err(err_converter),
+            &mut writers,
+        )
+        .await?;
+    }
+    Ok(row_count as u64)
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -313,6 +313,8 @@ pub trait BatchSerializer: Unpin + Send {
     async fn serialize(&mut self, batch: RecordBatch) -> Result<Bytes>;
 }
 
+/// Checks if any of the passed writers have encountered an error
+/// and if so, all writers are aborted.
 async fn check_for_errors<T, W: AsyncWrite + Unpin + Send>(
     result: Result<T>,
     writers: &mut [AbortableWrite<W>],

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -805,6 +805,18 @@ impl TableProvider for ListingTable {
             );
         }
 
+        // Inserts currently make no effort to preserve sort_order. This could lead to
+        // incorrect query results on the table after inserting incorrectly sorted data.
+        let unsorted: Vec<Vec<Expr>> = vec![];
+        if self.options.file_sort_order != unsorted{
+            return Err(
+                DataFusionError::NotImplemented(
+                    "Writing to a sorted listing table via insert into is not supported yet. \
+                    To write to this table in the meantime, register an equivalent table with \
+                    file_sort_order = vec![]".into())
+            )
+        }
+
         let table_path = &self.table_paths()[0];
         // Get the object store for the table path.
         let store = state.runtime_env().object_store(table_path)?;
@@ -935,6 +947,7 @@ mod tests {
     use super::*;
     use crate::datasource::file_format::file_type::GetExt;
     use crate::datasource::{provider_as_source, MemTable};
+    use crate::execution::options::ArrowReadOptions;
     use crate::physical_plan::collect;
     use crate::prelude::*;
     use crate::{
@@ -1434,26 +1447,6 @@ mod tests {
         Ok(Arc::new(table))
     }
 
-    fn load_empty_schema_csv_table(
-        schema: SchemaRef,
-        temp_path: &str,
-        insert_mode: ListingTableInsertMode,
-    ) -> Result<Arc<dyn TableProvider>> {
-        File::create(temp_path)?;
-        let table_path = ListingTableUrl::parse(temp_path).unwrap();
-
-        let file_format = CsvFormat::default();
-        let listing_options =
-            ListingOptions::new(Arc::new(file_format)).with_insert_mode(insert_mode);
-
-        let config = ListingTableConfig::new(table_path)
-            .with_listing_options(listing_options)
-            .with_schema(schema);
-
-        let table = ListingTable::try_new(config)?;
-        Ok(Arc::new(table))
-    }
-
     /// Check that the files listed by the table match the specified `output_partitioning`
     /// when the object store contains `files`.
     async fn assert_list_files_for_scan_grouping(
@@ -1559,23 +1552,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_append_plan_to_external_table_stored_as_csv() -> Result<()> {
-        let file_type = FileType::CSV;
-        let file_compression_type = FileCompressionType::UNCOMPRESSED;
+    async fn test_insert_into_append_to_json_file() -> Result<()>{
+        helper_test_insert_into_append_to_existing_files(FileType::JSON, FileCompressionType::UNCOMPRESSED).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_append_new_json_files() -> Result<()>{
+        helper_test_append_new_files_to_table(FileType::JSON, FileCompressionType::UNCOMPRESSED).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_append_to_csv_file() -> Result<()>{
+        helper_test_insert_into_append_to_existing_files(FileType::CSV, FileCompressionType::UNCOMPRESSED).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_append_new_csv_files() -> Result<()>{
+        helper_test_append_new_files_to_table(FileType::CSV, FileCompressionType::UNCOMPRESSED).await?;
+        Ok(())
+    }
+
+    fn load_empty_schema_table(
+        schema: SchemaRef,
+        temp_path: &str,
+        insert_mode: ListingTableInsertMode,
+        file_format: Arc<dyn FileFormat>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        File::create(temp_path)?;
+        let table_path = ListingTableUrl::parse(temp_path).unwrap();
+
+        let listing_options =
+            ListingOptions::new(file_format.clone()).with_insert_mode(insert_mode);
+
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(listing_options)
+            .with_schema(schema);
+
+        let table = ListingTable::try_new(config)?;
+        Ok(Arc::new(table))
+    }
+
+    /// Logic of testing inserting into listing table by Appending to existing files
+    /// is the same for all formats/options which support this. This helper allows
+    /// passing different options to execute the same test with different settings.
+    async fn helper_test_insert_into_append_to_existing_files(
+            file_type: FileType, 
+            file_compression_type: FileCompressionType) -> Result<()> {
 
         // Create the initial context, schema, and batch.
         let session_ctx = SessionContext::new();
         // Create a new schema with one field called "a" of type Int32
         let schema = Arc::new(Schema::new(vec![Field::new(
             "column1",
-            DataType::Int32,
+            DataType::Float64,
             false,
         )]));
 
         // Create a new batch of data to insert into the table
         let batch = RecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3]))],
+            vec![Arc::new(arrow_array::Float64Array::from(vec![1.0, 2.0, 3.0]))],
         )?;
 
         // Filename with extension
@@ -1592,12 +1631,23 @@ mod tests {
 
         // Create a temporary directory and a CSV file within it.
         let tmp_dir = TempDir::new()?;
-        let path = tmp_dir.path().join(filename);
+        //let path = tmp_dir.path().join(filename);
+        let tmppath = format!("/home/dev/dftest/test_tmp_out/{filename}");
+        let path = std::path::Path::new(&tmppath);
 
-        let initial_table = load_empty_schema_csv_table(
+        let file_format: Arc<dyn FileFormat> = match file_type{
+            FileType::CSV => Arc::new(CsvFormat::default().with_file_compression_type(file_compression_type)),
+            FileType::JSON => Arc::new(JsonFormat::default().with_file_compression_type(file_compression_type)),
+            FileType::PARQUET => Arc::new(ParquetFormat::default()),
+            FileType::AVRO => Arc::new(AvroFormat::default()),
+            FileType::ARROW => Arc::new(ArrowFormat{}),
+        };
+
+        let initial_table = load_empty_schema_table(
             schema.clone(),
             path.to_str().unwrap(),
             ListingTableInsertMode::AppendToFile,
+            file_format,
         )?;
         session_ctx.register_table("t", initial_table)?;
         // Create and register the source table with the provided schema and inserted data
@@ -1632,31 +1682,24 @@ mod tests {
 
         // Assert that the batches read from the file match the expected result.
         assert_batches_eq!(expected, &res);
-        // Open the CSV file, read its contents as a record batch, and collect the batches into a vector.
-        let file = File::open(path.clone())?;
-        let reader = csv::ReaderBuilder::new(schema.clone())
-            .has_header(true)
-            .with_batch_size(batch_size)
-            .build(file)
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
-
-        let batches = reader
-            .collect::<Vec<ArrowResult<RecordBatch>>>()
-            .into_iter()
-            .collect::<ArrowResult<Vec<RecordBatch>>>()
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+        // Read the records in the table
+        let batches = session_ctx
+            .sql("select * from t")
+            .await?
+            .collect()
+            .await?;
 
         // Define the expected result as a vector of strings.
         let expected = vec![
             "+---------+",
             "| column1 |",
             "+---------+",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
             "+---------+",
         ];
 
@@ -1684,74 +1727,121 @@ mod tests {
         assert_batches_eq!(expected, &res);
 
         // Open the CSV file, read its contents as a record batch, and collect the batches into a vector.
-        let file = File::open(path.clone())?;
-        let reader = csv::ReaderBuilder::new(schema.clone())
-            .has_header(true)
-            .with_batch_size(batch_size)
-            .build(file)
-            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
-
-        let batches = reader
-            .collect::<Vec<ArrowResult<RecordBatch>>>()
-            .into_iter()
-            .collect::<ArrowResult<Vec<RecordBatch>>>()
-            .map_err(|e| DataFusionError::Internal(e.to_string()));
+        let batches = session_ctx
+            .sql("select * from t")
+            .await?
+            .collect()
+            .await?;
 
         // Define the expected result after the second append.
         let expected = vec![
             "+---------+",
             "| column1 |",
             "+---------+",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
-            "| 1       |",
-            "| 2       |",
-            "| 3       |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
+            "| 1.0     |",
+            "| 2.0     |",
+            "| 3.0     |",
             "+---------+",
         ];
 
         // Assert that the batches read from the file after the second append match the expected result.
-        assert_batches_eq!(expected, &batches?);
+        assert_batches_eq!(expected, &batches);
 
         // Return Ok if the function
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_append_new_files_to_csv_table() -> Result<()> {
+    async fn helper_test_append_new_files_to_table(
+        file_type: FileType, 
+        file_compression_type: FileCompressionType
+    ) -> Result<()> {
         // Create the initial context, schema, and batch.
         let session_ctx = SessionContext::new();
         // Create a new schema with one field called "a" of type Int32
         let schema = Arc::new(Schema::new(vec![Field::new(
             "column1",
-            DataType::Int32,
+            DataType::Float64,
             false,
         )]));
 
         // Create a new batch of data to insert into the table
         let batch = RecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3]))],
+            vec![Arc::new(arrow_array::Float64Array::from(vec![1.0, 2.0, 3.0]))],
         )?;
 
-        // Create a temporary directory and a CSV file within it.
+        // Register appropriate table depending on file_type we want to test
         let tmp_dir = TempDir::new()?;
-        session_ctx
-            .register_csv(
-                "t",
-                tmp_dir.path().to_str().unwrap(),
-                CsvReadOptions::new()
-                    .insert_mode(ListingTableInsertMode::AppendNewFiles)
-                    .schema(schema.as_ref()),
-            )
-            .await?;
+        match file_type{
+            FileType::CSV => {
+                session_ctx
+                .register_csv(
+                    "t",
+                    tmp_dir.path().to_str().unwrap(),
+                    CsvReadOptions::new()
+                        .insert_mode(ListingTableInsertMode::AppendNewFiles)
+                        .schema(schema.as_ref()),
+                )
+                .await?;
+                },
+            FileType::JSON => {
+                session_ctx
+                .register_json(
+                    "t",
+                    tmp_dir.path().to_str().unwrap(),
+                    NdJsonReadOptions::default()
+                        .insert_mode(ListingTableInsertMode::AppendNewFiles)
+                        .schema(schema.as_ref()),
+                )
+                .await?;
+                },
+            FileType::PARQUET => {
+                session_ctx
+                .register_parquet(
+                    "t",
+                    tmp_dir.path().to_str().unwrap(),
+                    ParquetReadOptions::default()
+                        // TODO implement insert_mode for parquet
+                        //.insert_mode(ListingTableInsertMode::AppendNewFiles)
+                        //.schema(schema.as_ref()),
+                )
+                .await?;
+                },
+            FileType::AVRO => {
+                session_ctx
+                .register_avro(
+                    "t",
+                    tmp_dir.path().to_str().unwrap(),
+                    AvroReadOptions::default()
+                        // TODO implement insert_mode for avro
+                        //.insert_mode(ListingTableInsertMode::AppendNewFiles)
+                        .schema(schema.as_ref()),
+                )
+                .await?;
+                },
+            FileType::ARROW => {
+                session_ctx
+                .register_arrow(
+                    "t",
+                    tmp_dir.path().to_str().unwrap(),
+                    ArrowReadOptions::default()
+                        // TODO implement insert_mode for arrow
+                        //.insert_mode(ListingTableInsertMode::AppendNewFiles)
+                        .schema(schema.as_ref()),
+                )
+                .await?;
+                },
+            }
+        
         // Create and register the source table with the provided schema and inserted data
         let source_table = Arc::new(MemTable::try_new(
             schema.clone(),

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1653,7 +1653,7 @@ mod tests {
                 JsonFormat::default().with_file_compression_type(file_compression_type),
             ),
             FileType::PARQUET => Arc::new(ParquetFormat::default()),
-            FileType::AVRO => Arc::new(AvroFormat::default()),
+            FileType::AVRO => Arc::new(AvroFormat {}),
             FileType::ARROW => Arc::new(ArrowFormat {}),
         };
 


### PR DESCRIPTION
## Which issue does this PR close?

None, but progresses towards the goals of #5076 and #7079. Follow on to #7141. 

## Rationale for this change

Adds support for `insert into <table>` for tables which are backed by Json files. 

## What changes are included in this PR?

- Implements `JsonSink `in similar fashion to `CsvSink`
- Minor refactor of `CsvSink` to support code reuse with `JsonSink`
- Generalized existing tests of `insert into` to be easily extensible for additional `FileFormats` and `options`
- Added test coverage for appending to existing Json files and appending new Json files to a `ListingTable`
- Added checks and throw error if attempting insert to sorted or compressed table since not implemented yet

## Are these changes tested?

Yes

## Are there any user-facing changes?

Insert into Json table will work now.