### PR TITLE
Add a regexp_matches function

### DIFF
--- a/benchmarks/queries/q23.sql
+++ b/benchmarks/queries/q23.sql
@@ -1,0 +1,4 @@
+select count(*)
+from part
+where regexp_matches(p_type, 'BRASS$');
+

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -213,6 +213,8 @@ pub enum BuiltinScalarFunction {
     Random,
     /// regexp_replace
     RegexpReplace,
+    /// regexp_matches
+    RegexpMatches,
     /// repeat
     Repeat,
     /// replace
@@ -419,6 +421,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Trim => Volatility::Immutable,
             BuiltinScalarFunction::Upper => Volatility::Immutable,
             BuiltinScalarFunction::RegexpMatch => Volatility::Immutable,
+            BuiltinScalarFunction::RegexpMatches => Volatility::Immutable,
             BuiltinScalarFunction::Struct => Volatility::Immutable,
             BuiltinScalarFunction::FromUnixtime => Volatility::Immutable,
             BuiltinScalarFunction::ArrowTypeof => Volatility::Immutable,
@@ -743,6 +746,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Upper => {
                 utf8_to_str_type(&input_expr_types[0], "upper")
             }
+            BuiltinScalarFunction::RegexpMatches => Ok(Boolean),
             BuiltinScalarFunction::RegexpMatch => Ok(match input_expr_types[0] {
                 LargeUtf8 => List(Arc::new(Field::new("item", LargeUtf8, true))),
                 Utf8 => List(Arc::new(Field::new("item", Utf8, true))),
@@ -1104,7 +1108,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::NullIf => {
                 Signature::uniform(2, SUPPORTED_NULLIF_TYPES.to_vec(), self.volatility())
             }
-            BuiltinScalarFunction::RegexpMatch => Signature::one_of(
+            BuiltinScalarFunction::RegexpMatch | BuiltinScalarFunction::RegexpMatches => Signature::one_of(
                 vec![
                     Exact(vec![Utf8, Utf8]),
                     Exact(vec![LargeUtf8, Utf8]),
@@ -1280,6 +1284,7 @@ fn aliases(func: &BuiltinScalarFunction) -> &'static [&'static str] {
 
         // regex functions
         BuiltinScalarFunction::RegexpMatch => &["regexp_match"],
+        BuiltinScalarFunction::RegexpMatches => &["regexp_matches"],
         BuiltinScalarFunction::RegexpReplace => &["regexp_replace"],
 
         // time/date functions

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -674,6 +674,31 @@ pub fn create_physical_fun(
                 ))),
             })
         }
+        BuiltinScalarFunction::RegexpMatches => {
+            Arc::new(|args| match args[0].data_type() {
+                DataType::Utf8 => {
+                    let specializer_func = invoke_on_columnar_value_if_regex_expressions_feature_flag!(
+                        specialize_regexp_is_match,
+                        i32,
+                        "regexp_matches"
+                    );
+                    let func = specializer_func(args)?;
+                    func(args)
+                }
+                DataType::LargeUtf8 => {
+                    let specializer_func = invoke_on_columnar_value_if_regex_expressions_feature_flag!(
+                        specialize_regexp_is_match,
+                        i64,
+                        "regexp_matches"
+                    );
+                    let func = specializer_func(args)?;
+                    func(args)
+                }
+                other => Err(DataFusionError::Internal(format!(
+                    "Unsupported data type {other:?} for function regexp_matches",
+                ))),
+            })
+        }
         BuiltinScalarFunction::RegexpReplace => {
             Arc::new(|args| match args[0].data_type() {
                 DataType::Utf8 => {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2375,6 +2375,7 @@ pub enum ScalarFunction {
     ArrayReplaceAll = 110,
     Nanvl = 111,
     Flatten = 112,
+    RegexpIsMatch = 113,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2405,6 +2406,7 @@ impl ScalarFunction {
             ScalarFunction::Trunc => "Trunc",
             ScalarFunction::Array => "Array",
             ScalarFunction::RegexpMatch => "RegexpMatch",
+            ScalarFunction::RegexpIsMatch => "RegexpIsMatch",
             ScalarFunction::BitLength => "BitLength",
             ScalarFunction::Btrim => "Btrim",
             ScalarFunction::CharacterLength => "CharacterLength",

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -518,6 +518,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::Uuid => Self::Uuid,
             ScalarFunction::Translate => Self::Translate,
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
+            ScalarFunction::RegexpIsMatch => Self::RegexpMatches,
             ScalarFunction::Coalesce => Self::Coalesce,
             ScalarFunction::Pi => Self::Pi,
             ScalarFunction::Power => Self::Power,

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1517,6 +1517,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::CurrentTime => Self::CurrentTime,
             BuiltinScalarFunction::Translate => Self::Translate,
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,
+            BuiltinScalarFunction::RegexpMatches => Self::RegexpIsMatch,
             BuiltinScalarFunction::Coalesce => Self::Coalesce,
             BuiltinScalarFunction::Pi => Self::Pi,
             BuiltinScalarFunction::Power => Self::Power,


### PR DESCRIPTION
## Rationale for this change

I noticed that while using the `dataframe` API there was no convenient "does this column match a given regular expression" function. There is `regexp_match`, but this extracts the given match column which is not needed in all cases. 

## What changes are included in this PR?

Added a new `regexp_matches` method

## Notes:

I went down a rabbit hole while adding this extra functionality, and as I got it working I was not sure if this would even be accepted. I was also not sure if this is _already_ done, I'm very new to arrow-datafusion and I did see some references to `regexp_match` in the codebase. If i'm duplicating functionality, or misunderstanding something obvious, then I'm sorry for the PR spam! However if this is something that might be useful then I can continue some work on it.

Currently there are no proper tests and it needs to be cleaned up, however the results are hopeful and show pretty fast performance:

```
❯ select count(*) from 'index-0.parquet' 
where regexp_matches(path, '\\.py$');
+----------+
| COUNT(*) |
+----------+
| 29167686 |
+----------+
1 row in set. Query took 0.772 seconds.

❯ select count(*) from 'index-0.parquet' 
where path ILIKE '%.py';
+----------+
| COUNT(*) |
+----------+
| 29167689 |
+----------+
1 row in set. Query took 0.712 seconds.

❯ select count(*) from 'index-0.parquet' 
where array_length(regexp_match(path, '\\.py$')) is not NULL;
+----------+
| COUNT(*) |
+----------+
| 29167686 |
+----------+
1 row in set. Query took 27.781 seconds.
```

I'm aware I can use `LIKE` and other methods within SQL, but this addition is focused towards the dataframe API.