### PR TITLE
refactor!: decouple ExecutionPlan trait from datasource

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/avro.rs
+++ b/datafusion/core/src/datasource/physical_plan/avro.rs
@@ -33,6 +33,7 @@ use datafusion_physical_expr::{
 use std::any::Any;
 use std::sync::Arc;
 
+use super::file_scan_config::ScanFiles;
 use super::FileScanConfig;
 
 /// Execution plan for scanning Avro data source
@@ -162,8 +163,12 @@ impl ExecutionPlan for AvroExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
+    fn report_metadata(&self, metadata_collector: &mut dyn Any) -> bool {
+        if let Some(scan_files) = metadata_collector.downcast_mut::<ScanFiles>() {
+            scan_files.add(&self.base_config);
+            return true;
+        }
+        false
     }
 }
 

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -38,6 +38,7 @@ use datafusion_physical_expr::{
 };
 use tokio::io::AsyncWriteExt;
 
+use super::file_scan_config::ScanFiles;
 use super::FileScanConfig;
 
 use bytes::{Buf, Bytes};
@@ -242,8 +243,12 @@ impl ExecutionPlan for CsvExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
+    fn report_metadata(&self, metadata_collector: &mut dyn Any) -> bool {
+        if let Some(scan_files) = metadata_collector.downcast_mut::<ScanFiles>() {
+            scan_files.add(&self.base_config);
+            return true;
+        }
+        false
     }
 }
 

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -48,6 +48,7 @@ use std::task::Poll;
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinSet;
 
+use super::file_scan_config::ScanFiles;
 use super::FileScanConfig;
 
 /// Execution plan for scanning NdJson data source
@@ -171,8 +172,12 @@ impl ExecutionPlan for NdJsonExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
+    fn report_metadata(&self, metadata_collector: &mut dyn Any) -> bool {
+        if let Some(scan_files) = metadata_collector.downcast_mut::<ScanFiles>() {
+            scan_files.add(&self.base_config);
+            return true;
+        }
+        false
     }
 }
 

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -72,6 +72,8 @@ mod row_groups;
 
 pub use metrics::ParquetFileMetrics;
 
+use super::file_scan_config::ScanFiles;
+
 /// Execution plan for scanning one or more Parquet partitions
 #[derive(Debug, Clone)]
 pub struct ParquetExec {
@@ -391,8 +393,12 @@ impl ExecutionPlan for ParquetExec {
         self.projected_statistics.clone()
     }
 
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        Some(&self.base_config)
+    fn report_metadata(&self, metadata_collector: &mut dyn Any) -> bool {
+        if let Some(scan_files) = metadata_collector.downcast_mut::<ScanFiles>() {
+            scan_files.add(&self.base_config);
+            return true;
+        }
+        false
     }
 }
 

--- a/datafusion/core/src/physical_plan/mod.rs
+++ b/datafusion/core/src/physical_plan/mod.rs
@@ -23,7 +23,6 @@ use self::metrics::MetricsSet;
 use self::{
     coalesce_partitions::CoalescePartitionsExec, display::DisplayableExecutionPlan,
 };
-use crate::datasource::physical_plan::FileScanConfig;
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use datafusion_common::Result;
 pub use datafusion_common::{internal_err, ColumnStatistics, Statistics};
@@ -190,9 +189,14 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
     /// Returns the global output statistics for this `ExecutionPlan` node.
     fn statistics(&self) -> Statistics;
 
-    /// Returns the [`FileScanConfig`] in case this is a data source scanning execution plan or `None` otherwise.
-    fn file_scan_config(&self) -> Option<&FileScanConfig> {
-        None
+    /// Reports some metadata to the provided _metadata_collector_ if its type is recognized.
+    /// Returns whether or not that has been the case.
+    ///
+    /// Used to implement [`crate::datasource::physical_plan::get_scan_files`]
+    /// in a way that doesn't make this trait depend on the [`crate::datasource`] module.
+    #[allow(unused_variables)]
+    fn report_metadata(&self, metadata_collector: &mut dyn Any) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
Resolves #7357. Followup for #7175.

## Breaking changes

This commit removes `ExecutionPlan::file_scan_config` which is a breaking change.

/cc @alamb 