### PR TITLE
Minor: more flexible pool size setting for datafusion-cli

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "predicates",
+ "regex",
  "rstest",
  "rustyline",
  "tokio",

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -40,6 +40,7 @@ env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }
 object_store = { version = "0.7.0", features = ["aws", "gcp"] }
 parking_lot = { version = "0.12" }
+regex = "1.8"
 rustyline = "11.0"
 tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 url = "2.2"

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -361,10 +361,19 @@ mod tests {
         assert_conversion("2T", Ok(2 * 1024 * 1024 * 1024 * 1024));
 
         // Test invalid input
-        assert_conversion("invalid", Err("Invalid memory pool size 'invalid'".to_string()));
+        assert_conversion(
+            "invalid",
+            Err("Invalid memory pool size 'invalid'".to_string()),
+        );
         assert_conversion("4kbx", Err("Invalid memory pool size '4kbx'".to_string()));
-        assert_conversion("-20mb", Err("Negative memory pool size value is not allowed '-20mb'".to_string()));
-        assert_conversion("-100", Err("Negative memory pool size value is not allowed '-100'".to_string()));
+        assert_conversion(
+            "-20mb",
+            Err("Negative memory pool size value is not allowed '-20mb'".to_string()),
+        );
+        assert_conversion(
+            "-100",
+            Err("Negative memory pool size value is not allowed '-100'".to_string()),
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

re #7424.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Find the memory pool size setting string in datafusion-cli during performance testing, and we could make the byte string more flexible.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Parse the pool byte string as the number of bytes.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Add unit test and tested locally.


## Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.