### PR TITLE
Support Configuring Parquet Column Specific Options via SQL Statement Options

### DIFF
--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -28,7 +28,7 @@ use crate::{
     DataFusionError, Result,
 };
 
-use super::{StatementOptions, parse_utils::parse_column_level_option_tuples};
+use super::{parse_utils::parse_column_level_option_tuples, StatementOptions};
 
 /// Options for writing parquet files
 #[derive(Clone, Debug)]

--- a/datafusion/common/src/file_options/parse_utils.rs
+++ b/datafusion/common/src/file_options/parse_utils.rs
@@ -19,7 +19,7 @@
 
 use parquet::{
     basic::{BrotliLevel, GzipLevel, ZstdLevel},
-    file::properties::{EnabledStatistics, WriterVersion},
+    file::properties::{EnabledStatistics, WriterVersion}, schema::types::ColumnPath,
 };
 
 use crate::{DataFusionError, Result};
@@ -180,4 +180,33 @@ pub(crate) fn parse_statistics_string(str_setting: &str) -> Result<EnabledStatis
             valid options are 'none', 'page', and 'chunk'"
         ))),
     }
+}
+
+/// Parses a string which contains tuples which determine column level parquet settings
+/// e.g. '(col1 snappy, col2 zstd(5), col3.nested.nested2 zstd(10))'
+pub(crate) fn parse_column_level_option_tuples(col_options: &str) -> Result<Vec<(ColumnPath, String)>>{
+
+    println!("{}", col_options);
+
+    let col_options = col_options.replace('\'', "").trim().to_owned();
+
+    if !(col_options.chars().nth(0)==Some('(') && col_options.chars().nth_back(0)==Some(')')){
+        return Err(DataFusionError::Configuration(format!("Unable to parse column level options specified as {col_options}")))
+    }
+
+    println!("clipped {}", &col_options[1..col_options.len()-1]);
+    
+    col_options[1..col_options.len()-1]
+        .split(',')
+        .map(|s| s
+            .trim()
+            .split_once(' ')
+            .map(|(s1, s2)| (
+                ColumnPath::new(s1
+                    .split('.')
+                    .map(|sn| sn.to_owned())
+                    .collect::<Vec<String>>()), 
+                s2.to_owned()))
+            .ok_or(DataFusionError::Configuration(format!("Unable to parse column level options specified as {col_options}"))))
+        .collect()
 }

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -21,15 +21,15 @@ create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 
 
 # Copy to directory as multiple files
 query IT
-COPY source_table TO 'test_files/scratch/copy/table' (format parquet, single_file_output false, compression 'zstd(10)');
+COPY source_table TO 'test_files/scratch/copy/table' (format parquet, single_file_output false, compression_default 'zstd(10)');
 ----
 2
 
 query TT
-EXPLAIN COPY source_table TO 'test_files/scratch/copy/table' (format parquet, single_file_output false, compression 'zstd(10)');
+EXPLAIN COPY source_table TO 'test_files/scratch/copy/table' (format parquet, single_file_output false, compression_default 'zstd(10)');
 ----
 logical_plan
-CopyTo: format=parquet output_url=test_files/scratch/copy/table single_file_output=false options: (compression 'zstd(10)')
+CopyTo: format=parquet output_url=test_files/scratch/copy/table single_file_output=false options: (compression_default 'zstd(10)')
 --TableScan: source_table projection=[col1, col2]
 physical_plan
 InsertExec: sink=ParquetSink(writer_mode=PutMultipart, file_groups=[])
@@ -70,7 +70,8 @@ COPY source_table
 TO 'test_files/scratch/copy/table_with_options' 
 (format parquet,
 single_file_output false,
-compression 'snappy',
+compression_default 'snappy',
+compression '(col1 snappy, col2 zstd(5), col3.nested.nested2 zstd(10))',
 max_row_group_size 12345,
 data_pagesize_limit 1234,
 write_batch_size 1234,
@@ -80,7 +81,8 @@ created_by 'DF copy.slt',
 column_index_truncate_length 123,
 data_page_row_count_limit 1234,
 bloom_filter_enabled true,
-encoding plain,
+encoding_default plain,
+encoding '(col1 delta_binary_packed, col2 plain)',
 dictionary_enabled false,
 statistics_enabled page,
 max_statistics_size 123,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7442 

## Rationale for this change

Extends syntax and allowed options for SQL statement options to configure parquet column level options (e.g. different compression for each column).

## What changes are included in this PR?

Implements new parsing utils and options for parquet column specific options.

## Are these changes tested?

Somewhat by existing tests, more tests needed.

## Are there any user-facing changes?

Breaking change. Setting default parquet write settings are now suffixed with _default. E.g. "compression_default" since now "compression" expects column level settings.