### PR TITLE
Minor: remove stray `println!` from `array_expressions.rs`

### DIFF
--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -1000,7 +1000,6 @@ macro_rules! general_repeat_list {
 
 /// Array_empty SQL function
 pub fn array_empty(args: &[ArrayRef]) -> Result<ArrayRef> {
-    println!("args[0]: {:?}", &args[0]);
     if args[0].as_any().downcast_ref::<NullArray>().is_some() {
         return Ok(args[0].clone());
     }


### PR DESCRIPTION
## Which issue does this PR close?

This appears to have crept in as part of #7313

## Rationale for this change

when I run sqllogictest it looks like

```
Running "nullif.slt"
Running "array.slt"
Running "type_coercion.slt"
Running "clickbench.slt"
Running "information_schema_columns.slt"
Running "information_schema_multiple_catalogs.slt"
args[0]: ListArray
[
  PrimitiveArray<Int64>
[
  1,
],
]
args[0]: ListArray
[
  NullArray(0),
]
...
  PrimitiveArray<Int64>
[
  null,
  18,
],
],
]

Compilation finished at Wed Aug 23 14:32:11

```

## What changes are included in this PR?

delete `println!`

## Are these changes tested?
existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->