### PR TITLE
fix: inconsistent scalar types in `DistinctArrayAggAccumulator` state

### DIFF
--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -134,11 +134,13 @@ impl Accumulator for DistinctArrayAggAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         assert_eq!(values.len(), 1, "batch input should only include 1 column!");
 
-        let arr = &values[0];
-        for i in 0..arr.len() {
-            self.values.insert(ScalarValue::try_from_array(arr, i)?);
-        }
-        Ok(())
+        let array = &values[0];
+        (0..array.len()).try_for_each(|i| {
+            if !array.is_null(i) {
+                self.values.insert(ScalarValue::try_from_array(array, i)?);
+            }
+            Ok(())
+        })
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -146,14 +146,15 @@ impl Accumulator for DistinctArrayAggAccumulator {
             return Ok(());
         }
 
-        assert!(
-            states.len() == 1,
+        assert_eq!(
+            states.len(),
+            1,
             "array_agg_distinct states must contain single array"
         );
 
-        let state = &states[0];
-        (0..state.len()).try_for_each(|i| {
-            let scalar = ScalarValue::try_from_array(state, i)?;
+        let array = &states[0];
+        (0..array.len()).try_for_each(|i| {
+            let scalar = ScalarValue::try_from_array(array, i)?;
             if let ScalarValue::List(Some(values), _) = scalar {
                 self.values.extend(values);
                 Ok(())

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1271,18 +1271,31 @@ NULL 4 29 1.260869565217 123 -117 23
 NULL 5 -194 -13.857142857143 118 -101 14
 NULL NULL 781 7.81 125 -117 100
 
-# TODO this querys output is non determinisitic (the order of the elements
-# differs run to run
+# TODO: array_agg_distinct output is non-determinisitic -- rewrite with array_sort(list_sort)
+#       unnest is also not available, so manually unnesting via CROSS JOIN
+# additional count(1) forces array_agg_distinct instead of array_agg over aggregated by c2 data
 #
 # csv_query_array_agg_distinct
-# query T
-# SELECT array_agg(distinct c2) FROM aggregate_test_100
-# ----
-# [4, 2, 3, 5, 1]
-
-# additional count(1) forces array_agg_distinct instead of array_agg over aggregated by c2 data
-statement ok
-SELECT array_agg(distinct c2), count(1) FROM aggregate_test_100
+query III
+WITH indices AS (
+  SELECT 1 AS idx UNION ALL
+  SELECT 2 AS idx UNION ALL
+  SELECT 3 AS idx UNION ALL
+  SELECT 4 AS idx UNION ALL
+  SELECT 5 AS idx
+)
+SELECT data.arr[indices.idx] as element, array_length(data.arr) as array_len, dummy
+FROM (
+  SELECT array_agg(distinct c2) as arr, count(1) as dummy FROM aggregate_test_100
+) data
+  CROSS JOIN indices
+ORDER BY 1
+----
+1 5 100
+2 5 100
+3 5 100
+4 5 100
+5 5 100
 
 # aggregate_time_min_and_max
 query TT

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1280,6 +1280,10 @@ NULL NULL 781 7.81 125 -117 100
 # ----
 # [4, 2, 3, 5, 1]
 
+# additional count(1) forces array_agg_distinct instead of array_agg over aggregated by c2 data
+statement ok
+SELECT array_agg(distinct c2), count(1) FROM aggregate_test_100
+
 # aggregate_time_min_and_max
 query TT
 select min(t), max(t) from  (select '00:00:00' as t union select '00:00:01' union select '00:00:02')


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6743.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently `DistinctArrayAggAccumulator` stores its state as a set of scalar values and returns it as a single scalar list. The problem is that while merging state, accumulator, instead of adding list elements, simply adds the whole list to the state as a single value, which causes errors while executing `evaluate` on accumulator with merged state.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`merge_state` now unpacks scalar list input and updates state with its elements.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- tests for merging `DistinctArrayAggAccumulator`s have been added, 
- check for successful execution of `array_agg(distinct col)` has been added to sqllogictests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

`array_agg(distinct)` should not fail in case query execution requires merging accumulator states (e. g. aggregation over multiple partitions)

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->