### PR TITLE
Bug-fix/next_value() of Min/Max Scalar Values

### DIFF
--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -23,7 +23,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::{AddAssign, SubAssign};
 
 use crate::aggregate::min_max::{max, min};
-use crate::intervals::rounding::alter_fp_rounding_mode;
+use crate::intervals::rounding::{alter_fp_rounding_mode, next_down, next_up};
 
 use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::DataType;
@@ -252,7 +252,7 @@ impl Interval {
 
     /// This function returns the data type of this interval. If both endpoints
     /// do not have the same data type, returns an error.
-    pub(crate) fn get_datatype(&self) -> Result<DataType> {
+    pub fn get_datatype(&self) -> Result<DataType> {
         let lower_type = self.lower.get_datatype();
         let upper_type = self.upper.get_datatype();
         if lower_type == upper_type {
@@ -558,28 +558,60 @@ fn increment_decrement<const INC: bool, T: OneTrait + SubAssign + AddAssign>(
     val
 }
 
+macro_rules! check_infinite_bounds {
+    ($value:expr, $val:expr, $type:ident, $inc:expr) => {
+        if ($val == $type::MAX && $inc) || ($val == $type::MIN && !$inc) {
+            return $value;
+        }
+    };
+}
+
 /// This function returns the next/previous value depending on the `ADD` value.
 /// If `true`, it returns the next value; otherwise it returns the previous value.
 fn next_value<const INC: bool>(value: ScalarValue) -> ScalarValue {
     use ScalarValue::*;
     match value {
         Float32(Some(val)) => {
-            let incremented_bits = increment_decrement::<INC, u32>(val.to_bits());
-            Float32(Some(f32::from_bits(incremented_bits)))
+            let new_float = if INC { next_up(val) } else { next_down(val) };
+            Float32(Some(new_float))
         }
         Float64(Some(val)) => {
-            let incremented_bits = increment_decrement::<INC, u64>(val.to_bits());
-            Float64(Some(f64::from_bits(incremented_bits)))
+            let new_float = if INC { next_up(val) } else { next_down(val) };
+            Float64(Some(new_float))
         }
-        Int8(Some(val)) => Int8(Some(increment_decrement::<INC, i8>(val))),
-        Int16(Some(val)) => Int16(Some(increment_decrement::<INC, i16>(val))),
-        Int32(Some(val)) => Int32(Some(increment_decrement::<INC, i32>(val))),
-        Int64(Some(val)) => Int64(Some(increment_decrement::<INC, i64>(val))),
-        UInt8(Some(val)) => UInt8(Some(increment_decrement::<INC, u8>(val))),
-        UInt16(Some(val)) => UInt16(Some(increment_decrement::<INC, u16>(val))),
-        UInt32(Some(val)) => UInt32(Some(increment_decrement::<INC, u32>(val))),
-        UInt64(Some(val)) => UInt64(Some(increment_decrement::<INC, u64>(val))),
-        _ => value, // Infinite bounds or unsupported datatypes
+        Int8(Some(val)) => {
+            check_infinite_bounds!(value, val, i8, INC);
+            Int8(Some(increment_decrement::<INC, i8>(val)))
+        }
+        Int16(Some(val)) => {
+            check_infinite_bounds!(value, val, i16, INC);
+            Int16(Some(increment_decrement::<INC, i16>(val)))
+        }
+        Int32(Some(val)) => {
+            check_infinite_bounds!(value, val, i32, INC);
+            Int32(Some(increment_decrement::<INC, i32>(val)))
+        }
+        Int64(Some(val)) => {
+            check_infinite_bounds!(value, val, i64, INC);
+            Int64(Some(increment_decrement::<INC, i64>(val)))
+        }
+        UInt8(Some(val)) => {
+            check_infinite_bounds!(value, val, u8, INC);
+            UInt8(Some(increment_decrement::<INC, u8>(val)))
+        }
+        UInt16(Some(val)) => {
+            check_infinite_bounds!(value, val, u16, INC);
+            UInt16(Some(increment_decrement::<INC, u16>(val)))
+        }
+        UInt32(Some(val)) => {
+            check_infinite_bounds!(value, val, u32, INC);
+            UInt32(Some(increment_decrement::<INC, u32>(val)))
+        }
+        UInt64(Some(val)) => {
+            check_infinite_bounds!(value, val, u64, INC);
+            UInt64(Some(increment_decrement::<INC, u64>(val)))
+        }
+        _ => value, // Unsupported datatypes
     }
 }
 
@@ -1419,7 +1451,7 @@ mod tests {
             ScalarValue::new_one(&DataType::Int8)?,
         ];
 
-        let _ = zeros.into_iter().zip(ones.into_iter()).map(|(z, o)| {
+        zeros.into_iter().zip(ones.into_iter()).for_each(|(z, o)| {
             assert_eq!(next_value::<true>(z.clone()), o);
             assert_eq!(next_value::<false>(o), z);
         });
@@ -1435,29 +1467,35 @@ mod tests {
             ScalarValue::Float64(Some(1e-6)),
         ];
 
-        let _ = values.into_iter().zip(eps.into_iter()).map(|(v, e)| {
+        values.into_iter().zip(eps.into_iter()).for_each(|(v, e)| {
             assert!(next_value::<true>(v.clone()).sub(v.clone()).unwrap().lt(&e));
             assert!(v.clone().sub(next_value::<false>(v)).unwrap().lt(&e));
         });
 
-        // Min / Max values do not change
+        // Min / Max values do not change for integer values
         let min = vec![
             ScalarValue::UInt64(Some(u64::MIN)),
             ScalarValue::Int8(Some(i8::MIN)),
-            ScalarValue::Float32(Some(f32::MIN)),
-            ScalarValue::Float64(Some(f64::MIN)),
         ];
         let max = vec![
             ScalarValue::UInt64(Some(u64::MAX)),
             ScalarValue::Int8(Some(i8::MAX)),
-            ScalarValue::Float32(Some(f32::MAX)),
-            ScalarValue::Float64(Some(f64::MAX)),
         ];
 
-        let _ = min.into_iter().zip(max.into_iter()).map(|(min, max)| {
+        min.into_iter().zip(max.into_iter()).for_each(|(min, max)| {
             assert_eq!(next_value::<true>(max.clone()), max);
             assert_eq!(next_value::<false>(min.clone()), min);
         });
+
+        // Min / Max values results in infinity for floating point values
+        assert_eq!(
+            next_value::<true>(ScalarValue::Float32(Some(f32::MAX))),
+            ScalarValue::Float32(Some(f32::INFINITY))
+        );
+        assert_eq!(
+            next_value::<false>(ScalarValue::Float64(Some(f64::MIN))),
+            ScalarValue::Float64(Some(f64::NEG_INFINITY))
+        );
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/intervals/rounding.rs
+++ b/datafusion/physical-expr/src/intervals/rounding.rs
@@ -168,7 +168,6 @@ impl FloatBits for f64 {
 /// let next_f = next_up(f);
 /// assert_eq!(next_f, 1.0000001);
 /// ```
-#[allow(dead_code)]
 pub fn next_up<F: FloatBits + Copy>(float: F) -> F {
     let bits = float.to_bits();
     if float.float_is_nan() || bits == F::infinity().to_bits() {
@@ -202,7 +201,6 @@ pub fn next_up<F: FloatBits + Copy>(float: F) -> F {
 /// let next_f = next_down(f);
 /// assert_eq!(next_f, 0.99999994);
 /// ```
-#[allow(dead_code)]
 pub fn next_down<F: FloatBits + Copy>(float: F) -> F {
     let bits = float.to_bits();
     if float.float_is_nan() || bits == F::neg_infinity().to_bits() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

-->

In the interval arithmetic library, there is a function converting open bounds to closed bounds for convenience. This function increments or decrements a bound's value (according to the side of the bound) one step-size of the corresponding datatype. However, some buggy cases have been realized:

1. When a floating point value is 0 and it is tried to be decremented
2. When a value is tried to be incremented when it is at its maximum
3. When a value is tried to be decremented when it is at its minimum

After the fix, when an integer is at its maximum/minimu, it remains the same. When a floating value is at its maximum/minimum, it becomes infinity/negative infinity.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

There are minor changes in the implementation of next_value() function. The existing next_up()/next_down() functions are used for floating point values, while integers are checked firstly if they are at min/max.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:

1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->