### PR TITLE
Use DateTime::from_naive_utc_and_offset instead of DateTime::from_utc

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -831,15 +831,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -45,7 +45,7 @@ arrow-array = { workspace = true }
 async-compression = { version = "0.4.0", features = ["bzip2", "gzip", "xz", "zstd", "futures-io", "tokio"], optional = true }
 bytes = "1.4"
 bzip2 = { version = "0.4.3", optional = true }
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 flate2 = { version = "1.0.24", optional = true }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -60,7 +60,7 @@ async-compression = { version = "0.4.0", features = ["bzip2", "gzip", "xz", "zst
 async-trait = "0.1.41"
 bytes = "1.4"
 bzip2 = { version = "0.4.3", optional = true }
-chrono = { version = "0.4.23", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 dashmap = "5.4.0"
 datafusion-common = { path = "../common", version = "30.0.0", features = ["parquet", "object_store"] }
 datafusion-execution = { path = "../execution", version = "30.0.0" }

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -42,7 +42,7 @@ unicode_expressions = ["datafusion-physical-expr/unicode_expressions"]
 [dependencies]
 arrow = { workspace = true }
 async-trait = "0.1.41"
-chrono = { version = "0.4.23", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 datafusion-common = { path = "../common", version = "30.0.0" }
 datafusion-expr = { path = "../expr", version = "30.0.0" }
 datafusion-physical-expr = { path = "../physical-expr", version = "30.0.0", default-features = false }

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -345,7 +345,7 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
 
     // hard code the return value of now()
     let ts = NaiveDateTime::from_timestamp_opt(1666615693, 0).unwrap();
-    let now_time = DateTime::<Utc>::from_utc(ts, Utc);
+    let now_time = DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc);
     let config = OptimizerContext::new()
         .with_skip_failing_rules(false)
         .with_query_execution_start_time(now_time);

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -51,7 +51,7 @@ arrow-schema = { workspace = true }
 base64 = { version = "0.21", optional = true }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
-chrono = { version = "0.4.23", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 datafusion-common = { path = "../common", version = "30.0.0" }
 datafusion-expr = { path = "../expr", version = "30.0.0" }
 half = { version = "2.1", default-features = false }

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -466,7 +466,7 @@ fn to_utc_date_time(nanos: i64) -> DateTime<Utc> {
     let secs = nanos / 1_000_000_000;
     let nsec = (nanos % 1_000_000_000) as u32;
     let date = NaiveDateTime::from_timestamp_opt(secs, nsec).unwrap();
-    DateTime::<Utc>::from_utc(date, Utc)
+    DateTime::<Utc>::from_naive_utc_and_offset(date, Utc)
 }
 
 /// DATE_BIN sql function

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -41,7 +41,7 @@ json = ["pbjson", "serde", "serde_json"]
 
 [dependencies]
 arrow = { workspace = true }
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 datafusion = { path = "../core", version = "30.0.0" }
 datafusion-common = { path = "../common", version = "30.0.0" }
 datafusion-expr = { path = "../expr", version = "30.0.0" }

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -48,7 +48,7 @@ thiserror = "1.0.44"
 tokio = {version = "1.0"}
 bytes = {version = "1.4.0", optional = true}
 futures = {version = "0.3.28"}
-chrono = {version = "0.4.26", optional = true}
+chrono = {version = "0.4.27", optional = true}
 tokio-postgres = {version = "0.7.7", optional = true}
 postgres-types = {version = "0.2.4", optional = true}
 postgres-protocol = {version = "0.6.4", optional = true}

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.70"
 
 [dependencies]
 async-recursion = "1.0"
-chrono = { version = "0.4.23", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 datafusion = { version = "30.0.0", path = "../core" }
 itertools = "0.11"
 object_store = "0.7.0"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7450 

## Rationale for this change

This PR is to make CI happy.

## What changes are included in this PR?

## Are these changes tested?

Replace `DateTime::from_utc` with `DateTime::from_naive_utc_and_offset`.

## Are there any user-facing changes?
No.