### PR TITLE
Add `Expr::field`, `Expr::index`, and `Expr::slice`, add docs

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -942,9 +942,10 @@ impl Expr {
     /// You can access column "my_field" with
     ///
     /// ```
-    /// # use datafusion_expr::{lit, col, Expr};
+    /// # use datafusion_expr::{col};
     /// let expr = col("c1")
     ///    .field("my_field");
+    /// assert_eq!(expr.display_name().unwrap(), "c1[my_field]");
     /// ```
     pub fn field(self, name: impl Into<String>) -> Self {
         Expr::GetIndexedField(GetIndexedField {
@@ -971,6 +972,7 @@ impl Expr {
     /// # use datafusion_expr::{lit, col, Expr};
     /// let expr = col("c1")
     ///    .index(lit(3));
+    /// assert_eq!(expr.display_name().unwrap(), "c1[Int32(3)]");
     /// ```
     pub fn index(self, key: Expr) -> Self {
         Expr::GetIndexedField(GetIndexedField {
@@ -979,10 +981,10 @@ impl Expr {
         })
     }
 
-    /// Return element at `1` based index field. Example
-    /// `expr["name"]`
+    /// Return elements between `1` based `start` and `stop`, for
+    /// example `expr[1:3]`
     ///
-    /// ## Example: Access element 2 from column "c1"
+    /// ## Example: Access element 2, 3, 4 from column "c1"
     ///
     /// For example if column "c1" holds documents like this
     ///
@@ -990,14 +992,15 @@ impl Expr {
     /// [10, 20, 30, 40]
     /// ```
     ///
-    /// You can access the value "[20, 30, 40]" with
+    /// You can access the value `[20, 30, 40]` with
     ///
     /// ```
-    /// # use datafusion_expr::{lit, col, Expr};
+    /// # use datafusion_expr::{lit, col};
     /// let expr = col("c1")
-    ///    .slice(lit(30));
+    ///    .range(lit(2), lit(4));
+    /// assert_eq!(expr.display_name().unwrap(), "c1[Int32(2):Int32(4)]");
     /// ```
-    pub fn slice(self, start: Expr, stop: Expr) -> Self {
+    pub fn range(self, start: Expr, stop: Expr) -> Self {
         Expr::GetIndexedField(GetIndexedField {
             expr: Box::new(self),
             field: GetFieldAccess::ListRange {

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -116,7 +116,7 @@ pub enum Expr {
     /// arithmetic negation of an expression, the operand must be of a signed numeric data type
     Negative(Box<Expr>),
     /// Returns the field of a [`arrow::array::ListArray`] or
-    /// [`arrow::array::StructArray`] by key or key range
+    /// [`arrow::array::StructArray`] by index or range
     GetIndexedField(GetIndexedField),
     /// Whether an expression is between a given range.
     Between(Between),
@@ -362,7 +362,7 @@ impl ScalarUDF {
 /// Access a sub field of a nested type, such as `Field` or `List`
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum GetFieldAccess {
-    /// Named field, For example `struct["name"]`
+    /// Named field, for example `struct["name"]`
     NamedStructField { name: ScalarValue },
     /// Single list index, for example: `list[i]`
     ListIndex { key: Box<Expr> },

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -17,9 +17,9 @@
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{
-    Column, DFField, DFSchema, DataFusionError, Result, ScalarValue, TableReference,
+    Column, DFField, DFSchema, DataFusionError, Result, TableReference,
 };
-use datafusion_expr::{Case, Expr, GetFieldAccess, GetIndexedField};
+use datafusion_expr::{Case, Expr};
 use sqlparser::ast::{Expr as SQLExpr, Ident};
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
@@ -136,12 +136,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         )));
                     }
                     let nested_name = nested_names[0].to_string();
-                    Ok(Expr::GetIndexedField(GetIndexedField::new(
-                        Box::new(Expr::Column(field.qualified_column())),
-                        GetFieldAccess::NamedStructField {
-                            name: ScalarValue::Utf8(Some(nested_name)),
-                        },
-                    )))
+                    Ok(Expr::Column(field.qualified_column()).field(nested_name))
                 }
                 // found matching field with no spare identifier(s)
                 Some((field, _nested_names)) => {


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/7193
Follows https://github.com/apache/arrow-datafusion/pull/7215 from @izveigor 

## Rationale for this change
In order to have a good experience accessing fields, it should be easy to create field / lists accesses

## What changes are included in this PR?

See subject
## Are these changes tested?
Yes -- with doc tests 
## Are there any user-facing changes?
New methods on `Expr`