### PR TITLE
Minor: Remove [[example]] table from datafusion-examples/Cargo.toml

### DIFF
--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -29,11 +29,6 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 
-[[example]]
-name = "avro_sql"
-path = "examples/avro_sql.rs"
-required-features = ["datafusion/avro"]
-
 [dev-dependencies]
 arrow = { workspace = true }
 arrow-flight = { workspace = true }


### PR DESCRIPTION
Closes #.

## Rationale for this change
In `datafusion-examples/Cargo.toml`, `[[example]]` tables are defined like as follows.

```
[[example]]
name = "avro_sql"
path = "examples/avro_sql.rs"
required-features = ["datafusion/avro"]
```

But `avro_sql.rs` is in `examples`, we don't need to have `[[example]]` table for `avro_sql`.

## What changes are included in this PR?
Remove the `[[example]]` table from the `Cargo.toml`.

## Are these changes tested?
I confirmed `avro_sql` still work even after this change with `cargo run --example avro_sql --features datafusion/avro`

## Are there any user-facing changes?
No.