### PR TITLE
Minor(proto): Implement `TryFrom<&DFSchema>` for `protobuf::DfSchema`

### DIFF
--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -34,7 +34,9 @@ use arrow::datatypes::{
     DataType, Field, IntervalMonthDayNanoType, IntervalUnit, Schema, SchemaRef, TimeUnit,
     UnionMode,
 };
-use datafusion_common::{Column, DFField, DFSchemaRef, OwnedTableReference, ScalarValue};
+use datafusion_common::{
+    Column, DFField, DFSchema, DFSchemaRef, OwnedTableReference, ScalarValue,
+};
 use datafusion_expr::expr::{
     self, Alias, Between, BinaryExpr, Cast, GetFieldAccess, GetIndexedField, GroupingSet,
     InList, Like, Placeholder, ScalarFunction, ScalarUDF, Sort,
@@ -300,10 +302,10 @@ impl TryFrom<&DFField> for protobuf::DfField {
     }
 }
 
-impl TryFrom<&DFSchemaRef> for protobuf::DfSchema {
+impl TryFrom<&DFSchema> for protobuf::DfSchema {
     type Error = Error;
 
-    fn try_from(s: &DFSchemaRef) -> Result<Self, Self::Error> {
+    fn try_from(s: &DFSchema) -> Result<Self, Self::Error> {
         let columns = s
             .fields()
             .iter()
@@ -313,6 +315,14 @@ impl TryFrom<&DFSchemaRef> for protobuf::DfSchema {
             columns,
             metadata: s.metadata().clone(),
         })
+    }
+}
+
+impl TryFrom<&DFSchemaRef> for protobuf::DfSchema {
+    type Error = Error;
+
+    fn try_from(s: &DFSchemaRef) -> Result<Self, Self::Error> {
+        s.as_ref().try_into()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change
Currently, we have only implemented `TryFrom<&DFSchemaRef>` for `protobuf::DfSchema`.
In the example below, when encoding a `DFSchema`, we have to create an `Arc`, which can be considered wasteful.
```rust
let dfschema = datafusion::common::DFSchema::empty();
let arc_dfschema = Arc::new(dfschema);
let proto_dfschema: datafusion_proto::DfSchema =(&arc_dfschema).try_into().unwrap();
```

Implementing `TryFrom<&DFSchema>` for `protobuf::DfSchema` helps to avoid this issue, 
and then the code is simplified as follows.
```rust
let dfschema = datafusion::common::DFSchema::empty();
let proto_dfschema: datafusion_proto::DfSchema =(&dfschema).try_into().unwrap();
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
New API, without breaking changes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->