### PR TITLE
Minor: add `WriteOp::name` and `DmlStatement::name`

### DIFF
--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -96,6 +96,13 @@ pub struct DmlStatement {
     pub input: Arc<LogicalPlan>,
 }
 
+impl DmlStatement {
+    /// Return a descriptive name of this [`DmlStatement`]
+    pub fn name(&self) -> &str {
+        self.op.name()
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum WriteOp {
     InsertOverwrite,
@@ -105,14 +112,21 @@ pub enum WriteOp {
     Ctas,
 }
 
+impl WriteOp {
+    /// Return a descriptive name of this [`WriteOp`]
+    pub fn name(&self) -> &str {
+        match self {
+            WriteOp::InsertOverwrite => "Insert Overwrite",
+            WriteOp::InsertInto => "Insert Into",
+            WriteOp::Delete => "Delete",
+            WriteOp::Update => "Update",
+            WriteOp::Ctas => "Ctas",
+        }
+    }
+}
+
 impl Display for WriteOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WriteOp::InsertOverwrite => write!(f, "Insert Overwrite"),
-            WriteOp::InsertInto => write!(f, "Insert Into"),
-            WriteOp::Delete => write!(f, "Delete"),
-            WriteOp::Update => write!(f, "Update"),
-            WriteOp::Ctas => write!(f, "Ctas"),
-        }
+        write!(f, "{}", self.name())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
While working on https://github.com/influxdata/influxdb_iox/pull/8515  I found that DdlStatement had a `name()` but `DmlStatement` did not.  This was annoying and slowed me down (very slightly)

https://docs.rs/datafusion/latest/datafusion/logical_expr/enum.DdlStatement.html#method.name

## What changes are included in this PR?

1. Add  `WriteOp::name` and `DmlStatement::name`

## Are these changes tested?

Existing coverage

## Are there any user-facing changes?
New method
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->