### PR TITLE
Make IN expr work with multiple items

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -29,6 +29,9 @@ use crate::physical_expr::down_cast_any_ref;
 use crate::utils::expr_list_eq_any_order;
 use crate::PhysicalExpr;
 use arrow::array::*;
+use arrow::buffer::BooleanBuffer;
+use arrow::compute::kernels::boolean::{not, or_kleene};
+use arrow::compute::kernels::cmp::eq;
 use arrow::compute::take;
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
@@ -326,12 +329,26 @@ impl PhysicalExpr for InListExpr {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
-        let value = self.expr.evaluate(batch)?.into_array(1);
+        let value = self.expr.evaluate(batch)?;
         let r = match &self.static_filter {
-            Some(f) => f.contains(value.as_ref(), self.negated)?,
+            Some(f) => f.contains(value.into_array(1).as_ref(), self.negated)?,
             None => {
-                let list = evaluate_list(&self.list, batch)?;
-                make_set(list.as_ref())?.contains(value.as_ref(), self.negated)?
+                let value = value.into_array(batch.num_rows());
+                let found = self.list.iter().map(|expr| expr.evaluate(batch)).try_fold(
+                    BooleanArray::new(BooleanBuffer::new_unset(batch.num_rows()), None),
+                    |result, expr| -> Result<BooleanArray> {
+                        Ok(or_kleene(
+                            &result,
+                            &eq(&value, &expr?.into_array(batch.num_rows()))?,
+                        )?)
+                    },
+                )?;
+
+                if self.negated {
+                    not(&found)?
+                } else {
+                    found
+                }
             }
         };
         Ok(ColumnarValue::Array(Arc::new(r)))
@@ -1126,6 +1143,64 @@ mod tests {
             col_a.clone(),
             &schema
         );
+        Ok(())
+    }
+
+    #[test]
+    fn in_expr_with_multiple_element_in_list() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
+            Field::new("c", DataType::Float64, true),
+        ]);
+        let a = Float64Array::from(vec![
+            Some(0.0),
+            Some(1.0),
+            Some(2.0),
+            Some(f64::NAN),
+            Some(-f64::NAN),
+        ]);
+        let b = Float64Array::from(vec![
+            Some(8.0),
+            Some(1.0),
+            Some(5.0),
+            Some(f64::NAN),
+            Some(3.0),
+        ]);
+        let c = Float64Array::from(vec![
+            Some(6.0),
+            Some(7.0),
+            None,
+            Some(5.0),
+            Some(-f64::NAN),
+        ]);
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+        let col_c = col("c", &schema)?;
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(a), Arc::new(b), Arc::new(c)],
+        )?;
+
+        let list = vec![col_b.clone(), col_c.clone()];
+        in_list!(
+            batch,
+            list.clone(),
+            &false,
+            vec![Some(false), Some(true), None, Some(true), Some(true)],
+            col_a.clone(),
+            &schema
+        );
+
+        in_list!(
+            batch,
+            list,
+            &true,
+            vec![Some(true), Some(false), None, Some(false), Some(false)],
+            col_a.clone(),
+            &schema
+        );
+
         Ok(())
     }
 }

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -254,39 +254,91 @@ foo
 fazzz
 
 statement ok
-CREATE TABLE IF NOT EXISTS test_float AS VALUES(1.2),(2.1),(NULL),('NaN'::double),('-NaN'::double);
+CREATE TABLE IF NOT EXISTS test_float AS VALUES
+ (1.2, 2.3, 1.2, -3.5, 1.1),
+ (2.1, 'NaN'::double, -1.7, -8.2, NULL),
+ (NULL, NULL, '-NaN'::double, -5.4, 1.5),
+ ('NaN'::double, 'NaN'::double, 1.1, '-NaN'::double, NULL),
+ ('-NaN'::double, 6.2, 'NaN'::double, -3.3, 5.6)
+ ;
 
 # IN expr for float
 query R
-SELECT * FROM test_float WHERE column1 IN (0.0, -1.2)
+SELECT column1 FROM test_float WHERE column1 IN (0.0, -1.2)
 ----
 
 query R
-SELECT * FROM test_float WHERE column1 IN (0.0, 1.2)
+SELECT column1 FROM test_float WHERE column1 IN (0.0, 1.2)
 ----
 1.2
 
 query R
-SELECT * FROM test_float WHERE column1 IN (2.1, 1.2)
+SELECT column1 FROM test_float WHERE column1 IN (2.1, 1.2)
 ----
 1.2
 2.1
 
 query R
-SELECT * FROM test_float WHERE column1 IN (0.0, 1.2, NULL)
+SELECT column1 FROM test_float WHERE column1 IN (0.0, 1.2, NULL)
 ----
 1.2
 
 query R
-SELECT * FROM test_float WHERE column1 IN (0.0, -1.2, NULL)
+SELECT column1 FROM test_float WHERE column1 IN (0.0, -1.2, NULL)
 ----
 
 query R
-SELECT * FROM test_float WHERE column1 IN (0.0, 1.2, 'NaN'::double, '-NaN'::double)
+SELECT column1 FROM test_float WHERE column1 IN (0.0, 1.2, 'NaN'::double, '-NaN'::double)
 ----
 1.2
 NaN
 -NaN
+
+query RRRRR
+SELECT * FROM test_float WHERE column1 IN (column2, column3, column4, column5)
+----
+1.2 2.3 1.2 -3.5 1.1
+NaN NaN 1.1 -NaN NULL
+
+query RRRRR
+SELECT * FROM test_float WHERE column1 IN (column2, column3, column4, column5, 2.1, NULL, '-NaN'::double)
+----
+1.2 2.3 1.2 -3.5 1.1
+2.1 NaN -1.7 -8.2 NULL
+NaN NaN 1.1 -NaN NULL
+-NaN 6.2 NaN -3.3 5.6
+
+query RRRRR
+SELECT * FROM test_float WHERE column1 NOT IN (column2, column3, column4, column5)
+----
+-NaN 6.2 NaN -3.3 5.6
+
+query RRRRR
+SELECT * FROM test_float WHERE column1 NOT IN (column2, column3, column4, column5, 2.1, NULL, '-NaN'::double)
+----
+
+query R
+SELECT column1 FROM test_float WHERE NULL IN (column1, column1 + 1, column1 + 2, column1 + 3)
+----
+
+query R
+SELECT column1 FROM test_float WHERE 'NaN'::double IN (column1, column1 + 1, column1 + 2, column1 + 3)
+----
+NaN
+
+query R
+SELECT column1 FROM test_float WHERE '-NaN'::double IN (column1, column1 + 1, column1 + 2, column1 + 3)
+----
+-NaN
+
+query II
+SELECT c3, c7 FROM aggregate_test_100 WHERE c3 IN (c7 / 10, c7 / 20, c7 / 30, c7 / 40, 68, 103)
+----
+1 25
+103 146
+68 224
+68 121
+3 133
 
 ###
 # Test logical plan simplifies large OR chains


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7448 

## Rationale for this change

The failure cases shown in #7448 are apparently valid. So this PR is for bug fix.

## What changes are included in this PR?

The cause of the issue is that `in_expr` doesn't consider the case where the evaluated value of each expr in a list varies per row.
So the issue happens in such a case except for the case `IN` expr is simplified by the optimizer.
The fix is to care such a case and search the target value from the list sequentially per the given RecordBatch.

## Are there any user-facing changes?
Yes. But it's a bug fix.