### PR TITLE
Minor: make test_sort_fetch_memory_calculation fail fast on failure

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -1042,7 +1042,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sort_fetch_memory_calculation() -> Result<()> {
+    async fn test_sort_fetch_memory_calculation() {
         // This test mirrors down the size from the example above.
         let avg_batch_size = 4000;
         let partitions = 4;
@@ -1068,15 +1068,15 @@ mod tests {
                 sort_spill_reservation_bytes + avg_batch_size * (partitions - 1),
                 1.0,
             );
-            let runtime = Arc::new(RuntimeEnv::new(rt_config)?);
+            let runtime = Arc::new(RuntimeEnv::new(rt_config).unwrap());
             let task_ctx = Arc::new(
                 TaskContext::default()
                     .with_runtime(runtime)
                     .with_session_config(session_config),
             );
 
-            let tmp_dir = TempDir::new()?;
-            let csv = test::scan_partitioned_csv(partitions, tmp_dir.path())?;
+            let tmp_dir = TempDir::new().unwrap();
+            let csv = test::scan_partitioned_csv(partitions, tmp_dir.path()).unwrap();
             let schema = csv.schema();
 
             let sort_exec = Arc::new(
@@ -1084,17 +1084,17 @@ mod tests {
                     vec![
                         // c1 string column
                         PhysicalSortExpr {
-                            expr: col("c1", &schema)?,
+                            expr: col("c1", &schema).unwrap(),
                             options: SortOptions::default(),
                         },
                         // c2 uin32 column
                         PhysicalSortExpr {
-                            expr: col("c2", &schema)?,
+                            expr: col("c2", &schema).unwrap(),
                             options: SortOptions::default(),
                         },
                         // c7 uin8 column
                         PhysicalSortExpr {
-                            expr: col("c7", &schema)?,
+                            expr: col("c7", &schema).unwrap(),
                             options: SortOptions::default(),
                         },
                     ],
@@ -1103,14 +1103,13 @@ mod tests {
                 .with_fetch(fetch),
             );
 
-            let result = collect(sort_exec.clone(), task_ctx).await?;
+            let result = collect(sort_exec.clone(), task_ctx).await.unwrap();
             assert_eq!(result.len(), 1);
 
             let metrics = sort_exec.metrics().unwrap();
             let did_it_spill = metrics.spill_count().unwrap() > 0;
             assert_eq!(did_it_spill, expect_spillage, "with fetch: {fetch:?}");
         }
-        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

related to https://github.com/apache/arrow-datafusion/issues/7523

## Rationale for this change
As part of tracking down  I would like to know *WHAT* operation in the test is failing. At the moment all I know is *something* is failing


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Change the test to use `unwrap()` and fail fast rather than `?`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->