### PR TITLE
Fix Unnest for array aggregations.

### DIFF
--- a/datafusion/core/src/physical_plan/unnest.rs
+++ b/datafusion/core/src/physical_plan/unnest.rs
@@ -18,8 +18,8 @@
 //! Defines the unnest column plan for unnesting values in a column that contains a list
 //! type, conceptually is like joining each row with all the values in the list column.
 use arrow::array::{
-    new_null_array, Array, ArrayAccessor, ArrayRef, ArrowPrimitiveType,
-    FixedSizeListArray, Int32Array, LargeListArray, ListArray, PrimitiveArray,
+    new_empty_array, new_null_array, Array, ArrayAccessor, ArrayRef, ArrowPrimitiveType,
+    FixedSizeListArray, LargeListArray, ListArray, PrimitiveArray,
 };
 use arrow::compute::kernels;
 use arrow::datatypes::{
@@ -307,7 +307,7 @@ where
     //   1, null, 3, null, 2
     //
     // Depending on the list type the result may be Int32Array or Int64Array.
-    let list_lengths = list_lengths(list_array)?;
+    let list_lengths = kernels::length::length(list_array)?;
 
     // Create the indices for the take kernel and then use those indices to create
     // the unnested record batch.
@@ -459,6 +459,10 @@ where
         }
     };
 
+    if list_array.is_empty() {
+        return Ok(new_empty_array(elem_type));
+    }
+
     let null_row = new_null_array(elem_type, 1);
 
     // Create a vec of ArrayRef from the list elements.
@@ -477,34 +481,4 @@ where
     let arrays = arrays.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
 
     Ok(kernels::concat::concat(&arrays)?)
-}
-
-/// Returns an array with the lengths of each list in `list_array`. Returns null
-/// for a null value.
-fn list_lengths<T>(list_array: &T) -> Result<Arc<dyn Array + 'static>>
-where
-    T: ArrayAccessor<Item = ArrayRef>,
-{
-    match list_array.data_type() {
-        DataType::List(_) | DataType::LargeList(_) => {
-            Ok(kernels::length::length(list_array)?)
-        }
-        DataType::FixedSizeList(_, size) => {
-            // Handle FixedSizeList as it is not handled by the `length` kernel.
-            // https://github.com/apache/arrow-rs/issues/4517
-            let mut lengths = Vec::with_capacity(list_array.len());
-            for row in 0..list_array.len() {
-                if list_array.is_null(row) {
-                    lengths.push(None)
-                } else {
-                    lengths.push(Some(*size));
-                }
-            }
-
-            Ok(Arc::new(Int32Array::from(lengths)))
-        }
-        dt => Err(DataFusionError::Execution(format!(
-            "Invalid type {dt} for list_lengths"
-        ))),
-    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7299.

## Rationale for this change

When unnesting a list array created by `array_agg` aggregation fails with error:

```
ArrowError(ComputeError("concat requires input of at least one array"))
```

This PR adds code to prevent `concat` from being called with an empty array during unnesting.

## What changes are included in this PR?

This PR adds code to prevent `concat` from being called with an empty array during unnesting.

This PR also removes the `list_lengths` workaround fixed in  [arrow #4517](https://github.com/apache/arrow-rs/issues/4517).

## Are these changes tested?

Yes added a test for the failing scenario.


## Are there any user-facing changes?

No