### PR TITLE
Minor: Remove stray comment markings from encoding error message

### DIFF
--- a/datafusion/common/src/file_options/parse_utils.rs
+++ b/datafusion/common/src/file_options/parse_utils.rs
@@ -57,8 +57,8 @@ pub(crate) fn parse_encoding_string(
         _ => Err(DataFusionError::Configuration(format!(
             "Unknown or unsupported parquet encoding: \
         {str_setting}. Valid values are: plain, plain_dictionary, rle, \
-        /// bit_packed, delta_binary_packed, delta_length_byte_array, \
-        /// delta_byte_array, rle_dictionary, and byte_stream_split."
+        bit_packed, delta_binary_packed, delta_length_byte_array, \
+        delta_byte_array, rle_dictionary, and byte_stream_split."
         ))),
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

I noticed some stray comment markings (///) in an error message, probably because the message was copied from a comment in the code.

## What changes are included in this PR?

Remove the /// markings from the error message.

## Are these changes tested?

Yes by existing tests

## Are there any user-facing changes?

Will no longer see unneeded /// markings in error message.