### PR TITLE
New interface for `get_scan_files` to break dependency

### DIFF
--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -237,6 +237,11 @@ impl<'a> Default for ParquetReadOptions<'a> {
 }
 
 impl<'a> ParquetReadOptions<'a> {
+    /// Create default options
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     /// Specify parquet_pruning
     pub fn parquet_pruning(mut self, parquet_pruning: bool) -> Self {
         self.parquet_pruning = Some(parquet_pruning);
@@ -309,6 +314,11 @@ impl<'a> Default for ArrowReadOptions<'a> {
 }
 
 impl<'a> ArrowReadOptions<'a> {
+    /// Create default options
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     /// Specify table_partition_cols for partition pruning
     pub fn table_partition_cols(
         mut self,
@@ -357,6 +367,11 @@ impl<'a> Default for AvroReadOptions<'a> {
 }
 
 impl<'a> AvroReadOptions<'a> {
+    /// Create default options
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     /// Specify table_partition_cols for partition pruning
     pub fn table_partition_cols(
         mut self,
@@ -422,6 +437,11 @@ impl<'a> Default for NdJsonReadOptions<'a> {
 }
 
 impl<'a> NdJsonReadOptions<'a> {
+    /// Create default options
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     /// Specify table_partition_cols for partition pruning
     pub fn table_partition_cols(
         mut self,

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1015,7 +1015,6 @@ mod tests {
     use super::*;
 
     use crate::datasource::file_format::parquet::test_util::store_parquet;
-    use crate::datasource::physical_plan::get_scan_files;
     use crate::physical_plan::metrics::MetricValue;
     use crate::prelude::{SessionConfig, SessionContext};
     use arrow::array::{Array, ArrayRef, StringArray};
@@ -1606,25 +1605,6 @@ mod tests {
             .metadata()
             .clone();
         check_page_index_validation(builder.column_index(), builder.offset_index());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_get_scan_files() -> Result<()> {
-        let session_ctx = SessionContext::new();
-        let state = session_ctx.state();
-        let projection = Some(vec![9]);
-        let exec = get_exec(&state, "alltypes_plain.parquet", projection, None).await?;
-        let scan_files = get_scan_files(exec)?;
-        assert_eq!(scan_files.len(), 1);
-        assert_eq!(scan_files[0].len(), 1);
-        assert_eq!(scan_files[0][0].len(), 1);
-        assert!(scan_files[0][0][0]
-            .object_meta
-            .location
-            .to_string()
-            .contains("alltypes_plain.parquet"));
 
         Ok(())
     }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -75,10 +75,10 @@ pub struct PartitionedFile {
 
 impl PartitionedFile {
     /// Create a simple file without metadata or partition
-    pub fn new(path: String, size: u64) -> Self {
+    pub fn new(path: impl Into<String>, size: u64) -> Self {
         Self {
             object_meta: ObjectMeta {
-                location: Path::from(path),
+                location: Path::from(path.into()),
                 last_modified: chrono::Utc.timestamp_nanos(0),
                 size: size as usize,
                 e_tag: None,

--- a/datafusion/core/src/datasource/physical_plan/avro.rs
+++ b/datafusion/core/src/datasource/physical_plan/avro.rs
@@ -161,10 +161,6 @@ impl ExecutionPlan for AvroExec {
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
-
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
-    }
 }
 
 #[cfg(feature = "avro")]

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -241,10 +241,6 @@ impl ExecutionPlan for CsvExec {
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
-
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
-    }
 }
 
 /// A Config for [`CsvOpener`]

--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -22,7 +22,6 @@ use crate::datasource::{
     listing::{FileRange, PartitionedFile},
     object_store::ObjectStoreUrl,
 };
-use crate::physical_plan::ExecutionPlan;
 use crate::{
     error::{DataFusionError, Result},
     scalar::ScalarValue,
@@ -33,10 +32,7 @@ use arrow::buffer::Buffer;
 use arrow::datatypes::{ArrowNativeType, UInt16Type};
 use arrow_array::{ArrayRef, DictionaryArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use datafusion_common::{
-    exec_err,
-    tree_node::{TreeNode, VisitRecursion},
-};
+use datafusion_common::exec_err;
 use datafusion_common::{ColumnStatistics, Statistics};
 use datafusion_physical_expr::LexOrdering;
 
@@ -70,22 +66,6 @@ pub fn wrap_partition_type_in_dict(val_type: DataType) -> DataType {
 /// which can wrap the types.
 pub fn wrap_partition_value_in_dict(val: ScalarValue) -> ScalarValue {
     ScalarValue::Dictionary(Box::new(DataType::UInt16), Box::new(val))
-}
-
-/// Get all of the [`PartitionedFile`] to be scanned for an [`ExecutionPlan`]
-pub fn get_scan_files(
-    plan: Arc<dyn ExecutionPlan>,
-) -> Result<Vec<Vec<Vec<PartitionedFile>>>> {
-    let mut collector: Vec<Vec<Vec<PartitionedFile>>> = vec![];
-    plan.apply(&mut |plan| {
-        if let Some(file_scan_config) = plan.file_scan_config() {
-            collector.push(file_scan_config.file_groups.clone());
-            Ok(VisitRecursion::Skip)
-        } else {
-            Ok(VisitRecursion::Continue)
-        }
-    })?;
-    Ok(collector)
 }
 
 /// The base configurations to provide when creating a physical plan for

--- a/datafusion/core/src/datasource/physical_plan/finder.rs
+++ b/datafusion/core/src/datasource/physical_plan/finder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! [`FileScanFilder`] to scan [`ExecutionPlan`]` for input
+//! [`PartitionedFileFinder`] to scan [`ExecutionPlan`]` for input
 //! partitioned file sources.
 
 use std::sync::Arc;

--- a/datafusion/core/src/datasource/physical_plan/finder.rs
+++ b/datafusion/core/src/datasource/physical_plan/finder.rs
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`FileScanFilder`] to scan [`ExecutionPlan`]` for input
+//! partitioned file sources.
+
+use std::sync::Arc;
+
+use datafusion_common::{
+    tree_node::{TreeNode, VisitRecursion},
+    Result,
+};
+
+use crate::{datasource::listing::PartitionedFile, physical_plan::ExecutionPlan};
+
+use super::{AvroExec, CsvExec, NdJsonExec, ParquetExec};
+
+pub type FinderFunction =
+    Box<dyn Fn(&dyn ExecutionPlan) -> Option<Vec<Vec<PartitionedFile>>>>;
+
+/// Get all of the [`PartitionedFile`] to be scanned for an [`ExecutionPlan`]
+///
+/// This structure will find all `ScanFileConfig` in any built in
+/// [`ExecutionPlan`] and allows finding user defined nodes as well
+pub struct PartitionedFileFinder {
+    custom_finder: FinderFunction,
+}
+
+impl Default for PartitionedFileFinder {
+    fn default() -> Self {
+        Self {
+            // default custom finding function does nothing
+            custom_finder: Box::new(|_plan| None),
+        }
+    }
+}
+
+impl PartitionedFileFinder {
+    /// Create a new file finder
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Get all [`PartitionedFile`]s that are scanned for an
+    /// [`ExecutionPlan`],  by recursively checking all children
+    pub fn find(&self, plan: Arc<dyn ExecutionPlan>) -> Vec<Vec<Vec<PartitionedFile>>> {
+        let mut collector: Vec<Vec<Vec<PartitionedFile>>> = vec![];
+        plan.apply(&mut |plan| {
+            if let Some(files) = self.get_files(plan.as_ref()) {
+                collector.push(files);
+            }
+            Ok(VisitRecursion::Continue)
+        })
+        .expect("infallable");
+        collector
+    }
+
+    /// Provide a custom method to find `PartitionedFiles` for
+    /// `ExecutionPlans`
+    ///
+    /// Called on all [`ExecutionPlan`]s other than built ins such as
+    /// [`ParquetExec`] and can be used to extract
+    /// [`PartitionedFile`]s from user defined nodes
+    pub fn with_finder<F>(mut self, custom_finder: F) -> Self
+    where
+        F: Fn(&dyn ExecutionPlan) -> Option<Vec<Vec<PartitionedFile>>> + 'static,
+    {
+        self.custom_finder = Box::new(custom_finder);
+        self
+    }
+
+    /// Return the [`PartitionedFile`] scanned by this plan node, or
+    /// `None` if the plan does not can files
+    fn get_files(&self, plan: &dyn ExecutionPlan) -> Option<Vec<Vec<PartitionedFile>>> {
+        let plan_any = plan.as_any();
+        if let Some(parquet_exec) = plan_any.downcast_ref::<ParquetExec>() {
+            Some(parquet_exec.base_config().file_groups.clone())
+        } else if let Some(avro_exec) = plan_any.downcast_ref::<AvroExec>() {
+            Some(avro_exec.base_config().file_groups.clone())
+        } else if let Some(json_exec) = plan_any.downcast_ref::<NdJsonExec>() {
+            Some(json_exec.base_config().file_groups.clone())
+        } else if let Some(csv_exec) = plan_any.downcast_ref::<CsvExec>() {
+            Some(csv_exec.base_config().file_groups.clone())
+        } else {
+            (self.custom_finder)(plan)
+        }
+    }
+}
+
+/// Find all `[PartitionedFile]` scanned by any node in this plan.
+///
+/// There is one element in the returned array for each node in the
+/// plan that scans files. Each element is represents the groups of
+/// files that [`ExecutionPlan`] scans.
+pub fn get_scan_files(
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<Vec<Vec<Vec<PartitionedFile>>>> {
+    let files = PartitionedFileFinder::new().find(plan);
+    Ok(files)
+}

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -170,10 +170,6 @@ impl ExecutionPlan for NdJsonExec {
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
-
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
-    }
 }
 
 /// A [`FileOpener`] that opens a JSON file and yields a [`FileOpenFuture`]

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -43,9 +43,10 @@ pub use json::{JsonOpener, NdJsonExec};
 mod file_scan_config;
 pub(crate) use file_scan_config::PartitionColumnProjector;
 pub use file_scan_config::{
-    get_scan_files, wrap_partition_type_in_dict, wrap_partition_value_in_dict,
-    FileScanConfig,
+    wrap_partition_type_in_dict, wrap_partition_value_in_dict, FileScanConfig,
 };
+mod finder;
+pub use finder::{get_scan_files, PartitionedFileFinder};
 
 use crate::error::{DataFusionError, Result};
 use crate::{

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -390,10 +390,6 @@ impl ExecutionPlan for ParquetExec {
     fn statistics(&self) -> Statistics {
         self.projected_statistics.clone()
     }
-
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
-    }
 }
 
 /// Implements [`FileOpener`] for a parquet file

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -23,7 +23,6 @@ use self::metrics::MetricsSet;
 use self::{
     coalesce_partitions::CoalescePartitionsExec, display::DisplayableExecutionPlan,
 };
-use crate::datasource::physical_plan::FileScanConfig;
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use datafusion_common::Result;
 pub use datafusion_common::{internal_err, ColumnStatistics, Statistics};
@@ -189,11 +188,6 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
 
     /// Returns the global output statistics for this `ExecutionPlan` node.
     fn statistics(&self) -> Statistics;
-
-    /// Returns the [`FileScanConfig`] in case this is a data source scanning execution plan or `None` otherwise.
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        None
-    }
 }
 
 /// Indicate whether a data exchange is needed for the input of `plan`, which will be very helpful


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/7357

## Rationale for this change
I am trying to break DataFusion into smaller modules and to do so I need to disconnect DataSource and ExecutionPlan. However the API introduced in https://github.com/apache/arrow-datafusion/pull/7175 creates a new (explicit) dependency.

I would like to make an API that both allows for getting the scan files from @not-my-profile 's  usescase but also doesn't add this new explicit dependency.

For more details https://github.com/apache/arrow-datafusion/issues/7357 

## What changes are included in this PR?

1. Add `PartitionedFileFinder` that can find PartitionedFiles in arbitrary ExecutionPlan trees
2. Add some `::new()` functions to make config easier to use
3. Update tests showing how this is used

## Are these changes tested?
Yes

## Are there any user-facing changes?
yes, this is both an API change (it is an alternate API to the one introduced in https://github.com/apache/arrow-datafusion/pull/7175)

