### PR TITLE
Propagate error from spawned task reading spills

### DIFF
--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -109,9 +109,13 @@ pub(crate) fn spawn_buffered(
             builder.spawn(async move {
                 while let Some(item) = input.next().await {
                     if sender.send(item).await.is_err() {
-                        return;
+                        return Err(DataFusionError::Execution(
+                            "Failed to send record batch".to_string(),
+                        ));
                     }
                 }
+
+                Ok(())
             });
 
             builder.build()

--- a/datafusion/core/src/physical_plan/common.rs
+++ b/datafusion/core/src/physical_plan/common.rs
@@ -109,9 +109,9 @@ pub(crate) fn spawn_buffered(
             builder.spawn(async move {
                 while let Some(item) = input.next().await {
                     if sender.send(item).await.is_err() {
-                        return Err(DataFusionError::Execution(
-                            "Failed to send record batch".to_string(),
-                        ));
+                        // receiver dropped when query is shutdown early (e.g., limit) or error,
+                        // no need to return propagate the send error.
+                        return Ok(());
                     }
                 }
 

--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -616,9 +616,11 @@ fn read_spill_as_stream(
     let sender = builder.tx();
 
     builder.spawn_blocking(move || {
-        if let Err(e) = read_spill(sender, path.path()) {
+        let result = read_spill(sender, path.path());
+        if let Err(e) = &result {
             error!("Failure while reading spill file: {:?}. Error: {}", path, e);
         }
+        result
     });
 
     Ok(builder.build())

--- a/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -848,6 +848,8 @@ mod tests {
                     // This causes the MergeStream to wait for more input
                     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
                 }
+
+                Ok(())
             });
 
             streams.push(builder.build());

--- a/datafusion/core/src/physical_plan/stream.rs
+++ b/datafusion/core/src/physical_plan/stream.rs
@@ -24,9 +24,9 @@ use std::task::Poll;
 
 use crate::physical_plan::displayable;
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
-use datafusion_common::internal_err;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result;
+use datafusion_common::{exec_err, internal_err};
 use datafusion_execution::TaskContext;
 use futures::stream::BoxStream;
 use futures::{Future, Stream, StreamExt};
@@ -177,7 +177,7 @@ impl RecordBatchReceiverStreamBuilder {
                             Ok(_) => continue,
                             // This means a blocking task error
                             Err(e) => {
-                                return Some(internal_err!("Spawned Task error: {e}"));
+                                return Some(exec_err!("Spawned Task error: {e}"));
                             }
                         }
                     }

--- a/datafusion/core/src/test/exec.rs
+++ b/datafusion/core/src/test/exec.rs
@@ -228,6 +228,8 @@ impl ExecutionPlan for MockExec {
                         println!("ERROR batch via delayed stream: {e}");
                     }
                 }
+
+                Ok(())
             });
             // returned stream simply reads off the rx stream
             Ok(builder.build())
@@ -364,6 +366,8 @@ impl ExecutionPlan for BarrierExec {
                     println!("ERROR batch via barrier stream stream: {e}");
                 }
             }
+
+            Ok(())
         });
 
         // returned stream simply reads off the rx stream


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7509.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Any error happened in the spawned task reading spills cannot propagate out currently. So these errors will be ignored and it doesn't look correct as the sorted result will be incorrect.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Propagating errors from spawned task reading spills.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->