### PR TITLE
Bug-fix/find_orderings_of_exprs

### DIFF
--- a/datafusion/physical-expr/src/utils.rs
+++ b/datafusion/physical-expr/src/utils.rs
@@ -1985,7 +1985,7 @@ mod tests {
             Field::new("b", DataType::Int32, true),
             Field::new("c", DataType::Int32, true),
         ]);
-        let empty_ordering = find_orderings_of_exprs(
+        let one_ordering = find_orderings_of_exprs(
             &[
                 (Arc::new(Column::new("b", 1)), "b_new".to_string()),
                 (Arc::new(Column::new("a", 0)), "a_new".to_string()),
@@ -2006,7 +2006,7 @@ mod tests {
                 }),
                 None,
             ],
-            empty_ordering
+            one_ordering
         );
 
         let schema = Schema::new(vec![

--- a/datafusion/physical-expr/src/utils.rs
+++ b/datafusion/physical-expr/src/utils.rs
@@ -934,8 +934,11 @@ pub fn get_indices_of_matching_sort_exprs_with_order_eq(
 ///
 /// * `expr` - A slice of tuples containing expressions and their corresponding aliases.
 ///
-/// * `input` - A reference to an execution plan that provides output ordering and equivalence
-/// properties.
+/// * `input_output_ordering` - Output ordering of the input plan.
+///
+/// * `input_equal_properties` - Equivalence properties of the columns in the input plan.
+///
+/// * `input_ordering_equal_properties` - Ordering equivalence properties of the columns in the input plan.
 ///
 /// # Returns
 ///
@@ -951,7 +954,7 @@ pub fn find_orderings_of_exprs(
 ) -> Result<Vec<Option<PhysicalSortExpr>>> {
     let mut orderings: Vec<Option<PhysicalSortExpr>> = vec![];
     if let Some(leading_ordering) =
-        input_output_ordering.map(|output_ordering| &output_ordering[0])
+        input_output_ordering.and_then(|output_ordering| output_ordering.first())
     {
         for (index, (expression, name)) in expr.iter().enumerate() {
             let initial_expr = ExprOrdering::new(expression.clone());

--- a/datafusion/physical-expr/src/utils.rs
+++ b/datafusion/physical-expr/src/utils.rs
@@ -975,6 +975,8 @@ pub fn find_orderings_of_exprs(
                 orderings.push(None);
             }
         }
+    } else {
+        orderings.extend(expr.iter().map(|_| None));
     }
     Ok(orderings)
 }
@@ -1972,6 +1974,57 @@ mod tests {
         .iter()
         .zip(expected_oeq.classes())
         .any(|(a, b)| a.head().ne(b.head()) || a.others().ne(b.others())));
+
+        Ok(())
+    }
+
+    #[test]
+    fn project_empty_output_ordering() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+        ]);
+        let empty_ordering = find_orderings_of_exprs(
+            &[
+                (Arc::new(Column::new("b", 1)), "b_new".to_string()),
+                (Arc::new(Column::new("a", 0)), "a_new".to_string()),
+            ],
+            Some(&[PhysicalSortExpr {
+                expr: Arc::new(Column::new("b", 1)),
+                options: SortOptions::default(),
+            }]),
+            EquivalenceProperties::new(Arc::new(schema.clone())),
+            OrderingEquivalenceProperties::new(Arc::new(schema.clone())),
+        )?;
+
+        assert_eq!(
+            vec![
+                Some(PhysicalSortExpr {
+                    expr: Arc::new(Column::new("b_new", 0)),
+                    options: SortOptions::default(),
+                }),
+                None,
+            ],
+            empty_ordering
+        );
+
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+        ]);
+        let empty_ordering = find_orderings_of_exprs(
+            &[
+                (Arc::new(Column::new("c", 2)), "c_new".to_string()),
+                (Arc::new(Column::new("b", 1)), "b_new".to_string()),
+            ],
+            Some(&[]),
+            EquivalenceProperties::new(Arc::new(schema.clone())),
+            OrderingEquivalenceProperties::new(Arc::new(schema)),
+        )?;
+
+        assert_eq!(vec![None, None], empty_ordering);
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/utils.rs
+++ b/datafusion/physical-expr/src/utils.rs
@@ -1985,7 +1985,7 @@ mod tests {
             Field::new("b", DataType::Int32, true),
             Field::new("c", DataType::Int32, true),
         ]);
-        let one_ordering = find_orderings_of_exprs(
+        let orderings = find_orderings_of_exprs(
             &[
                 (Arc::new(Column::new("b", 1)), "b_new".to_string()),
                 (Arc::new(Column::new("a", 0)), "a_new".to_string()),
@@ -2006,7 +2006,7 @@ mod tests {
                 }),
                 None,
             ],
-            one_ordering
+            orderings
         );
 
         let schema = Schema::new(vec![
@@ -2014,7 +2014,7 @@ mod tests {
             Field::new("b", DataType::Int32, true),
             Field::new("c", DataType::Int32, true),
         ]);
-        let empty_ordering = find_orderings_of_exprs(
+        let orderings = find_orderings_of_exprs(
             &[
                 (Arc::new(Column::new("c", 2)), "c_new".to_string()),
                 (Arc::new(Column::new("b", 1)), "b_new".to_string()),
@@ -2024,7 +2024,7 @@ mod tests {
             OrderingEquivalenceProperties::new(Arc::new(schema)),
         )?;
 
-        assert_eq!(vec![None, None], empty_ordering);
+        assert_eq!(vec![None, None], orderings);
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7418 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

IOx tests failed. This error has not been encountered in Datafusion because in the absence of output ordering, `input.output_ordering()` returns None, not Some([]). This issue is fixed now.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->