### PR TITLE
Add `not_impl_err` error macro

### DIFF
--- a/benchmarks/src/tpch/convert.rs
+++ b/benchmarks/src/tpch/convert.rs
@@ -19,6 +19,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use datafusion::common::not_impl_err;
 use datafusion::error::DataFusionError;
 use datafusion::error::Result;
 use datafusion::prelude::*;
@@ -117,9 +118,7 @@ impl ConvertOpt {
                     ctx.write_parquet(csv, output_path, Some(props)).await?
                 }
                 other => {
-                    return Err(DataFusionError::NotImplemented(format!(
-                        "Invalid output format: {other}"
-                    )));
+                    return not_impl_err!("Invalid output format: {other}");
                 }
             }
             println!("Conversion completed in {} ms", start.elapsed().as_millis());
@@ -139,9 +138,7 @@ impl ConvertOpt {
             "lz0" => Compression::LZO,
             "zstd" => Compression::ZSTD(Default::default()),
             other => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Invalid compression format: {other}"
-                )));
+                return not_impl_err!("Invalid compression format: {other}");
             }
         })
     }

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -451,9 +451,13 @@ make_error!(plan_err, Plan);
 // Exposes a macro to create `DataFusionError::Internal`
 make_error!(internal_err, Internal);
 
+// Exposes a macro to create `DataFusionError::NotImplemented`
+make_error!(not_impl_err, NotImplemented);
+
 // To avoid compiler error when using macro in the same crate:
 // macros from the current crate cannot be referred to by absolute paths
 pub use internal_err as _internal_err;
+pub use not_impl_err as _not_impl_err;
 
 #[cfg(test)]
 mod test {

--- a/datafusion/common/src/join_type.rs
+++ b/datafusion/common/src/join_type.rs
@@ -22,6 +22,7 @@ use std::{
     str::FromStr,
 };
 
+use crate::error::_not_impl_err;
 use crate::{DataFusionError, Result};
 
 /// Join type
@@ -81,9 +82,7 @@ impl FromStr for JoinType {
             "RIGHTSEMI" => Ok(JoinType::RightSemi),
             "LEFTANTI" => Ok(JoinType::LeftAnti),
             "RIGHTANTI" => Ok(JoinType::RightAnti),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "The join type {s} does not exist or is not implemented"
-            ))),
+            _ => _not_impl_err!("The join type {s} does not exist or is not implemented"),
         }
     }
 }

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -30,7 +30,7 @@ use crate::cast::{
     as_fixed_size_binary_array, as_fixed_size_list_array, as_list_array, as_struct_array,
 };
 use crate::delta::shift_months;
-use crate::error::{DataFusionError, Result, _internal_err};
+use crate::error::{DataFusionError, Result, _internal_err, _not_impl_err};
 use arrow::buffer::NullBuffer;
 use arrow::compute::nullif;
 use arrow::datatypes::{i256, FieldRef, Fields, SchemaBuilder};
@@ -617,9 +617,7 @@ macro_rules! decimal_right {
         -$TERM
     };
     ($TERM:expr, /) => {
-        Err(DataFusionError::NotImplemented(format!(
-            "Decimal reciprocation not yet supported",
-        )))
+        _not_impl_err!("Decimal reciprocation not yet supported",)
     };
 }
 
@@ -1870,9 +1868,9 @@ impl ScalarValue {
                 ScalarValue::DurationNanosecond(None)
             }
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create a zero scalar from data_type \"{datatype:?}\""
-                )));
+                );
             }
         })
     }
@@ -1892,9 +1890,9 @@ impl ScalarValue {
             DataType::Float32 => ScalarValue::Float32(Some(1.0)),
             DataType::Float64 => ScalarValue::Float64(Some(1.0)),
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create an one scalar from data_type \"{datatype:?}\""
-                )));
+                );
             }
         })
     }
@@ -1910,9 +1908,9 @@ impl ScalarValue {
             DataType::Float32 => ScalarValue::Float32(Some(-1.0)),
             DataType::Float64 => ScalarValue::Float64(Some(-1.0)),
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create a negative one scalar from data_type \"{datatype:?}\""
-                )));
+                );
             }
         })
     }
@@ -1931,9 +1929,9 @@ impl ScalarValue {
             DataType::Float32 => ScalarValue::Float32(Some(10.0)),
             DataType::Float64 => ScalarValue::Float64(Some(10.0)),
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create a negative one scalar from data_type \"{datatype:?}\""
-                )));
+                );
             }
         })
     }
@@ -3257,9 +3255,9 @@ impl ScalarValue {
             }
 
             other => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create a scalar from array of type \"{other:?}\""
-                )));
+                );
             }
         })
     }
@@ -3820,9 +3818,9 @@ impl TryFrom<&DataType> for ScalarValue {
             DataType::Struct(fields) => ScalarValue::Struct(None, fields.clone()),
             DataType::Null => ScalarValue::Null,
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return _not_impl_err!(
                     "Can't create a scalar from data_type \"{datatype:?}\""
-                )));
+                );
             }
         })
     }

--- a/datafusion/core/src/catalog/mod.rs
+++ b/datafusion/core/src/catalog/mod.rs
@@ -25,7 +25,7 @@ pub use datafusion_sql::{ResolvedTableReference, TableReference};
 
 use crate::catalog::schema::SchemaProvider;
 use dashmap::DashMap;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -125,9 +125,7 @@ pub trait CatalogProvider: Sync + Send {
         // use variables to avoid unused variable warnings
         let _ = name;
         let _ = schema;
-        Err(DataFusionError::NotImplemented(
-            "Registering new schemas is not supported".to_string(),
-        ))
+        not_impl_err!("Registering new schemas is not supported")
     }
 
     /// Removes a schema from this catalog. Implementations of this method should return
@@ -145,9 +143,7 @@ pub trait CatalogProvider: Sync + Send {
         _name: &str,
         _cascade: bool,
     ) -> Result<Option<Arc<dyn SchemaProvider>>> {
-        Err(DataFusionError::NotImplemented(
-            "Deregistering new schemas is not supported".to_string(),
-        ))
+        not_impl_err!("Deregistering new schemas is not supported")
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -27,7 +27,7 @@ use arrow::csv::WriterBuilder;
 use arrow::datatypes::{DataType, Field, Fields, Schema};
 use arrow::{self, datatypes::SchemaRef};
 use arrow_array::RecordBatch;
-use datafusion_common::DataFusionError;
+use datafusion_common::{not_impl_err, DataFusionError};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::PhysicalExpr;
 
@@ -267,15 +267,11 @@ impl FileFormat for CsvFormat {
         conf: FileSinkConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if conf.overwrite {
-            return Err(DataFusionError::NotImplemented(
-                "Overwrites are not implemented yet for CSV".into(),
-            ));
+            return not_impl_err!("Overwrites are not implemented yet for CSV");
         }
 
         if self.file_compression_type != FileCompressionType::UNCOMPRESSED {
-            return Err(DataFusionError::NotImplemented(
-                "Inserting compressed CSV is not implemented yet.".into(),
-            ));
+            return not_impl_err!("Inserting compressed CSV is not implemented yet.");
         }
 
         let sink_schema = conf.output_schema().clone();
@@ -512,7 +508,7 @@ impl DataSink for CsvSink {
         match self.config.writer_mode {
             FileWriterMode::Append => {
                 if !self.config.per_thread_output {
-                    return Err(DataFusionError::NotImplemented("per_thread_output=false is not implemented for CsvSink in Append mode".into()));
+                    return not_impl_err!("per_thread_output=false is not implemented for CsvSink in Append mode");
                 }
                 for file_group in &self.config.file_groups {
                     // In append mode, consider has_header flag only when file is empty (at the start).
@@ -538,9 +534,7 @@ impl DataSink for CsvSink {
                 }
             }
             FileWriterMode::Put => {
-                return Err(DataFusionError::NotImplemented(
-                    "Put Mode is not implemented for CSV Sink yet".into(),
-                ))
+                return not_impl_err!("Put Mode is not implemented for CSV Sink yet")
             }
             FileWriterMode::PutMultipart => {
                 // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)

--- a/datafusion/core/src/datasource/file_format/file_type.rs
+++ b/datafusion/core/src/datasource/file_format/file_type.rs
@@ -17,7 +17,7 @@
 
 //! File type abstraction
 
-use crate::common::internal_err;
+use crate::common::{internal_err, not_impl_err};
 use crate::datasource::file_format::arrow::DEFAULT_ARROW_EXTENSION;
 use crate::datasource::file_format::avro::DEFAULT_AVRO_EXTENSION;
 use crate::datasource::file_format::csv::DEFAULT_CSV_EXTENSION;
@@ -144,9 +144,7 @@ impl FileCompressionType {
                 .boxed(),
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {
-                return Err(DataFusionError::NotImplemented(
-                    "Compression feature is not enabled".to_owned(),
-                ))
+                return not_impl_err!("Compression feature is not enabled")
             }
             UNCOMPRESSED => s.boxed(),
         })
@@ -169,9 +167,7 @@ impl FileCompressionType {
             ZSTD => Box::new(ZstdEncoder::new(w)),
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {
-                return Err(DataFusionError::NotImplemented(
-                    "Compression feature is not enabled".to_owned(),
-                ))
+                return not_impl_err!("Compression feature is not enabled")
             }
             UNCOMPRESSED => w,
         })
@@ -201,9 +197,7 @@ impl FileCompressionType {
                 .boxed(),
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {
-                return Err(DataFusionError::NotImplemented(
-                    "Compression feature is not enabled".to_owned(),
-                ))
+                return not_impl_err!("Compression feature is not enabled")
             }
             UNCOMPRESSED => s.boxed(),
         })
@@ -228,9 +222,7 @@ impl FileCompressionType {
             },
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {
-                return Err(DataFusionError::NotImplemented(
-                    "Compression feature is not enabled".to_owned(),
-                ))
+                return not_impl_err!("Compression feature is not enabled")
             }
             UNCOMPRESSED => Box::new(r),
         })
@@ -275,9 +267,7 @@ impl FromStr for FileType {
             "PARQUET" => Ok(FileType::PARQUET),
             "CSV" => Ok(FileType::CSV),
             "JSON" | "NDJSON" => Ok(FileType::JSON),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unknown FileType: {s}"
-            ))),
+            _ => not_impl_err!("Unknown FileType: {s}"),
         }
     }
 }

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -20,6 +20,7 @@
 use std::any::Any;
 
 use bytes::Bytes;
+use datafusion_common::not_impl_err;
 use datafusion_common::DataFusionError;
 use datafusion_execution::TaskContext;
 use rand::distributions::Alphanumeric;
@@ -174,15 +175,11 @@ impl FileFormat for JsonFormat {
         conf: FileSinkConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if conf.overwrite {
-            return Err(DataFusionError::NotImplemented(
-                "Overwrites are not implemented yet for Json".into(),
-            ));
+            return not_impl_err!("Overwrites are not implemented yet for Json");
         }
 
         if self.file_compression_type != FileCompressionType::UNCOMPRESSED {
-            return Err(DataFusionError::NotImplemented(
-                "Inserting compressed JSON is not implemented yet.".into(),
-            ));
+            return not_impl_err!("Inserting compressed JSON is not implemented yet.");
         }
         let sink_schema = conf.output_schema().clone();
         let sink = Arc::new(JsonSink::new(conf, self.file_compression_type));
@@ -281,7 +278,7 @@ impl DataSink for JsonSink {
         match self.config.writer_mode {
             FileWriterMode::Append => {
                 if !self.config.per_thread_output {
-                    return Err(DataFusionError::NotImplemented("per_thread_output=false is not implemented for JsonSink in Append mode".into()));
+                    return not_impl_err!("per_thread_output=false is not implemented for JsonSink in Append mode");
                 }
                 for file_group in &self.config.file_groups {
                     let serializer = JsonSerializer::new();
@@ -299,9 +296,7 @@ impl DataSink for JsonSink {
                 }
             }
             FileWriterMode::Put => {
-                return Err(DataFusionError::NotImplemented(
-                    "Put Mode is not implemented for Json Sink yet".into(),
-                ))
+                return not_impl_err!("Put Mode is not implemented for Json Sink yet")
             }
             FileWriterMode::PutMultipart => {
                 // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -40,7 +40,7 @@ use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::physical_plan::{ExecutionPlan, Statistics};
 
-use datafusion_common::DataFusionError;
+use datafusion_common::{not_impl_err, DataFusionError};
 use datafusion_physical_expr::PhysicalExpr;
 
 use async_trait::async_trait;
@@ -100,8 +100,7 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
         _state: &SessionState,
         _conf: FileSinkConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let msg = "Writer not implemented for this format".to_owned();
-        Err(DataFusionError::NotImplemented(msg))
+        not_impl_err!("Writer not implemented for this format")
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -28,7 +28,7 @@ use arrow::datatypes::SchemaRef;
 use arrow::datatypes::{Fields, Schema};
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
-use datafusion_common::{plan_err, DataFusionError};
+use datafusion_common::{not_impl_err, plan_err, DataFusionError};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::PhysicalExpr;
 use futures::{StreamExt, TryStreamExt};
@@ -231,9 +231,7 @@ impl FileFormat for ParquetFormat {
         conf: FileSinkConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if conf.overwrite {
-            return Err(DataFusionError::NotImplemented(
-                "Overwrites are not implemented yet for Parquet".into(),
-            ));
+            return not_impl_err!("Overwrites are not implemented yet for Parquet");
         }
 
         let sink_schema = conf.output_schema().clone();
@@ -826,9 +824,9 @@ impl ParquetSink {
                     "Appending to Parquet files is not supported by the file format!"
                 )
             }
-            FileWriterMode::Put => Err(DataFusionError::NotImplemented(
-                "FileWriterMode::Put is not implemented for ParquetSink".into(),
-            )),
+            FileWriterMode::Put => {
+                not_impl_err!("FileWriterMode::Put is not implemented for ParquetSink")
+            }
             FileWriterMode::PutMultipart => {
                 let (_, multipart_writer) = object_store
                     .put_multipart(&object.location)
@@ -869,9 +867,7 @@ impl DataSink for ParquetSink {
                 )
             }
             FileWriterMode::Put => {
-                return Err(DataFusionError::NotImplemented(
-                    "Put Mode is not implemented for ParquetSink yet".into(),
-                ))
+                return not_impl_err!("Put Mode is not implemented for ParquetSink yet")
             }
             FileWriterMode::PutMultipart => {
                 // Currently assuming only 1 partition path (i.e. not hive-style partitioning on a column)

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -26,7 +26,9 @@ use std::sync::Arc;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
-use datafusion_common::{plan_err, Constraints, DataFusionError, SchemaExt};
+use datafusion_common::{
+    not_impl_err, plan_err, Constraints, DataFusionError, SchemaExt,
+};
 use datafusion_execution::TaskContext;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
@@ -214,9 +216,7 @@ impl TableProvider for MemTable {
             );
         }
         if overwrite {
-            return Err(DataFusionError::NotImplemented(
-                "Overwrite not implemented for MemoryTable yet".into(),
-            ));
+            return not_impl_err!("Overwrite not implemented for MemoryTable yet");
         }
         let sink = Arc::new(MemSink::new(self.batches.clone()));
         Ok(Arc::new(FileSinkExec::new(

--- a/datafusion/core/src/datasource/provider.rs
+++ b/datafusion/core/src/datasource/provider.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion_common::{Constraints, DataFusionError, Statistics};
+use datafusion_common::{not_impl_err, Constraints, DataFusionError, Statistics};
 use datafusion_expr::{CreateExternalTable, LogicalPlan};
 pub use datafusion_expr::{TableProviderFilterPushDown, TableType};
 
@@ -129,8 +129,7 @@ pub trait TableProvider: Sync + Send {
         _input: Arc<dyn ExecutionPlan>,
         _overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let msg = "Insert into not implemented for this table".to_owned();
-        Err(DataFusionError::NotImplemented(msg))
+        not_impl_err!("Insert into not implemented for this table")
     }
 }
 

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -28,7 +28,7 @@ use crate::{
     optimizer::optimizer::Optimizer,
     physical_optimizer::optimizer::{PhysicalOptimizer, PhysicalOptimizerRule},
 };
-use datafusion_common::{alias::AliasGenerator, plan_err};
+use datafusion_common::{alias::AliasGenerator, not_impl_err, plan_err};
 use datafusion_execution::registry::SerializerRegistry;
 use datafusion_expr::{
     logical_plan::{DdlStatement, Statement},
@@ -1643,9 +1643,9 @@ impl SessionState {
         })?;
         let mut statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
         if statements.len() > 1 {
-            return Err(DataFusionError::NotImplemented(
-                "The context currently only supports a single SQL statement".to_string(),
-            ));
+            return not_impl_err!(
+                "The context currently only supports a single SQL statement"
+            );
         }
         let statement = statements.pop_front().ok_or_else(|| {
             DataFusionError::NotImplemented(
@@ -2069,10 +2069,10 @@ impl SerializerRegistry for EmptySerializerRegistry {
         &self,
         node: &dyn UserDefinedLogicalNode,
     ) -> Result<Vec<u8>> {
-        Err(DataFusionError::NotImplemented(format!(
+        not_impl_err!(
             "Serializing user defined logical plan node `{}` is not supported",
             node.name()
-        )))
+        )
     }
 
     fn deserialize_logical_plan(
@@ -2080,9 +2080,9 @@ impl SerializerRegistry for EmptySerializerRegistry {
         name: &str,
         _bytes: &[u8],
     ) -> Result<Arc<dyn UserDefinedLogicalNode>> {
-        Err(DataFusionError::NotImplemented(format!(
+        not_impl_err!(
             "Deserializing user defined logical plan node `{name}` is not supported"
-        )))
+        )
     }
 }
 
@@ -2683,9 +2683,7 @@ mod tests {
             _logical_plan: &LogicalPlan,
             _session_state: &SessionState,
         ) -> Result<Arc<dyn ExecutionPlan>> {
-            Err(DataFusionError::NotImplemented(
-                "query not supported".to_string(),
-            ))
+            not_impl_err!("query not supported")
         }
 
         fn create_physical_expr(

--- a/datafusion/core/src/physical_plan/aggregates/mod.rs
+++ b/datafusion/core/src/physical_plan/aggregates/mod.rs
@@ -30,7 +30,7 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::utils::longest_consecutive_prefix;
-use datafusion_common::{plan_err, DataFusionError, Result};
+use datafusion_common::{not_impl_err, plan_err, DataFusionError, Result};
 use datafusion_execution::TaskContext;
 use datafusion_expr::Accumulator;
 use datafusion_physical_expr::{
@@ -448,9 +448,9 @@ fn get_finest_requirement<
             // If neither of the requirements satisfy the other, this means
             // requirements are conflicting. Currently, we do not support
             // conflicting requirements.
-            return Err(DataFusionError::NotImplemented(
-                "Conflicting ordering requirements in aggregate functions is not supported".to_string(),
-            ));
+            return not_impl_err!(
+                "Conflicting ordering requirements in aggregate functions is not supported"
+            );
         } else {
             finest_req = Some(fn_req.clone());
         }

--- a/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
+++ b/datafusion/core/src/physical_plan/joins/sort_merge_join.rs
@@ -49,7 +49,9 @@ use arrow::compute::{concat_batches, take, SortOptions};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{internal_err, plan_err, DataFusionError, JoinType, Result};
+use datafusion_common::{
+    internal_err, not_impl_err, plan_err, DataFusionError, JoinType, Result,
+};
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{OrderingEquivalenceProperties, PhysicalSortRequirement};
@@ -101,9 +103,9 @@ impl SortMergeJoinExec {
         let right_schema = right.schema();
 
         if join_type == JoinType::RightSemi {
-            return Err(DataFusionError::NotImplemented(
-                "SortMergeJoinExec does not support JoinType::RightSemi".to_string(),
-            ));
+            return not_impl_err!(
+                "SortMergeJoinExec does not support JoinType::RightSemi"
+            );
         }
 
         check_join_is_valid(&left_schema, &right_schema, &on)?;
@@ -1301,9 +1303,9 @@ fn compare_join_arrays(
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
             _ => {
-                return Err(DataFusionError::NotImplemented(
-                    "Unsupported data type in sort merge join comparator".to_owned(),
-                ));
+                return not_impl_err!(
+                    "Unsupported data type in sort merge join comparator"
+                );
             }
         }
         if !res.is_eq() {
@@ -1367,9 +1369,9 @@ fn is_join_arrays_equal(
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
             _ => {
-                return Err(DataFusionError::NotImplemented(
-                    "Unsupported data type in sort merge join comparator".to_owned(),
-                ));
+                return not_impl_err!(
+                    "Unsupported data type in sort merge join comparator"
+                );
             }
         }
         if !is_equal {

--- a/datafusion/core/src/physical_plan/repartition/mod.rs
+++ b/datafusion/core/src/physical_plan/repartition/mod.rs
@@ -45,7 +45,7 @@ use super::{DisplayAs, RecordBatchStream, SendableRecordBatchStream};
 use arrow::array::{ArrayRef, UInt64Builder};
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{OrderingEquivalenceProperties, PhysicalExpr};
@@ -119,11 +119,7 @@ impl BatchPartitioner {
                 random_state: ahash::RandomState::with_seeds(0, 0, 0, 0),
                 hash_buffer: vec![],
             },
-            other => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported repartitioning scheme {other:?}"
-                )))
-            }
+            other => return not_impl_err!("Unsupported repartitioning scheme {other:?}"),
         };
 
         Ok(Self { state, timer })

--- a/datafusion/core/src/physical_plan/udaf.rs
+++ b/datafusion/core/src/physical_plan/udaf.rs
@@ -28,7 +28,7 @@ use arrow::{
 
 use super::{expressions::format_state_name, Accumulator, AggregateExpr};
 use crate::physical_plan::PhysicalExpr;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 pub use datafusion_expr::AggregateUDF;
 
 use datafusion_physical_expr::aggregate::utils::down_cast_any_ref;
@@ -152,11 +152,11 @@ impl AggregateExpr for AggregateFunctionExpr {
         // approach. In window function (when they use a window frame)
         // they get all the desired range during evaluation.
         if !accumulator.supports_retract_batch() {
-            return Err(DataFusionError::NotImplemented(format!(
+            return not_impl_err!(
                 "Aggregate can not be used as a sliding accumulator because \
                      `retract_batch` is not implemented: {}",
                 self.name
-            )));
+            );
         }
         Ok(accumulator)
     }

--- a/datafusion/core/src/physical_plan/unnest.rs
+++ b/datafusion/core/src/physical_plan/unnest.rs
@@ -28,7 +28,9 @@ use arrow::datatypes::{
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion_common::UnnestOptions;
-use datafusion_common::{cast::as_primitive_array, DataFusionError, Result};
+use datafusion_common::{
+    cast::as_primitive_array, not_impl_err, DataFusionError, Result,
+};
 use datafusion_execution::TaskContext;
 use futures::Stream;
 use futures::StreamExt;
@@ -147,9 +149,7 @@ impl ExecutionPlan for UnnestExec {
         let input = self.input.execute(partition, context)?;
 
         if !self.options.preserve_nulls {
-            return Err(DataFusionError::NotImplemented(
-                "Unnest with preserve_nulls=false".to_string(),
-            ));
+            return not_impl_err!("Unnest with preserve_nulls=false");
         }
 
         Ok(Box::pin(UnnestStream {

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -72,7 +72,7 @@ use crate::{
 use arrow::compute::SortOptions;
 use arrow::datatypes::{Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion_common::{internal_err, plan_err, DFSchema, ScalarValue};
+use datafusion_common::{internal_err, not_impl_err, plan_err, DFSchema, ScalarValue};
 use datafusion_expr::expr::{
     self, AggregateFunction, AggregateUDF, Alias, Between, BinaryExpr, Cast,
     GetFieldAccess, GetIndexedField, GroupingSet, InList, Like, ScalarUDF, TryCast,
@@ -291,15 +291,15 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
                 Ok(format!("{expr} IN ({list:?})"))
             }
         }
-        Expr::Exists { .. } => Err(DataFusionError::NotImplemented(
-            "EXISTS is not yet supported in the physical plan".to_string(),
-        )),
-        Expr::InSubquery(_) => Err(DataFusionError::NotImplemented(
-            "IN subquery is not yet supported in the physical plan".to_string(),
-        )),
-        Expr::ScalarSubquery(_) => Err(DataFusionError::NotImplemented(
-            "Scalar subqueries are not yet supported in the physical plan".to_string(),
-        )),
+        Expr::Exists { .. } => {
+            not_impl_err!("EXISTS is not yet supported in the physical plan")
+        }
+        Expr::InSubquery(_) => {
+            not_impl_err!("IN subquery is not yet supported in the physical plan")
+        }
+        Expr::ScalarSubquery(_) => {
+            not_impl_err!("Scalar subqueries are not yet supported in the physical plan")
+        }
         Expr::Between(Between {
             expr,
             negated,
@@ -940,7 +940,7 @@ impl DefaultPhysicalPlanner {
                             Partitioning::Hash(runtime_expr, *n)
                         }
                         LogicalPartitioning::DistributeBy(_) => {
-                            return Err(DataFusionError::NotImplemented("Physical plan does not support DistributeBy partitioning".to_string()));
+                            return not_impl_err!("Physical plan does not support DistributeBy partitioning");
                         }
                     };
                     Ok(Arc::new(RepartitionExec::try_new(
@@ -1136,7 +1136,7 @@ impl DefaultPhysicalPlanner {
                         // Sort-Merge join support currently is experimental
                         if join_filter.is_some() {
                             // TODO SortMergeJoinExec need to support join filter
-                            Err(DataFusionError::NotImplemented("SortMergeJoinExec does not support join_filter now.".to_string()))
+                            not_impl_err!("SortMergeJoinExec does not support join_filter now.")
                         } else {
                             let join_on_len = join_on.len();
                             Ok(Arc::new(SortMergeJoinExec::try_new(
@@ -1226,30 +1226,30 @@ impl DefaultPhysicalPlanner {
                     // the appropriate table can be registered with
                     // the context)
                     let name = ddl.name();
-                    Err(DataFusionError::NotImplemented(
-                        format!("Unsupported logical plan: {name}")
-                    ))
+                    not_impl_err!(
+                        "Unsupported logical plan: {name}"
+                    )
                 }
                 LogicalPlan::Prepare(_) => {
                     // There is no default plan for "PREPARE" -- it must be
                     // handled at a higher level (so that the appropriate
                     // statement can be prepared)
-                    Err(DataFusionError::NotImplemented(
-                        "Unsupported logical plan: Prepare".to_string(),
-                    ))
+                    not_impl_err!(
+                        "Unsupported logical plan: Prepare"
+                    )
                 }
                 LogicalPlan::Dml(_) => {
                     // DataFusion is a read-only query engine, but also a library, so consumers may implement this
-                    Err(DataFusionError::NotImplemented(
-                        "Unsupported logical plan: Dml".to_string(),
-                    ))
+                    not_impl_err!(
+                        "Unsupported logical plan: Dml"
+                    )
                 }
                 LogicalPlan::Statement(statement) => {
                     // DataFusion is a read-only query engine, but also a library, so consumers may implement this
                     let name = statement.name();
-                    Err(DataFusionError::NotImplemented(
-                        format!("Unsupported logical plan: Statement({name})")
-                    ))
+                    not_impl_err!(
+                        "Unsupported logical plan: Statement({name})"
+                    )
                 }
                 LogicalPlan::DescribeTable(_) => {
                     internal_err!(

--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -32,7 +32,7 @@ use datafusion::physical_plan::{
 use datafusion::prelude::*;
 use datafusion::scalar::ScalarValue;
 use datafusion_common::cast::as_primitive_array;
-use datafusion_common::DataFusionError;
+use datafusion_common::{not_impl_err, DataFusionError};
 use datafusion_expr::expr::{BinaryExpr, Cast};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -160,21 +160,17 @@ impl TableProvider for CustomProvider {
                             ScalarValue::Int32(Some(v)) => *v as i64,
                             ScalarValue::Int64(Some(v)) => *v,
                             other_value => {
-                                return Err(DataFusionError::NotImplemented(format!(
+                                return not_impl_err!(
                                     "Do not support value {other_value:?}"
-                                )));
+                                );
                             }
                         },
                         other_expr => {
-                            return Err(DataFusionError::NotImplemented(format!(
-                                "Do not support expr {other_expr:?}"
-                            )));
+                            return not_impl_err!("Do not support expr {other_expr:?}");
                         }
                     },
                     other_expr => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Do not support expr {other_expr:?}"
-                        )));
+                        return not_impl_err!("Do not support expr {other_expr:?}");
                     }
                 };
 

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -21,7 +21,9 @@ use std::{
     sync::Arc,
 };
 
-use datafusion_common::{DFSchemaRef, DataFusionError, OwnedTableReference};
+use datafusion_common::{
+    not_impl_err, DFSchemaRef, DataFusionError, OwnedTableReference,
+};
 
 use crate::LogicalPlan;
 
@@ -62,9 +64,7 @@ impl FromStr for OutputFileFormat {
             "parquet" => Ok(OutputFileFormat::PARQUET),
             "avro" => Ok(OutputFileFormat::AVRO),
             "arrow" => Ok(OutputFileFormat::ARROW),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unknown or not supported file format {s}!"
-            ))),
+            _ => not_impl_err!("Unknown or not supported file format {s}!"),
         }
     }
 }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1896,7 +1896,7 @@ mod tests {
     use crate::{col, exists, in_subquery, lit};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::tree_node::TreeNodeVisitor;
-    use datafusion_common::{DFSchema, TableReference};
+    use datafusion_common::{not_impl_err, DFSchema, TableReference};
     use std::collections::HashMap;
 
     fn employee_schema() -> Schema {
@@ -2029,9 +2029,7 @@ digraph {
                 LogicalPlan::Filter { .. } => "pre_visit Filter",
                 LogicalPlan::TableScan { .. } => "pre_visit TableScan",
                 _ => {
-                    return Err(DataFusionError::NotImplemented(
-                        "unknown plan type".to_string(),
-                    ));
+                    return not_impl_err!("unknown plan type");
                 }
             };
 
@@ -2045,9 +2043,7 @@ digraph {
                 LogicalPlan::Filter { .. } => "post_visit Filter",
                 LogicalPlan::TableScan { .. } => "post_visit TableScan",
                 _ => {
-                    return Err(DataFusionError::NotImplemented(
-                        "unknown plan type".to_string(),
-                    ));
+                    return not_impl_err!("unknown plan type");
                 }
             };
 
@@ -2181,9 +2177,7 @@ digraph {
 
         fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<VisitRecursion> {
             if self.return_error_from_pre_in.dec() {
-                return Err(DataFusionError::NotImplemented(
-                    "Error in pre_visit".to_string(),
-                ));
+                return not_impl_err!("Error in pre_visit");
             }
 
             self.inner.pre_visit(plan)
@@ -2191,9 +2185,7 @@ digraph {
 
         fn post_visit(&mut self, plan: &LogicalPlan) -> Result<VisitRecursion> {
             if self.return_error_from_post_in.dec() {
-                return Err(DataFusionError::NotImplemented(
-                    "Error in post_visit".to_string(),
-                ));
+                return not_impl_err!("Error in post_visit");
             }
 
             self.inner.post_visit(plan)

--- a/datafusion/expr/src/partition_evaluator.rs
+++ b/datafusion/expr/src/partition_evaluator.rs
@@ -18,8 +18,7 @@
 //! Partition evaluation module
 
 use arrow::array::ArrayRef;
-use datafusion_common::Result;
-use datafusion_common::{DataFusionError, ScalarValue};
+use datafusion_common::{not_impl_err, DataFusionError, Result, ScalarValue};
 use std::fmt::Debug;
 use std::ops::Range;
 
@@ -168,9 +167,7 @@ pub trait PartitionEvaluator: Debug + Send {
                 .collect::<Result<Vec<_>>>()?;
             ScalarValue::iter_to_array(res.into_iter())
         } else {
-            Err(DataFusionError::NotImplemented(
-                "evaluate_all is not implemented by default".into(),
-            ))
+            not_impl_err!("evaluate_all is not implemented by default")
         }
     }
 
@@ -193,9 +190,7 @@ pub trait PartitionEvaluator: Debug + Send {
         _values: &[ArrayRef],
         _range: &Range<usize>,
     ) -> Result<ScalarValue> {
-        Err(DataFusionError::NotImplemented(
-            "evaluate is not implemented by default".into(),
-        ))
+        not_impl_err!("evaluate is not implemented by default")
     }
 
     /// [`PartitionEvaluator::evaluate_all_with_rank`] is called for window
@@ -230,9 +225,7 @@ pub trait PartitionEvaluator: Debug + Send {
         _num_rows: usize,
         _ranks_in_partition: &[Range<usize>],
     ) -> Result<ArrayRef> {
-        Err(DataFusionError::NotImplemented(
-            "evaluate_partition_with_rank is not implemented by default".into(),
-        ))
+        not_impl_err!("evaluate_partition_with_rank is not implemented by default")
     }
 
     /// Can the window function be incrementally computed using

--- a/datafusion/physical-expr/src/aggregate/approx_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_distinct.rs
@@ -29,8 +29,9 @@ use arrow::datatypes::{
     ArrowPrimitiveType, DataType, Field, Int16Type, Int32Type, Int64Type, Int8Type,
     UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
-use datafusion_common::{downcast_value, ScalarValue};
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::Accumulator;
 use std::any::Any;
 use std::convert::TryFrom;
@@ -102,9 +103,9 @@ impl AggregateExpr for ApproxDistinct {
             DataType::Binary => Box::new(BinaryHLLAccumulator::<i32>::new()),
             DataType::LargeBinary => Box::new(BinaryHLLAccumulator::<i64>::new()),
             other => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return not_impl_err!(
                 "Support for 'approx_distinct' for data type {other} is not implemented"
-            )))
+            )
             }
         };
         Ok(accumulator)

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -27,11 +27,10 @@ use arrow::{
     },
     datatypes::{DataType, Field},
 };
-use datafusion_common::internal_err;
-use datafusion_common::plan_err;
-use datafusion_common::DataFusionError;
-use datafusion_common::Result;
-use datafusion_common::{downcast_value, ScalarValue};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, plan_err, DataFusionError, Result,
+    ScalarValue,
+};
 use datafusion_expr::Accumulator;
 use std::{any::Any, iter, sync::Arc};
 
@@ -108,9 +107,9 @@ impl ApproxPercentileCont {
                 }
             }
             other => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return not_impl_err!(
                     "Support for 'APPROX_PERCENTILE_CONT' for data type {other} is not implemented"
-                )))
+                )
             }
         };
         Ok(accumulator)
@@ -146,10 +145,10 @@ fn validate_input_percentile_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<f64> {
     let percentile = match lit {
         ScalarValue::Float32(Some(q)) => *q as f64,
         ScalarValue::Float64(Some(q)) => *q,
-        got => return Err(DataFusionError::NotImplemented(format!(
+        got => return not_impl_err!(
             "Percentile value for 'APPROX_PERCENTILE_CONT' must be Float32 or Float64 literal (got data type {})",
             got.get_datatype()
-        )))
+        )
     };
 
     // Ensure the percentile is between 0 and 1.
@@ -181,10 +180,10 @@ fn validate_input_max_size_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<usize> {
         ScalarValue::Int64(Some(q)) if *q > 0 => *q as usize,
         ScalarValue::Int16(Some(q)) if *q > 0 => *q as usize,
         ScalarValue::Int8(Some(q)) if *q > 0 => *q as usize,
-        got => return Err(DataFusionError::NotImplemented(format!(
+        got => return not_impl_err!(
             "Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be UInt > 0 literal (got data type {}).",
             got.get_datatype()
-        )))
+        )
     };
     Ok(max_size)
 }

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -40,9 +40,9 @@ use arrow::{
 use arrow_array::{
     Array, ArrowNativeTypeOp, ArrowNumericType, ArrowPrimitiveType, PrimitiveArray,
 };
-use datafusion_common::internal_err;
-use datafusion_common::{downcast_value, ScalarValue};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::Accumulator;
 
 use super::groups_accumulator::EmitTo;
@@ -184,10 +184,11 @@ impl AggregateExpr for Avg {
                 )))
             }
 
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "AvgGroupsAccumulator for ({} --> {})",
-                self.sum_data_type, self.rt_data_type,
-            ))),
+                self.sum_data_type,
+                self.rt_data_type
+            ),
         }
     }
 }

--- a/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
+++ b/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
@@ -34,8 +34,9 @@ use arrow::{
     },
     datatypes::Field,
 };
-use datafusion_common::internal_err;
-use datafusion_common::{downcast_value, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::Accumulator;
 use std::collections::HashSet;
 
@@ -218,11 +219,11 @@ impl AggregateExpr for BitAnd {
                     .bitand_assign(y))
             }
 
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {} with {}",
                 self.name(),
                 self.data_type
-            ))),
+            ),
         }
     }
 
@@ -376,11 +377,11 @@ impl AggregateExpr for BitOr {
                 instantiate_accumulator!(self, 0, UInt64Type, |x, y| x.bitor_assign(y))
             }
 
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {} with {}",
                 self.name(),
                 self.data_type
-            ))),
+            ),
         }
     }
 
@@ -534,11 +535,11 @@ impl AggregateExpr for BitXor {
                 instantiate_accumulator!(self, 0, UInt64Type, |x, y| x.bitxor_assign(y))
             }
 
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {} with {}",
                 self.name(),
                 self.data_type
-            ))),
+            ),
         }
     }
 

--- a/datafusion/physical-expr/src/aggregate/bool_and_or.rs
+++ b/datafusion/physical-expr/src/aggregate/bool_and_or.rs
@@ -23,8 +23,9 @@ use arrow::{
     array::{ArrayRef, BooleanArray},
     datatypes::Field,
 };
-use datafusion_common::internal_err;
-use datafusion_common::{downcast_value, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::Accumulator;
 use std::any::Any;
 use std::sync::Arc;
@@ -138,11 +139,11 @@ impl AggregateExpr for BoolAnd {
             DataType::Boolean => {
                 Ok(Box::new(BooleanGroupsAccumulator::new(|x, y| x && y)))
             }
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {} with {}",
                 self.name(),
                 self.data_type
-            ))),
+            ),
         }
     }
 
@@ -271,11 +272,11 @@ impl AggregateExpr for BoolOr {
             DataType::Boolean => {
                 Ok(Box::new(BooleanGroupsAccumulator::new(|x, y| x || y)))
             }
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {} with {}",
                 self.name(),
                 self.data_type
-            ))),
+            ),
         }
     }
 

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -29,7 +29,7 @@
 use crate::aggregate::regr::RegrType;
 use crate::{expressions, AggregateExpr, PhysicalExpr, PhysicalSortExpr};
 use arrow::datatypes::Schema;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::aggregate_function::sum_type_of_avg;
 pub use datafusion_expr::AggregateFunction;
 use std::sync::Arc;
@@ -138,9 +138,9 @@ pub fn create_aggregate_expr(
         }
         (AggregateFunction::ArrayAgg, true) => {
             if !ordering_req.is_empty() {
-                return Err(DataFusionError::NotImplemented(
-                    "ARRAY_AGG(DISTINCT ORDER BY a ASC) order-sensitive aggregations are not available".to_string(),
-                ));
+                return not_impl_err!(
+                    "ARRAY_AGG(DISTINCT ORDER BY a ASC) order-sensitive aggregations are not available"
+                );
             }
             Arc::new(expressions::DistinctArrayAgg::new(
                 input_phy_exprs[0].clone(),
@@ -170,9 +170,7 @@ pub fn create_aggregate_expr(
             ))
         }
         (AggregateFunction::Avg, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "AVG(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("AVG(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::Variance, false) => Arc::new(expressions::Variance::new(
             input_phy_exprs[0].clone(),
@@ -180,17 +178,13 @@ pub fn create_aggregate_expr(
             rt_type,
         )),
         (AggregateFunction::Variance, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "VAR(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("VAR(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::VariancePop, false) => Arc::new(
             expressions::VariancePop::new(input_phy_exprs[0].clone(), name, rt_type),
         ),
         (AggregateFunction::VariancePop, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "VAR_POP(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("VAR_POP(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::Covariance, false) => Arc::new(expressions::Covariance::new(
             input_phy_exprs[0].clone(),
@@ -199,9 +193,7 @@ pub fn create_aggregate_expr(
             rt_type,
         )),
         (AggregateFunction::Covariance, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "COVAR(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("COVAR(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::CovariancePop, false) => {
             Arc::new(expressions::CovariancePop::new(
@@ -212,9 +204,7 @@ pub fn create_aggregate_expr(
             ))
         }
         (AggregateFunction::CovariancePop, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "COVAR_POP(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("COVAR_POP(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::Stddev, false) => Arc::new(expressions::Stddev::new(
             input_phy_exprs[0].clone(),
@@ -222,9 +212,7 @@ pub fn create_aggregate_expr(
             rt_type,
         )),
         (AggregateFunction::Stddev, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "STDDEV(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("STDDEV(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::StddevPop, false) => Arc::new(expressions::StddevPop::new(
             input_phy_exprs[0].clone(),
@@ -232,9 +220,7 @@ pub fn create_aggregate_expr(
             rt_type,
         )),
         (AggregateFunction::StddevPop, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "STDDEV_POP(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("STDDEV_POP(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::Correlation, false) => {
             Arc::new(expressions::Correlation::new(
@@ -245,9 +231,7 @@ pub fn create_aggregate_expr(
             ))
         }
         (AggregateFunction::Correlation, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "CORR(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("CORR(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::RegrSlope, false) => Arc::new(expressions::Regr::new(
             input_phy_exprs[0].clone(),
@@ -324,10 +308,7 @@ pub fn create_aggregate_expr(
             | AggregateFunction::RegrSXY,
             true,
         ) => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "{}(DISTINCT) aggregations are not available",
-                fun
-            )));
+            return not_impl_err!("{}(DISTINCT) aggregations are not available", fun);
         }
         (AggregateFunction::ApproxPercentileCont, false) => {
             if input_phy_exprs.len() == 2 {
@@ -347,10 +328,9 @@ pub fn create_aggregate_expr(
             }
         }
         (AggregateFunction::ApproxPercentileCont, true) => {
-            return Err(DataFusionError::NotImplemented(
+            return not_impl_err!(
                 "approx_percentile_cont(DISTINCT) aggregations are not available"
-                    .to_string(),
-            ));
+            );
         }
         (AggregateFunction::ApproxPercentileContWithWeight, false) => {
             Arc::new(expressions::ApproxPercentileContWithWeight::new(
@@ -361,10 +341,9 @@ pub fn create_aggregate_expr(
             )?)
         }
         (AggregateFunction::ApproxPercentileContWithWeight, true) => {
-            return Err(DataFusionError::NotImplemented(
+            return not_impl_err!(
                 "approx_percentile_cont_with_weight(DISTINCT) aggregations are not available"
-                    .to_string(),
-            ));
+            );
         }
         (AggregateFunction::ApproxMedian, false) => {
             Arc::new(expressions::ApproxMedian::try_new(
@@ -374,9 +353,9 @@ pub fn create_aggregate_expr(
             )?)
         }
         (AggregateFunction::ApproxMedian, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "APPROX_MEDIAN(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!(
+                "APPROX_MEDIAN(DISTINCT) aggregations are not available"
+            );
         }
         (AggregateFunction::Median, false) => Arc::new(expressions::Median::new(
             input_phy_exprs[0].clone(),
@@ -384,9 +363,7 @@ pub fn create_aggregate_expr(
             rt_type,
         )),
         (AggregateFunction::Median, true) => {
-            return Err(DataFusionError::NotImplemented(
-                "MEDIAN(DISTINCT) aggregations are not available".to_string(),
-            ));
+            return not_impl_err!("MEDIAN(DISTINCT) aggregations are not available");
         }
         (AggregateFunction::FirstValue, _) => Arc::new(expressions::FirstValue::new(
             input_phy_exprs[0].clone(),

--- a/datafusion/physical-expr/src/aggregate/grouping.rs
+++ b/datafusion/physical-expr/src/aggregate/grouping.rs
@@ -24,7 +24,7 @@ use crate::aggregate::utils::down_cast_any_ref;
 use crate::{AggregateExpr, PhysicalExpr};
 use arrow::datatypes::DataType;
 use arrow::datatypes::Field;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::Accumulator;
 
 use crate::expressions::format_state_name;
@@ -82,10 +82,9 @@ impl AggregateExpr for Grouping {
     }
 
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
-        Err(DataFusionError::NotImplemented(
+        not_impl_err!(
             "physical plan is not yet implemented for GROUPING aggregate function"
-                .to_owned(),
-        ))
+        )
     }
 
     fn name(&self) -> &str {

--- a/datafusion/physical-expr/src/aggregate/mod.rs
+++ b/datafusion/physical-expr/src/aggregate/mod.rs
@@ -18,7 +18,7 @@
 use crate::expressions::{FirstValue, LastValue, OrderSensitiveArrayAgg};
 use crate::{PhysicalExpr, PhysicalSortExpr};
 use arrow::datatypes::Field;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::Accumulator;
 use std::any::Any;
 use std::fmt::Debug;
@@ -114,9 +114,7 @@ pub trait AggregateExpr: Send + Sync + Debug + PartialEq<dyn Any> {
     /// For maximum performance, a [`GroupsAccumulator`] should be
     /// implemented in addition to [`Accumulator`].
     fn create_groups_accumulator(&self) -> Result<Box<dyn GroupsAccumulator>> {
-        Err(DataFusionError::NotImplemented(format!(
-            "GroupsAccumulator hasn't been implemented for {self:?} yet"
-        )))
+        not_impl_err!("GroupsAccumulator hasn't been implemented for {self:?} yet")
     }
 
     /// Construct an expression that calculates the aggregate in reverse.
@@ -129,9 +127,7 @@ pub trait AggregateExpr: Send + Sync + Debug + PartialEq<dyn Any> {
 
     /// Creates accumulator implementation that supports retract
     fn create_sliding_accumulator(&self) -> Result<Box<dyn Accumulator>> {
-        Err(DataFusionError::NotImplemented(format!(
-            "Retractable Accumulator hasn't been implemented for {self:?} yet"
-        )))
+        not_impl_err!("Retractable Accumulator hasn't been implemented for {self:?} yet")
     }
 }
 

--- a/datafusion/physical-expr/src/aggregate/sum.rs
+++ b/datafusion/physical-expr/src/aggregate/sum.rs
@@ -43,8 +43,9 @@ use arrow_array::types::{
     Decimal128Type, Decimal256Type, Float32Type, Float64Type, Int32Type, Int64Type,
     UInt32Type, UInt64Type,
 };
-use datafusion_common::internal_err;
-use datafusion_common::{downcast_value, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    downcast_value, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::Accumulator;
 
 /// SUM aggregate expression
@@ -175,10 +176,11 @@ impl AggregateExpr for Sum {
                 instantiate_primitive_accumulator!(self, Decimal256Type, |x, y| *x =
                     *x + y)
             }
-            _ => Err(DataFusionError::NotImplemented(format!(
+            _ => not_impl_err!(
                 "GroupsAccumulator not supported for {}: {}",
-                self.name, self.data_type
-            ))),
+                self.name,
+                self.data_type
+            ),
         }
     }
 

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::{DataType, Field, UInt64Type};
 use arrow_buffer::NullBuffer;
 use core::any::type_name;
 use datafusion_common::cast::{as_generic_string_array, as_int64_array, as_list_array};
-use datafusion_common::{internal_err, plan_err, ScalarValue};
+use datafusion_common::{internal_err, not_impl_err, plan_err, ScalarValue};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 use itertools::Itertools;
@@ -388,9 +388,7 @@ fn array_array(args: &[ArrayRef], data_type: DataType) -> Result<ArrayRef> {
         DataType::UInt32 => array!(args, UInt32Array, UInt32Builder),
         DataType::UInt64 => array!(args, UInt64Array, UInt64Builder),
         data_type => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "Array is not implemented for type '{data_type:?}'."
-            )))
+            return not_impl_err!("Array is not implemented for type '{data_type:?}'.")
         }
     };
 
@@ -856,9 +854,7 @@ pub fn array_concat(args: &[ArrayRef]) -> Result<ArrayRef> {
         let (ndim, lower_data_type) =
             compute_array_ndims_with_datatype(Some(arg.clone()))?;
         if ndim.is_none() || ndim == Some(1) {
-            return Err(DataFusionError::NotImplemented(format!(
-                "Array is not type '{lower_data_type:?}'."
-            )));
+            return not_impl_err!("Array is not type '{lower_data_type:?}'.");
         } else if !lower_data_type.equals_datatype(&DataType::Null) {
             new_args.push(arg.clone());
         }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -42,8 +42,9 @@ use datafusion_common::cast::{
     as_timestamp_microsecond_array, as_timestamp_millisecond_array,
     as_timestamp_nanosecond_array, as_timestamp_second_array,
 };
-use datafusion_common::{internal_err, DataFusionError, Result};
-use datafusion_common::{ScalarType, ScalarValue};
+use datafusion_common::{
+    internal_err, not_impl_err, DataFusionError, Result, ScalarType, ScalarValue,
+};
 use datafusion_expr::ColumnarValue;
 use std::sync::Arc;
 
@@ -544,9 +545,9 @@ fn date_bin_impl(
             if months != 0 {
                 // Return error if days or nanos is not zero
                 if days != 0 || nanos != 0 {
-                    return Err(DataFusionError::NotImplemented(
-                        "DATE_BIN stride does not support combination of month, day and nanosecond intervals".to_string(),
-                    ));
+                    return not_impl_err!(
+                        "DATE_BIN stride does not support combination of month, day and nanosecond intervals"
+                    );
                 } else {
                     Interval::Months(months as i64)
                 }
@@ -569,10 +570,11 @@ fn date_bin_impl(
                 v.get_datatype()
             )))
         }
-        ColumnarValue::Array(_) => return Err(DataFusionError::NotImplemented(
+        ColumnarValue::Array(_) => {
+            return not_impl_err!(
             "DATE_BIN only supports literal values for the stride argument, not arrays"
-                .to_string(),
-        )),
+        )
+        }
     };
 
     let origin = match origin {
@@ -583,10 +585,9 @@ fn date_bin_impl(
                 v.get_datatype()
             )))
         }
-        ColumnarValue::Array(_) => return Err(DataFusionError::NotImplemented(
+        ColumnarValue::Array(_) => return not_impl_err!(
             "DATE_BIN only supports literal values for the origin argument, not arrays"
-                .to_string(),
-        )),
+        ),
     };
 
     let (stride, stride_fn) = stride.bin_fn();

--- a/datafusion/physical-expr/src/encoding_expressions.rs
+++ b/datafusion/physical-expr/src/encoding_expressions.rs
@@ -25,7 +25,7 @@ use base64::{engine::general_purpose, Engine as _};
 use datafusion_common::ScalarValue;
 use datafusion_common::{
     cast::{as_generic_binary_array, as_generic_string_array},
-    internal_err, plan_err,
+    internal_err, not_impl_err, plan_err,
 };
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
@@ -305,13 +305,13 @@ pub fn encode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             ScalarValue::Utf8(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
                 method.parse::<Encoding>()
             }
-            _ => Err(DataFusionError::NotImplemented(
-                "Second argument to encode must be a constant: Encode using dynamically decided method is not yet supported".into(),
-            )),
+            _ => not_impl_err!(
+                "Second argument to encode must be a constant: Encode using dynamically decided method is not yet supported"
+            ),
         },
-        ColumnarValue::Array(_) => Err(DataFusionError::NotImplemented(
-            "Second argument to encode must be a constant: Encode using dynamically decided method is not yet supported".into(),
-        )),
+        ColumnarValue::Array(_) => not_impl_err!(
+            "Second argument to encode must be a constant: Encode using dynamically decided method is not yet supported"
+        ),
     }?;
     encode_process(&args[0], encoding)
 }
@@ -331,13 +331,13 @@ pub fn decode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             ScalarValue::Utf8(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
                 method.parse::<Encoding>()
             }
-            _ => Err(DataFusionError::NotImplemented(
-                "Second argument to decode must be a utf8 constant: Decode using dynamically decided method is not yet supported".into(),
-            )),
+            _ => not_impl_err!(
+                "Second argument to decode must be a utf8 constant: Decode using dynamically decided method is not yet supported"
+            ),
         },
-        ColumnarValue::Array(_) => Err(DataFusionError::NotImplemented(
-            "Second argument to decode must be a utf8 constant: Decode using dynamically decided method is not yet supported".into(),
-        )),
+        ColumnarValue::Array(_) => not_impl_err!(
+            "Second argument to decode must be a utf8 constant: Decode using dynamically decided method is not yet supported"
+        ),
     }?;
     decode_process(&args[0], encoding)
 }

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -29,8 +29,7 @@ use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use compute::can_cast_types;
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
-use datafusion_common::ScalarValue;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::ColumnarValue;
 
 const DEFAULT_CAST_OPTIONS: CastOptions<'static> = CastOptions {
@@ -195,9 +194,7 @@ pub fn cast_with_options(
     } else if can_cast_types(&expr_type, &cast_type) {
         Ok(Arc::new(CastExpr::new(expr, cast_type, cast_options)))
     } else {
-        Err(DataFusionError::NotImplemented(format!(
-            "Unsupported CAST from {expr_type:?} to {cast_type:?}"
-        )))
+        not_impl_err!("Unsupported CAST from {expr_type:?} to {cast_type:?}")
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -35,7 +35,7 @@ use arrow::util::bit_iterator::BitIndexIterator;
 use arrow::{downcast_dictionary_array, downcast_primitive_array};
 use datafusion_common::{
     cast::{as_boolean_array, as_generic_binary_array, as_string_array},
-    internal_err, DataFusionError, Result, ScalarValue,
+    internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::ColumnarValue;
 use hashbrown::hash_map::RawEntryMut;
@@ -194,7 +194,7 @@ fn make_set(array: &dyn Array) -> Result<Arc<dyn Set>> {
             Arc::new(ArraySet::new(array, make_hash_set(array)))
         }
         DataType::Dictionary(_, _) => unreachable!("dictionary should have been flattened"),
-        d => return Err(DataFusionError::NotImplemented(format!("DataType::{d} not supported in InList")))
+        d => return not_impl_err!("DataType::{d} not supported in InList")
     })
 }
 

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -28,8 +28,7 @@ use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use compute::can_cast_types;
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
-use datafusion_common::ScalarValue;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::ColumnarValue;
 
 /// TRY_CAST expression casts an expression to a specific data type and retuns NULL on invalid cast
@@ -142,9 +141,7 @@ pub fn try_cast(
     } else if can_cast_types(&expr_type, &cast_type) {
         Ok(Arc::new(TryCastExpr::new(expr, cast_type)))
     } else {
-        Err(DataFusionError::NotImplemented(format!(
-            "Unsupported TRY_CAST from {expr_type:?} to {cast_type:?}"
-        )))
+        not_impl_err!("Unsupported TRY_CAST from {expr_type:?} to {cast_type:?}")
     }
 }
 

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -23,7 +23,7 @@ use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::utils::DataPtr;
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 
 use std::any::Any;
@@ -76,9 +76,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
 
     /// Computes bounds for the expression using interval arithmetic.
     fn evaluate_bounds(&self, _children: &[&Interval]) -> Result<Interval> {
-        Err(DataFusionError::NotImplemented(format!(
-            "Not implemented for {self}"
-        )))
+        not_impl_err!("Not implemented for {self}")
     }
 
     /// Updates/shrinks bounds for the expression using interval arithmetic.
@@ -90,9 +88,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
         _interval: &Interval,
         _children: &[&Interval],
     ) -> Result<Vec<Option<Interval>>> {
-        Err(DataFusionError::NotImplemented(format!(
-            "Not implemented for {self}"
-        )))
+        not_impl_err!("Not implemented for {self}")
     }
 
     /// Update the hash `state` with this expression requirements from

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -25,8 +25,9 @@ use crate::{
     PhysicalExpr,
 };
 use arrow::datatypes::Schema;
-use datafusion_common::plan_err;
-use datafusion_common::{internal_err, DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    internal_err, not_impl_err, plan_err, DFSchema, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::expr::{Alias, Cast, InList, ScalarFunction, ScalarUDF};
 use datafusion_expr::{
     binary_expr, Between, BinaryExpr, Expr, GetFieldAccess, GetIndexedField, Like,
@@ -443,8 +444,8 @@ pub fn create_physical_expr(
                 expressions::in_list(value_expr, list_exprs, negated, input_schema)
             }
         },
-        other => Err(DataFusionError::NotImplemented(format!(
-            "Physical plan does not support logical expression {other:?}"
-        ))),
+        other => {
+            not_impl_err!("Physical plan does not support logical expression {other:?}")
+        }
     }
 }

--- a/datafusion/physical-expr/src/struct_expressions.rs
+++ b/datafusion/physical-expr/src/struct_expressions.rs
@@ -19,7 +19,7 @@
 
 use arrow::array::*;
 use arrow::datatypes::{DataType, Field};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 use std::sync::Arc;
 
@@ -57,9 +57,9 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
                     )),
                     arg.clone(),
                 )),
-                data_type => Err(DataFusionError::NotImplemented(format!(
-                    "Struct is not implemented for type '{data_type:?}'."
-                ))),
+                data_type => {
+                    not_impl_err!("Struct is not implemented for type '{data_type:?}'.")
+                }
             }
         })
         .collect::<Result<Vec<_>>>()?;

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -38,6 +38,7 @@ use datafusion::{
     datasource::{provider_as_source, source_as_provider},
     prelude::SessionContext,
 };
+use datafusion_common::not_impl_err;
 use datafusion_common::{
     context, internal_err, parsers::CompressionTypeVariant, DataFusionError,
     OwnedTableReference, Result,
@@ -132,15 +133,11 @@ impl LogicalExtensionCodec for DefaultLogicalExtensionCodec {
         _inputs: &[LogicalPlan],
         _ctx: &SessionContext,
     ) -> Result<Extension> {
-        Err(DataFusionError::NotImplemented(
-            "LogicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("LogicalExtensionCodec is not provided")
     }
 
     fn try_encode(&self, _node: &Extension, _buf: &mut Vec<u8>) -> Result<()> {
-        Err(DataFusionError::NotImplemented(
-            "LogicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("LogicalExtensionCodec is not provided")
     }
 
     fn try_decode_table_provider(
@@ -149,9 +146,7 @@ impl LogicalExtensionCodec for DefaultLogicalExtensionCodec {
         _schema: SchemaRef,
         _ctx: &SessionContext,
     ) -> Result<Arc<dyn TableProvider>> {
-        Err(DataFusionError::NotImplemented(
-            "LogicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("LogicalExtensionCodec is not provided")
     }
 
     fn try_encode_table_provider(
@@ -159,9 +154,7 @@ impl LogicalExtensionCodec for DefaultLogicalExtensionCodec {
         _node: Arc<dyn TableProvider>,
         _buf: &mut Vec<u8>,
     ) -> Result<()> {
-        Err(DataFusionError::NotImplemented(
-            "LogicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("LogicalExtensionCodec is not provided")
     }
 }
 
@@ -1087,9 +1080,9 @@ impl AsLogicalPlan for LogicalPlanNode {
                     ))),
                 })
             }
-            LogicalPlan::Subquery(_) => Err(DataFusionError::NotImplemented(
-                "LogicalPlan serde is not yet implemented for subqueries".to_string(),
-            )),
+            LogicalPlan::Subquery(_) => {
+                not_impl_err!("LogicalPlan serde is not yet implemented for subqueries")
+            }
             LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {
                 let input: protobuf::LogicalPlanNode =
                     protobuf::LogicalPlanNode::try_from_logical_plan(
@@ -1170,9 +1163,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                         PartitionMethod::RoundRobin(*partition_count as u64)
                     }
                     Partitioning::DistributeBy(_) => {
-                        return Err(DataFusionError::NotImplemented(
-                            "DistributeBy".to_string(),
-                        ))
+                        return not_impl_err!("DistributeBy")
                     }
                 };
 
@@ -1464,7 +1455,7 @@ mod roundtrip_tests {
     };
     use datafusion::test_util::{TestTableFactory, TestTableProvider};
     use datafusion_common::{
-        internal_err, plan_err, DFSchemaRef, DataFusionError, Result, ScalarValue,
+        internal_err, plan_err, DFSchemaRef, DataFusionError, Result, ScalarValue, not_impl_err,
     };
     use datafusion_expr::expr::{
         self, Between, BinaryExpr, Case, Cast, GroupingSet, InList, Like, ScalarFunction,
@@ -1551,15 +1542,11 @@ mod roundtrip_tests {
             _inputs: &[LogicalPlan],
             _ctx: &SessionContext,
         ) -> Result<Extension> {
-            Err(DataFusionError::NotImplemented(
-                "No extension codec provided".to_string(),
-            ))
+            not_impl_err!("No extension codec provided")
         }
 
         fn try_encode(&self, _node: &Extension, _buf: &mut Vec<u8>) -> Result<()> {
-            Err(DataFusionError::NotImplemented(
-                "No extension codec provided".to_string(),
-            ))
+            not_impl_err!("No extension codec provided")
         }
 
         fn try_decode_table_provider(

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1455,7 +1455,8 @@ mod roundtrip_tests {
     };
     use datafusion::test_util::{TestTableFactory, TestTableProvider};
     use datafusion_common::{
-        internal_err, plan_err, DFSchemaRef, DataFusionError, Result, ScalarValue, not_impl_err,
+        internal_err, not_impl_err, plan_err, DFSchemaRef, DataFusionError, Result,
+        ScalarValue,
     };
     use datafusion_expr::expr::{
         self, Between, BinaryExpr, Case, Cast, GroupingSet, InList, Like, ScalarFunction,

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -39,7 +39,7 @@ use datafusion::physical_plan::{
     functions, Partitioning,
 };
 use datafusion::physical_plan::{ColumnStatistics, PhysicalExpr, Statistics};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use object_store::path::Path;
 use object_store::ObjectMeta;
 use std::convert::{TryFrom, TryInto};
@@ -124,19 +124,17 @@ pub fn parse_physical_expr(
             )?,
         )),
         ExprType::AggregateExpr(_) => {
-            return Err(DataFusionError::NotImplemented(
-                "Cannot convert aggregate expr node to physical expression".to_owned(),
-            ));
+            return not_impl_err!(
+                "Cannot convert aggregate expr node to physical expression"
+            );
         }
         ExprType::WindowExpr(_) => {
-            return Err(DataFusionError::NotImplemented(
-                "Cannot convert window expr node to physical expression".to_owned(),
-            ));
+            return not_impl_err!(
+                "Cannot convert window expr node to physical expression"
+            );
         }
         ExprType::Sort(_) => {
-            return Err(DataFusionError::NotImplemented(
-                "Cannot convert sort expr node to physical expression".to_owned(),
-            ));
+            return not_impl_err!("Cannot convert sort expr node to physical expression");
         }
         ExprType::IsNullExpr(e) => {
             Arc::new(IsNullExpr::new(parse_required_physical_expr(

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -47,7 +47,7 @@ use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
     udaf, AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr, WindowExpr,
 };
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 use prost::bytes::BufMut;
 use prost::Message;
 
@@ -1349,9 +1349,7 @@ impl PhysicalExtensionCodec for DefaultPhysicalExtensionCodec {
         _inputs: &[Arc<dyn ExecutionPlan>],
         _registry: &dyn FunctionRegistry,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(DataFusionError::NotImplemented(
-            "PhysicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("PhysicalExtensionCodec is not provided")
     }
 
     fn try_encode(
@@ -1359,9 +1357,7 @@ impl PhysicalExtensionCodec for DefaultPhysicalExtensionCodec {
         _node: Arc<dyn ExecutionPlan>,
         _buf: &mut Vec<u8>,
     ) -> Result<()> {
-        Err(DataFusionError::NotImplemented(
-            "PhysicalExtensionCodec is not provided".to_string(),
-        ))
+        not_impl_err!("PhysicalExtensionCodec is not provided")
     }
 }
 

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -52,7 +52,7 @@ use datafusion::physical_expr::expressions::{GetFieldAccessExpr, GetIndexedField
 use datafusion::physical_expr::{PhysicalSortExpr, ScalarFunctionExpr};
 use datafusion::physical_plan::joins::utils::JoinSide;
 use datafusion::physical_plan::udaf::AggregateFunctionExpr;
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 
 impl TryFrom<Arc<dyn AggregateExpr>> for protobuf::PhysicalExprNode {
     type Error = DataFusionError;
@@ -176,9 +176,7 @@ impl TryFrom<Arc<dyn AggregateExpr>> for protobuf::PhysicalExprNode {
                 });
             }
 
-            Err(DataFusionError::NotImplemented(format!(
-                "Aggregate function not supported: {a:?}"
-            )))
+            not_impl_err!("Aggregate function not supported: {a:?}")
         }?;
 
         Ok(protobuf::PhysicalExprNode {

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, SqlToRel};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::Operator;
 use sqlparser::ast::BinaryOperator;
 
@@ -47,9 +47,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             BinaryOperator::PGBitwiseShiftRight => Ok(Operator::BitwiseShiftRight),
             BinaryOperator::PGBitwiseShiftLeft => Ok(Operator::BitwiseShiftLeft),
             BinaryOperator::StringConcat => Ok(Operator::StringConcat),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported SQL binary operator {op:?}"
-            ))),
+            _ => not_impl_err!("Unsupported SQL binary operator {op:?}"),
         }
     }
 }

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::plan_err;
-use datafusion_common::{DFSchema, DataFusionError, Result};
+use datafusion_common::{not_impl_err, plan_err, DFSchema, DataFusionError, Result};
 use datafusion_expr::expr::{ScalarFunction, ScalarUDF};
 use datafusion_expr::function::suggest_valid_function;
 use datafusion_expr::window_frame::regularize;
@@ -213,9 +212,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 self.sql_expr_to_logical_expr(arg, schema, planner_context)
             }
             FunctionArg::Unnamed(FunctionArgExpr::Wildcard) => Ok(Expr::Wildcard),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported qualified wildcard argument: {sql:?}"
-            ))),
+            _ => not_impl_err!("Unsupported qualified wildcard argument: {sql:?}"),
         }
     }
 

--- a/datafusion/sql/src/expr/json_access.rs
+++ b/datafusion/sql/src/expr/json_access.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, SqlToRel};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::Operator;
 use sqlparser::ast::JsonOperator;
 
@@ -25,9 +25,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         match op {
             JsonOperator::AtArrow => Ok(Operator::AtArrow),
             JsonOperator::ArrowAt => Ok(Operator::ArrowAt),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported SQL json operator {op:?}"
-            ))),
+            _ => not_impl_err!("Unsupported SQL json operator {op:?}"),
         }
     }
 }

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -30,8 +30,10 @@ mod value;
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use arrow_schema::DataType;
 use datafusion_common::tree_node::{Transformed, TreeNode};
-use datafusion_common::{internal_err, plan_err};
-use datafusion_common::{Column, DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    internal_err, not_impl_err, plan_err, Column, DFSchema, DataFusionError, Result,
+    ScalarValue,
+};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::expr::{InList, Placeholder};
 use datafusion_expr::{
@@ -191,9 +193,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         planner_context,
                     )
                 } else {
-                    Err(DataFusionError::NotImplemented(format!(
+                    not_impl_err!(
                         "map access requires an identifier, found column {column} instead"
-                    )))
+                    )
                 }
             }
 
@@ -475,9 +477,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 self.parse_array_agg(array_agg, schema, planner_context)
             }
 
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported ast node in sqltorel: {sql:?}"
-            ))),
+            _ => not_impl_err!("Unsupported ast node in sqltorel: {sql:?}"),
         }
     }
 
@@ -503,15 +503,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         };
 
         if let Some(limit) = limit {
-            return Err(DataFusionError::NotImplemented(format!(
-                "LIMIT not supported in ARRAY_AGG: {limit}"
-            )));
+            return not_impl_err!("LIMIT not supported in ARRAY_AGG: {limit}");
         }
 
         if within_group {
-            return Err(DataFusionError::NotImplemented(
-                "WITHIN GROUP not supported in ARRAY_AGG".to_string(),
-            ));
+            return not_impl_err!("WITHIN GROUP not supported in ARRAY_AGG");
         }
 
         let args =

--- a/datafusion/sql/src/expr/unary_op.rs
+++ b/datafusion/sql/src/expr/unary_op.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{DFSchema, DataFusionError, Result};
+use datafusion_common::{not_impl_err, DFSchema, DataFusionError, Result};
 use datafusion_expr::{lit, Expr};
 use sqlparser::ast::{Expr as SQLExpr, UnaryOperator, Value};
 
@@ -58,9 +58,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     _ => Ok(Expr::Negative(Box::new(self.sql_expr_to_logical_expr(expr, schema, planner_context)?))),
                 }
             }
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported SQL unary operator {op:?}"
-            ))),
+            _ => not_impl_err!("Unsupported SQL unary operator {op:?}"),
         }
     }
 }

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -18,7 +18,9 @@
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use arrow::compute::kernels::cast_utils::parse_interval_month_day_nano;
 use arrow_schema::DataType;
-use datafusion_common::{plan_err, DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    not_impl_err, plan_err, DFSchema, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::expr::{BinaryExpr, Placeholder};
 use datafusion_expr::{lit, Expr, Operator};
 use log::debug;
@@ -141,9 +143,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     values.push(scalar);
                 }
                 _ => {
-                    return Err(DataFusionError::NotImplemented(format!(
+                    return not_impl_err!(
                         "Arrays with elements other than literal are not supported: {value}"
-                    )));
+                    );
                 }
             }
         }
@@ -154,9 +156,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if data_types.is_empty() {
             Ok(lit(ScalarValue::new_list(None, DataType::Utf8)))
         } else if data_types.len() > 1 {
-            Err(DataFusionError::NotImplemented(format!(
-                "Arrays with different types are not supported: {data_types:?}",
-            )))
+            not_impl_err!("Arrays with different types are not supported: {data_types:?}")
         } else {
             let data_type = values[0].get_datatype();
 
@@ -174,24 +174,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
         if interval.leading_precision.is_some() {
-            return Err(DataFusionError::NotImplemented(format!(
+            return not_impl_err!(
                 "Unsupported Interval Expression with leading_precision {:?}",
-                interval.leading_precision,
-            )));
+                interval.leading_precision
+            );
         }
 
         if interval.last_field.is_some() {
-            return Err(DataFusionError::NotImplemented(format!(
+            return not_impl_err!(
                 "Unsupported Interval Expression with last_field {:?}",
-                interval.last_field,
-            )));
+                interval.last_field
+            );
         }
 
         if interval.fractional_seconds_precision.is_some() {
-            return Err(DataFusionError::NotImplemented(format!(
+            return not_impl_err!(
                 "Unsupported Interval Expression with fractional_seconds_precision {:?}",
-                interval.fractional_seconds_precision,
-            )));
+                interval.fractional_seconds_precision
+            );
         }
 
         // Only handle string exprs for now
@@ -226,9 +226,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     BinaryOperator::Plus => Operator::Plus,
                     BinaryOperator::Minus => Operator::Minus,
                     _ => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Unsupported interval operator: {op:?}"
-                        )));
+                        return not_impl_err!("Unsupported interval operator: {op:?}");
                     }
                 };
                 match (interval.leading_field, left.as_ref(), right.as_ref()) {
@@ -294,17 +292,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     }
                     _ => {
                         let value = SQLExpr::BinaryOp { left, op, right };
-                        return Err(DataFusionError::NotImplemented(format!(
+                        return not_impl_err!(
                             "Unsupported interval argument. Expected string literal, got: {value:?}"
-                        )));
+                        );
                     }
                 }
             }
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return not_impl_err!(
                     "Unsupported interval argument. Expected string literal, got: {:?}",
-                    interval.value,
-                )));
+                    interval.value
+                );
             }
         };
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -30,8 +30,10 @@ use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption};
 use sqlparser::ast::{DataType as SQLDataType, Ident, ObjectName, TableAlias};
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::plan_err;
-use datafusion_common::{unqualified_field_not_found, DFSchema, DataFusionError, Result};
+use datafusion_common::{
+    not_impl_err, plan_err, unqualified_field_not_found, DFSchema, DataFusionError,
+    Result,
+};
 use datafusion_common::{OwnedTableReference, TableReference};
 use datafusion_expr::logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use datafusion_expr::utils::find_column_exprs;
@@ -298,9 +300,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     "field", data_type, true,
                 ))))
             }
-            SQLDataType::Array(None) => Err(DataFusionError::NotImplemented(
-                "Arrays with unspecified type is not supported".to_string(),
-            )),
+            SQLDataType::Array(None) => {
+                not_impl_err!("Arrays with unspecified type is not supported")
+            }
             other => self.convert_simple_data_type(other),
         }
     }
@@ -347,9 +349,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     Ok(DataType::Time64(TimeUnit::Nanosecond))
                 } else {
                     // We dont support TIMETZ and TIME WITH TIME ZONE for now
-                    Err(DataFusionError::NotImplemented(format!(
+                    not_impl_err!(
                         "Unsupported SQL type {sql_type:?}"
-                    )))
+                    )
                 }
             }
             SQLDataType::Numeric(exact_number_info)
@@ -394,9 +396,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             | SQLDataType::Dec(_)
             | SQLDataType::BigNumeric(_)
             | SQLDataType::BigDecimal(_)
-            | SQLDataType::Clob(_) => Err(DataFusionError::NotImplemented(format!(
+            | SQLDataType::Clob(_) => not_impl_err!(
                 "Unsupported SQL type {sql_type:?}"
-            ))),
+            ),
         }
     }
 

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 
-use datafusion_common::{Constraints, DataFusionError, Result, ScalarValue};
+use datafusion_common::{
+    not_impl_err, plan_err, Constraints, DataFusionError, Result, ScalarValue,
+};
 use datafusion_expr::{
     CreateMemoryTable, DdlStatement, Expr, LogicalPlan, LogicalPlanBuilder,
 };
@@ -27,7 +29,6 @@ use sqlparser::ast::{
     Expr as SQLExpr, Offset as SQLOffset, OrderByExpr, Query, SetExpr, Value,
 };
 
-use datafusion_common::plan_err;
 use sqlparser::parser::ParserError::ParserError;
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
@@ -53,9 +54,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             // Process CTEs from top to bottom
             // do not allow self-references
             if with.recursive {
-                return Err(DataFusionError::NotImplemented(
-                    "Recursive CTEs are not supported".to_string(),
-                ));
+                return not_impl_err!("Recursive CTEs are not supported");
             }
 
             for cte in with.cte_tables {

--- a/datafusion/sql/src/relation/join.rs
+++ b/datafusion/sql/src/relation/join.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{Column, DataFusionError, Result};
+use datafusion_common::{not_impl_err, Column, DataFusionError, Result};
 use datafusion_expr::{JoinType, LogicalPlan, LogicalPlanBuilder};
 use sqlparser::ast::{Join, JoinConstraint, JoinOperator, TableWithJoins};
 use std::collections::HashSet;
@@ -106,9 +106,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 self.parse_join(left, right, constraint, JoinType::Full, planner_context)
             }
             JoinOperator::CrossJoin => self.parse_cross_join(left, right),
-            other => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported JOIN operator {other:?}"
-            ))),
+            other => not_impl_err!("Unsupported JOIN operator {other:?}"),
         }
     }
 
@@ -174,9 +172,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .build()
                 }
             }
-            JoinConstraint::None => Err(DataFusionError::NotImplemented(
-                "NONE constraint is not supported".to_string(),
-            )),
+            JoinConstraint::None => not_impl_err!("NONE constraint is not supported"),
         }
     }
 }

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::{LogicalPlan, LogicalPlanBuilder};
 use sqlparser::ast::TableFactor;
 
@@ -64,9 +64,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             ),
             // @todo Support TableFactory::TableFunction?
             _ => {
-                return Err(DataFusionError::NotImplemented(format!(
+                return not_impl_err!(
                     "Unsupported ast node {relation:?} in create_relation"
-                )));
+                );
             }
         };
         if let Some(alias) = alias {

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -24,9 +24,9 @@ use crate::utils::{
     resolve_columns, resolve_positions_to_exprs,
 };
 
-use datafusion_common::plan_err;
 use datafusion_common::{
-    get_target_functional_dependencies, DFSchemaRef, DataFusionError, Result,
+    get_target_functional_dependencies, not_impl_err, plan_err, DFSchemaRef,
+    DataFusionError, Result,
 };
 use datafusion_expr::expr::Alias;
 use datafusion_expr::expr_rewriter::{
@@ -52,19 +52,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<LogicalPlan> {
         // check for unsupported syntax first
         if !select.cluster_by.is_empty() {
-            return Err(DataFusionError::NotImplemented("CLUSTER BY".to_string()));
+            return not_impl_err!("CLUSTER BY");
         }
         if !select.lateral_views.is_empty() {
-            return Err(DataFusionError::NotImplemented("LATERAL VIEWS".to_string()));
+            return not_impl_err!("LATERAL VIEWS");
         }
         if select.qualify.is_some() {
-            return Err(DataFusionError::NotImplemented("QUALIFY".to_string()));
+            return not_impl_err!("QUALIFY");
         }
         if select.top.is_some() {
-            return Err(DataFusionError::NotImplemented("TOP".to_string()));
+            return not_impl_err!("TOP");
         }
         if !select.sort_by.is_empty() {
-            return Err(DataFusionError::NotImplemented("SORT BY".to_string()));
+            return not_impl_err!("SORT BY");
         }
 
         // process `from` clause
@@ -209,9 +209,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             .distinct
             .map(|distinct| match distinct {
                 Distinct::Distinct => Ok(true),
-                Distinct::On(_) => Err(DataFusionError::NotImplemented(
-                    "DISTINCT ON Exprs not supported".to_string(),
-                )),
+                Distinct::On(_) => not_impl_err!("DISTINCT ON Exprs not supported"),
             })
             .transpose()?
             .unwrap_or(false);
@@ -386,9 +384,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         } = options;
 
         if opt_rename.is_some() || opt_replace.is_some() {
-            Err(DataFusionError::NotImplemented(
-                "wildcard * with RENAME or REPLACE not supported ".to_string(),
-            ))
+            not_impl_err!("wildcard * with RENAME or REPLACE not supported ")
         } else {
             Ok(())
         }

--- a/datafusion/sql/src/set_expr.rs
+++ b/datafusion/sql/src/set_expr.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::{LogicalPlan, LogicalPlanBuilder};
 use sqlparser::ast::{SetExpr, SetOperator, SetQuantifier};
 
@@ -39,14 +39,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     SetQuantifier::All => true,
                     SetQuantifier::Distinct | SetQuantifier::None => false,
                     SetQuantifier::ByName => {
-                        return Err(DataFusionError::NotImplemented(
-                            "UNION BY NAME not implemented".to_string(),
-                        ));
+                        return not_impl_err!("UNION BY NAME not implemented");
                     }
                     SetQuantifier::AllByName => {
-                        return Err(DataFusionError::NotImplemented(
-                            "UNION ALL BY NAME not implemented".to_string(),
-                        ))
+                        return not_impl_err!("UNION ALL BY NAME not implemented")
                     }
                 };
 
@@ -74,9 +70,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
             }
             SetExpr::Query(q) => self.query_to_plan(*q, planner_context),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Query {set_expr} not implemented yet"
-            ))),
+            _ => not_impl_err!("Query {set_expr} not implemented yet"),
         }
     }
 }

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -17,7 +17,7 @@
 
 use async_recursion::async_recursion;
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
-use datafusion::common::{DFField, DFSchema, DFSchemaRef};
+use datafusion::common::{not_impl_err, DFField, DFSchema, DFSchemaRef};
 use datafusion::logical_expr::{
     aggregate_function, window_function::find_df_window_func, BinaryExpr,
     BuiltinScalarFunction, Case, Expr, LogicalPlan, Operator,
@@ -106,9 +106,7 @@ pub fn name_to_op(name: &str) -> Result<Operator> {
         "bitwise_xor" => Ok(Operator::BitwiseXor),
         "bitwise_shift_right" => Ok(Operator::BitwiseShiftRight),
         "bitwise_shift_left" => Ok(Operator::BitwiseShiftLeft),
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported function name: {name:?}"
-        ))),
+        _ => not_impl_err!("Unsupported function name: {name:?}"),
     }
 }
 
@@ -125,9 +123,7 @@ fn scalar_function_type_from_str(name: &str) -> Result<ScalarFunctionType> {
         "not" => Ok(ScalarFunctionType::Not),
         "like" => Ok(ScalarFunctionType::Like),
         "ilike" => Ok(ScalarFunctionType::ILike),
-        others => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported function name: {others:?}"
-        ))),
+        others => not_impl_err!("Unsupported function name: {others:?}"),
     }
 }
 
@@ -145,13 +141,9 @@ pub async fn from_substrait_plan(
                 MappingType::ExtensionFunction(ext_f) => {
                     Ok((ext_f.function_anchor, &ext_f.name))
                 }
-                _ => Err(DataFusionError::NotImplemented(format!(
-                    "Extension type not supported: {ext:?}"
-                ))),
+                _ => not_impl_err!("Extension type not supported: {ext:?}"),
             },
-            None => Err(DataFusionError::NotImplemented(
-                "Cannot parse empty extension".to_string(),
-            )),
+            None => not_impl_err!("Cannot parse empty extension"),
         })
         .collect::<Result<HashMap<_, _>>>()?;
     // Parse relations
@@ -169,10 +161,10 @@ pub async fn from_substrait_plan(
                 None => plan_err!("Cannot parse plan relation: None")
             }
         },
-        _ => Err(DataFusionError::NotImplemented(format!(
+        _ => not_impl_err!(
             "Substrait plan with more than 1 relation trees not supported. Number of relation trees: {:?}",
             plan.relations.len()
-        )))
+        )
     }
 }
 
@@ -208,9 +200,7 @@ pub async fn from_substrait_rel(
                 }
                 input.project(exprs)?.build()
             } else {
-                Err(DataFusionError::NotImplemented(
-                    "Projection without an input is not supported".to_string(),
-                ))
+                not_impl_err!("Projection without an input is not supported")
             }
         }
         Some(RelType::Filter(filter)) => {
@@ -223,14 +213,10 @@ pub async fn from_substrait_rel(
                         from_substrait_rex(condition, input.schema(), extensions).await?;
                     input.filter(expr.as_ref().clone())?.build()
                 } else {
-                    Err(DataFusionError::NotImplemented(
-                        "Filter without an condition is not valid".to_string(),
-                    ))
+                    not_impl_err!("Filter without an condition is not valid")
                 }
             } else {
-                Err(DataFusionError::NotImplemented(
-                    "Filter without an input is not valid".to_string(),
-                ))
+                not_impl_err!("Filter without an input is not valid")
             }
         }
         Some(RelType::Fetch(fetch)) => {
@@ -242,9 +228,7 @@ pub async fn from_substrait_rel(
                 let count = fetch.count as usize;
                 input.limit(offset, Some(count))?.build()
             } else {
-                Err(DataFusionError::NotImplemented(
-                    "Fetch without an input is not valid".to_string(),
-                ))
+                not_impl_err!("Fetch without an input is not valid")
             }
         }
         Some(RelType::Sort(sort)) => {
@@ -256,9 +240,7 @@ pub async fn from_substrait_rel(
                     from_substrait_sorts(&sort.sorts, input.schema(), extensions).await?;
                 input.sort(sorts)?.build()
             } else {
-                Err(DataFusionError::NotImplemented(
-                    "Sort without an input is not valid".to_string(),
-                ))
+                not_impl_err!("Sort without an input is not valid")
             }
         }
         Some(RelType::Aggregate(agg)) => {
@@ -271,10 +253,9 @@ pub async fn from_substrait_rel(
 
                 let groupings = match agg.groupings.len() {
                     1 => Ok(&agg.groupings[0]),
-                    _ => Err(DataFusionError::NotImplemented(
+                    _ => not_impl_err!(
                         "Aggregate with multiple grouping sets is not supported"
-                            .to_string(),
-                    )),
+                    ),
                 };
 
                 for e in &groupings?.grouping_expressions {
@@ -318,19 +299,16 @@ pub async fn from_substrait_rel(
                             )
                             .await
                         }
-                        None => Err(DataFusionError::NotImplemented(
+                        None => not_impl_err!(
                             "Aggregate without aggregate function is not supported"
-                                .to_string(),
-                        )),
+                        ),
                     };
                     aggr_expr.push(agg_func?.as_ref().clone());
                 }
 
                 input.aggregate(group_expr, aggr_expr)?.build()
             } else {
-                Err(DataFusionError::NotImplemented(
-                    "Aggregate without an input is not valid".to_string(),
-                ))
+                not_impl_err!("Aggregate without an input is not valid")
             }
         }
         Some(RelType::Join(join)) => {
@@ -457,9 +435,7 @@ pub async fn from_substrait_rel(
                     _ => Ok(t),
                 }
             }
-            _ => Err(DataFusionError::NotImplemented(
-                "Only NamedTable reads are supported".to_string(),
-            )),
+            _ => not_impl_err!("Only NamedTable reads are supported"),
         },
         Some(RelType::Set(set)) => match set_rel::SetOp::from_i32(set.op) {
             Some(set_op) => match set_op {
@@ -474,18 +450,12 @@ pub async fn from_substrait_rel(
                         }
                         union_builder?.build()
                     } else {
-                        Err(DataFusionError::NotImplemented(
-                            "Union relation requires at least one input".to_string(),
-                        ))
+                        not_impl_err!("Union relation requires at least one input")
                     }
                 }
-                _ => Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported set operator: {set_op:?}"
-                ))),
+                _ => not_impl_err!("Unsupported set operator: {set_op:?}"),
             },
-            None => Err(DataFusionError::NotImplemented(
-                "Invalid set operation type None".to_string(),
-            )),
+            None => not_impl_err!("Invalid set operation type None"),
         },
         Some(RelType::ExtensionLeaf(extension)) => {
             let Some(ext_detail) = &extension.detail else {
@@ -536,10 +506,7 @@ pub async fn from_substrait_rel(
             let plan = plan.from_template(&plan.expressions(), &inputs);
             Ok(LogicalPlan::Extension(Extension { node: plan }))
         }
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported RelType: {:?}",
-            rel.rel_type
-        ))),
+        _ => not_impl_err!("Unsupported RelType: {:?}", rel.rel_type),
     }
 }
 
@@ -573,9 +540,9 @@ pub async fn from_substrait_sorts(
             Some(k) => match k {
                 Direction(d) => {
                     let Some(direction) = SortDirection::from_i32(*d) else {
-                        return Err(DataFusionError::NotImplemented(
-                            format!("Unsupported Substrait SortDirection value {d}"),
-                        ))
+                        return not_impl_err!(
+                            "Unsupported Substrait SortDirection value {d}"
+                        )
                     };
 
                     match direction {
@@ -583,25 +550,19 @@ pub async fn from_substrait_sorts(
                         SortDirection::AscNullsLast => Ok((true, false)),
                         SortDirection::DescNullsFirst => Ok((false, true)),
                         SortDirection::DescNullsLast => Ok((false, false)),
-                        SortDirection::Clustered => Err(DataFusionError::NotImplemented(
+                        SortDirection::Clustered => not_impl_err!(
                             "Sort with direction clustered is not yet supported"
-                                .to_string(),
-                        )),
+                        ),
                         SortDirection::Unspecified => {
-                            Err(DataFusionError::NotImplemented(
-                                "Unspecified sort direction is invalid".to_string(),
-                            ))
+                            not_impl_err!("Unspecified sort direction is invalid")
                         }
                     }
                 }
-                ComparisonFunctionReference(_) => Err(DataFusionError::NotImplemented(
+                ComparisonFunctionReference(_) => not_impl_err!(
                     "Sort using comparison function reference is not supported"
-                        .to_string(),
-                )),
+                ),
             },
-            None => Err(DataFusionError::NotImplemented(
-                "Sort without sort kind is invalid".to_string(),
-            )),
+            None => not_impl_err!("Sort without sort kind is invalid"),
         };
         let (asc, nulls_first) = asc_nullfirst.unwrap();
         sorts.push(Expr::Sort(Sort {
@@ -639,9 +600,9 @@ pub async fn from_substriat_func_args(
             Some(ArgType::Value(e)) => {
                 from_substrait_rex(e, input_schema, extensions).await
             }
-            _ => Err(DataFusionError::NotImplemented(
-                "Aggregated function argument non-Value type not supported".to_string(),
-            )),
+            _ => {
+                not_impl_err!("Aggregated function argument non-Value type not supported")
+            }
         };
         args.push(arg_expr?.as_ref().clone());
     }
@@ -663,9 +624,9 @@ pub async fn from_substrait_agg_func(
             Some(ArgType::Value(e)) => {
                 from_substrait_rex(e, input_schema, extensions).await
             }
-            _ => Err(DataFusionError::NotImplemented(
-                "Aggregated function argument non-Value type not supported".to_string(),
-            )),
+            _ => {
+                not_impl_err!("Aggregated function argument non-Value type not supported")
+            }
         };
         args.push(arg_expr?.as_ref().clone());
     }
@@ -674,10 +635,10 @@ pub async fn from_substrait_agg_func(
         Some(function_name) => {
             aggregate_function::AggregateFunction::from_str(function_name)
         }
-        None => Err(DataFusionError::NotImplemented(format!(
+        None => not_impl_err!(
             "Aggregated function not found: function anchor = {:?}",
             f.function_reference
-        ))),
+        ),
     };
 
     Ok(Arc::new(Expr::AggregateFunction(expr::AggregateFunction {
@@ -715,10 +676,9 @@ pub async fn from_substrait_rex(
         Some(RexType::Selection(field_ref)) => match &field_ref.reference_type {
             Some(DirectReference(direct)) => match &direct.reference_type.as_ref() {
                 Some(StructField(x)) => match &x.child.as_ref() {
-                    Some(_) => Err(DataFusionError::NotImplemented(
+                    Some(_) => not_impl_err!(
                         "Direct reference StructField with child is not supported"
-                            .to_string(),
-                    )),
+                    ),
                     None => {
                         let column =
                             input_schema.field(x.field as usize).qualified_column();
@@ -728,14 +688,11 @@ pub async fn from_substrait_rex(
                         })))
                     }
                 },
-                _ => Err(DataFusionError::NotImplemented(
+                _ => not_impl_err!(
                     "Direct reference with types other than StructField is not supported"
-                        .to_string(),
-                )),
+                ),
             },
-            _ => Err(DataFusionError::NotImplemented(
-                "unsupported field ref type".to_string(),
-            )),
+            _ => not_impl_err!("unsupported field ref type"),
         },
         Some(RexType::IfThen(if_then)) => {
             // Parse `ifs`
@@ -814,10 +771,9 @@ pub async fn from_substrait_rex(
                             Some(ArgType::Value(e)) => {
                                 from_substrait_rex(e, input_schema, extensions).await
                             }
-                            _ => Err(DataFusionError::NotImplemented(
+                            _ => not_impl_err!(
                                 "Aggregated function argument non-Value type not supported"
-                                    .to_string(),
-                            )),
+                            ),
                         };
                         args.push(arg_expr?.as_ref().clone());
                     }
@@ -828,9 +784,9 @@ pub async fn from_substrait_rex(
                 }
                 ScalarFunctionType::Op(op) => {
                     if f.arguments.len() != 2 {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Expect two arguments for binary operator {op:?}",
-                        )));
+                        return not_impl_err!(
+                            "Expect two arguments for binary operator {op:?}"
+                        );
                     }
                     let lhs = &f.arguments[0].arg_type;
                     let rhs = &f.arguments[1].arg_type;
@@ -853,9 +809,9 @@ pub async fn from_substrait_rex(
                                 ),
                             })))
                         }
-                        (l, r) => Err(DataFusionError::NotImplemented(format!(
+                        (l, r) => not_impl_err!(
                             "Invalid arguments for binary expression: {l:?} and {r:?}"
-                        ))),
+                        ),
                     }
                 }
                 ScalarFunctionType::Not => {
@@ -872,9 +828,7 @@ pub async fn from_substrait_rex(
                                 .clone();
                             Ok(Arc::new(Expr::Not(Box::new(expr))))
                         }
-                        _ => Err(DataFusionError::NotImplemented(
-                            "Invalid arguments for Not expression".to_string(),
-                        )),
+                        _ => not_impl_err!("Invalid arguments for Not expression"),
                     }
                 }
                 ScalarFunctionType::Like => {
@@ -910,10 +864,10 @@ pub async fn from_substrait_rex(
         Some(RexType::WindowFunction(window)) => {
             let fun = match extensions.get(&window.function_reference) {
                 Some(function_name) => Ok(find_df_window_func(function_name)),
-                None => Err(DataFusionError::NotImplemented(format!(
+                None => not_impl_err!(
                     "Window function not found: function anchor = {:?}",
                     &window.function_reference
-                ))),
+                ),
             };
             let order_by =
                 from_substrait_sorts(&window.sorts, input_schema, extensions).await?;
@@ -948,9 +902,7 @@ pub async fn from_substrait_rex(
                 },
             })))
         }
-        _ => Err(DataFusionError::NotImplemented(
-            "unsupported rex_type".to_string(),
-        )),
+        _ => not_impl_err!("unsupported rex_type"),
     }
 }
 
@@ -961,30 +913,30 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
             r#type::Kind::I8(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int8),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt8),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I16(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int16),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt16),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I32(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int32),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt32),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I64(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(DataType::Int64),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(DataType::UInt64),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Fp32(_) => Ok(DataType::Float32),
             r#type::Kind::Fp64(_) => Ok(DataType::Float64),
@@ -1001,23 +953,23 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 TIMESTAMP_NANO_TYPE_REF => {
                     Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
                 }
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Date(date) => match date.type_variation_reference {
                 DATE_32_TYPE_REF => Ok(DataType::Date32),
                 DATE_64_TYPE_REF => Ok(DataType::Date64),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Binary(binary) => match binary.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::Binary),
                 LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeBinary),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::FixedBinary(fixed) => {
                 Ok(DataType::FixedSizeBinary(fixed.length))
@@ -1025,9 +977,9 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
             r#type::Kind::String(string) => match string.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::Utf8),
                 LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeUtf8),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::List(list) => {
                 let inner_type =
@@ -1040,9 +992,9 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 match list.type_variation_reference {
                     DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::List(field)),
                     LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeList(field)),
-                    v => Err(DataFusionError::NotImplemented(format!(
+                    v => not_impl_err!(
                         "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                    )))?,
+                    )?,
                 }
             }
             r#type::Kind::Decimal(d) => match d.type_variation_reference {
@@ -1052,17 +1004,13 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                 DECIMAL_256_TYPE_REF => {
                     Ok(DataType::Decimal256(d.precision as u8, d.scale as i8))
                 }
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                ))),
+                ),
             },
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported Substrait type: {s_kind:?}"
-            ))),
+            _ => not_impl_err!("Unsupported Substrait type: {s_kind:?}"),
         },
-        _ => Err(DataFusionError::NotImplemented(
-            "`None` Substrait kind is not supported".to_string(),
-        )),
+        _ => not_impl_err!("`None` Substrait kind is not supported"),
     }
 }
 
@@ -1201,12 +1149,7 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
             )
         }
         Some(LiteralType::Null(ntype)) => from_substrait_null(ntype)?,
-        _ => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "Unsupported literal_type: {:?}",
-                lit.literal_type
-            )))
-        }
+        _ => return not_impl_err!("Unsupported literal_type: {:?}", lit.literal_type),
     };
 
     Ok(scalar_value)
@@ -1219,30 +1162,30 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
             r#type::Kind::I8(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int8(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt8(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I16(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int16(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt16(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I32(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int32(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt32(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::I64(integer) => match integer.type_variation_reference {
                 DEFAULT_TYPE_REF => Ok(ScalarValue::Int64(None)),
                 UNSIGNED_INTEGER_TYPE_REF => Ok(ScalarValue::UInt64(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Fp32(_) => Ok(ScalarValue::Float32(None)),
             r#type::Kind::Fp64(_) => Ok(ScalarValue::Float64(None)),
@@ -1257,45 +1200,41 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                 TIMESTAMP_NANO_TYPE_REF => {
                     Ok(ScalarValue::TimestampNanosecond(None, None))
                 }
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Date(date) => match date.type_variation_reference {
                 DATE_32_TYPE_REF => Ok(ScalarValue::Date32(None)),
                 DATE_64_TYPE_REF => Ok(ScalarValue::Date64(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Binary(binary) => match binary.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Binary(None)),
                 LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeBinary(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             // FixedBinary is not supported because `None` doesn't have length
             r#type::Kind::String(string) => match string.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::Utf8(None)),
                 LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeUtf8(None)),
-                v => Err(DataFusionError::NotImplemented(format!(
+                v => not_impl_err!(
                     "Unsupported Substrait type variation {v} of type {kind:?}"
-                ))),
+                ),
             },
             r#type::Kind::Decimal(d) => Ok(ScalarValue::Decimal128(
                 None,
                 d.precision as u8,
                 d.scale as i8,
             )),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "Unsupported Substrait type: {kind:?}"
-            ))),
+            _ => not_impl_err!("Unsupported Substrait type: {kind:?}"),
         }
     } else {
-        Err(DataFusionError::NotImplemented(
-            "Null type without kind is not supported".to_string(),
-        ))
+        not_impl_err!("Null type without kind is not supported")
     }
 }
 
@@ -1307,33 +1246,31 @@ async fn make_datafusion_like(
 ) -> Result<Arc<Expr>> {
     let fn_name = if case_insensitive { "ILIKE" } else { "LIKE" };
     if f.arguments.len() != 3 {
-        return Err(DataFusionError::NotImplemented(format!(
-            "Expect three arguments for `{fn_name}` expr"
-        )));
+        return not_impl_err!("Expect three arguments for `{fn_name}` expr");
     }
 
     let Some(ArgType::Value(expr_substrait)) = &f.arguments[0].arg_type else {
-        return Err(DataFusionError::NotImplemented(
-            format!("Invalid arguments type for `{fn_name}` expr")
-        ))
+        return not_impl_err!(
+            "Invalid arguments type for `{fn_name}` expr"
+        )
     };
     let expr = from_substrait_rex(expr_substrait, input_schema, extensions)
         .await?
         .as_ref()
         .clone();
     let Some(ArgType::Value(pattern_substrait)) = &f.arguments[1].arg_type else {
-        return Err(DataFusionError::NotImplemented(
-            format!("Invalid arguments type for `{fn_name}` expr")
-        ))
+        return not_impl_err!(
+            "Invalid arguments type for `{fn_name}` expr"
+        )
     };
     let pattern = from_substrait_rex(pattern_substrait, input_schema, extensions)
         .await?
         .as_ref()
         .clone();
     let Some(ArgType::Value(escape_char_substrait)) = &f.arguments[2].arg_type else {
-        return Err(DataFusionError::NotImplemented(
-            format!("Invalid arguments type for `{fn_name}` expr")
-        ))
+        return not_impl_err!(
+            "Invalid arguments type for `{fn_name}` expr"
+        )
     };
     let escape_char_expr =
         from_substrait_rex(escape_char_substrait, input_schema, extensions)

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -28,8 +28,8 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use datafusion::common::internal_err;
 use datafusion::common::DFSchemaRef;
+use datafusion::common::{internal_err, not_impl_err};
 #[allow(unused_imports)]
 use datafusion::logical_expr::aggregate_function;
 use datafusion::logical_expr::expr::{
@@ -273,9 +273,7 @@ pub fn to_substrait_rel(
             match join.join_constraint {
                 JoinConstraint::On => {}
                 JoinConstraint::Using => {
-                    return Err(DataFusionError::NotImplemented(
-                        "join constraint: `using`".to_string(),
-                    ))
+                    return not_impl_err!("join constraint: `using`")
                 }
             }
             // parse filter if exists
@@ -413,9 +411,7 @@ pub fn to_substrait_rel(
                 rel_type: Some(rel_type),
             }))
         }
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported operator: {plan:?}"
-        ))),
+        _ => not_impl_err!("Unsupported operator: {plan:?}"),
     }
 }
 
@@ -952,9 +948,7 @@ pub fn to_substrait_rex(
             col_ref_offset,
             extension_info,
         ),
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported expression: {expr:?}"
-        ))),
+        _ => not_impl_err!("Unsupported expression: {expr:?}"),
     }
 }
 
@@ -1136,9 +1130,7 @@ fn to_substrait_type(dt: &DataType) -> Result<substrait::proto::Type> {
                 precision: *p as i32,
             })),
         }),
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported cast type: {dt:?}"
-        ))),
+        _ => not_impl_err!("Unsupported cast type: {dt:?}"),
     }
 }
 
@@ -1563,9 +1555,7 @@ fn try_to_substrait_null(v: &ScalarValue) -> Result<LiteralType> {
             }))
         }
         // TODO: Extend support for remaining data types
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported literal: {v:?}"
-        ))),
+        _ => not_impl_err!("Unsupported literal: {v:?}"),
     }
 }
 
@@ -1595,9 +1585,7 @@ fn substrait_sort_field(
                 sort_kind: Some(SortKind::Direction(d as i32)),
             })
         }
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Expecting sort expression but got {expr:?}"
-        ))),
+        _ => not_impl_err!("Expecting sort expression but got {expr:?}"),
     }
 }
 

--- a/datafusion/substrait/src/physical_plan/consumer.rs
+++ b/datafusion/substrait/src/physical_plan/consumer.rs
@@ -18,6 +18,7 @@
 use async_recursion::async_recursion;
 use chrono::DateTime;
 use datafusion::arrow::datatypes::Schema;
+use datafusion::common::not_impl_err;
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{FileScanConfig, ParquetExec};
@@ -42,19 +43,13 @@ pub async fn from_substrait_rel(
     match &rel.rel_type {
         Some(RelType::Read(read)) => {
             if read.filter.is_some() || read.best_effort_filter.is_some() {
-                return Err(DataFusionError::NotImplemented(
-                    "Read with filter is not supported".to_string(),
-                ));
+                return not_impl_err!("Read with filter is not supported");
             }
             if read.base_schema.is_some() {
-                return Err(DataFusionError::NotImplemented(
-                    "Read with schema is not supported".to_string(),
-                ));
+                return not_impl_err!("Read with schema is not supported");
             }
             if read.advanced_extension.is_some() {
-                return Err(DataFusionError::NotImplemented(
-                    "Read with AdvancedExtension is not supported".to_string(),
-                ));
+                return not_impl_err!("Read with AdvancedExtension is not supported");
             }
             match &read.as_ref().read_type {
                 Some(ReadType::LocalFiles(files)) => {
@@ -131,15 +126,11 @@ pub async fn from_substrait_rel(
                     Ok(Arc::new(ParquetExec::new(base_config, None, None))
                         as Arc<dyn ExecutionPlan>)
                 }
-                _ => Err(DataFusionError::NotImplemented(
+                _ => not_impl_err!(
                     "Only LocalFile reads are supported when parsing physical"
-                        .to_string(),
-                )),
+                ),
             }
         }
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported RelType: {:?}",
-            rel.rel_type
-        ))),
+        _ => not_impl_err!("Unsupported RelType: {:?}", rel.rel_type),
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

Related to https://github.com/apache/arrow-datafusion/pull/6740 https://github.com/apache/arrow-datafusion/pull/7115

## Rationale for this change
Add `not_impl_err!` error macro to replace `DatafusionError::NotImplemented` with more concise code and make error handling in single place
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->