### PR TITLE
Minor: Add comments and clearer constructors to `Interval`

### DIFF
--- a/datafusion/physical-expr/src/analysis.rs
+++ b/datafusion/physical-expr/src/analysis.rs
@@ -91,13 +91,11 @@ impl ExprBoundaries {
         Self {
             column: Column::new(&col, index),
             interval: Interval::new(
-                IntervalBound::new(
+                IntervalBound::new_closed(
                     stats.min_value.clone().unwrap_or(ScalarValue::Null),
-                    false,
                 ),
-                IntervalBound::new(
+                IntervalBound::new_closed(
                     stats.max_value.clone().unwrap_or(ScalarValue::Null),
-                    false,
                 ),
             ),
             distinct_count: stats.distinct_count,

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -188,8 +188,8 @@ impl ExprIntervalGraphNode {
         if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
             let value = literal.value();
             let interval = Interval::new(
-                IntervalBound::new(value.clone(), false),
-                IntervalBound::new(value.clone(), false),
+                IntervalBound::new_closed(value.clone()),
+                IntervalBound::new_closed(value.clone()),
             );
             ExprIntervalGraphNode::new_with_interval(expr, interval)
         } else {
@@ -279,13 +279,13 @@ fn comparison_operator_target(
     let unbounded = IntervalBound::make_unbounded(&datatype)?;
     let zero = ScalarValue::new_zero(&datatype)?;
     Ok(match *op {
-        Operator::GtEq => Interval::new(IntervalBound::new(zero, false), unbounded),
-        Operator::Gt => Interval::new(IntervalBound::new(zero, true), unbounded),
-        Operator::LtEq => Interval::new(unbounded, IntervalBound::new(zero, false)),
-        Operator::Lt => Interval::new(unbounded, IntervalBound::new(zero, true)),
+        Operator::GtEq => Interval::new(IntervalBound::new_closed(zero), unbounded),
+        Operator::Gt => Interval::new(IntervalBound::new_open(zero), unbounded),
+        Operator::LtEq => Interval::new(unbounded, IntervalBound::new_closed(zero)),
+        Operator::Lt => Interval::new(unbounded, IntervalBound::new_open(zero)),
         Operator::Eq => Interval::new(
-            IntervalBound::new(zero.clone(), false),
-            IntervalBound::new(zero, false),
+            IntervalBound::new_closed(zero.clone()),
+            IntervalBound::new_closed(zero),
         ),
         _ => unreachable!(),
     })


### PR DESCRIPTION
## Which issue does this PR close?

related to https://github.com/apache/arrow-datafusion/pull/7467

## Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/7467 I found I had to remind myself several times what open/closed meant in the context of intervals. 

## What changes are included in this PR?

1. Clarify comments on `Interval` (they were already nice, just could be somewhat clearer)
2. Add `Interval::new_open` and `Interval::new_closed` as a way to make the code more self documenting
3. Change some uses of `Interval::new` to `Interval::new_open` and `Interval::new_closed`  

I am happy to change more uses but I wanted to see what people thought of the idea first

## Are these changes tested?

Existing tests

## Are there any user-facing changes?
No functional change intended, just easier to understand code

