### PR TITLE
[Minor], Bug Fix: Add empty ordering check at the source.

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -960,7 +960,7 @@ fn get_projected_output_ordering(
             break;
         }
         // do not push empty entries
-        // otherwise we will have Some(vec![]) output ordering.
+        // otherwise we may have `Some(vec![])` at the output ordering.
         if !new_ordering.is_empty() {
             all_orderings.push(new_ordering);
         }

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -959,7 +959,11 @@ fn get_projected_output_ordering(
             // since rest of the orderings are violated
             break;
         }
-        all_orderings.push(new_ordering);
+        // do not push empty entries
+        // otherwise we will have Some(vec![]) output ordering.
+        if !new_ordering.is_empty() {
+            all_orderings.push(new_ordering);
+        }
     }
     all_orderings
 }

--- a/datafusion/core/tests/sqllogictests/test_files/groupby.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/groupby.slt
@@ -3459,3 +3459,14 @@ AggregateExec: mode=Final, gby=[], aggr=[FIRST_VALUE(foo.x)]
 --CoalescePartitionsExec
 ----AggregateExec: mode=Partial, gby=[], aggr=[FIRST_VALUE(foo.x)]
 ------MemoryExec: partitions=8, partition_sizes=[1, 0, 0, 0, 0, 0, 0, 0]
+
+
+query TT
+EXPLAIN SELECT c
+FROM multiple_ordered_table
+ORDER BY c ASC;
+----
+logical_plan
+Sort: multiple_ordered_table.c ASC NULLS LAST
+--TableScan: multiple_ordered_table projection=[c]
+physical_plan CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[c], output_ordering=[c@0 ASC NULLS LAST], has_header=true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
At the projection of the source, we keep track of ordering as long as they are used in the query.
Consider table below
```sql
CREATE EXTERNAL TABLE multiple_ordered_table (
  a0 INTEGER,
  a INTEGER,
  b INTEGER,
  c INTEGER,
  d INTEGER
)
STORED AS CSV
WITH HEADER ROW
WITH ORDER (a ASC, b ASC)
WITH ORDER (c ASC)
LOCATION 'tests/data/window_2.csv';
```

which satisfies ordering `a ASC, b ASC` and `c ASC`.
If we run the query below on this table.
```sql
SELECT c
FROM multiple_ordered_table
ORDER BY c ASC;
```
since, only column `c` is used. We will not keep track of ordering `a ASC, b ASC`. However, during projection of orderings
empty vectors are still added to output ordering. Since, first entry in among alternative orderings is output_ordering. Output ordering of the `CsvExec` is empty. 
In this PR, we add emptiness check, with this check we no longer store empty orderings(after projection) at the source. After this PR output ordering of the `CsvExec` is no longer empty.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, new tests are added.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->