### PR TITLE
Adding order equivalence support on MemoryExec

### DIFF
--- a/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
+++ b/datafusion/core/src/physical_plan/joins/symmetric_hash_join.rs
@@ -1520,8 +1520,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -1595,8 +1595,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -1658,7 +1658,8 @@ mod tests {
             build_sides_record_batches(TABLE_SIZE, cardinality)?;
         let left_schema = &left_batch.schema();
         let right_schema = &right_batch.schema();
-        let (left, right) = create_memory_table(left_batch, right_batch, None, None, 13)?;
+        let (left, right) =
+            create_memory_table(left_batch, right_batch, vec![], vec![], 13)?;
 
         let on = vec![(
             Column::new_with_schema("lc1", left_schema)?,
@@ -1709,7 +1710,8 @@ mod tests {
         let (left_batch, right_batch) = build_sides_record_batches(TABLE_SIZE, (11, 21))?;
         let left_schema = &left_batch.schema();
         let right_schema = &right_batch.schema();
-        let (left, right) = create_memory_table(left_batch, right_batch, None, None, 13)?;
+        let (left, right) =
+            create_memory_table(left_batch, right_batch, vec![], vec![], 13)?;
 
         let on = vec![(
             Column::new_with_schema("lc1", left_schema)?,
@@ -1764,8 +1766,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -1828,8 +1830,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -1891,8 +1893,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -1955,8 +1957,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -2015,8 +2017,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 
@@ -2097,8 +2099,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             10,
         )?;
 
@@ -2226,8 +2228,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
         let intermediate_schema = Schema::new(vec![
@@ -2310,8 +2312,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
         let intermediate_schema = Schema::new(vec![
@@ -2379,8 +2381,8 @@ mod tests {
         let (left, right) = create_memory_table(
             left_batch,
             right_batch,
-            Some(left_sorted),
-            Some(right_sorted),
+            vec![left_sorted],
+            vec![right_sorted],
             13,
         )?;
 

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -173,7 +173,24 @@ impl MemoryExec {
         })
     }
 
-    /// Set sort information
+    /// A memory table can be ordered by multiple expressions simultaneously.
+    /// `OrderingEquivalenceProperties` keeps track of expressions that describe the
+    /// global ordering of the schema. These columns are not necessarily same; e.g.
+    /// ```text
+    /// ┌-------┐
+    /// | a | b |
+    /// |---|---|
+    /// | 1 | 9 |
+    /// | 2 | 8 |
+    /// | 3 | 7 |
+    /// | 5 | 5 |
+    /// └---┴---┘
+    /// ```
+    /// where both `a ASC` and `b DESC` can describe the table ordering. With
+    /// `OrderingEquivalenceProperties`, we can keep track of these equivalences
+    /// and treat `a ASC` and `b DESC` as the same ordering requirement
+    /// by outputting the `a ASC` from output_ordering API
+    /// and add `b DESC` into `OrderingEquivalenceProperties`
     pub fn with_sort_information(mut self, sort_information: Vec<LexOrdering>) -> Self {
         self.sort_information = sort_information;
         self

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -46,7 +46,7 @@ pub struct MemoryExec {
     projected_schema: SchemaRef,
     /// Optional projection
     projection: Option<Vec<usize>>,
-    // Optional sort information
+    // Sort information, including order equivalence
     sort_information: Vec<LexOrdering>,
 }
 

--- a/datafusion/core/src/physical_plan/memory.rs
+++ b/datafusion/core/src/physical_plan/memory.rs
@@ -46,7 +46,7 @@ pub struct MemoryExec {
     projected_schema: SchemaRef,
     /// Optional projection
     projection: Option<Vec<usize>>,
-    // Sort information, including order equivalence
+    // Sort information: one or more equivalent orderings
     sort_information: Vec<LexOrdering>,
 }
 

--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -94,7 +94,7 @@ async fn run_aggregate_test(input1: Vec<RecordBatch>, group_by_columns: Vec<&str
     let running_source = Arc::new(
         MemoryExec::try_new(&[input1.clone()], schema.clone(), None)
             .unwrap()
-            .with_sort_information(sort_keys),
+            .with_sort_information(vec![sort_keys]),
     );
 
     let aggregate_expr = vec![Arc::new(Sum::new(

--- a/datafusion/core/tests/fuzz_cases/sort_preserving_repartition_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_preserving_repartition_fuzz.rs
@@ -107,7 +107,7 @@ mod sp_repartition_fuzz_tests {
         let running_source = Arc::new(
             MemoryExec::try_new(&[input1.clone()], schema.clone(), None)
                 .unwrap()
-                .with_sort_information(sort_keys.clone()),
+                .with_sort_information(vec![sort_keys.clone()]),
         );
         let hash_exprs = vec![col("c", &schema).unwrap()];
 

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -432,7 +432,7 @@ async fn run_window_test(
     ];
     let memory_exec =
         MemoryExec::try_new(&[vec![concat_input_record]], schema.clone(), None).unwrap();
-    let memory_exec = memory_exec.with_sort_information(source_sort_keys.clone());
+    let memory_exec = memory_exec.with_sort_information(vec![source_sort_keys.clone()]);
     let mut exec1 = Arc::new(memory_exec) as Arc<dyn ExecutionPlan>;
     // Table is ordered according to ORDER BY a, b, c In linear test we use PARTITION BY b, ORDER BY a
     // For WindowAggExec  to produce correct result it need table to be ordered by b,a. Hence add a sort.
@@ -460,7 +460,7 @@ async fn run_window_test(
     let exec2 = Arc::new(
         MemoryExec::try_new(&[input1.clone()], schema.clone(), None)
             .unwrap()
-            .with_sort_information(source_sort_keys.clone()),
+            .with_sort_information(vec![source_sort_keys.clone()]),
     );
     let running_window_exec = Arc::new(
         BoundedWindowAggExec::try_new(

--- a/datafusion/core/tests/memory_limit.rs
+++ b/datafusion/core/tests/memory_limit.rs
@@ -27,7 +27,7 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion_expr::{Expr, TableType};
-use datafusion_physical_expr::PhysicalSortExpr;
+use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 use futures::StreamExt;
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
@@ -515,7 +515,7 @@ impl Scenario {
                     descending: false,
                     nulls_first: false,
                 };
-                let sort_information = vec![
+                let sort_information = vec![vec![
                     PhysicalSortExpr {
                         expr: col("a", &schema).unwrap(),
                         options,
@@ -524,7 +524,7 @@ impl Scenario {
                         expr: col("b", &schema).unwrap(),
                         options,
                     },
-                ];
+                ]];
 
                 let table = SortedTableProvider::new(batches, sort_information);
                 Arc::new(table)
@@ -637,14 +637,11 @@ impl PartitionStream for DummyStreamPartition {
 struct SortedTableProvider {
     schema: SchemaRef,
     batches: Vec<Vec<RecordBatch>>,
-    sort_information: Vec<PhysicalSortExpr>,
+    sort_information: Vec<LexOrdering>,
 }
 
 impl SortedTableProvider {
-    fn new(
-        batches: Vec<Vec<RecordBatch>>,
-        sort_information: Vec<PhysicalSortExpr>,
-    ) -> Self {
+    fn new(batches: Vec<Vec<RecordBatch>>, sort_information: Vec<LexOrdering>) -> Self {
         let schema = batches[0][0].schema();
         Self {
             schema,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Currently, MemoryExec does not accept multi-globally ordered expressions, unlike the external tables with multiple WITH ORDER. This PR adds it, just like the external tables. 

## What changes are included in this PR?

MemoryExec API is changed.

## Are these changes tested?

Yes

## Are there any user-facing changes?

Not currently.