### PR TITLE
fix(functions): support `Dictionary` for string and int functions

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/functions.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/functions.slt
@@ -64,6 +64,11 @@ SELECT left('abcde', -2)
 abc
 
 query T
+SELECT left(arrow_cast('abcde', 'Dictionary(Int32, Utf8)'), -2)
+----
+abc
+
+query T
 SELECT left('abcde', -200)
 ----
 (empty)
@@ -104,12 +109,22 @@ SELECT length('')
 0
 
 query I
+SELECT length(arrow_cast('', 'Dictionary(Int32, Utf8)'))
+----
+0
+
+query I
 SELECT length('chars')
 ----
 5
 
 query I
 SELECT length('josé')
+----
+4
+
+query I
+SELECT length(arrow_cast('josé', 'Dictionary(Int32, Utf8)'))
 ----
 4
 
@@ -159,6 +174,11 @@ SELECT lpad('hi', 5)
    hi
 
 query T
+SELECT lpad(arrow_cast('hi', 'Dictionary(Int32, Utf8)'), 5)
+----
+   hi
+
+query T
 SELECT lpad('hi', CAST(NULL AS INT), 'xy')
 ----
 NULL
@@ -189,6 +209,11 @@ SELECT reverse('abcde')
 edcba
 
 query T
+SELECT reverse(arrow_cast('abcde', 'Dictionary(Int32, Utf8)'))
+----
+edcba
+
+query T
 SELECT reverse('loẅks')
 ----
 sk̈wol
@@ -202,6 +227,11 @@ query T
 SELECT right('abcde', -2)
 ----
 cde
+
+query T
+SELECT right(arrow_cast('abcde', 'Dictionary(Int32, Utf8)'), 1)
+----
+e
 
 query T
 SELECT right('abcde', -200)
@@ -265,6 +295,11 @@ hiabcdefabcdefabcdefa
 
 query T
 SELECT rpad('hi', 5, 'xy')
+----
+hixyx
+
+query T
+SELECT rpad(arrow_cast('hi', 'Dictionary(Int32, Utf8)'), 5, 'xy')
 ----
 hixyx
 
@@ -380,6 +415,11 @@ NULL
 
 query T
 SELECT translate('12345', '143', 'ax')
+----
+a2x5
+
+query T
+SELECT translate(arrow_cast('12345', 'Dictionary(Int32, Utf8)'), '143', 'ax')
 ----
 a2x5
 
@@ -565,3 +605,164 @@ SELECT sqrt(column1),sqrt(column2),sqrt(column3),sqrt(column4),sqrt(column5),sqr
 
 statement ok
 drop table t
+
+
+query T
+SELECT upper('foo')
+----
+FOO
+
+query T
+select upper(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+FOO
+
+query T
+SELECT btrim('   foo  ')
+----
+foo
+
+query T
+SELECT btrim(arrow_cast('   foo  ', 'Dictionary(Int32, Utf8)'))
+----
+foo
+
+query T
+SELECT initcap('foo')
+----
+Foo
+
+query T
+SELECT initcap(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+Foo
+
+query T
+SELECT lower('FOObar')
+----
+foobar
+
+query T
+SELECT lower(arrow_cast('FOObar', 'Dictionary(Int32, Utf8)'))
+----
+foobar
+
+query T
+SELECT ltrim('   foo')
+----
+foo
+
+query T
+SELECT ltrim(arrow_cast('    foo', 'Dictionary(Int32, Utf8)'))
+----
+foo
+
+query T
+SELECT md5('foo')
+----
+acbd18db4cc2f85cedef654fccc4a4d8
+
+query T
+SELECT md5(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+acbd18db4cc2f85cedef654fccc4a4d8
+
+query T
+SELECT regexp_replace('foobar', 'bar', 'xx', 'gi')
+----
+fooxx
+
+query T
+SELECT regexp_replace(arrow_cast('foobar', 'Dictionary(Int32, Utf8)'), 'bar', 'xx', 'gi')
+----
+fooxx
+
+query T
+SELECT repeat('foo', 3)
+----
+foofoofoo
+
+query T
+SELECT repeat(arrow_cast('foo', 'Dictionary(Int32, Utf8)'), 3)
+----
+foofoofoo
+
+query T
+SELECT replace('foobar', 'bar', 'hello')
+----
+foohello
+
+query T
+SELECT replace(arrow_cast('foobar', 'Dictionary(Int32, Utf8)'), 'bar', 'hello')
+----
+foohello
+
+query T
+SELECT rtrim(' foo  ')
+----
+ foo
+
+query T
+SELECT rtrim(arrow_cast(' foo  ', 'Dictionary(Int32, Utf8)'))
+----
+ foo
+
+query T
+SELECT split_part('foo_bar', '_', 2)
+----
+bar
+
+query T
+SELECT split_part(arrow_cast('foo_bar', 'Dictionary(Int32, Utf8)'), '_', 2)
+----
+bar
+
+query T
+SELECT trim('  foo  ')
+----
+foo
+
+query T
+SELECT trim(arrow_cast('  foo  ', 'Dictionary(Int32, Utf8)'))
+----
+foo
+
+query I
+SELECT bit_length('foo')
+----
+24
+
+query I
+SELECT bit_length(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+24
+
+query I
+SELECT character_length('foo')
+----
+3
+
+query I
+SELECT character_length(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+3
+
+query I
+SELECT octet_length('foo')
+----
+3
+
+query I
+SELECT octet_length(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+----
+3
+
+query I
+SELECT strpos('helloworld', 'world')
+----
+6
+
+query I
+SELECT strpos(arrow_cast('helloworld', 'Dictionary(Int32, Utf8)'), 'world')
+----
+6

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -1397,6 +1397,20 @@ macro_rules! make_utf8_to_return_type {
                 DataType::LargeUtf8 => $largeUtf8Type,
                 DataType::Utf8 => $utf8Type,
                 DataType::Null => DataType::Null,
+                DataType::Dictionary(_, value_type) => {
+                    match **value_type {
+                        DataType::LargeUtf8 => $largeUtf8Type,
+                        DataType::Utf8 => $utf8Type,
+                        DataType::Null => DataType::Null,
+                        _ => {
+                            // this error is internal as `data_types` should have captured this.
+                            return Err(DataFusionError::Internal(format!(
+                                "The {:?} function can only accept strings.",
+                                name
+                            )));
+                        }
+                    }
+                }
                 _ => {
                     // this error is internal as `data_types` should have captured this.
                     return Err(DataFusionError::Internal(format!(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5471.

## Rationale for this change

Running `upper(col)` where `col` is a dictionary results in an internal error:

```
Internal error: The "upper" function can only accept strings.. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

Other functions like `length` and `character_length` also have the same issue. Here is a list of all the functions with the same issue:

```
$ grep utf8_to_str_type

datafusion/expr/src/built_in_function.rs
600:                utf8_to_str_type(&input_expr_types[0], "btrim")
628:                utf8_to_str_type(&input_expr_types[0], "initcap")
630:            BuiltinScalarFunction::Left => utf8_to_str_type(&input_expr_types[0], "left"),
632:                utf8_to_str_type(&input_expr_types[0], "lower")
634:            BuiltinScalarFunction::Lpad => utf8_to_str_type(&input_expr_types[0], "lpad"),
636:                utf8_to_str_type(&input_expr_types[0], "ltrim")
638:            BuiltinScalarFunction::MD5 => utf8_to_str_type(&input_expr_types[0], "md5"),
651:                utf8_to_str_type(&input_expr_types[0], "regex_replace")
654:                utf8_to_str_type(&input_expr_types[0], "repeat")
657:                utf8_to_str_type(&input_expr_types[0], "replace")
660:                utf8_to_str_type(&input_expr_types[0], "reverse")
663:                utf8_to_str_type(&input_expr_types[0], "right")
665:            BuiltinScalarFunction::Rpad => utf8_to_str_type(&input_expr_types[0], "rpad"),
667:                utf8_to_str_type(&input_expr_types[0], "rtrimp")
711:                utf8_to_str_type(&input_expr_types[0], "split_part")
718:                utf8_to_str_type(&input_expr_types[0], "substr")
740:                utf8_to_str_type(&input_expr_types[0], "translate")
742:            BuiltinScalarFunction::Trim => utf8_to_str_type(&input_expr_types[0], "trim"),
744:                utf8_to_str_type(&input_expr_types[0], "upper")
```

```
$ grep utf8_to_int_type

datafusion/expr/src/built_in_function.rs
597:                utf8_to_int_type(&input_expr_types[0], "bit_length")
603:                utf8_to_int_type(&input_expr_types[0], "character_length")
645:                utf8_to_int_type(&input_expr_types[0], "octet_length")
715:                utf8_to_int_type(&input_expr_types[0], "strpos")
```

## What changes are included in this PR?

Support `Dictionary` data type for string functions and int functions

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, tests are added for all the functions listed above

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

User will be able to use `upper` function and other string and int functions where `col` is a dictionary without problem