### PR TITLE
refactor: change file type logic for create table

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -682,7 +682,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if (file_type == "PARQUET" || file_type == "AVRO" || file_type == "ARROW")
             && file_compression_type != CompressionTypeVariant::UNCOMPRESSED
         {
-            plan_err!("File compression type cannot be set for PARQUET, AVRO, or ARROW files.")?;
+            plan_err!(
+                "File compression type cannot be set for PARQUET, AVRO, or ARROW files."
+            )?;
         }
 
         let schema = self.build_schema(columns)?;

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -679,11 +679,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             options,
         } = statement;
 
-        if file_type != "CSV"
-            && file_type != "JSON"
+        if (file_type == "PARQUET" || file_type == "AVRO" || file_type == "ARROW")
             && file_compression_type != CompressionTypeVariant::UNCOMPRESSED
         {
-            plan_err!("File compression type can be specified for CSV/JSON files.")?;
+            plan_err!("File compression type cannot be set for PARQUET, AVRO, or ARROW files.")?;
         }
 
         let schema = self.build_schema(columns)?;

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1850,6 +1850,7 @@ fn create_external_table_with_compression_type() {
             "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV COMPRESSION TYPE BZIP2 LOCATION 'foo.csv.bz2'",
             "CREATE EXTERNAL TABLE t(c1 int) STORED AS JSON COMPRESSION TYPE GZIP LOCATION 'foo.json.gz'",
             "CREATE EXTERNAL TABLE t(c1 int) STORED AS JSON COMPRESSION TYPE BZIP2 LOCATION 'foo.json.bz2'",
+            "CREATE EXTERNAL TABLE t(c1 int) STORED AS NONSTANDARD COMPRESSION TYPE GZIP LOCATION 'foo.unk'",
         ];
     for sql in sqls {
         let expected = "CreateExternalTable: Bare { table: \"t\" }";
@@ -1862,11 +1863,13 @@ fn create_external_table_with_compression_type() {
         "CREATE EXTERNAL TABLE t STORED AS AVRO COMPRESSION TYPE BZIP2 LOCATION 'foo.avro'",
         "CREATE EXTERNAL TABLE t STORED AS PARQUET COMPRESSION TYPE GZIP LOCATION 'foo.parquet'",
         "CREATE EXTERNAL TABLE t STORED AS PARQUET COMPRESSION TYPE BZIP2 LOCATION 'foo.parquet'",
+        "CREATE EXTERNAL TABLE t STORED AS ARROW COMPRESSION TYPE GZIP LOCATION 'foo.arrow'",
+        "CREATE EXTERNAL TABLE t STORED AS ARROW COMPRESSION TYPE BZIP2 LOCATION 'foo.arrow'",
     ];
     for sql in sqls {
         let err = logical_plan(sql).expect_err("query should have failed");
         assert_eq!(
-            "Plan(\"File compression type can be specified for CSV/JSON files.\")",
+            "Plan(\"File compression type cannot be set for PARQUET, AVRO, or ARROW files.\")",
             format!("{err:?}")
         );
     }

--- a/docs/source/user-guide/sql/ddl.md
+++ b/docs/source/user-guide/sql/ddl.md
@@ -79,7 +79,7 @@ LOCATION <literal>
 
 `file_type` is one of `CSV`, `PARQUET`, `AVRO` or `JSON`
 
-`LOCATION <literal>` specfies the location to find the data. It can be
+`LOCATION <literal>` specifies the location to find the data. It can be
 a path to a file or directory of partitioned files locally or on an
 object store.
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7445

## Rationale for this change

The goal of this PR is to make it possible to create external tables using compression that are not in the built-in table factory, but are still valid. I.e. the logic now throws are error if you pass it a file type that's not CSV or JSON with a file compression type that's not uncompressed. Put another way, I have a `TableProviderFactory` with a custom file type that can be gzipped, and I'd like to create a table using the SQL syntax.

Another possible change is that this `plan_err` could just be removed, and the logic could be moved into the `ListingTableFactory`'s `create` method. I haven't tested this approach however.

## What changes are included in this PR?

* Update the if logic to check the exact types that aren't allowed for a more generic "not"
* Update the tests to check that the new case passes
* Update the error test table to include ARROW as I think it should've been in the logic.

## Are these changes tested?

Add/updated tests to include more cases.

## Are there any user-facing changes?

No