### PR TITLE
Return error if spill file does not exist in ExternalSorter

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -328,6 +328,12 @@ impl ExternalSorter {
             }
 
             for spill in self.spills.drain(..) {
+                if !spill.path().exists() {
+                    return Err(DataFusionError::Internal(format!(
+                        "Spill file {:?} does not exist",
+                        spill.path()
+                    )));
+                }
                 let stream = read_spill_as_stream(spill, self.schema.clone())?;
                 streams.push(stream);
             }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We've seen such error but the sorter still continues to merge batches:

```
Failure while reading spill file: NamedTempFile("/var/folders/zq/2tdnn5955wvdcw7qfy6qhvk00000gn/T/.tmpkgzYB9/.tmp2bAVMU"). Error: IO error: No such file or directory (os error 2) 
```

If any spill file doesn't exist anymore, it seems more reasonable to stop merging final sort output and return an error.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->