### PR TITLE
chore: public sql_statement_to_plan_with_context()

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -95,11 +95,22 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     /// Generate a logical plan from an SQL statement
     pub fn sql_statement_to_plan(&self, statement: Statement) -> Result<LogicalPlan> {
-        self.sql_statement_to_plan_with_context(statement, &mut PlannerContext::new())
+        self.sql_statement_to_plan_with_context_impl(
+            statement,
+            &mut PlannerContext::new(),
+        )
     }
 
     /// Generate a logical plan from an SQL statement
-    fn sql_statement_to_plan_with_context(
+    pub fn sql_statement_to_plan_with_context(
+        &self,
+        statement: Statement,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        self.sql_statement_to_plan_with_context_impl(statement, planner_context)
+    }
+
+    fn sql_statement_to_plan_with_context_impl(
         &self,
         statement: Statement,
         planner_context: &mut PlannerContext,
@@ -318,7 +329,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     .with_prepare_param_data_types(data_types.clone());
 
                 // Build logical plan for inner statement of the prepare statement
-                let plan = self.sql_statement_to_plan_with_context(
+                let plan = self.sql_statement_to_plan_with_context_impl(
                     *statement,
                     &mut planner_context,
                 )?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This patch makes `sql_statement_to_plan_with_context()` public. Compared to `sql_statement_to_plan`, it accepts an external `PlannerContext`, which allows pre-registering some external context for planning

## What changes are included in this PR?

Like above

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?


A new public API `sql_statement_to_plan_with_context`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->