### PR TITLE
chore(deps): update tokio requirement to 1.28

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -88,7 +88,7 @@ rand = "0.8"
 smallvec = { version = "1.6", features = ["union"] }
 sqlparser = { workspace = true }
 tempfile = "3"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
+tokio = { version = "1.28", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-util = { version = "0.7.4", features = ["io"] }
 url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
## Which issue does this PR close?
 Discussed in https://github.com/apache/arrow-datafusion/discussions/7253


## Rationale for this change
We are using a new API `JoinSet::spawn_blocking` introduced in tokio 1.28.
https://github.com/apache/arrow-datafusion/blob/f2c0100a5a10bf3ea166a1a590d94b8c9b6cf673/datafusion/core/src/physical_plan/stream.rs#L97

tokio v1.28 [changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md#1280-april-25th-2023):
> 1.28.0 (April 25th, 2023)
Added
task: add JoinSet::spawn_blocking and JoinSet::spawn_blocking_on (https://github.com/tokio-rs/tokio/pull/5612)


So it’s better for us to raise the minimum required tokio version to 1.28.
This can help avoid compilation failures for users.

## What changes are included in this PR?
Bump tokio version

## Are these changes tested?
N/A

## Are there any user-facing changes?
No
