### PR TITLE
Fix IN expr for NaN

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -94,7 +94,7 @@ impl<T> Set for ArraySet<T>
 where
     T: Array + 'static,
     for<'a> &'a T: ArrayAccessor,
-    for<'a> <&'a T as ArrayAccessor>::Item: PartialEq + HashValue,
+    for<'a> <&'a T as ArrayAccessor>::Item: IsEqual + HashValue,
 {
     fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
         downcast_dictionary_array! {
@@ -118,7 +118,7 @@ where
                         .hash_set
                         .map
                         .raw_entry()
-                        .from_hash(hash, |idx| in_array.value(*idx) == v)
+                        .from_hash(hash, |idx| in_array.value(*idx).is_equal(&v))
                         .is_some();
 
                     match contains {
@@ -141,7 +141,7 @@ where
 fn make_hash_set<T>(array: T) -> ArrayHashSet
 where
     T: ArrayAccessor,
-    T::Item: PartialEq + HashValue,
+    T::Item: IsEqual + HashValue,
 {
     let state = RandomState::new();
     let mut map: HashMap<usize, (), ()> =
@@ -152,7 +152,7 @@ where
         let hash = value.hash_one(&state);
         if let RawEntryMut::Vacant(v) = map
             .raw_entry_mut()
-            .from_hash(hash, |x| array.value(*x) == value)
+            .from_hash(hash, |x| array.value(*x).is_equal(&value))
         {
             v.insert_with_hasher(hash, idx, (), |x| array.value(*x).hash_one(&state));
         }
@@ -227,6 +227,40 @@ fn try_cast_static_filter_to_set(
     let batch = RecordBatch::new_empty(Arc::new(schema.clone()));
     make_set(evaluate_list(list, &batch)?.as_ref())
 }
+
+/// Custom equality check function which is used with [`ArrayHashSet`] for existence check.
+trait IsEqual: HashValue {
+    fn is_equal(&self, other: &Self) -> bool;
+}
+
+impl<'a, T: IsEqual + ?Sized> IsEqual for &'a T {
+    fn is_equal(&self, other: &Self) -> bool {
+        T::is_equal(self, other)
+    }
+}
+
+macro_rules! is_equal {
+    ($($t:ty),+) => {
+        $(impl IsEqual for $t {
+            fn is_equal(&self, other: &Self) -> bool {
+                self == other
+            }
+        })*
+    };
+}
+is_equal!(i8, i16, i32, i64, i128, i256, u8, u16, u32, u64);
+is_equal!(bool, str, [u8]);
+
+macro_rules! is_equal_float {
+    ($($t:ty),+) => {
+        $(impl IsEqual for $t {
+            fn is_equal(&self, other: &Self) -> bool {
+                self.to_bits() == other.to_bits()
+            }
+        })*
+    };
+}
+is_equal_float!(half::f16, f32, f64);
 
 impl InListExpr {
     /// Create a new InList expression
@@ -609,50 +643,100 @@ mod tests {
     #[test]
     fn in_list_float64() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Float64, true)]);
-        let a = Float64Array::from(vec![Some(0.0), Some(0.2), None]);
+        let a = Float64Array::from(vec![
+            Some(0.0),
+            Some(0.2),
+            None,
+            Some(f64::NAN),
+            Some(-f64::NAN),
+        ]);
         let col_a = col("a", &schema)?;
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
-        // expression: "a in (0.0, 0.2)"
+        // expression: "a in (0.0, 0.1)"
         let list = vec![lit(0.0f64), lit(0.1f64)];
         in_list!(
             batch,
             list,
             &false,
-            vec![Some(true), Some(false), None],
+            vec![Some(true), Some(false), None, Some(false), Some(false)],
             col_a.clone(),
             &schema
         );
 
-        // expression: "a not in (0.0, 0.2)"
+        // expression: "a not in (0.0, 0.1)"
         let list = vec![lit(0.0f64), lit(0.1f64)];
         in_list!(
             batch,
             list,
             &true,
-            vec![Some(false), Some(true), None],
+            vec![Some(false), Some(true), None, Some(true), Some(true)],
             col_a.clone(),
             &schema
         );
 
-        // expression: "a in (0.0, 0.2, NULL)"
+        // expression: "a in (0.0, 0.1, NULL)"
         let list = vec![lit(0.0f64), lit(0.1f64), lit(ScalarValue::Null)];
         in_list!(
             batch,
             list,
             &false,
-            vec![Some(true), None, None],
+            vec![Some(true), None, None, None, None],
             col_a.clone(),
             &schema
         );
 
-        // expression: "a not in (0.0, 0.2, NULL)"
+        // expression: "a not in (0.0, 0.1, NULL)"
         let list = vec![lit(0.0f64), lit(0.1f64), lit(ScalarValue::Null)];
         in_list!(
             batch,
             list,
             &true,
-            vec![Some(false), None, None],
+            vec![Some(false), None, None, None, None],
+            col_a.clone(),
+            &schema
+        );
+
+        // expression: "a in (0.0, 0.1, NaN)"
+        let list = vec![lit(0.0f64), lit(0.1f64), lit(f64::NAN)];
+        in_list!(
+            batch,
+            list,
+            &false,
+            vec![Some(true), Some(false), None, Some(true), Some(false)],
+            col_a.clone(),
+            &schema
+        );
+
+        // expression: "a not in (0.0, 0.1, NaN)"
+        let list = vec![lit(0.0f64), lit(0.1f64), lit(f64::NAN)];
+        in_list!(
+            batch,
+            list,
+            &true,
+            vec![Some(false), Some(true), None, Some(false), Some(true)],
+            col_a.clone(),
+            &schema
+        );
+
+        // expression: "a in (0.0, 0.1, -NaN)"
+        let list = vec![lit(0.0f64), lit(0.1f64), lit(-f64::NAN)];
+        in_list!(
+            batch,
+            list,
+            &false,
+            vec![Some(true), Some(false), None, Some(false), Some(true)],
+            col_a.clone(),
+            &schema
+        );
+
+        // expression: "a not in (0.0, 0.1, -NaN)"
+        let list = vec![lit(0.0f64), lit(0.1f64), lit(-f64::NAN)];
+        in_list!(
+            batch,
+            list,
+            &true,
+            vec![Some(false), Some(true), None, Some(true), Some(false)],
             col_a.clone(),
             &schema
         );

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -94,7 +94,7 @@ impl<T> Set for ArraySet<T>
 where
     T: Array + 'static,
     for<'a> &'a T: ArrayAccessor,
-    for<'a> <&'a T as ArrayAccessor>::Item: IsEqual + HashValue,
+    for<'a> <&'a T as ArrayAccessor>::Item: IsEqual,
 {
     fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
         downcast_dictionary_array! {
@@ -141,7 +141,7 @@ where
 fn make_hash_set<T>(array: T) -> ArrayHashSet
 where
     T: ArrayAccessor,
-    T::Item: IsEqual + HashValue,
+    T::Item: IsEqual,
 {
     let state = RandomState::new();
     let mut map: HashMap<usize, (), ()> =

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -252,7 +252,7 @@ fazzz
 statement ok
 CREATE TABLE IF NOT EXISTS test_float AS VALUES(1.2),(2.1),(NULL),('NaN'::double),('-NaN'::double);
 
-# async fn in_list_float
+# IN expr for float
 query R
 SELECT * FROM test_float WHERE column1 IN (0.0, -1.2)
 ----

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -249,6 +249,40 @@ SELECT * FROM test WHERE column1 IN ('foo', 'Bar', 'fazzz')
 foo
 fazzz
 
+statement ok
+CREATE TABLE IF NOT EXISTS test_float AS VALUES(1.2),(2.1),(NULL),('NaN'::double),('-NaN'::double);
+
+# async fn in_list_float
+query R
+SELECT * FROM test_float WHERE column1 IN (0.0, -1.2)
+----
+
+query R
+SELECT * FROM test_float WHERE column1 IN (0.0, 1.2)
+----
+1.2
+
+query R
+SELECT * FROM test_float WHERE column1 IN (2.1, 1.2)
+----
+1.2
+2.1
+
+query R
+SELECT * FROM test_float WHERE column1 IN (0.0, 1.2, NULL)
+----
+1.2
+
+query R
+SELECT * FROM test_float WHERE column1 IN (0.0, -1.2, NULL)
+----
+
+query R
+SELECT * FROM test_float WHERE column1 IN (0.0, 1.2, 'NaN'::double, '-NaN'::double)
+----
+1.2
+NaN
+NaN
 
 ###
 # Test logical plan simplifies large OR chains
@@ -347,6 +381,9 @@ drop table alltypes_plain;
 
 statement ok
 DROP TABLE test;
+
+statement ok
+DROP TABLE test_float;
 
 #########
 # Predicates on memory tables / statistics generation


### PR DESCRIPTION
## Which issue does this PR close?
Closes #7377 

## Rationale for this change
This PR fixes an issue that `'NaN'::double in ('NaN'::double)` is evaluated as `false`, which is inconsistent with the result of `'NaN'::double = 'NaN'::double`.

## What changes are included in this PR?
The root cause is that equality is evaluated using `PartialEq::eq`. So the fix is using `to_bits` for equality check for float values like as `ScalarValue::Float64` does.

NOTE: This issue doesn't happen when `Simplifier` simplifies `IN` expr like
```
a IN (x, y, z) -> a = x OR a = y OR a = z
```

## Are these changes tested?
Modified an existing test.

## Are there any user-facing changes?
Yes, but this change is for correctness.