### PR TITLE
Make sqllogictest distinguish NaN from -NaN

### DIFF
--- a/datafusion/sqllogictest/src/engines/conversion.rs
+++ b/datafusion/sqllogictest/src/engines/conversion.rs
@@ -41,7 +41,11 @@ pub(crate) fn varchar_to_str(value: &str) -> String {
 
 pub(crate) fn f16_to_str(value: f16) -> String {
     if value.is_nan() {
-        "NaN".to_string()
+        if value.is_sign_positive() {
+            "NaN".to_string()
+        } else {
+            "-NaN".to_string()
+        }
     } else if value == f16::INFINITY {
         "Infinity".to_string()
     } else if value == f16::NEG_INFINITY {
@@ -53,7 +57,11 @@ pub(crate) fn f16_to_str(value: f16) -> String {
 
 pub(crate) fn f32_to_str(value: f32) -> String {
     if value.is_nan() {
-        "NaN".to_string()
+        if value.is_sign_positive() {
+            "NaN".to_string()
+        } else {
+            "-NaN".to_string()
+        }
     } else if value == f32::INFINITY {
         "Infinity".to_string()
     } else if value == f32::NEG_INFINITY {
@@ -65,7 +73,11 @@ pub(crate) fn f32_to_str(value: f32) -> String {
 
 pub(crate) fn f64_to_str(value: f64) -> String {
     if value.is_nan() {
-        "NaN".to_string()
+        if value.is_sign_positive() {
+            "NaN".to_string()
+        } else {
+            "-NaN".to_string()
+        }
     } else if value == f64::INFINITY {
         "Infinity".to_string()
     } else if value == f64::NEG_INFINITY {

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -95,10 +95,10 @@ SELECT atan2(2.0, 1.0), atan2(-2.0, 1.0), atan2(2.0, -1.0), atan2(-2.0, -1.0), a
 1.107148717794 -1.107148717794 2.034443935796 -2.034443935796 NULL NULL NULL
 
 # nanvl
-query RRR
-SELECT nanvl(asin(10), 1.0), nanvl(1.0, 2.0), nanvl(asin(10), asin(10))
+query RRB
+SELECT nanvl(asin(10), 1.0), nanvl(1.0, 2.0), isnan(nanvl(asin(10), asin(10)))
 ----
-1 1 NaN
+1 1 true
 
 # isnan
 query BBBB

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -286,7 +286,7 @@ SELECT * FROM test_float WHERE column1 IN (0.0, 1.2, 'NaN'::double, '-NaN'::doub
 ----
 1.2
 NaN
-NaN
+-NaN
 
 ###
 # Test logical plan simplifies large OR chains

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -543,10 +543,10 @@ select ln(0);
 query RRR rowsort
 select round(ln(a), 5), round(ln(b), 5), round(ln(c), 5) from signed_integers;
 ----
-0.69315 NaN 4.81218
+-NaN 4.60517 -NaN
+-NaN 9.21034 -NaN
+0.69315 -NaN 4.81218
 1.38629 NULL NULL
-NaN 4.60517 NaN
-NaN 9.21034 NaN
 
 ## log
 
@@ -595,10 +595,10 @@ Infinity 2 2
 query RRR rowsort
 select log(a, 64) a, log(b), log(10, b) from signed_integers;
 ----
+-NaN 2 2
+-NaN 4 4
 3 NULL NULL
-6 NaN NaN
-NaN 2 2
-NaN 4 4
+6 -NaN -NaN
 
 ## log10
 
@@ -625,10 +625,10 @@ select log10(0);
 query RRR rowsort
 select round(log(a), 5), round(log(b), 5), round(log(c), 5) from signed_integers;
 ----
-0.30103 NaN 2.08991
+-NaN 2 -NaN
+-NaN 4 -NaN
+0.30103 -NaN 2.08991
 0.60206 NULL NULL
-NaN 2 NaN
-NaN 4 NaN
 
 ## log2
 
@@ -655,10 +655,10 @@ select log2(0);
 query RRR rowsort
 select round(log2(a), 5), round(log2(b), 5), round(log2(c), 5) from signed_integers;
 ----
-1 NaN 6.94251
+-NaN 13.28771 -NaN
+-NaN 6.64386 -NaN
+1 -NaN 6.94251
 2 NULL NULL
-NaN 13.28771 NaN
-NaN 6.64386 NaN
 
 ## nanvl
 
@@ -779,10 +779,10 @@ NULL
 query RRR rowsort
 select round(power(a, b), 5), round(power(c, d), 5), round(power(e, f), 5) from small_floats;
 ----
-1.1487 0 NaN
+-NaN -NaN 2.32282
+1.1487 0 -NaN
 1.17462 1 0.31623
 NULL NULL NULL
-NaN NaN 2.32282
 
 ## radians
 
@@ -918,10 +918,10 @@ NULL
 query RRR rowsort
 select round(sqrt(a), 5), round(sqrt(b), 5), round(sqrt(c), 5) from signed_integers;
 ----
-1.41421 NaN 11.09054
+-NaN 10 -NaN
+-NaN 100 -NaN
+1.41421 -NaN 11.09054
 2 NULL NULL
-NaN 10 NaN
-NaN 100 NaN
 
 ## tan
 

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -224,6 +224,12 @@ select
 ----
 false true false true true false false true false true true false true true false false true
 
+# select NaNs
+query RRRR
+select 'NaN'::double a, '-NaN'::double b, 'NaN'::float c, '-NaN'::float d
+----
+NaN -NaN NaN -NaN
+
 # select limit clause
 query I
 select * from (select 1 a union all select 2) b order by a limit 1;


### PR DESCRIPTION
## Which issue does this PR close?
Closes #7402 

## Rationale for this change
DataFusion distinguishes `NaN` and `-NaN` so sqllogictest should distinguish them for precise test.

## What changes are included in this PR?
Changed `conversion.rs` so that it returns `"-NaN"` if a value is a kind of `NaN` and its sign is negative.

## Are these changes tested?
Modified existing test and added a simple test to `select.rs`.

## Are there any user-facing changes?
No.