### PR TITLE
Add filename / more context to IO errors

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -427,6 +427,16 @@ impl DataFusionError {
 
         "".to_string()
     }
+
+    /// Add additional context to this error
+    pub fn with_context(self, details: impl Into<String>) -> Self {
+        Self::Context(details.into(), Box::new(self))
+    }
+
+    /// Create a [`DataFusionError::IoError`] with context from a [`std::io::Error`]
+    pub fn io_error(e: std::io::Error, details: impl Into<String>) -> Self {
+        Self::IoError(e).with_context(details)
+    }
 }
 
 /// Unwrap an `Option` if possible. Otherwise return an `DataFusionError::Internal`.

--- a/datafusion/common/src/file_options/file_type.rs
+++ b/datafusion/common/src/file_options/file_type.rs
@@ -135,19 +135,19 @@ impl FileCompressionType {
         Ok(match self.variant {
             #[cfg(feature = "compression")]
             GZIP => ReaderStream::new(AsyncGzEncoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             BZIP2 => ReaderStream::new(AsyncBzEncoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             XZ => ReaderStream::new(AsyncXzEncoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             ZSTD => ReaderStream::new(AsyncZstdEncoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {
@@ -192,19 +192,19 @@ impl FileCompressionType {
         Ok(match self.variant {
             #[cfg(feature = "compression")]
             GZIP => ReaderStream::new(AsyncGzDecoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             BZIP2 => ReaderStream::new(AsyncBzDecoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             XZ => ReaderStream::new(AsyncXzDecoder::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(feature = "compression")]
             ZSTD => ReaderStream::new(AsyncZstdDecoer::new(StreamReader::new(s)))
-                .map_err(DataFusionError::from)
+                .map_err(DataFusionError::IoError)
                 .boxed(),
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -2382,7 +2382,7 @@ mod tests {
         ];
         for compression in test_compressions.into_iter() {
             let df = test_df.clone();
-            let tmp_dir = TempDir::new()?;
+            let tmp_dir = TempDir::new().unwrap();
             let local = Arc::new(LocalFileSystem::new_with_prefix(&tmp_dir)?);
             let local_url = Url::parse("file://local").unwrap();
             let ctx = &test_df.session_state;
@@ -2399,7 +2399,8 @@ mod tests {
             .await?;
 
             // Check that file actually used the specified compression
-            let file = std::fs::File::open(tmp_dir.into_path().join("test.parquet"))?;
+            let file =
+                std::fs::File::open(tmp_dir.into_path().join("test.parquet")).unwrap();
 
             let reader =
                 parquet::file::serialized_reader::SerializedFileReader::new(file)

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -24,7 +24,7 @@ mod url;
 
 use crate::error::Result;
 use chrono::TimeZone;
-use datafusion_common::ScalarValue;
+use datafusion_common::{DataFusionError, ScalarValue};
 use futures::Stream;
 use object_store::{path::Path, ObjectMeta};
 use std::pin::Pin;
@@ -106,7 +106,11 @@ impl PartitionedFile {
 
     /// Return a file reference from the given path
     pub fn from_path(path: String) -> Result<Self> {
-        let size = std::fs::metadata(path.clone())?.len();
+        let size = std::fs::metadata(path.clone())
+            .map_err(|e| {
+                DataFusionError::io_error(e, format!("Reading metadata for: {path}"))
+            })?
+            .len();
         Ok(Self::new(path, size))
     }
 }

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1257,9 +1257,9 @@ mod tests {
 
     #[tokio::test]
     async fn unbounded_csv_table_without_schema() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join("dummy.csv");
-        File::create(file_path)?;
+        File::create(file_path).unwrap();
         let ctx = SessionContext::new();
         let error = ctx
             .register_csv(
@@ -1277,9 +1277,9 @@ mod tests {
 
     #[tokio::test]
     async fn unbounded_json_table_without_schema() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join("dummy.json");
-        File::create(file_path)?;
+        File::create(file_path).unwrap();
         let ctx = SessionContext::new();
         let error = ctx
             .register_json(
@@ -1297,9 +1297,9 @@ mod tests {
 
     #[tokio::test]
     async fn unbounded_avro_table_without_schema() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join("dummy.avro");
-        File::create(file_path)?;
+        File::create(file_path).unwrap();
         let ctx = SessionContext::new();
         let error = ctx
             .register_avro(
@@ -1887,7 +1887,7 @@ mod tests {
         insert_mode: ListingTableInsertMode,
         file_format: Arc<dyn FileFormat>,
     ) -> Result<Arc<dyn TableProvider>> {
-        File::create(temp_path)?;
+        File::create(temp_path).unwrap();
         let table_path = ListingTableUrl::parse(temp_path).unwrap();
 
         let listing_options =
@@ -1940,7 +1940,7 @@ mod tests {
         );
 
         // Create a temporary directory and a CSV file within it.
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().join(filename);
 
         let file_format: Arc<dyn FileFormat> = match file_type {
@@ -2016,7 +2016,7 @@ mod tests {
         assert_batches_eq!(expected, &batches);
 
         // Assert that only 1 file was added to the table
-        let num_files = tmp_dir.path().read_dir()?.count();
+        let num_files = tmp_dir.path().read_dir().unwrap().count();
         assert_eq!(num_files, 1);
 
         // Create a physical plan from the insert plan
@@ -2066,7 +2066,7 @@ mod tests {
         assert_batches_eq!(expected, &batches);
 
         // Assert that no additional files were added to the table
-        let num_files = tmp_dir.path().read_dir()?.count();
+        let num_files = tmp_dir.path().read_dir().unwrap().count();
         assert_eq!(num_files, 1);
 
         // Return Ok if the function
@@ -2101,7 +2101,7 @@ mod tests {
         )?;
 
         // Register appropriate table depending on file_type we want to test
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         match file_type {
             FileType::CSV => {
                 session_ctx
@@ -2217,7 +2217,7 @@ mod tests {
         assert_batches_eq!(expected, &batches);
 
         // Assert that 6 files were added to the table
-        let num_files = tmp_dir.path().read_dir()?.count();
+        let num_files = tmp_dir.path().read_dir().unwrap().count();
         assert_eq!(num_files, 6);
 
         // Create a physical plan from the insert plan
@@ -2260,7 +2260,7 @@ mod tests {
         assert_batches_eq!(expected, &batches);
 
         // Assert that another 6 files were added to the table
-        let num_files = tmp_dir.path().read_dir()?.count();
+        let num_files = tmp_dir.path().read_dir().unwrap().count();
         assert_eq!(num_files, 12);
 
         // Return Ok if the function
@@ -2286,7 +2286,7 @@ mod tests {
         };
 
         // create table
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let tmp_path = tmp_dir.into_path();
         let str_path = tmp_path.to_str().expect("Temp path should convert to &str");
         session_ctx

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -918,7 +918,7 @@ mod tests {
     async fn write_parquet_results_error_handling() -> Result<()> {
         let ctx = SessionContext::new();
         // register a local file system object store for /tmp directory
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let local = Arc::new(LocalFileSystem::new_with_prefix(&tmp_dir)?);
         let local_url = Url::parse("file://local").unwrap();
         ctx.runtime_env().register_object_store(&local_url, local);
@@ -1911,12 +1911,12 @@ mod tests {
         for partition in 0..partition_count {
             let filename = format!("partition-{partition}.{file_extension}");
             let file_path = tmp_dir.path().join(filename);
-            let mut file = File::create(file_path)?;
+            let mut file = File::create(file_path).unwrap();
 
             // generate some data
             for i in 0..=10 {
                 let data = format!("{},{},{}\n", partition, i, i % 2 == 0);
-                file.write_all(data.as_bytes())?;
+                file.write_all(data.as_bytes()).unwrap();
             }
         }
 
@@ -1926,7 +1926,7 @@ mod tests {
     #[tokio::test]
     async fn write_parquet_results() -> Result<()> {
         // create partitioned input file and context
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         // let mut ctx = create_ctx(&tmp_dir, 4).await?;
         let ctx =
             SessionContext::with_config(SessionConfig::new().with_target_partitions(8));
@@ -1959,7 +1959,8 @@ mod tests {
         let mut paths = fs::read_dir(&out_dir).unwrap();
         let path = paths.next();
         let name = path
-            .unwrap()?
+            .unwrap()
+            .unwrap()
             .path()
             .file_name()
             .expect("Should be a file name")

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -2322,7 +2322,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_variable_expr() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let partition_count = 4;
         let ctx = create_ctx(&tmp_dir, partition_count).await?;
 
@@ -2364,7 +2364,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_deregister() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let partition_count = 4;
         let ctx = create_ctx(&tmp_dir, partition_count).await?;
 
@@ -2460,7 +2460,7 @@ mod tests {
 
     #[tokio::test]
     async fn query_csv_with_custom_partition_extension() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
 
         // The main stipulation of this test: use a file extension that isn't .csv.
         let file_extension = ".tst";
@@ -2495,7 +2495,7 @@ mod tests {
     async fn send_context_to_threads() -> Result<()> {
         // ensure SessionContexts can be used in a multi-threaded
         // environment. Usecase is for concurrent planing.
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let partition_count = 4;
         let ctx = Arc::new(create_ctx(&tmp_dir, partition_count).await?);
 
@@ -2872,12 +2872,12 @@ mod tests {
         for partition in 0..partition_count {
             let filename = format!("partition-{partition}.{file_extension}");
             let file_path = tmp_dir.path().join(filename);
-            let mut file = File::create(file_path)?;
+            let mut file = File::create(file_path).unwrap();
 
             // generate some data
             for i in 0..=10 {
                 let data = format!("{},{},{}\n", partition, i, i % 2 == 0);
-                file.write_all(data.as_bytes())?;
+                file.write_all(data.as_bytes()).unwrap();
             }
         }
 

--- a/datafusion/core/src/physical_plan/coalesce_partitions.rs
+++ b/datafusion/core/src/physical_plan/coalesce_partitions.rs
@@ -185,7 +185,7 @@ mod tests {
         let task_ctx = Arc::new(TaskContext::default());
 
         let num_partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(num_partitions, tmp_dir.path())?;
 
         // input should have 4 partitions

--- a/datafusion/core/src/physical_plan/filter.rs
+++ b/datafusion/core/src/physical_plan/filter.rs
@@ -399,7 +399,7 @@ mod tests {
         let schema = test_util::aggr_test_schema();
 
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
 
         let predicate: Arc<dyn PhysicalExpr> = binary(
@@ -427,7 +427,7 @@ mod tests {
     async fn with_new_children() -> Result<()> {
         let schema = test_util::aggr_test_schema();
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let input = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
 
         let predicate: Arc<dyn PhysicalExpr> =

--- a/datafusion/core/src/physical_plan/limit.rs
+++ b/datafusion/core/src/physical_plan/limit.rs
@@ -534,7 +534,7 @@ mod tests {
         let task_ctx = Arc::new(TaskContext::default());
 
         let num_partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(num_partitions, tmp_dir.path())?;
 
         // input should have 4 partitions
@@ -651,7 +651,7 @@ mod tests {
         let task_ctx = Arc::new(TaskContext::default());
 
         let num_partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(num_partitions, tmp_dir.path())?;
 
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
@@ -741,7 +741,7 @@ mod tests {
         fetch: Option<usize>,
     ) -> Result<Option<usize>> {
         let num_partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(num_partitions, tmp_dir.path())?;
 
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
@@ -756,7 +756,7 @@ mod tests {
         num_partitions: usize,
         fetch: usize,
     ) -> Result<Option<usize>> {
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(num_partitions, tmp_dir.path())?;
 
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);

--- a/datafusion/core/src/physical_plan/projection.rs
+++ b/datafusion/core/src/physical_plan/projection.rs
@@ -536,7 +536,7 @@ mod tests {
         let schema = test_util::aggr_test_schema();
 
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
 
         // pick column c1 and name it column c1 in the output schema
@@ -574,7 +574,7 @@ mod tests {
         let schema = test_util::aggr_test_schema();
 
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
 
         // pick column c1 and name it column c1 in the output schema
@@ -589,7 +589,7 @@ mod tests {
         let schema = test_util::aggr_test_schema();
 
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
 
         let c1 = col("c2", &schema).unwrap();
@@ -607,7 +607,7 @@ mod tests {
     async fn project_no_column() -> Result<()> {
         let task_ctx = Arc::new(TaskContext::default());
 
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(1, tmp_dir.path())?;
         let expected = collect(csv.execute(0, task_ctx.clone())?).await.unwrap();
 

--- a/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort_preserving_merge.rs
@@ -563,7 +563,7 @@ mod tests {
     async fn test_partition_sort() -> Result<()> {
         let task_ctx = Arc::new(TaskContext::default());
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path()).unwrap();
         let schema = csv.schema();
 
@@ -636,7 +636,7 @@ mod tests {
         context: Arc<TaskContext>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let partitions = 4;
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let csv = test::scan_partitioned_csv(partitions, tmp_dir.path()).unwrap();
 
         let sorted = basic_sort(csv, sort, context).await;

--- a/datafusion/core/src/physical_plan/union.rs
+++ b/datafusion/core/src/physical_plan/union.rs
@@ -612,7 +612,7 @@ mod tests {
     async fn test_union_partitions() -> Result<()> {
         let task_ctx = Arc::new(TaskContext::default());
 
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
 
         // Create csv's with different partitioning
         let csv = test::scan_partitioned_csv(4, tmp_dir.path())?;

--- a/datafusion/core/src/physical_plan/windows/mod.rs
+++ b/datafusion/core/src/physical_plan/windows/mod.rs
@@ -552,7 +552,7 @@ mod tests {
         );
 
         let task_ctx = Arc::new(TaskContext::default());
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let (input, schema) = create_test_schema(1, tmp_dir.path())?;
 
         let window_exec = Arc::new(WindowAggExec::try_new(
@@ -585,7 +585,7 @@ mod tests {
     #[tokio::test]
     async fn window_function() -> Result<()> {
         let task_ctx = Arc::new(TaskContext::default());
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = TempDir::new().unwrap();
         let (input, schema) = create_test_schema(1, tmp_dir.path())?;
 
         let window_exec = Arc::new(WindowAggExec::try_new(

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -155,7 +155,7 @@ pub fn partitioned_file_groups(
         files.push(filename);
     }
 
-    let f = File::open(path)?;
+    let f = File::open(path).unwrap();
     let f = BufReader::new(f);
     for (i, line) in f.lines().enumerate() {
         let line = line.unwrap();

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -147,12 +147,19 @@ fn create_local_dirs(local_dirs: Vec<PathBuf>) -> Result<Vec<TempDir>> {
         .iter()
         .map(|root| {
             if !std::path::Path::new(root).exists() {
-                std::fs::create_dir(root)?;
+                std::fs::create_dir(root).map_err(|e| {
+                    DataFusionError::io_error(e, format!("Trying to create {root:?}"))
+                })?;
             }
             Builder::new()
                 .prefix("datafusion-")
                 .tempdir_in(root)
-                .map_err(DataFusionError::IoError)
+                .map_err(|e| {
+                    DataFusionError::io_error(
+                        e,
+                        format!("Trying to create tempdir in {root:?}"),
+                    )
+                })
         })
         .collect()
 }

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -923,7 +923,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                     let mut bytes = vec![];
                     extension_codec
                         .try_encode_table_provider(provider, &mut bytes)
-                        .map_err(|e| context!("Error serializing custom table", e))?;
+                        .map_err(|e| e.with_context("Error serializing custom table"))?;
                     let scan = CustomScan(CustomTableScanNode {
                         table_name: Some(table_name.clone().into()),
                         projection,


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/7523

## Rationale for this change

While tracking down https://github.com/apache/arrow-datafusion/issues/7523 I would like to know *WHAT* file was not found. The current errors don't include this information, so let's add it

I also think this is more generally useful information to pass up

## What changes are included in this PR?

Add a `DataFusionError::with_context` and `DataFusionError::io_error` constructors to add error context and use these functions in a bunch of callsites

## Are these changes tested?
Existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->