### PR TITLE
Minor: Add `ScalarValue::data_type()` for consistency with other APIs

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -1072,8 +1072,8 @@ impl ScalarValue {
         })
     }
 
-    /// Getter for the `DataType` of the value
-    pub fn get_datatype(&self) -> DataType {
+    /// return the [`DataType`] of this `ScalarValue`
+    pub fn data_type(&self) -> DataType {
         match self {
             ScalarValue::Boolean(_) => DataType::Boolean,
             ScalarValue::UInt8(_) => DataType::UInt8,
@@ -1147,6 +1147,13 @@ impl ScalarValue {
             }
             ScalarValue::Null => DataType::Null,
         }
+    }
+
+    /// Getter for the `DataType` of the value.
+    ///
+    /// Suggest using  [`Self::data_type`] as a more standard API
+    pub fn get_datatype(&self) -> DataType {
+        self.data_type()
     }
 
     /// Calculate arithmetic negation for a scalar value

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -939,11 +939,11 @@ impl LogicalPlan {
                 // Verify if the types of the params matches the types of the values
                 let iter = prepare_lp.data_types.iter().zip(param_values.iter());
                 for (i, (param_type, value)) in iter.enumerate() {
-                    if *param_type != value.get_datatype() {
+                    if *param_type != value.data_type() {
                         return plan_err!(
                             "Expected parameter of type {:?}, got {:?} at index {}",
                             param_type,
-                            value.get_datatype(),
+                            value.data_type(),
                             i
                         );
                     }
@@ -1183,11 +1183,11 @@ impl LogicalPlan {
                         ))
                     })?;
                     // check if the data type of the value matches the data type of the placeholder
-                    if Some(value.get_datatype()) != *data_type {
+                    if Some(value.data_type()) != *data_type {
                         return internal_err!(
                             "Placeholder value type mismatch: expected {:?}, got {:?}",
                             data_type,
-                            value.get_datatype()
+                            value.data_type()
                         );
                     }
                     // Replace the placeholder with the value

--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -298,7 +298,7 @@ fn try_cast_literal_to_type(
     lit_value: &ScalarValue,
     target_type: &DataType,
 ) -> Result<Option<ScalarValue>> {
-    let lit_data_type = lit_value.get_datatype();
+    let lit_data_type = lit_value.data_type();
     // the rule just support the signed numeric data type now
     if !is_support_data_type(&lit_data_type) || !is_support_data_type(target_type) {
         return Ok(None);
@@ -817,7 +817,7 @@ mod tests {
             for s2 in &scalars {
                 let expected_value = ExpectedCast::Value(s2.clone());
 
-                expect_cast(s1.clone(), s2.get_datatype(), expected_value);
+                expect_cast(s1.clone(), s2.data_type(), expected_value);
             }
         }
     }
@@ -842,7 +842,7 @@ mod tests {
             for s2 in &scalars {
                 let expected_value = ExpectedCast::Value(s2.clone());
 
-                expect_cast(s1.clone(), s2.get_datatype(), expected_value);
+                expect_cast(s1.clone(), s2.data_type(), expected_value);
             }
         }
 
@@ -976,10 +976,10 @@ mod tests {
             assert_eq!(lit_tz_none, lit_tz_utc);
 
             // e.g. DataType::Timestamp(_, None)
-            let dt_tz_none = lit_tz_none.get_datatype();
+            let dt_tz_none = lit_tz_none.data_type();
 
             // e.g. DataType::Timestamp(_, Some(utc))
-            let dt_tz_utc = lit_tz_utc.get_datatype();
+            let dt_tz_utc = lit_tz_utc.data_type();
 
             // None <--> None
             expect_cast(
@@ -1102,7 +1102,7 @@ mod tests {
                 if let (
                     DataType::Timestamp(left_unit, left_tz),
                     DataType::Timestamp(right_unit, right_tz),
-                ) = (actual_value.get_datatype(), expected_value.get_datatype())
+                ) = (actual_value.data_type(), expected_value.data_type())
                 {
                     assert_eq!(left_unit, right_unit);
                     assert_eq!(left_tz, right_tz);

--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -147,7 +147,7 @@ fn validate_input_percentile_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<f64> {
         ScalarValue::Float64(Some(q)) => *q,
         got => return not_impl_err!(
             "Percentile value for 'APPROX_PERCENTILE_CONT' must be Float32 or Float64 literal (got data type {})",
-            got.get_datatype()
+            got.data_type()
         )
     };
 
@@ -182,7 +182,7 @@ fn validate_input_max_size_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<usize> {
         ScalarValue::Int8(Some(q)) if *q > 0 => *q as usize,
         got => return not_impl_err!(
             "Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be UInt > 0 literal (got data type {}).",
-            got.get_datatype()
+            got.data_type()
         )
     };
     Ok(max_size)

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -151,14 +151,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
 
         let data_types: HashSet<DataType> =
-            values.iter().map(|e| e.get_datatype()).collect();
+            values.iter().map(|e| e.data_type()).collect();
 
         if data_types.is_empty() {
             Ok(lit(ScalarValue::new_list(None, DataType::Utf8)))
         } else if data_types.len() > 1 {
             not_impl_err!("Arrays with different types are not supported: {data_types:?}")
         } else {
-            let data_type = values[0].get_datatype();
+            let data_type = values[0].data_type();
 
             Ok(lit(ScalarValue::new_list(Some(values), data_type)))
         }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The fact that most of the DataFusion codebase uses `fn data_type()` to retrieve the datatype but `ScalarValue` uses `get_datatype` is frustrating to me. It is a very small rough edge, but one that is easy to fix

Here is the example showing exsiting APIs that use `data_type()`:  https://github.com/search?q=repo%3Aapache%2Farrow-datafusion%20data_type&type=code

## What changes are included in this PR?
1. Add `ScalarValue::data_type()`
2. Add docs to `ScalarValue::get_datatype`

Note I did not actually `#deprecate` get_datatype as I thought that would be too large a change. I can do so if people would like however.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
I changed a few locations to call `ScalarValue::data_type`
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->