### PR TITLE
Fix Decimal256 scalar display string in sqllogictest

### DIFF
--- a/datafusion/sqllogictest/src/engines/conversion.rs
+++ b/datafusion/sqllogictest/src/engines/conversion.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::datatypes::{Decimal128Type, DecimalType};
+use arrow::datatypes::{i256, Decimal128Type, Decimal256Type, DecimalType};
 use bigdecimal::BigDecimal;
 use half::f16;
 use rust_decimal::prelude::*;
@@ -78,6 +78,13 @@ pub(crate) fn f64_to_str(value: f64) -> String {
 pub(crate) fn i128_to_str(value: i128, precision: &u8, scale: &i8) -> String {
     big_decimal_to_str(
         BigDecimal::from_str(&Decimal128Type::format_decimal(value, *precision, *scale))
+            .unwrap(),
+    )
+}
+
+pub(crate) fn i256_to_str(value: i256, precision: &u8, scale: &i8) -> String {
+    big_decimal_to_str(
+        BigDecimal::from_str(&Decimal256Type::format_decimal(value, *precision, *scale))
             .unwrap(),
     )
 }

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
@@ -217,6 +217,10 @@ pub fn cell_to_string(col: &ArrayRef, row: usize) -> Result<String> {
                 let value = get_row_value!(array::Decimal128Array, col, row);
                 Ok(i128_to_str(value, precision, scale))
             }
+            DataType::Decimal256(precision, scale) => {
+                let value = get_row_value!(array::Decimal256Array, col, row);
+                Ok(i256_to_str(value, precision, scale))
+            }
             DataType::LargeUtf8 => Ok(varchar_to_str(get_row_value!(
                 array::LargeStringArray,
                 col,

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -202,7 +202,7 @@ SELECT
   col_d256
   FROM foo;
 ----
-100 100.00
+100 100
 
 statement ok
 drop table foo


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

A followup to #7048.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In #7048, one question is the display string of Decimal256 scalar is different to Decimal128 in sqllogictest. This patch fixes it.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->