### PR TITLE
fix: typo in substrait

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -471,7 +471,7 @@ pub fn operator_to_name(op: Operator) -> &'static str {
         Operator::Gt => "gt",
         Operator::GtEq => "gte",
         Operator::Plus => "add",
-        Operator::Minus => "substract",
+        Operator::Minus => "subtract",
         Operator::Multiply => "multiply",
         Operator::Divide => "divide",
         Operator::Modulo => "mod",

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -411,6 +411,21 @@ async fn roundtrip_outer_join() -> Result<()> {
 }
 
 #[tokio::test]
+async fn roundtrip_arithmetic_ops() -> Result<()> {
+    roundtrip("SELECT a - a FROM data").await?;
+    roundtrip("SELECT a + a FROM data").await?;
+    roundtrip("SELECT a * a FROM data").await?;
+    roundtrip("SELECT a / a FROM data").await?;
+    roundtrip("SELECT a = a FROM data").await?;
+    roundtrip("SELECT a != a FROM data").await?;
+    roundtrip("SELECT a > a FROM data").await?;
+    roundtrip("SELECT a >= a FROM data").await?;
+    roundtrip("SELECT a < a FROM data").await?;
+    roundtrip("SELECT a <= a FROM data").await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn roundtrip_like() -> Result<()> {
     roundtrip("SELECT f FROM data WHERE f LIKE 'a%b'").await
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Try to encode `-` in substrait will report an error that "substract" is not supported

```
 170   │ 2023-08-08T03:52:46.109050Z  WARN servers::mysql::server: Internal error occurred during query exec, server actively close the channel to let client try next time: Failed to collect recordbatch, source: Failed to poll stream, source: External error: External er
       │ ror, source: Failed to request remote peer, source: Failed to do Flight get, code: Internal error, source: This feature is not implemented: Unsupported function name: "substract".
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Correct typo "substract" to "subtract" 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes
## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->