### PR TITLE
Minor: rename `GetFieldAccessCharacteristic` and add docs

### DIFF
--- a/datafusion/expr/src/field_util.rs
+++ b/datafusion/expr/src/field_util.rs
@@ -20,64 +20,65 @@
 use arrow::datatypes::{DataType, Field};
 use datafusion_common::{plan_err, DataFusionError, Result, ScalarValue};
 
-pub enum GetFieldAccessCharacteristic {
-    /// returns the field `struct[field]`. For example `struct["name"]`
+/// Types of the field access expression of a nested type, such as `Field` or `List`
+pub enum GetFieldAccessSchema {
+    /// Named field, For example `struct["name"]`
     NamedStructField { name: ScalarValue },
-    /// single list index
-    // list[i]
+    /// Single list index, for example: `list[i]`
     ListIndex { key_dt: DataType },
-    /// list range `list[i:j]`
+    /// List range, for example `list[i:j]`
     ListRange {
         start_dt: DataType,
         stop_dt: DataType,
     },
 }
 
-/// Returns the field access indexed by `key` and/or `extra_key` from a [`DataType::List`] or [`DataType::Struct`]
-/// # Error
-/// Errors if
-/// * the `data_type` is not a Struct or a List,
-/// * the `data_type` of extra key does not match with `data_type` of key
-/// * there is no field key is not of the required index type
-pub fn get_indexed_field(
-    data_type: &DataType,
-    field_characteristic: &GetFieldAccessCharacteristic,
-) -> Result<Field> {
-    match field_characteristic {
-        GetFieldAccessCharacteristic::NamedStructField{ name } => {
-            match (data_type, name) {
-                (DataType::Struct(fields), ScalarValue::Utf8(Some(s))) => {
-                    if s.is_empty() {
-                        plan_err!(
-                            "Struct based indexed access requires a non empty string"
-                        )
-                    } else {
-                        let field = fields.iter().find(|f| f.name() == s);
-                        field.ok_or(DataFusionError::Plan(format!("Field {s} not found in struct"))).map(|f| f.as_ref().clone())
+impl GetFieldAccessSchema {
+    /// Returns the schema [`Field`] from a [`DataType::List`] or
+    /// [`DataType::Struct`] indexed by this structure
+    ///
+    /// # Error
+    /// Errors if
+    /// * the `data_type` is not a Struct or a List,
+    /// * the `data_type` of extra key does not match with `data_type` of key
+    /// * there is no field key is not of the required index type
+    pub fn get_accessed_field(&self, data_type: &DataType) -> Result<Field> {
+        match self {
+            Self::NamedStructField{ name } => {
+                match (data_type, name) {
+                    (DataType::Struct(fields), ScalarValue::Utf8(Some(s))) => {
+                        if s.is_empty() {
+                            plan_err!(
+                                "Struct based indexed access requires a non empty string"
+                            )
+                        } else {
+                            let field = fields.iter().find(|f| f.name() == s);
+                            field.ok_or(DataFusionError::Plan(format!("Field {s} not found in struct"))).map(|f| f.as_ref().clone())
+                        }
                     }
+                    (DataType::Struct(_), _) => plan_err!(
+                        "Only utf8 strings are valid as an indexed field in a struct"
+                    ),
+                    (other, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
                 }
-                (DataType::Struct(_), _) => plan_err!(
-                    "Only utf8 strings are valid as an indexed field in a struct"
-                ),
-                (other, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
             }
-        }
-        GetFieldAccessCharacteristic::ListIndex{ key_dt } => {
-            match (data_type, key_dt) {
-                (DataType::List(lt), DataType::Int64) => Ok(Field::new("list", lt.data_type().clone(), true)),
-                (DataType::List(_), _) => plan_err!(
-                    "Only ints are valid as an indexed field in a list"
-                ),
-                (other, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
+            Self::ListIndex{ key_dt } => {
+                match (data_type, key_dt) {
+                    (DataType::List(lt), DataType::Int64) => Ok(Field::new("list", lt.data_type().clone(), true)),
+                    (DataType::List(_), _) => plan_err!(
+                        "Only ints are valid as an indexed field in a list"
+                    ),
+                    (other, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
+                }
             }
-        }
-        GetFieldAccessCharacteristic::ListRange{ start_dt, stop_dt } => {
-            match (data_type, start_dt, stop_dt) {
-                (DataType::List(_), DataType::Int64, DataType::Int64) => Ok(Field::new("list", data_type.clone(), true)),
-                (DataType::List(_), _, _) => plan_err!(
-                    "Only ints are valid as an indexed field in a list"
-                ),
-                (other, _, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
+            Self::ListRange{ start_dt, stop_dt } => {
+                match (data_type, start_dt, stop_dt) {
+                    (DataType::List(_), DataType::Int64, DataType::Int64) => Ok(Field::new("list", data_type.clone(), true)),
+                    (DataType::List(_), _, _) => plan_err!(
+                        "Only ints are valid as an indexed field in a list"
+                    ),
+                    (other, _, _) => plan_err!("The expression to get an indexed field is only valid for `List` or `Struct` types, got {other}"),
+                }
             }
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/7193
Follows https://github.com/apache/arrow-datafusion/pull/7215 from @izveigor 

## Rationale for this change
In order to have a good experience accessing fields, it should be easy to use the code that manipulates them


## What changes are included in this PR?

1. Rename `GetFieldAccessCharacteristic` to `GetFieldAccessSchema` to better reflect what it does
2. move the calculation into  `GetFieldAccessSchema::get_accessed_field` 
3. Reduce duplication

## Are these changes tested?
Covered by existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No, these are unreleased APIs (added in https://github.com/apache/arrow-datafusion/pull/7215)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->