### PR TITLE
Minor: Debug log when FairPool is created

### DIFF
--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -143,6 +143,7 @@ struct FairSpillPoolState {
 impl FairSpillPool {
     /// Allocate up to `limit` bytes
     pub fn new(pool_size: usize) -> Self {
+        debug!("Created new FairSpillPool(pool_size={pool_size})");
         Self {
             pool_size,
             state: Mutex::new(FairSpillPoolState {


### PR DESCRIPTION
## Which issue does this PR close?

Follow up to https://github.com/apache/arrow-datafusion/pull/7424

## Rationale for this change

I noticed that there was a log entry when a Greedy pool was created, but not entry when a Fair pool was created.


## What changes are included in this PR?
Add debug log entry when `FairSpillPool` is created

This is the same basic message as for the existing greedy pool: 
https://github.com/apache/arrow-datafusion/blob/2503bda50ced1bc983280e0b7783a482bc1d5714/datafusion/execution/src/memory_pool/pool.rs#L63

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->