### PR TITLE
minor: do not fail analyzer if subquery plan contains extension

### DIFF
--- a/datafusion/optimizer/src/analyzer/subquery.rs
+++ b/datafusion/optimizer/src/analyzer/subquery.rs
@@ -225,6 +225,7 @@ fn check_inner_plan(
                 Ok(())
             }
         },
+        LogicalPlan::Extension(_) => Ok(()),
         _ => plan_err!("Unsupported operator in the subquery plan."),
     }
 }

--- a/datafusion/optimizer/src/analyzer/subquery.rs
+++ b/datafusion/optimizer/src/analyzer/subquery.rs
@@ -339,3 +339,57 @@ fn check_mixed_out_refer_in_window(window: &Window) -> Result<()> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use datafusion_common::{DFSchema, DFSchemaRef};
+    use datafusion_expr::{Extension, UserDefinedLogicalNodeCore};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct MockUserDefinedLogicalPlan {
+        empty_schema: DFSchemaRef,
+    }
+
+    impl UserDefinedLogicalNodeCore for MockUserDefinedLogicalPlan {
+        fn name(&self) -> &str {
+            "MockUserDefinedLogicalPlan"
+        }
+
+        fn inputs(&self) -> Vec<&LogicalPlan> {
+            vec![]
+        }
+
+        fn schema(&self) -> &datafusion_common::DFSchemaRef {
+            &self.empty_schema
+        }
+
+        fn expressions(&self) -> Vec<Expr> {
+            vec![]
+        }
+
+        fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "MockUserDefinedLogicalPlan")
+        }
+
+        fn from_template(&self, _exprs: &[Expr], _inputs: &[LogicalPlan]) -> Self {
+            Self {
+                empty_schema: self.empty_schema.clone(),
+            }
+        }
+    }
+
+    #[test]
+    fn wont_fail_extension_plan() {
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(MockUserDefinedLogicalPlan {
+                empty_schema: DFSchemaRef::new(DFSchema::empty()),
+            }),
+        });
+
+        check_inner_plan(&plan, false, false, true).unwrap();
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If some analyze rule inserts extension plan, the post-analyze check will fail.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

It looks acceptable for an analyzer rule to do so and can simply "ignore" extension plan node, e.g., the outermost node can either be `[Projection, Filter, Window, Aggregate, Join]`, or an extension node

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
n/a

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
n/a
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->