### PR TITLE
Minor: Followup tasks for `nanvl`

### DIFF
--- a/datafusion/physical-expr/src/math_expressions.rs
+++ b/datafusion/physical-expr/src/math_expressions.rs
@@ -1057,9 +1057,9 @@ mod tests {
             Arc::new(Float64Array::from(vec![5.0, 6.0, f64::NAN, f64::NAN])), // x
         ];
 
-        let result = nanvl(&args).expect("failed to initialize function atan2");
+        let result = nanvl(&args).expect("failed to initialize function nanvl");
         let floats =
-            as_float64_array(&result).expect("failed to initialize function atan2");
+            as_float64_array(&result).expect("failed to initialize function nanvl");
 
         assert_eq!(floats.len(), 4);
         assert_eq!(floats.value(0), 1.0);
@@ -1075,9 +1075,9 @@ mod tests {
             Arc::new(Float32Array::from(vec![5.0, 6.0, f32::NAN, f32::NAN])), // x
         ];
 
-        let result = nanvl(&args).expect("failed to initialize function atan2");
+        let result = nanvl(&args).expect("failed to initialize function nanvl");
         let floats =
-            as_float32_array(&result).expect("failed to initialize function atan2");
+            as_float32_array(&result).expect("failed to initialize function nanvl");
 
         assert_eq!(floats.len(), 4);
         assert_eq!(floats.value(0), 1.0);

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -101,6 +101,7 @@ expressions such as `col("a") + col("b")` to be used.
 | log(base, x)          | logarithm of x for a particular base              |
 | log10(x)              | base 10 logarithm                                 |
 | log2(x)               | base 2 logarithm                                  |
+| nanvl(x, y)           | returns x if x is not NaN otherwise returns y     |
 | pi()                  | approximate value of π                            |
 | power(base, exponent) | base raised to the power of exponent              |
 | radians(x)            | converts degrees to radians                       |


### PR DESCRIPTION
Closes #7310 

## Rationale for this change
`nanvl` was added in #7171 but some additional change needed.
One is adding an entry to the function list table in `user-guide/expressions.md` for `nanvl`.
Another is modifying the error message in tests newly added to `math_expressions.rs`.

## What changes are included in this PR?
This PR added an entry to the function list table for `nanvl` and fix the error message in `math_expressions.rs`.

## Are these changes tested?
Existing tests pass with `cargo test --workspace`.

## Are there any user-facing changes?
No.