### PR TITLE
feat: Add support for PostgreSQL bitwise XOR operator

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -1032,6 +1032,31 @@ select a ^ b, c ^ d, e ^ f from signed_integers;
 -998 -133 -16
 NULL NULL NULL
 
+statement ok
+set datafusion.sql_parser.dialect = postgresql;
+
+# postgresql bitwise xor with column and scalar
+query I rowsort
+select c#856 from signed_integers;
+----
+-138
+-367
+803
+NULL
+
+# postgresql bitwise xor with columns
+query III rowsort
+select a#b, c#d, e#f from signed_integers;
+----
+-10003 -3026 -10
+-101 -1591 -10
+-998 -133 -16
+NULL NULL NULL
+
+statement ok
+set datafusion.sql_parser.dialect = generic;
+
+
 ## bitwise right shift
 
 # bitwise right shift with column and scalar

--- a/datafusion/core/tests/sqllogictests/test_files/scalar.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/scalar.slt
@@ -1032,12 +1032,21 @@ select a ^ b, c ^ d, e ^ f from signed_integers;
 -998 -133 -16
 NULL NULL NULL
 
+# bitwise xor with other operators
+query II rowsort
+select 2 * c - 1 ^ 856 + d + 3, d ^ 7 >> 4 from signed_integers;
+----
+-3328 128
+-822 64
+686 -16
+NULL -32
+
 statement ok
 set datafusion.sql_parser.dialect = postgresql;
 
 # postgresql bitwise xor with column and scalar
 query I rowsort
-select c#856 from signed_integers;
+select c # 856 from signed_integers;
 ----
 -138
 -367
@@ -1046,12 +1055,21 @@ NULL
 
 # postgresql bitwise xor with columns
 query III rowsort
-select a#b, c#d, e#f from signed_integers;
+select a # b, c # d, e # f from signed_integers;
 ----
 -10003 -3026 -10
 -101 -1591 -10
 -998 -133 -16
 NULL NULL NULL
+
+# postgresql bitwise xor with other operators
+query II rowsort
+select 2 * c - 1 # 856 + d + 3, d # 7 >> 4 from signed_integers;
+----
+-3328 128
+-822 64
+686 -16
+NULL -32
 
 statement ok
 set datafusion.sql_parser.dialect = generic;

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -69,7 +69,7 @@ pub enum Operator {
     BitwiseAnd,
     /// Bitwise or, like `|`
     BitwiseOr,
-    /// Bitwise xor, like `#`
+    /// Bitwise xor, such as `^` or `#` in PostgreSQL
     BitwiseXor,
     /// Bitwise right, like `>>`
     BitwiseShiftRight,
@@ -253,7 +253,7 @@ impl fmt::Display for Operator {
             Operator::IsNotDistinctFrom => "IS NOT DISTINCT FROM",
             Operator::BitwiseAnd => "&",
             Operator::BitwiseOr => "|",
-            Operator::BitwiseXor => "#",
+            Operator::BitwiseXor => "BIT_XOR",
             Operator::BitwiseShiftRight => ">>",
             Operator::BitwiseShiftLeft => "<<",
             Operator::StringConcat => "||",
@@ -443,7 +443,7 @@ mod tests {
         // BitXor
         assert_eq!(
             format!("{}", lit(1u32) ^ lit(2u32)),
-            "UInt32(1) # UInt32(2)"
+            "UInt32(1) BIT_XOR UInt32(2)"
         );
         // Shl
         assert_eq!(

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -69,7 +69,7 @@ pub enum Operator {
     BitwiseAnd,
     /// Bitwise or, like `|`
     BitwiseOr,
-    /// Bitwise xor, such as `^` or `#` in PostgreSQL
+    /// Bitwise xor, such as `^` in MySQL or `#` in PostgreSQL
     BitwiseXor,
     /// Bitwise right, like `>>`
     BitwiseShiftRight,

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -43,6 +43,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             BinaryOperator::BitwiseAnd => Ok(Operator::BitwiseAnd),
             BinaryOperator::BitwiseOr => Ok(Operator::BitwiseOr),
             BinaryOperator::BitwiseXor => Ok(Operator::BitwiseXor),
+            BinaryOperator::PGBitwiseXor => Ok(Operator::BitwiseXor),
             BinaryOperator::PGBitwiseShiftRight => Ok(Operator::BitwiseShiftRight),
             BinaryOperator::PGBitwiseShiftLeft => Ok(Operator::BitwiseShiftLeft),
             BinaryOperator::StringConcat => Ok(Operator::StringConcat),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7255.

## Rationale for this change

`'#'` is PostgreSQL-specific bitwise XOR  operator,  which is not supported in Datafusion.
```sh
DataFusion CLI v28.0.0
❯  set datafusion.sql_parser.dialect = postgresql;
0 rows in set. Query took 0.002 seconds.

❯ select 17#5;
This feature is not implemented: Unsupported SQL binary operator PGBitwiseXor
```

## What changes are included in this PR?
-  Add support for PostgreSQL bitwise XOR operator.
- Unify the display name of bitwise XOR operator.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes
## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->