### PR TITLE
Deprecate `batch_byte_size`

### DIFF
--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -131,7 +131,11 @@ pub fn compute_record_batch_statistics(
 ) -> Statistics {
     let nb_rows = batches.iter().flatten().map(RecordBatch::num_rows).sum();
 
-    let total_byte_size = batches.iter().flatten().map(batch_byte_size).sum();
+    let total_byte_size = batches
+        .iter()
+        .flatten()
+        .map(|b| b.get_array_memory_size())
+        .sum();
 
     let projection = match projection {
         Some(p) => p,
@@ -340,7 +344,7 @@ impl IPCWriter {
         self.writer.write(batch)?;
         self.num_batches += 1;
         self.num_rows += batch.num_rows() as u64;
-        let num_bytes: usize = batch_byte_size(batch);
+        let num_bytes: usize = batch.get_array_memory_size();
         self.num_bytes += num_bytes as u64;
         Ok(())
     }
@@ -357,12 +361,9 @@ impl IPCWriter {
 }
 
 /// Returns the total number of bytes of memory occupied physically by this batch.
+#[deprecated(since = "28.0.0", note = "RecordBatch::get_array_memory_size")]
 pub fn batch_byte_size(batch: &RecordBatch) -> usize {
-    batch
-        .columns()
-        .iter()
-        .map(|array| array.get_array_memory_size())
-        .sum()
+    batch.get_array_memory_size()
 }
 
 #[cfg(test)]

--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -19,7 +19,7 @@
 //! It will do in-memory sorting if it has enough memory budget
 //! but spills to disk if needed.
 
-use crate::physical_plan::common::{batch_byte_size, spawn_buffered, IPCWriter};
+use crate::physical_plan::common::{spawn_buffered, IPCWriter};
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
@@ -258,7 +258,7 @@ impl ExternalSorter {
             return Ok(());
         }
 
-        let size = batch_byte_size(&input);
+        let size = input.get_array_memory_size();
         if self.reservation.try_grow(size).is_err() {
             let before = self.reservation.size();
             self.in_mem_sort().await?;


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/5885

## Rationale for this change

Suggested by @yjshen in https://github.com/apache/arrow-datafusion/pull/7130#discussion_r1287837220

`batch_byte_size` has been ported upstream and is now available as [`RecordBatch::get_array_memory_size`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html#method.get_array_memory_size)


## What changes are included in this PR?

Changes
1. deprecate batch_byte_size
2. Update to use `RecordBatch::get_array_memory_size` instead

## Are these changes tested?
Yes, by clippy CI check

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
A deprecated function telling them what to change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->