### PR TITLE
pushdown projection handle empty projections

### DIFF
--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -291,9 +291,13 @@ impl Optimizer {
                 let result = self.optimize_recursively(rule, &new_plan, config);
 
                 match result {
-                    Ok(Some(plan)) => {
-                        assert_schema_is_the_same(rule.name(), &new_plan, &plan)?;
-                        new_plan = plan;
+                    Ok(Some(optimized_plan)) => {
+                        assert_schema_is_the_same(
+                            rule.name(),
+                            &new_plan,
+                            &optimized_plan,
+                        )?;
+                        new_plan = optimized_plan;
                         observer(&new_plan, rule.as_ref());
                         log_plan(rule.name(), &new_plan);
                     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7241.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It is possible to select no columns at all when using `exclude`. In such cases the `push_down_projection` rule will alter the schema  which will then blow up in the optimizer as rules are not suppose to change the plan's schema. 

I can't tell if empty selection is even legit.. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Both empty projection and empty projection with filter has been tweaked to do not alter the original schema.

## Are these changes tested?
Yeah
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No