### PR TITLE
fix: skip EliminateCrossJoin rule if inner join with filter is found

### DIFF
--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -370,6 +370,12 @@ mod tests {
         assert_eq!(plan.schema(), optimized_plan.schema())
     }
 
+    fn assert_optimization_rule_fails(plan: &LogicalPlan) {
+        let rule = EliminateCrossJoin::new();
+        let optimized_plan = rule.try_optimize(plan, &OptimizerContext::new()).unwrap();
+        assert!(optimized_plan.is_none());
+    }
+
     #[test]
     fn eliminate_cross_with_simple_and() -> Result<()> {
         let t1 = test_table_scan_with_name("t1")?;
@@ -534,6 +540,30 @@ mod tests {
             "    TableScan: t2 [a:UInt32, b:UInt32, c:UInt32]",
         ];
         assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    /// See https://github.com/apache/arrow-datafusion/issues/7530
+    fn eliminate_cross_not_possible_nested_inner_join_with_filter() -> Result<()> {
+        let t1 = test_table_scan_with_name("t1")?;
+        let t2 = test_table_scan_with_name("t2")?;
+        let t3 = test_table_scan_with_name("t3")?;
+
+        // could not eliminate to inner join with filter
+        let plan = LogicalPlanBuilder::from(t1)
+            .join(
+                t3,
+                JoinType::Inner,
+                (vec!["t1.a"], vec!["t3.a"]),
+                Some(col("t1.a").gt(lit(20u32))),
+            )?
+            .join(t2, JoinType::Inner, (vec!["t1.a"], vec!["t2.a"]), None)?
+            .filter(col("t1.a").gt(lit(15u32)))?
+            .build()?;
+
+        assert_optimization_rule_fails(&plan);
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7530

## Rationale for this change

Explained in issue

## What changes are included in this PR?

EliminateCrossJoin optimization rule should be skipped for InnerJoin with filter, this PR fixes a bug were nested InnerJoins with filter do not cause the rule to be skipped.

## Are these changes tested?

yes see `eliminate_cross_not_possible_nested_inner_join_with_filter`

## Are there any user-facing changes?

There are no API changes but query results might differ.