### PR TITLE
Test with 0.6.3-alpha of `zerocopy` (DO NOT MERGE)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ opt-level = 3
 overflow-checks = false
 panic = 'unwind'
 rpath = false
+
+[patch.crates-io]
+zerocopy = { git = "https://github.com/alamb/zerocopy.git", branch = "alamb/v0.6.3-test" }


### PR DESCRIPTION
This is a pre-release test of `zerocopy` `0.6.3`, as requested by @joshlf  in  https://github.com/google/zerocopy/issues/228#issuecomment-1668577806

Related to https://github.com/apache/arrow-datafusion/issues/7221

To test I forked the proposed `0.6.3` version of`zerocopy` and set the version to 0.6.3 on this branch: https://github.com/alamb/zerocopy/tree/alamb/v0.6.3-test

(BTW if anyone has a better way to test such a pre-release I would love to know - since DataFusion doesn't have a direct dependecy on `zerocopy` I couldn't figure out anywhere I could tell cargo to use `0.6.3-alpha` instead of `0.6.0`