### PR TITLE
Fix error type of invalid argument types, remove misleading comments

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -525,7 +525,7 @@ impl BuiltinScalarFunction {
                             }
                         }
                         _ => {
-                            return internal_err!(
+                            return plan_err!(
                                 "The {self} function can only accept list as the args."
                             )
                         }
@@ -542,7 +542,7 @@ impl BuiltinScalarFunction {
             }
             BuiltinScalarFunction::ArrayElement => match &input_expr_types[0] {
                 List(field) => Ok(field.data_type().clone()),
-                _ => internal_err!(
+                _ => plan_err!(
                     "The {self} function can only accept list as the first argument"
                 ),
             },
@@ -608,7 +608,7 @@ impl BuiltinScalarFunction {
                     Timestamp(Microsecond, _) => Ok(Timestamp(Microsecond, None)),
                     Timestamp(Millisecond, _) => Ok(Timestamp(Millisecond, None)),
                     Timestamp(Second, _) => Ok(Timestamp(Second, None)),
-                    _ => internal_err!(
+                    _ => plan_err!(
                     "The {self} function can only accept timestamp as the second arg."
                 ),
                 }
@@ -677,8 +677,7 @@ impl BuiltinScalarFunction {
                 LargeBinary => LargeUtf8,
                 Null => Null,
                 _ => {
-                    // this error is internal as `data_types` should have captured this.
-                    return internal_err!(
+                    return plan_err!(
                         "The encode function can only accept utf8 or binary."
                     );
                 }
@@ -690,8 +689,7 @@ impl BuiltinScalarFunction {
                 LargeBinary => LargeBinary,
                 Null => Null,
                 _ => {
-                    // this error is internal as `data_types` should have captured this.
-                    return internal_err!(
+                    return plan_err!(
                         "The decode function can only accept utf8 or binary."
                     );
                 }
@@ -709,10 +707,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ToHex => Ok(match input_expr_types[0] {
                 Int8 | Int16 | Int32 | Int64 => Utf8,
                 _ => {
-                    // this error is internal as `data_types` should have captured this.
-                    return internal_err!(
-                        "The to_hex function can only accept integers."
-                    );
+                    return plan_err!("The to_hex function can only accept integers.");
                 }
             }),
             BuiltinScalarFunction::ToTimestamp => Ok(Timestamp(Nanosecond, None)),
@@ -737,8 +732,7 @@ impl BuiltinScalarFunction {
                 Utf8 => List(Arc::new(Field::new("item", Utf8, true))),
                 Null => Null,
                 _ => {
-                    // this error is internal as `data_types` should have captured this.
-                    return internal_err!(
+                    return plan_err!(
                         "The regexp_extract function can only accept strings."
                     );
                 }
@@ -1400,7 +1394,6 @@ macro_rules! make_utf8_to_return_type {
                     DataType::Utf8 => $utf8Type,
                     DataType::Null => DataType::Null,
                     _ => {
-                        // this error is internal as `data_types` should have captured this.
                         return plan_err!(
                             "The {:?} function can only accept strings, but got {:?}.",
                             name,
@@ -1409,7 +1402,6 @@ macro_rules! make_utf8_to_return_type {
                     }
                 },
                 data_type => {
-                    // this error is internal as `data_types` should have captured this.
                     return plan_err!(
                         "The {:?} function can only accept strings, but got {:?}.",
                         name,
@@ -1432,8 +1424,7 @@ fn utf8_or_binary_to_binary_type(arg_type: &DataType, name: &str) -> Result<Data
         | DataType::LargeBinary => DataType::Binary,
         DataType::Null => DataType::Null,
         _ => {
-            // this error is internal as `data_types` should have captured this.
-            return internal_err!(
+            return plan_err!(
                 "The {name:?} function can only accept strings or binary arrays."
             );
         }


### PR DESCRIPTION
## Which issue does this PR close?
related to #6108 and https://github.com/apache/arrow-datafusion/issues/7326
related to https://github.com/apache/arrow-datafusion/pull/7339/

## Rationale for this change

While trying to clean up a comment I saw left over from https://github.com/apache/arrow-datafusion/pull/7339 I realized that not only are the comments in the rest of this file misleading the same bug also applied. Specifically, despite the comments' claims that "this should have been covered earlier" it is clearly not and these error paths are directly user visible due to invalid queries (and thus should be plan errors, not internal errors):

```
DataFusion CLI v29.0.0
❯ select encode(1,2);
Internal error: The encode function can only accept utf8 or binary.. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
❯ select array_concat(1,2);
Internal error: The array_concat function can only accept list as the args.. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

## What changes are included in this PR?

1. Change to DataFusionError::Plan
2. Update tests
3. Update comments


## Are these changes tested?
Yes

## Are there any user-facing changes?
yes, better error messages

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->