### PR TITLE
Allow `skip_failed_rules` to skip  buggy logical plan rules that have a schema mismatch

### DIFF
--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -292,7 +292,7 @@ impl Optimizer {
                     self.optimize_recursively(rule, &new_plan, config)
                         .and_then(|plan| {
                             if let Some(plan) = &plan {
-                                assert_schema_is_the_same(rule.name(), &new_plan, &plan)?;
+                                assert_schema_is_the_same(rule.name(), &new_plan, plan)?;
                             }
                             Ok(plan)
                         });

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -513,6 +513,17 @@ mod tests {
     }
 
     #[test]
+    fn skip_generate_different_schema() {
+        let opt = Optimizer::with_rules(vec![Arc::new(GetTableScanRule {})]);
+        let config = OptimizerContext::new().with_skip_failing_rules(true);
+        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::empty()),
+        });
+        opt.optimize(&plan, &config, &observe).unwrap();
+    }
+
+    #[test]
     fn generate_same_schema_different_metadata() -> Result<()> {
         // if the plan creates more metadata than previously (because
         // some wrapping functions are removed, etc) do not error

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -291,11 +291,10 @@ impl Optimizer {
                 let result =
                     self.optimize_recursively(rule, &new_plan, config)
                         .and_then(|plan| {
-                            plan.map(|p| {
-                                assert_schema_is_the_same(rule.name(), &new_plan, &p)
-                                    .map(|_| Some(p))
-                            })
-                            .unwrap_or(Ok(None))
+                            if let Some(plan) = &plan {
+                                assert_schema_is_the_same(rule.name(), &new_plan, &plan)?;
+                            }
+                            Ok(plan)
                         });
                 match result {
                     Ok(Some(plan)) => {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

In connection to #7241.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
If we allow buggy logical plans to be skipped then plans that don't fail but produce different schemas should also be skippable. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Moved checking schema equality before handling logical plan errors so that the same option `skip_failed_rules` can be applied to these rules as well

## Are these changes tested?
Added a new test for this case. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

The error message changed slightly. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Don't think so
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Nope