### PR TITLE
chore(functions): fix function names typo

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -648,7 +648,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Random => Ok(Float64),
             BuiltinScalarFunction::Uuid => Ok(Utf8),
             BuiltinScalarFunction::RegexpReplace => {
-                utf8_to_str_type(&input_expr_types[0], "regex_replace")
+                utf8_to_str_type(&input_expr_types[0], "regexp_replace")
             }
             BuiltinScalarFunction::Repeat => {
                 utf8_to_str_type(&input_expr_types[0], "repeat")

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -664,7 +664,7 @@ impl BuiltinScalarFunction {
             }
             BuiltinScalarFunction::Rpad => utf8_to_str_type(&input_expr_types[0], "rpad"),
             BuiltinScalarFunction::Rtrim => {
-                utf8_to_str_type(&input_expr_types[0], "rtrimp")
+                utf8_to_str_type(&input_expr_types[0], "rtrim")
             }
             BuiltinScalarFunction::SHA224 => {
                 utf8_or_binary_to_binary_type(&input_expr_types[0], "sha224")


### PR DESCRIPTION
## Which issue does this PR close?

No related PR

## Rationale for this change

I found typos in function names that will printout in error message:
* `regex_replace` should be `regexp_replace`
* `rtrimp` should be `rtrim`

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix typos

## Are these changes tested?

No, there is no logic change in this PR

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Users will see the correct function names in the error messages for `regexp_replace` and `rtrim`