### PR TITLE
fix: CLI should support different sql dialects

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -119,7 +119,9 @@ pub async fn exec_from_repl(
     print_options: &mut PrintOptions,
 ) -> rustyline::Result<()> {
     let mut rl = Editor::new()?;
-    rl.set_helper(Some(CliHelper::default()));
+    rl.set_helper(Some(CliHelper::new(
+        &ctx.task_ctx().session_config().options().sql_parser.dialect,
+    )));
     rl.load_history(".history").ok();
 
     let mut print_options = print_options.clone();
@@ -166,6 +168,10 @@ pub async fn exec_from_repl(
                     Ok(_) => {}
                     Err(err) => eprintln!("{err}"),
                 }
+                // dialect might have changed
+                rl.helper_mut().unwrap().set_dialect(
+                    &ctx.task_ctx().session_config().options().sql_parser.dialect,
+                );
             }
             Err(ReadlineError::Interrupted) => {
                 println!("^C");

--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -95,7 +95,7 @@ impl CliHelper {
 
 impl Default for CliHelper {
     fn default() -> Self {
-        Self::new("dialect")
+        Self::new("generic")
     }
 }
 
@@ -259,7 +259,9 @@ mod tests {
         // shoule be invalid in generic dialect
         let result =
             readline_direct(Cursor::new(r"select 1 # 2;".as_bytes()), &validator)?;
-        assert!(matches!(result, ValidationResult::Invalid(Some(_))));
+        assert!(
+            matches!(result, ValidationResult::Invalid(Some(e)) if e.contains("Invalid statement"))
+        );
 
         // valid in postgresql dialect
         validator.set_dialect("postgresql");

--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -20,6 +20,7 @@
 
 use datafusion::error::DataFusionError;
 use datafusion::sql::parser::{DFParser, Statement};
+use datafusion::sql::sqlparser::dialect::dialect_from_str;
 use datafusion::sql::sqlparser::parser::ParserError;
 use rustyline::completion::Completer;
 use rustyline::completion::FilenameCompleter;
@@ -34,12 +35,25 @@ use rustyline::Context;
 use rustyline::Helper;
 use rustyline::Result;
 
-#[derive(Default)]
 pub struct CliHelper {
     completer: FilenameCompleter,
+    dialect: String,
 }
 
 impl CliHelper {
+    pub fn new(dialect: &str) -> Self {
+        Self {
+            completer: FilenameCompleter::new(),
+            dialect: dialect.into(),
+        }
+    }
+
+    pub fn set_dialect(&mut self, dialect: &str) {
+        if dialect != self.dialect {
+            self.dialect = dialect.to_string();
+        }
+    }
+
     fn validate_input(&self, input: &str) -> Result<ValidationResult> {
         if let Some(sql) = input.strip_suffix(';') {
             let sql = match unescape_input(sql) {
@@ -50,7 +64,18 @@ impl CliHelper {
                     ))))
                 }
             };
-            match DFParser::parse_sql(&sql) {
+
+            let dialect = match dialect_from_str(&self.dialect) {
+                Some(dialect) => dialect,
+                None => {
+                    return Ok(ValidationResult::Invalid(Some(format!(
+                        "  🤔 Invalid dialect: {}",
+                        self.dialect
+                    ))))
+                }
+            };
+
+            match DFParser::parse_sql_with_dialect(&sql, dialect.as_ref()) {
                 Ok(statements) if statements.is_empty() => Ok(ValidationResult::Invalid(
                     Some("  🤔 You entered an empty statement".to_string()),
                 )),
@@ -65,6 +90,12 @@ impl CliHelper {
         } else {
             Ok(ValidationResult::Incomplete)
         }
+    }
+}
+
+impl Default for CliHelper {
+    fn default() -> Self {
+        Self::new("dialect")
     }
 }
 
@@ -217,6 +248,24 @@ mod tests {
             &validator,
         )?;
         assert!(matches!(result, ValidationResult::Invalid(Some(_))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn sql_dialect() -> Result<()> {
+        let mut validator = CliHelper::default();
+
+        // shoule be invalid in generic dialect
+        let result =
+            readline_direct(Cursor::new(r"select 1 # 2;".as_bytes()), &validator)?;
+        assert!(matches!(result, ValidationResult::Invalid(Some(_))));
+
+        // valid in postgresql dialect
+        validator.set_dialect("postgresql");
+        let result =
+            readline_direct(Cursor::new(r"select 1 # 2;".as_bytes()), &validator)?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?
Partially #7255

datafusion-cli currently only supports the generic dialect.
For example: 
```
DataFusion CLI v28.0.0
❯ set datafusion.sql_parser.dialect = postgresql;
0 rows in set. Query took 0.003 seconds.

❯ select 17 # 5;  🤔 Invalid statement: sql parser error: No infix parser for token Sharp
```
`select 17 # 5` is valid in the PostgreSQL dialect, but got an ‘Invalid statement’ error.

This is because the rustyline validator only supports the generic dialect, not the one specified by the current user.
https://github.com/apache/arrow-datafusion/blob/bb185a64d1ec14eb3f6c638147d382a2a0fcf4dd/datafusion-cli/src/helper.rs#L53


## Rationale for this change
- rustyline validator takes into consideration the current user’s dialect setting. 
- After SQL statement execution is completed, attempt to synchronize the validator’s dialect.


## What changes are included in this PR?
CLI support different sql dialects.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No

