### PR TITLE
Unnecessary to list all files during partition pruning

### DIFF
--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -324,7 +324,11 @@ pub async fn pruned_partition_list<'a>(
 
     // if no partition col => simply list all the files
     if partition_cols.is_empty() {
-        return Ok(Box::pin(table_path.list_all_files(store, file_extension).map_ok(|object_meta| object_meta.into())));
+        return Ok(Box::pin(
+            table_path
+                .list_all_files(store, file_extension)
+                .map_ok(|object_meta| object_meta.into()),
+        ));
     }
 
     let partitions = list_partitions(store, table_path, partition_cols.len()).await?;

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -321,11 +321,10 @@ pub async fn pruned_partition_list<'a>(
     file_extension: &'a str,
     partition_cols: &'a [(String, DataType)],
 ) -> Result<BoxStream<'a, Result<PartitionedFile>>> {
-    let list = table_path.list_all_files(store, file_extension);
 
     // if no partition col => simply list all the files
     if partition_cols.is_empty() {
-        return Ok(Box::pin(list.map_ok(|object_meta| object_meta.into())));
+        return Ok(Box::pin(table_path.list_all_files(store, file_extension).map_ok(|object_meta| object_meta.into())));
     }
 
     let partitions = list_partitions(store, table_path, partition_cols.len()).await?;

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -321,7 +321,6 @@ pub async fn pruned_partition_list<'a>(
     file_extension: &'a str,
     partition_cols: &'a [(String, DataType)],
 ) -> Result<BoxStream<'a, Result<PartitionedFile>>> {
-
     // if no partition col => simply list all the files
     if partition_cols.is_empty() {
         return Ok(Box::pin(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
No need to iterate through all files when query contains partition criteria.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->