### PR TITLE
Implement Support for Copy To Logical and Physical plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ datafusion/CHANGELOG.md.bak
 .githubchangeloggenerator.cache*
 
 # Generated tpch data
-datafusion/core/tests/sqllogictests/test_files/tpch/data/*
+datafusion/sqllogictests/test_files/tpch/data/*
 
 # Scratch temp dir for sqllogictests
-datafusion/core/tests/sqllogictests/test_files/scratch*
+datafusion/sqllogictest/test_files/scratch*

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ datafusion/CHANGELOG.md.bak
 
 # Generated tpch data
 datafusion/core/tests/sqllogictests/test_files/tpch/data/*
+
+# Scratch temp dir for sqllogictests
+datafusion/core/tests/sqllogictests/test_files/scratch*

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -47,7 +47,7 @@ use crate::datasource::physical_plan::{
 };
 use crate::error::Result;
 use crate::execution::context::SessionState;
-use crate::physical_plan::insert::{DataSink, InsertExec};
+use crate::physical_plan::insert::{DataSink, FileSinkExec};
 use crate::physical_plan::{DisplayAs, DisplayFormatType, Statistics};
 use crate::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use rand::distributions::{Alphanumeric, DistString};
@@ -277,6 +277,7 @@ impl FileFormat for CsvFormat {
                 "Inserting compressed CSV is not implemented yet.".into(),
             ));
         }
+
         let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(CsvSink::new(
             conf,
@@ -285,7 +286,7 @@ impl FileFormat for CsvFormat {
             self.file_compression_type,
         ));
 
-        Ok(Arc::new(InsertExec::new(input, sink, sink_schema)) as _)
+        Ok(Arc::new(FileSinkExec::new(input, sink, sink_schema)) as _)
     }
 }
 
@@ -505,12 +506,14 @@ impl DataSink for CsvSink {
         let object_store = context
             .runtime_env()
             .object_store(&self.config.object_store_url)?;
-
         // Construct serializer and writer for each file group
         let mut serializers: Vec<Box<dyn BatchSerializer>> = vec![];
         let mut writers = vec![];
         match self.config.writer_mode {
             FileWriterMode::Append => {
+                if !self.config.per_thread_output {
+                    return Err(DataFusionError::NotImplemented("per_thread_output=false is not implemented for CsvSink in Append mode".into()));
+                }
                 for file_group in &self.config.file_groups {
                     // In append mode, consider has_header flag only when file is empty (at the start).
                     // For other modes, use has_header flag as is.
@@ -542,38 +545,72 @@ impl DataSink for CsvSink {
             FileWriterMode::PutMultipart => {
                 // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)
                 let base_path = &self.config.table_paths[0];
-                // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
-                let write_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-                for part_idx in 0..num_partitions {
-                    let header = self.has_header;
-                    let builder = WriterBuilder::new().with_delimiter(self.delimiter);
-                    let serializer = CsvSerializer::new()
-                        .with_builder(builder)
-                        .with_header(header);
-                    let file_path = base_path
-                        .prefix()
-                        .child(format!("/{}_{}.csv", write_id, part_idx));
-                    let object_meta = ObjectMeta {
-                        location: file_path,
-                        last_modified: chrono::offset::Utc::now(),
-                        size: 0,
-                        e_tag: None,
-                    };
-                    let writer = create_writer(
-                        self.config.writer_mode,
-                        self.file_compression_type,
-                        object_meta.into(),
-                        object_store.clone(),
-                    )
-                    .await?;
-
-                    serializers.push(Box::new(serializer));
-                    writers.push(writer);
+                match self.config.per_thread_output {
+                    true => {
+                        // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
+                        let write_id =
+                            Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+                        for part_idx in 0..num_partitions {
+                            let header = self.has_header;
+                            let builder =
+                                WriterBuilder::new().with_delimiter(self.delimiter);
+                            let serializer = CsvSerializer::new()
+                                .with_builder(builder)
+                                .with_header(header);
+                            serializers.push(Box::new(serializer));
+                            let file_path = base_path
+                                .prefix()
+                                .child(format!("{}_{}.csv", write_id, part_idx));
+                            let object_meta = ObjectMeta {
+                                location: file_path,
+                                last_modified: chrono::offset::Utc::now(),
+                                size: 0,
+                                e_tag: None,
+                            };
+                            let writer = create_writer(
+                                self.config.writer_mode,
+                                self.file_compression_type,
+                                object_meta.into(),
+                                object_store.clone(),
+                            )
+                            .await?;
+                            writers.push(writer);
+                        }
+                    }
+                    false => {
+                        let header = self.has_header;
+                        let builder = WriterBuilder::new().with_delimiter(self.delimiter);
+                        let serializer = CsvSerializer::new()
+                            .with_builder(builder)
+                            .with_header(header);
+                        serializers.push(Box::new(serializer));
+                        let file_path = base_path.prefix();
+                        let object_meta = ObjectMeta {
+                            location: file_path.clone(),
+                            last_modified: chrono::offset::Utc::now(),
+                            size: 0,
+                            e_tag: None,
+                        };
+                        let writer = create_writer(
+                            self.config.writer_mode,
+                            self.file_compression_type,
+                            object_meta.into(),
+                            object_store.clone(),
+                        )
+                        .await?;
+                        writers.push(writer);
+                    }
                 }
             }
         }
 
-        stateless_serialize_and_write_files(data, serializers, writers).await
+        stateless_serialize_and_write_files(
+            data,
+            serializers,
+            writers,
+            self.config.per_thread_output,
+        )
+        .await
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -43,7 +43,7 @@ use object_store::{GetResult, ObjectMeta, ObjectStore};
 
 use crate::datasource::physical_plan::FileGroupDisplay;
 use crate::physical_plan::insert::DataSink;
-use crate::physical_plan::insert::InsertExec;
+use crate::physical_plan::insert::FileSinkExec;
 use crate::physical_plan::SendableRecordBatchStream;
 use crate::physical_plan::{DisplayAs, DisplayFormatType, Statistics};
 
@@ -187,7 +187,7 @@ impl FileFormat for JsonFormat {
         let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(JsonSink::new(conf, self.file_compression_type));
 
-        Ok(Arc::new(InsertExec::new(input, sink, sink_schema)) as _)
+        Ok(Arc::new(FileSinkExec::new(input, sink, sink_schema)) as _)
     }
 }
 
@@ -280,6 +280,9 @@ impl DataSink for JsonSink {
         let mut writers = vec![];
         match self.config.writer_mode {
             FileWriterMode::Append => {
+                if !self.config.per_thread_output {
+                    return Err(DataFusionError::NotImplemented("per_thread_output=false is not implemented for JsonSink in Append mode".into()));
+                }
                 for file_group in &self.config.file_groups {
                     let serializer = JsonSerializer::new();
                     serializers.push(Box::new(serializer));
@@ -303,33 +306,63 @@ impl DataSink for JsonSink {
             FileWriterMode::PutMultipart => {
                 // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)
                 let base_path = &self.config.table_paths[0];
-                // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
-                let write_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-                for part_idx in 0..num_partitions {
-                    let serializer = JsonSerializer::new();
-                    serializers.push(Box::new(serializer));
-                    let file_path = base_path
-                        .prefix()
-                        .child(format!("/{}_{}.json", write_id, part_idx));
-                    let object_meta = ObjectMeta {
-                        location: file_path,
-                        last_modified: chrono::offset::Utc::now(),
-                        size: 0,
-                        e_tag: None,
-                    };
-                    let writer = create_writer(
-                        self.config.writer_mode,
-                        self.file_compression_type,
-                        object_meta.into(),
-                        object_store.clone(),
-                    )
-                    .await?;
-                    writers.push(writer);
+                match self.config.per_thread_output {
+                    true => {
+                        // Uniquely identify this batch of files with a random string, to prevent collisions overwriting files
+                        let write_id =
+                            Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+                        for part_idx in 0..num_partitions {
+                            let serializer = JsonSerializer::new();
+                            serializers.push(Box::new(serializer));
+                            let file_path = base_path
+                                .prefix()
+                                .child(format!("{}_{}.json", write_id, part_idx));
+                            let object_meta = ObjectMeta {
+                                location: file_path,
+                                last_modified: chrono::offset::Utc::now(),
+                                size: 0,
+                                e_tag: None,
+                            };
+                            let writer = create_writer(
+                                self.config.writer_mode,
+                                self.file_compression_type,
+                                object_meta.into(),
+                                object_store.clone(),
+                            )
+                            .await?;
+                            writers.push(writer);
+                        }
+                    }
+                    false => {
+                        let serializer = JsonSerializer::new();
+                        serializers.push(Box::new(serializer));
+                        let file_path = base_path.prefix();
+                        let object_meta = ObjectMeta {
+                            location: file_path.clone(),
+                            last_modified: chrono::offset::Utc::now(),
+                            size: 0,
+                            e_tag: None,
+                        };
+                        let writer = create_writer(
+                            self.config.writer_mode,
+                            self.file_compression_type,
+                            object_meta.into(),
+                            object_store.clone(),
+                        )
+                        .await?;
+                        writers.push(writer);
+                    }
                 }
             }
         }
 
-        stateless_serialize_and_write_files(data, serializers, writers).await
+        stateless_serialize_and_write_files(
+            data,
+            serializers,
+            writers,
+            self.config.per_thread_output,
+        )
+        .await
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/write.rs
+++ b/datafusion/core/src/datasource/file_format/write.rs
@@ -328,16 +328,29 @@ pub(crate) async fn stateless_serialize_and_write_files(
     mut data: Vec<SendableRecordBatchStream>,
     mut serializers: Vec<Box<dyn BatchSerializer>>,
     mut writers: Vec<AbortableWrite<Box<dyn AsyncWrite + Send + Unpin>>>,
+    per_thread_output: bool,
 ) -> Result<u64> {
+    if !per_thread_output && (serializers.len() != 1 || writers.len() != 1) {
+        return Err(DataFusionError::Internal(
+            "per_thread_output is false, but got more than 1 writer!".into(),
+        ));
+    }
     let num_partitions = data.len();
+    if per_thread_output && (num_partitions != writers.len()) {
+        return Err(DataFusionError::Internal("per_thread_output is true, but did not get 1 writer for each output partition!".into()));
+    }
     let mut row_count = 0;
     // Map errors to DatafusionError.
     let err_converter =
         |_| DataFusionError::Internal("Unexpected FileSink Error".to_string());
     // TODO parallelize serialization accross partitions and batches within partitions
     // see: https://github.com/apache/arrow-datafusion/issues/7079
-    for idx in 0..num_partitions {
-        while let Some(maybe_batch) = data[idx].next().await {
+    for (part_idx, data_stream) in data.iter_mut().enumerate().take(num_partitions) {
+        let idx = match per_thread_output {
+            true => part_idx,
+            false => 0,
+        };
+        while let Some(maybe_batch) = data_stream.next().await {
             // Write data to files in a round robin fashion:
             let serializer = &mut serializers[idx];
             let batch = check_for_errors(maybe_batch, &mut writers).await?;

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -883,6 +883,8 @@ impl TableProvider for ListingTable {
             output_schema: self.schema(),
             table_partition_cols: self.options.table_partition_cols.clone(),
             writer_mode,
+            // TODO: when listing table is known to be backed by a single file, this should be false
+            per_thread_output: true,
             overwrite,
         };
 

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -107,7 +107,6 @@ impl ListingTableUrl {
         .map_err(|_| DataFusionError::Internal(format!("Can not open path: {s}")))?;
         // TODO: Currently we do not have an IO-related error variant that accepts ()
         //       or a string. Once we have such a variant, change the error type above.
-
         Ok(Self::new(url, glob))
     }
 

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -35,7 +35,7 @@ use crate::datasource::{TableProvider, TableType};
 use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::logical_expr::Expr;
-use crate::physical_plan::insert::{DataSink, InsertExec};
+use crate::physical_plan::insert::{DataSink, FileSinkExec};
 use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::{common, SendableRecordBatchStream};
 use crate::physical_plan::{repartition::RepartitionExec, Partitioning};
@@ -219,7 +219,11 @@ impl TableProvider for MemTable {
             ));
         }
         let sink = Arc::new(MemSink::new(self.batches.clone()));
-        Ok(Arc::new(InsertExec::new(input, sink, self.schema.clone())))
+        Ok(Arc::new(FileSinkExec::new(
+            input,
+            sink,
+            self.schema.clone(),
+        )))
     }
 }
 

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -660,7 +660,7 @@ mod tests {
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
     use rstest::*;
-    use std::fs::File;
+    use std::fs::{self, File};
     use std::io::Write;
     use tempfile::TempDir;
     use url::Url;
@@ -1191,11 +1191,32 @@ mod tests {
             Field::new("c2", DataType::UInt64, false),
         ]));
 
+        // get name of first part
+        let paths = fs::read_dir(&out_dir).unwrap();
+        let mut part_0_name: String = "".to_owned();
+        for path in paths {
+            let path = path.unwrap();
+            let name = path
+                .path()
+                .file_name()
+                .expect("Should be a file name")
+                .to_str()
+                .expect("Should be a str")
+                .to_owned();
+            if name.ends_with("_0.csv") {
+                part_0_name = name;
+                break;
+            }
+        }
+
+        if part_0_name.is_empty() {
+            panic!("Did not find part_0 in csv output files!")
+        }
         // register each partition as well as the top level dir
         let csv_read_option = CsvReadOptions::new().schema(&schema);
         ctx.register_csv(
             "part0",
-            &format!("{out_dir}/part-0.csv"),
+            &format!("{out_dir}/{part_0_name}"),
             csv_read_option.clone(),
         )
         .await?;

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -331,6 +331,7 @@ mod tests {
     use crate::test::partitioned_file_groups;
     use datafusion_common::cast::{as_int32_array, as_int64_array, as_string_array};
     use rstest::*;
+    use std::fs;
     use std::path::Path;
     use tempfile::TempDir;
     use url::Url;
@@ -699,11 +700,33 @@ mod tests {
         // create a new context and verify that the results were saved to a partitioned csv file
         let ctx = SessionContext::new();
 
+        // get name of first part
+        let paths = fs::read_dir(&out_dir).unwrap();
+        let mut part_0_name: String = "".to_owned();
+        for path in paths {
+            let name = path
+                .unwrap()
+                .path()
+                .file_name()
+                .expect("Should be a file name")
+                .to_str()
+                .expect("Should be a str")
+                .to_owned();
+            if name.ends_with("_0.json") {
+                part_0_name = name;
+                break;
+            }
+        }
+
+        if part_0_name.is_empty() {
+            panic!("Did not find part_0 in json output files!")
+        }
+
         // register each partition as well as the top level dir
         let json_read_option = NdJsonReadOptions::default();
         ctx.register_json(
             "part0",
-            &format!("{out_dir}/part-0.json"),
+            &format!("{out_dir}/{part_0_name}"),
             json_read_option.clone(),
         )
         .await?;

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -332,6 +332,10 @@ pub struct FileSinkConfig {
     pub table_partition_cols: Vec<(String, DataType)>,
     /// A writer mode that determines how data is written to the file
     pub writer_mode: FileWriterMode,
+    /// If false, it is assumed there is a single table_path which is a file to which all data should be written
+    /// regardless of input partitioning. Otherwise, each table path is assumed to be a directory
+    /// to which each output partition is written to its own output file.
+    pub per_thread_output: bool,
     /// Controls whether existing data should be overwritten by this sink
     pub overwrite: bool,
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -768,7 +768,7 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
     use object_store::ObjectMeta;
-    use std::fs::File;
+    use std::fs::{self, File};
     use std::io::Write;
     use tempfile::TempDir;
     use url::Url;
@@ -1956,31 +1956,46 @@ mod tests {
         df.write_parquet(out_dir_url, None).await?;
         // write_parquet(&mut ctx, "SELECT c1, c2 FROM test", &out_dir, None).await?;
 
-        // create a new context and verify that the results were saved to a partitioned csv file
+        // create a new context and verify that the results were saved to a partitioned parquet file
         let ctx = SessionContext::new();
+
+        // get write_id
+        let mut paths = fs::read_dir(&out_dir).unwrap();
+        let path = paths.next();
+        let name = path
+            .unwrap()?
+            .path()
+            .file_name()
+            .expect("Should be a file name")
+            .to_str()
+            .expect("Should be a str")
+            .to_owned();
+        println!("{name}");
+        let (parsed_id, _) = name.split_once('_').expect("File should contain _ !");
+        let write_id = parsed_id.to_owned();
 
         // register each partition as well as the top level dir
         ctx.register_parquet(
             "part0",
-            &format!("{out_dir}/part-0.parquet"),
+            &format!("{out_dir}/{write_id}_0.parquet"),
             ParquetReadOptions::default(),
         )
         .await?;
         ctx.register_parquet(
             "part1",
-            &format!("{out_dir}/part-1.parquet"),
+            &format!("{out_dir}/{write_id}_1.parquet"),
             ParquetReadOptions::default(),
         )
         .await?;
         ctx.register_parquet(
             "part2",
-            &format!("{out_dir}/part-2.parquet"),
+            &format!("{out_dir}/{write_id}_2.parquet"),
             ParquetReadOptions::default(),
         )
         .await?;
         ctx.register_parquet(
             "part3",
-            &format!("{out_dir}/part-3.parquet"),
+            &format!("{out_dir}/{write_id}_3.parquet"),
             ParquetReadOptions::default(),
         )
         .await?;

--- a/datafusion/core/src/datasource/provider.rs
+++ b/datafusion/core/src/datasource/provider.rs
@@ -119,10 +119,10 @@ pub trait TableProvider: Sync + Send {
     ///
     /// # See Also
     ///
-    /// See [`InsertExec`] for the common pattern of inserting a
-    /// single stream of `RecordBatch`es.
+    /// See [`FileSinkExec`] for the common pattern of inserting a
+    /// streams of `RecordBatch`es as files to an ObjectStore.
     ///
-    /// [`InsertExec`]: crate::physical_plan::insert::InsertExec
+    /// [`FileSinkExec`]: crate::physical_plan::insert::FileSinkExec
     async fn insert_into(
         &self,
         _state: &SessionState,

--- a/datafusion/core/src/physical_plan/insert.rs
+++ b/datafusion/core/src/physical_plan/insert.rs
@@ -64,7 +64,7 @@ pub trait DataSink: DisplayAs + Debug + Send + Sync {
 /// Execution plan for writing record batches to a [`DataSink`]
 ///
 /// Returns a single row with the number of values written
-pub struct InsertExec {
+pub struct FileSinkExec {
     /// Input plan that produces the record batches to be written.
     input: Arc<dyn ExecutionPlan>,
     /// Sink to which to write
@@ -75,13 +75,13 @@ pub struct InsertExec {
     count_schema: SchemaRef,
 }
 
-impl fmt::Debug for InsertExec {
+impl fmt::Debug for FileSinkExec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "InsertExec schema: {:?}", self.count_schema)
+        write!(f, "FileSinkExec schema: {:?}", self.count_schema)
     }
 }
 
-impl InsertExec {
+impl FileSinkExec {
     /// Create a plan to write to `sink`
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
@@ -149,7 +149,7 @@ impl InsertExec {
     }
 }
 
-impl DisplayAs for InsertExec {
+impl DisplayAs for FileSinkExec {
     fn fmt_as(
         &self,
         t: DisplayFormatType,
@@ -164,7 +164,7 @@ impl DisplayAs for InsertExec {
     }
 }
 
-impl ExecutionPlan for InsertExec {
+impl ExecutionPlan for FileSinkExec {
     /// Return a reference to Any that can be used for downcasting
     fn as_any(&self) -> &dyn Any {
         self
@@ -233,7 +233,7 @@ impl ExecutionPlan for InsertExec {
     ) -> Result<SendableRecordBatchStream> {
         if partition != 0 {
             return Err(DataFusionError::Internal(
-                "InsertExec can only be called on partition 0!".into(),
+                "FileSinkExec can only be called on partition 0!".into(),
             ));
         }
         let data = self.execute_all_input_streams(context.clone())?;

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -17,6 +17,7 @@
 
 //! This module provides a builder for creating LogicalPlans
 
+use crate::dml::{CopyTo, OutputFileFormat};
 use crate::expr::Alias;
 use crate::expr_rewriter::{
     coerce_plan_expr_for_schema, normalize_col,
@@ -230,6 +231,23 @@ impl LogicalPlanBuilder {
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         Self::scan_with_filters(table_name, table_source, projection, vec![])
+    }
+
+    /// Create a [CopyTo] for copying the contents of this builder to the specified file(s)
+    pub fn copy_to(
+        input: LogicalPlan,
+        output_url: String,
+        file_format: OutputFileFormat,
+        per_thread_output: bool,
+        options: Vec<(String, String)>,
+    ) -> Result<Self> {
+        Ok(Self::from(LogicalPlan::Copy(CopyTo {
+            input: Arc::new(input),
+            output_url,
+            file_format,
+            per_thread_output,
+            options,
+        })))
     }
 
     /// Create a [DmlStatement] for inserting the contents of this builder into the named table

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -17,12 +17,70 @@
 
 use std::{
     fmt::{self, Display},
+    str::FromStr,
     sync::Arc,
 };
 
-use datafusion_common::{DFSchemaRef, OwnedTableReference};
+use datafusion_common::{DFSchemaRef, DataFusionError, OwnedTableReference};
 
 use crate::LogicalPlan;
+
+/// Operator that copies the contents of a database to file(s)
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct CopyTo {
+    /// The relation that determines the tuples to write to the output file(s)
+    pub input: Arc<LogicalPlan>,
+    /// The location to write the file(s)
+    pub output_url: String,
+    /// The file format to output (explicitly defined or inferred from file extension)
+    pub file_format: OutputFileFormat,
+    /// If false, it is assumed output_url is a file to which all data should be written
+    /// regardless of input partitioning. Otherwise, output_url is assumed to be a directory
+    /// to which each output partition is written to its own output file
+    pub per_thread_output: bool,
+    /// Arbitrary options as tuples
+    pub options: Vec<(String, String)>,
+}
+
+/// The file formats that CopyTo can output
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum OutputFileFormat {
+    CSV,
+    JSON,
+    PARQUET,
+    AVRO,
+    ARROW,
+}
+
+impl FromStr for OutputFileFormat {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self, DataFusionError> {
+        match s {
+            "csv" => Ok(OutputFileFormat::CSV),
+            "json" => Ok(OutputFileFormat::JSON),
+            "parquet" => Ok(OutputFileFormat::PARQUET),
+            "avro" => Ok(OutputFileFormat::AVRO),
+            "arrow" => Ok(OutputFileFormat::ARROW),
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "Unknown or not supported file format {s}!"
+            ))),
+        }
+    }
+}
+
+impl Display for OutputFileFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let out = match self {
+            OutputFileFormat::CSV => "csv",
+            OutputFileFormat::JSON => "json",
+            OutputFileFormat::PARQUET => "parquet",
+            OutputFileFormat::AVRO => "avro",
+            OutputFileFormat::ARROW => "arrow",
+        };
+        write!(f, "{}", out)
+    }
+}
 
 /// The operator that modifies the content of a database (adapted from
 /// substrait WriteRel)

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -18,7 +18,7 @@
 pub mod builder;
 mod ddl;
 pub mod display;
-mod dml;
+pub mod dml;
 mod extension;
 mod plan;
 mod statement;

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -31,6 +31,7 @@ use crate::{
     build_join_schema, Expr, ExprSchemable, TableProviderFilterPushDown, TableSource,
 };
 
+use super::dml::CopyTo;
 use super::DdlStatement;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -120,6 +121,8 @@ pub enum LogicalPlan {
     Dml(DmlStatement),
     /// CREATE / DROP TABLES / VIEWS / SCHEMAs
     Ddl(DdlStatement),
+    /// COPY TO
+    Copy(CopyTo),
     /// Describe the schema of table
     DescribeTable(DescribeTable),
     /// Unnest a column that contains a nested list type.
@@ -157,6 +160,7 @@ impl LogicalPlan {
                 dummy_schema
             }
             LogicalPlan::Dml(DmlStatement { table_schema, .. }) => table_schema,
+            LogicalPlan::Copy(CopyTo { input, .. }) => input.schema(),
             LogicalPlan::Ddl(ddl) => ddl.schema(),
             LogicalPlan::Unnest(Unnest { schema, .. }) => schema,
         }
@@ -203,6 +207,7 @@ impl LogicalPlan {
             | LogicalPlan::EmptyRelation(_)
             | LogicalPlan::Ddl(_)
             | LogicalPlan::Dml(_)
+            | LogicalPlan::Copy(_)
             | LogicalPlan::Values(_)
             | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Union(_)
@@ -343,6 +348,7 @@ impl LogicalPlan {
             | LogicalPlan::Distinct(_)
             | LogicalPlan::Dml(_)
             | LogicalPlan::Ddl(_)
+            | LogicalPlan::Copy(_)
             | LogicalPlan::DescribeTable(_)
             | LogicalPlan::Prepare(_) => Ok(()),
         }
@@ -371,6 +377,7 @@ impl LogicalPlan {
             LogicalPlan::Explain(explain) => vec![&explain.plan],
             LogicalPlan::Analyze(analyze) => vec![&analyze.input],
             LogicalPlan::Dml(write) => vec![&write.input],
+            LogicalPlan::Copy(copy) => vec![&copy.input],
             LogicalPlan::Ddl(ddl) => ddl.inputs(),
             LogicalPlan::Unnest(Unnest { input, .. }) => vec![input],
             LogicalPlan::Prepare(Prepare { input, .. }) => vec![input],
@@ -477,6 +484,7 @@ impl LogicalPlan {
             | LogicalPlan::Analyze(_)
             | LogicalPlan::Extension(_)
             | LogicalPlan::Dml(_)
+            | LogicalPlan::Copy(_)
             | LogicalPlan::Ddl(_)
             | LogicalPlan::DescribeTable(_)
             | LogicalPlan::Unnest(_) => Ok(None),
@@ -640,6 +648,7 @@ impl LogicalPlan {
             | LogicalPlan::Explain(_)
             | LogicalPlan::Analyze(_)
             | LogicalPlan::Dml(_)
+            | LogicalPlan::Copy(_)
             | LogicalPlan::DescribeTable(_)
             | LogicalPlan::Prepare(_)
             | LogicalPlan::Statement(_)
@@ -1082,6 +1091,24 @@ impl LogicalPlan {
                     }
                     LogicalPlan::Dml(DmlStatement { table_name, op, .. }) => {
                         write!(f, "Dml: op=[{op}] table=[{table_name}]")
+                    }
+                    LogicalPlan::Copy(CopyTo {
+                        input: _,
+                        output_url,
+                        file_format,
+                        per_thread_output,
+                        options,
+                    }) => {
+                        let mut op_str = String::new();
+                        op_str.push('(');
+                        for (key, val) in options {
+                            if !op_str.is_empty() {
+                                op_str.push(',');
+                            }
+                            op_str.push_str(&format!("{key} {val}"));
+                        }
+                        op_str.push(')');
+                        write!(f, "CopyTo: format={file_format} output_url={output_url} per_thread_output={per_thread_output} options: {op_str}")
                     }
                     LogicalPlan::Ddl(ddl) => {
                         write!(f, "{}", ddl.display())

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -17,6 +17,7 @@
 
 //! Expression utilities
 
+use crate::dml::CopyTo;
 use crate::expr::{Alias, Sort, WindowFunction};
 use crate::logical_plan::builder::build_join_schema;
 use crate::logical_plan::{
@@ -744,6 +745,19 @@ pub fn from_plan(
             table_schema: table_schema.clone(),
             op: op.clone(),
             input: Arc::new(inputs[0].clone()),
+        })),
+        LogicalPlan::Copy(CopyTo {
+            input: _,
+            output_url,
+            file_format,
+            per_thread_output,
+            options,
+        }) => Ok(LogicalPlan::Copy(CopyTo {
+            input: Arc::new(inputs[0].clone()),
+            output_url: output_url.clone(),
+            file_format: file_format.clone(),
+            per_thread_output: *per_thread_output,
+            options: options.clone(),
         })),
         LogicalPlan::Values(Values { schema, .. }) => Ok(LogicalPlan::Values(Values {
             schema: schema.clone(),

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -368,6 +368,7 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::Distinct(_)
             | LogicalPlan::Extension(_)
             | LogicalPlan::Dml(_)
+            | LogicalPlan::Copy(_)
             | LogicalPlan::Unnest(_)
             | LogicalPlan::Prepare(_) => {
                 // apply the optimization to all inputs of the plan

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1429,6 +1429,9 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::Dml(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for Dml",
             )),
+            LogicalPlan::Copy(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for Copy",
+            )),
             LogicalPlan::DescribeTable(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DescribeTable",
             )),

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use crate::parser::{
-    CopyToStatement, CreateExternalTable, DFParser, DescribeTableStmt, LexOrdering,
-    Statement as DFStatement,
+    CopyToSource, CopyToStatement, CreateExternalTable, DFParser, DescribeTableStmt,
+    LexOrdering, Statement as DFStatement,
 };
 use crate::planner::{
     object_name_to_qualifier, ContextProvider, PlannerContext, SqlToRel,
@@ -31,6 +31,7 @@ use datafusion_common::{
     DataFusionError, ExprSchema, OwnedTableReference, Result, SchemaReference,
     TableReference, ToDFSchema,
 };
+use datafusion_expr::dml::{CopyTo, OutputFileFormat};
 use datafusion_expr::expr::Placeholder;
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::builder::project;
@@ -55,6 +56,8 @@ use sqlparser::parser::ParserError::ParserError;
 
 use datafusion_common::plan_err;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 fn ident_to_string(ident: &Ident) -> String {
@@ -377,7 +380,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let _ = into; // optional keyword doesn't change behavior
                 self.insert_to_plan(table_name, columns, source, overwrite)
             }
-
             Statement::Update {
                 table,
                 assignments,
@@ -547,11 +549,71 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }))
     }
 
-    fn copy_to_plan(&self, _statement: CopyToStatement) -> Result<LogicalPlan> {
-        // TODO: implement as part of https://github.com/apache/arrow-datafusion/issues/5654
-        Err(DataFusionError::NotImplemented(
-            "`COPY .. TO ..` statement is not yet supported".to_string(),
-        ))
+    fn copy_to_plan(&self, statement: CopyToStatement) -> Result<LogicalPlan> {
+        // determine if source is table or query and handle accordingly
+        let copy_source = statement.source;
+        let input = match copy_source {
+            CopyToSource::Relation(object_name) => {
+                let table_ref =
+                    self.object_name_to_table_reference(object_name.clone())?;
+                let table_source = self.schema_provider.get_table_provider(table_ref)?;
+                LogicalPlanBuilder::scan(
+                    object_name_to_string(&object_name),
+                    table_source,
+                    None,
+                )?
+                .build()?
+            }
+            CopyToSource::Query(query) => {
+                self.query_to_plan(query, &mut PlannerContext::new())?
+            }
+        };
+
+        // convert options to lowercase strings, check for explicitly set "format" option
+        let mut options = vec![];
+        let mut explicit_format = None;
+        // default behavior is to assume the user is specifying a single file to which
+        // we should output all data regardless of input partitioning.
+        let mut per_thread_output: bool = false;
+        for (key, value) in statement.options {
+            let (k, v) = (key.to_lowercase(), value.to_string().to_lowercase());
+            // check for options important to planning
+            if k == "format" {
+                explicit_format = Some(OutputFileFormat::from_str(&v)?);
+            }
+            if k == "per_thread_output" {
+                per_thread_output = match v.as_str(){
+                    "true" => true,
+                    "false" => false,
+                    _ => return Err(DataFusionError::Plan(
+                        format!("Copy to option 'per_thread_output' must be true or false, got {value}")
+                    ))
+                }
+            }
+            options.push((k, v));
+        }
+        let format = match explicit_format {
+            Some(file_format) => file_format,
+            None => {
+                // try to infer file format from file extension
+                let extension: &str = &Path::new(&statement.target)
+                    .extension()
+                    .ok_or(
+                        DataFusionError::Plan("Copy To format not explicitly set and unable to get file extension!".to_string()))?
+                    .to_str()
+                    .ok_or(DataFusionError::Plan("Copy to format not explicitly set and failed to parse file extension!".to_string()))?
+                    .to_lowercase();
+
+                OutputFileFormat::from_str(extension)?
+            }
+        };
+        Ok(LogicalPlan::Copy(CopyTo {
+            input: Arc::new(input),
+            output_url: statement.target,
+            file_format: format,
+            per_thread_output,
+            options,
+        }))
     }
 
     fn build_order_by(

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -326,6 +326,30 @@ fn plan_rollback_transaction_chained() {
 }
 
 #[test]
+fn plan_copy_to() {
+    let sql = "COPY test_decimal to 'output.csv'";
+    let plan = r#"
+CopyTo: format=csv output_url=output.csv per_thread_output=false options: ()
+  TableScan: test_decimal
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
+fn plan_copy_to_query() {
+    let sql = "COPY (select * from test_decimal limit 10) to 'output.csv'";
+    let plan = r#"
+CopyTo: format=csv output_url=output.csv per_thread_output=false options: ()
+  Limit: skip=0, fetch=10
+    Projection: test_decimal.id, test_decimal.price
+      TableScan: test_decimal
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
 fn plan_insert() {
     let sql =
         "insert into person (id, first_name, last_name) values (1, 'Alan', 'Turing')";

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::ffi::OsStr;
+use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(target_family = "windows")]
 use std::thread;
@@ -54,9 +55,25 @@ pub async fn main() -> Result<()> {
     run_tests().await
 }
 
+/// Sets up an empty directory at tests/sqllogictests/test_files/scratch/
+/// creating it if needed and clearing any file contents if it exists
+/// This allows tests for inserting to external tables or copy to
+/// to persist data to disk and have consistent state when running
+/// a new test
+fn setup_scratch_dir() -> Result<()> {
+    let path = std::path::Path::new("tests/sqllogictests/test_files/scratch");
+    if path.exists() {
+        fs::remove_dir_all(path)?;
+    }
+    fs::create_dir(path)?;
+    Ok(())
+}
+
 async fn run_tests() -> Result<()> {
     // Enable logging (e.g. set RUST_LOG=debug to see debug logs)
     env_logger::init();
+
+    setup_scratch_dir()?;
 
     let options = Options::new();
 

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -55,13 +55,13 @@ pub async fn main() -> Result<()> {
     run_tests().await
 }
 
-/// Sets up an empty directory at tests/sqllogictests/test_files/scratch/
+/// Sets up an empty directory at test_files/scratch
 /// creating it if needed and clearing any file contents if it exists
 /// This allows tests for inserting to external tables or copy to
 /// to persist data to disk and have consistent state when running
 /// a new test
 fn setup_scratch_dir() -> Result<()> {
-    let path = std::path::Path::new("tests/sqllogictests/test_files/scratch");
+    let path = std::path::Path::new("test_files/scratch");
     if path.exists() {
         fs::remove_dir_all(path)?;
     }

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -21,26 +21,26 @@ create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 
 
 # Copy to directory as multiple files
 query IT
-COPY source_table TO 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true);
+COPY source_table TO 'test_files/scratch/table' (format parquet, per_thread_output true);
 ----
 2
 
 #Explain copy queries not currently working
-query error DataFusion error: This feature is not implemented: Unsupported SQL statement: Some\("COPY source_table TO 'tests/sqllogictests/test_files/scratch/table'"\)
-EXPLAIN COPY source_table to 'tests/sqllogictests/test_files/scratch/table'
+query error DataFusion error: This feature is not implemented: Unsupported SQL statement: Some\("COPY source_table TO 'test_files/scratch/table'"\)
+EXPLAIN COPY source_table to 'test_files/scratch/table'
 
 query error DataFusion error: SQL error: ParserError\("Expected end of statement, found: source_table"\)
-EXPLAIN COPY source_table to 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true)
+EXPLAIN COPY source_table to 'test_files/scratch/table' (format parquet, per_thread_output true)
 
 # Copy more files to directory via query
 query IT
-COPY (select * from source_table UNION ALL select * from source_table) to 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true);
+COPY (select * from source_table UNION ALL select * from source_table) to 'test_files/scratch/table' (format parquet, per_thread_output true);
 ----
 4
 
 # validate multiple parquet file output
 statement ok
-CREATE EXTERNAL TABLE validate_parquet STORED AS PARQUET LOCATION 'tests/sqllogictests/test_files/scratch/table/';
+CREATE EXTERNAL TABLE validate_parquet STORED AS PARQUET LOCATION 'test_files/scratch/table/';
 
 query IT
 select * from validate_parquet;
@@ -54,13 +54,13 @@ select * from validate_parquet;
 
 # Copy from table to single file
 query IT
-COPY source_table to 'tests/sqllogictests/test_files/scratch/table.parquet';
+COPY source_table to 'test_files/scratch/table.parquet';
 ----
 2
 
 # validate single parquet file output
 statement ok
-CREATE EXTERNAL TABLE validate_parquet_single STORED AS PARQUET LOCATION 'tests/sqllogictests/test_files/scratch/table.parquet';
+CREATE EXTERNAL TABLE validate_parquet_single STORED AS PARQUET LOCATION 'test_files/scratch/table.parquet';
 
 query IT
 select * from validate_parquet_single;
@@ -70,13 +70,13 @@ select * from validate_parquet_single;
 
 # copy from table to folder of csv files
 query IT
-COPY source_table  to 'tests/sqllogictests/test_files/scratch/table_csv' (format csv, per_thread_output true);
+COPY source_table  to 'test_files/scratch/table_csv' (format csv, per_thread_output true);
 ----
 2
 
 # validate folder of csv files
 statement ok
-CREATE EXTERNAL TABLE validate_csv STORED AS csv WITH HEADER ROW LOCATION 'tests/sqllogictests/test_files/scratch/table_csv';
+CREATE EXTERNAL TABLE validate_csv STORED AS csv WITH HEADER ROW LOCATION 'test_files/scratch/table_csv';
 
 query IT
 select * from validate_csv;
@@ -86,13 +86,13 @@ select * from validate_csv;
 
 # Copy from table to single csv
 query IT
-COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.csv';
+COPY source_table  to 'test_files/scratch/table.csv';
 ----
 2
 
 # Validate single csv output
 statement ok
-CREATE EXTERNAL TABLE validate_single_csv STORED AS csv WITH HEADER ROW LOCATION 'tests/sqllogictests/test_files/scratch/table.csv';
+CREATE EXTERNAL TABLE validate_single_csv STORED AS csv WITH HEADER ROW LOCATION 'test_files/scratch/table.csv';
 
 query IT
 select * from validate_single_csv;
@@ -102,13 +102,13 @@ select * from validate_single_csv;
 
 # Copy from table to folder of json
 query IT
-COPY source_table to 'tests/sqllogictests/test_files/scratch/table_json' (format json, per_thread_output true);
+COPY source_table to 'test_files/scratch/table_json' (format json, per_thread_output true);
 ----
 2
 
 # Validate json output
 statement ok
-CREATE EXTERNAL TABLE validate_json STORED AS json LOCATION 'tests/sqllogictests/test_files/scratch/table_json';
+CREATE EXTERNAL TABLE validate_json STORED AS json LOCATION 'test_files/scratch/table_json';
 
 query IT
 select * from validate_json;
@@ -118,13 +118,13 @@ select * from validate_json;
 
 # Copy from table to single json file
 query IT
-COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json';
+COPY source_table  to 'test_files/scratch/table.json';
 ----
 2
 
 # Validate single JSON file`
 statement ok
-CREATE EXTERNAL TABLE validate_single_json STORED AS json LOCATION 'tests/sqllogictests/test_files/scratch/table_json';
+CREATE EXTERNAL TABLE validate_single_json STORED AS json LOCATION 'test_files/scratch/table_json';
 
 query IT
 select * from validate_single_json;
@@ -134,13 +134,13 @@ select * from validate_single_json;
 
 # Copy from table with options
 query IT
-COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json' (row_group_size 55);
+COPY source_table  to 'test_files/scratch/table.json' (row_group_size 55);
 ----
 2
 
 # Copy from table with options (and trailing comma)
 query IT
-COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json' (row_group_size 55, row_group_limit_bytes 9,);
+COPY source_table  to 'test_files/scratch/table.json' (row_group_size 55, row_group_limit_bytes 9,);
 ----
 2
 

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -16,29 +16,131 @@
 # under the License.
 
 # tests for copy command
-
 statement ok
 create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 'Bar');
 
-# Copy from table
-statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
-COPY source_table  to '/tmp/table.parquet';
+# Copy to directory as multiple files
+query IT
+COPY source_table TO 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true);
+----
+2
 
+# Copy more files to directory via query
+query IT
+COPY (select * from source_table UNION ALL select * from source_table) to 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true);
+----
+4
+
+# validate multiple parquet file output
+statement ok
+CREATE EXTERNAL TABLE validate_parquet STORED AS PARQUET LOCATION 'tests/sqllogictests/test_files/scratch/table/';
+
+query IT
+select * from validate_parquet;
+----
+1 Foo
+2 Bar
+1 Foo
+2 Bar
+1 Foo
+2 Bar
+
+# Copy from table to single file
+query IT
+COPY source_table to 'tests/sqllogictests/test_files/scratch/table.parquet';
+----
+2
+
+# validate single parquet file output
+statement ok
+CREATE EXTERNAL TABLE validate_parquet_single STORED AS PARQUET LOCATION 'tests/sqllogictests/test_files/scratch/table.parquet';
+
+query IT
+select * from validate_parquet_single;
+----
+1 Foo
+2 Bar
+
+# copy from table to folder of csv files
+query IT
+COPY source_table  to 'tests/sqllogictests/test_files/scratch/table_csv' (format csv, per_thread_output true);
+----
+2
+
+# validate folder of csv files
+statement ok
+CREATE EXTERNAL TABLE validate_csv STORED AS csv WITH HEADER ROW LOCATION 'tests/sqllogictests/test_files/scratch/table_csv';
+
+query IT
+select * from validate_csv;
+----
+1 Foo
+2 Bar
+
+# Copy from table to single csv
+query IT
+COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.csv';
+----
+2
+
+# Validate single csv output
+statement ok
+CREATE EXTERNAL TABLE validate_single_csv STORED AS csv WITH HEADER ROW LOCATION 'tests/sqllogictests/test_files/scratch/table.csv';
+
+query IT
+select * from validate_single_csv;
+----
+1 Foo
+2 Bar
+
+# Copy from table to folder of json
+query IT
+COPY source_table to 'tests/sqllogictests/test_files/scratch/table_json' (format json, per_thread_output true);
+----
+2
+
+# Validate json output
+statement ok
+CREATE EXTERNAL TABLE validate_json STORED AS json LOCATION 'tests/sqllogictests/test_files/scratch/table_json';
+
+query IT
+select * from validate_json;
+----
+1 Foo
+2 Bar
+
+# Copy from table to single json file
+query IT
+COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json';
+----
+2
+
+# Validate single JSON file`
+statement ok
+CREATE EXTERNAL TABLE validate_single_json STORED AS json LOCATION 'tests/sqllogictests/test_files/scratch/table_json';
+
+query IT
+select * from validate_single_json;
+----
+1 Foo
+2 Bar
+
+# TODO add tests for statement level overrides once implemented (currently they have no effect)
 # Copy from table with options
-statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
-COPY source_table  to '/tmp/table.parquet' (row_group_size 55);
+#statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
+#COPY source_table  to '/home/dev/test/table.parquet' (row_group_size 55);
 
 # Copy from table with options (and trailing comma)
-statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
-COPY source_table  to '/tmp/table.parquet' (row_group_size 55, row_group_limit_bytes 9,);
+#statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
+#COPY source_table  to '/tmp/table.parquet' (row_group_size 55, row_group_limit_bytes 9,);
 
 
 # Error cases:
 
 # Incomplete statement
-statement error DataFusion error: SQL error: ParserError\("Expected \), found: EOF"\)
+query error DataFusion error: SQL error: ParserError\("Expected \), found: EOF"\)
 COPY (select col2, sum(col1) from source_table
 
 # Copy from table with non literal
-statement error DataFusion error: SQL error: ParserError\("Expected ',' or '\)' after option definition, found: \+"\)
+query error DataFusion error: SQL error: ParserError\("Expected ',' or '\)' after option definition, found: \+"\)
 COPY source_table  to '/tmp/table.parquet' (row_group_size 55 + 102);

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -25,6 +25,13 @@ COPY source_table TO 'tests/sqllogictests/test_files/scratch/table' (format parq
 ----
 2
 
+#Explain copy queries not currently working
+query error DataFusion error: This feature is not implemented: Unsupported SQL statement: Some\("COPY source_table TO 'tests/sqllogictests/test_files/scratch/table'"\)
+EXPLAIN COPY source_table to 'tests/sqllogictests/test_files/scratch/table'
+
+query error DataFusion error: SQL error: ParserError\("Expected end of statement, found: source_table"\)
+EXPLAIN COPY source_table to 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true)
+
 # Copy more files to directory via query
 query IT
 COPY (select * from source_table UNION ALL select * from source_table) to 'tests/sqllogictests/test_files/scratch/table' (format parquet, per_thread_output true);
@@ -125,14 +132,17 @@ select * from validate_single_json;
 1 Foo
 2 Bar
 
-# TODO add tests for statement level overrides once implemented (currently they have no effect)
 # Copy from table with options
-#statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
-#COPY source_table  to '/home/dev/test/table.parquet' (row_group_size 55);
+query IT
+COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json' (row_group_size 55);
+----
+2
 
 # Copy from table with options (and trailing comma)
-#statement error DataFusion error: This feature is not implemented: `COPY \.\. TO \.\.` statement is not yet supported
-#COPY source_table  to '/tmp/table.parquet' (row_group_size 55, row_group_limit_bytes 9,);
+query IT
+COPY source_table  to 'tests/sqllogictests/test_files/scratch/table.json' (row_group_size 55, row_group_limit_bytes 9,);
+----
+2
 
 
 # Error cases:


### PR DESCRIPTION
## Which issue does this PR close?

closes #5076 
closes https://github.com/apache/arrow-datafusion/pull/6539
Part of #5654 

## Rationale for this change

In many cases, we want to be able to export data to file(s) in an ObjectStore without first registering an external table. This is possible with `COPY ... TO ...` statements. We can leverage the FileSinks created to support inserting to ListingTables for part of the implementation for this.

## What changes are included in this PR?

- Implement a logical plan for Copy To statements
- Generalize name of `InsertExec` to `FileSinkExec`
- Implement a physical plan for Copy To statements relying on `FileSinkExec`
- Expand sqllogictests in copy.slt, add support for automatically cleared directory in sqllogictests for writing files fresh
- Reimplement `DataFrame::write_* `methods to use `Copy To`
- Add support for [per_thread_output ](https://duckdb.org/docs/sql/statements/copy.html) setting in `FileSinks `and `Copy To`  so user can specify if they want only one file output or possibly many is ok

Note that this PR does not add support for most statement level settings / overrides yet. That will be important to implement before closing out #5654.  

This graphic shows how all of the write related code is wired up after this PR:
![datafusion_writes](https://github.com/apache/arrow-datafusion/assets/14827143/bfa49a11-21db-4857-bcc7-72db7f362039)


## Are these changes tested?

Yes, see expanded copy.slt for new tests.

I also have plans to expand insert.slt to improve testing of recent additions of `insert into` support.

## Are there any user-facing changes?

Copy To statements (less most statement level overrides) are supported now. 

DataFrame write_* APIs have some small changes will need more changes as support for statement level overrides is added for copy to