### PR TITLE
Minor: Improve doc comments to datafusion-sql

### DIFF
--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -15,8 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! This module provides a SQL parser that translates SQL queries into an abstract syntax
-//! tree (AST), and a SQL query planner that creates a logical plan from the AST.
+//! This module provides:
+//!
+//! 1. A SQL parser, [`DFParser`], that translates SQL query text into
+//! an abstract syntax tree (AST), [`Statement`].
+//!
+//! 2. A SQL query planner [`SqlToRel`] that creates [`LogicalPlan`]s
+//! from `Statements`.
+//!
+//! [`DFParser`]: parser::DFParser
+//! [`Statement`]: parser::Statement
+//! [`SqlToRel`]: planner::SqlToRel
+//! [`LogicalPlan`]: datafusion_expr::logical_plan::LogicalPlan
 
 mod expr;
 pub mod parser;

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion SQL Parser based on [`sqlparser`]
+//! [`DFParser`]: DataFusion SQL Parser based on [`sqlparser`]
 
 use datafusion_common::parsers::CompressionTypeVariant;
 use sqlparser::ast::{OrderByExpr, Query, Value};
@@ -191,9 +191,13 @@ pub struct DescribeTableStmt {
     pub table_name: ObjectName,
 }
 
-/// DataFusion Statement representations.
+/// DataFusion SQL Statement.
 ///
-/// Tokens parsed by [`DFParser`] are converted into these values.
+/// This can either be a [`Statement`] from [`sqlparser`] from a
+/// standard SQL dialect, or a DataFusion extension such as `CREATE
+/// EXTERAL TABLE`. See [`DFParser`] for more information.
+///
+/// [`Statement`]: sqlparser::ast::Statement
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
     /// ANSI SQL AST node (from sqlparser-rs)
@@ -219,8 +223,13 @@ impl fmt::Display for Statement {
 
 /// DataFusion SQL Parser based on [`sqlparser`]
 ///
-/// This parser handles DataFusion specific statements, delegating to
-/// [`Parser`](sqlparser::parser::Parser) for other SQL statements.
+/// Parses DataFusion's SQL dialect, often delegating to [`sqlparser`]'s
+/// [`Parser`](sqlparser::parser::Parser).
+///
+/// DataFusion mostly follows existing SQL dialects via
+/// `sqlparser`. However, certain statements such as `COPY` and
+/// `CREATE EXTERNAL TABLE` have special syntax in DataFusion. See
+/// [`Statement`] for a list of this special syntax
 pub struct DFParser<'a> {
     parser: Parser<'a>,
 }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! SQL Query Planner (produces logical plan from SQL AST)
+//! [`SqlToRel`]: SQL Query Planner (produces [`LogicalPlan`] from SQL AST)
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;


### PR DESCRIPTION
## Which issue does this PR close?

N/A
## Rationale for this change
@devinjdangelo  noted that the distinction between the DataFusion SQL parser and sqlparser was somewhat unclear: https://github.com/apache/arrow-datafusion/pull/7291#discussion_r1296541827


## What changes are included in this PR?

Update doc comments in the `datafusion-sql` module to try and make the rationale / distinction clearer

## Are these changes tested?
N/A
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Just documentation
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->