### PR TITLE
fix: incorrect nullability calculation of `InListExpr`

### DIFF
--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1325,21 +1325,22 @@ SELECT arrow_typeof(c8), arrow_typeof(c6), arrow_typeof(c8 + c6) FROM aggregate_
 Int32 Int64 Int64
 
 # in list array
-query BBBBB rowsort
+query BBBBBB rowsort
 SELECT c1 IN ('a', 'c') AS utf8_in_true
       ,c1 IN ('x', 'y') AS utf8_in_false
       ,c1 NOT IN ('x', 'y') AS utf8_not_in_true
       ,c1 NOT IN ('a', 'c') AS utf8_not_in_false
       ,NULL IN ('a', 'c') AS utf8_in_null
+      ,'a' IN (c1, NULL, 'c') uft8_in_column
 FROM aggregate_test_100 WHERE c12 < 0.05
 ----
-false false true true NULL
-false false true true NULL
-false false true true NULL
-false false true true NULL
-true false true false NULL
-true false true false NULL
-true false true false NULL
+false false true true NULL NULL
+false false true true NULL NULL
+false false true true NULL NULL
+false false true true NULL NULL
+true false true false NULL NULL
+true false true false NULL true
+true false true false NULL true
 
 # csv count star
 query III


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7495

## Rationale for this change
Both the base expression and the list expressions should be considered in the nullability calculation.


## What changes are included in this PR?

## Are these changes tested?

Yes

## Are there any user-facing changes?

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->