### PR TITLE
Clarify documentation for read only queries

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -184,17 +184,18 @@ where
 /// assert_batches_eq!(
 ///  &[
 ///    "+---+----------------+",
-///    "| a | MIN(example.b) |",
+///    "| a | MIN(?table?.b) |",
 ///    "+---+----------------+",
 ///    "| 1 | 2              |",
 ///    "+---+----------------+",
+///  ],
 ///  &results
 /// );
 /// # Ok(())
 /// # }
 /// ```
 ///
-/// # Example: SQL APU
+/// # Example: SQL API
 ///
 /// The following example demonstrates how to execute the same query using SQL:
 ///
@@ -217,6 +218,7 @@ where
 ///    "+---+----------------+",
 ///    "| 1 | 2              |",
 ///    "+---+----------------+",
+///  ],
 ///  &results
 /// );
 /// # Ok(())

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -99,7 +99,6 @@ pub mod select;
 pub mod subqueries;
 pub mod timestamp;
 pub mod udf;
-mod readonly;
 
 fn assert_float_eq<T>(expected: &[Vec<T>], received: &[Vec<String>])
 where

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -99,6 +99,7 @@ pub mod select;
 pub mod subqueries;
 pub mod timestamp;
 pub mod udf;
+mod readonly;
 
 fn assert_float_eq<T>(expected: &[Vec<T>], received: &[Vec<String>])
 where


### PR DESCRIPTION
## Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/7272

## Rationale for this change

As @UlfarErl notes in https://github.com/apache/arrow-datafusion/issues/7272, it is somewhat unclear how to use DataFusion to run SQL that can not modify the catalog. 

## What changes are included in this PR?

1. Update docs with examples of how to run SQL that can not modify the catalog.

As I was working on these examples, it became clear that the current API is confusing as well as there is no way to avoid `DML` (aka Insert / COPY). I filed https://github.com/apache/arrow-datafusion/issues/7328 to track this

## Are these changes tested?
Yes, doc tests

## Are there any user-facing changes?
Docs
