### PR TITLE
Fix a race condition issue on reading spilled file

### DIFF
--- a/datafusion/core/src/physical_plan/sorts/sort.rs
+++ b/datafusion/core/src/physical_plan/sorts/sort.rs
@@ -36,6 +36,7 @@ use arrow::datatypes::SchemaRef;
 use arrow::ipc::reader::FileReader;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{exec_err, plan_err, DataFusionError, Result};
+use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::memory_pool::{
     human_readable_size, MemoryConsumer, MemoryReservation,
 };
@@ -51,7 +52,6 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tempfile::NamedTempFile;
 use tokio::sync::mpsc::Sender;
 use tokio::task;
 
@@ -202,7 +202,7 @@ struct ExternalSorter {
     in_mem_batches_sorted: bool,
     /// If data has previously been spilled, the locations of the
     /// spill files (in Arrow IPC format)
-    spills: Vec<NamedTempFile>,
+    spills: Vec<RefCountedTempFile>,
     /// Sort expressions
     expr: Arc<[PhysicalSortExpr]>,
     /// Runtime metrics
@@ -609,7 +609,7 @@ async fn spill_sorted_batches(
 }
 
 fn read_spill_as_stream(
-    path: NamedTempFile,
+    path: RefCountedTempFile,
     schema: SchemaRef,
 ) -> Result<SendableRecordBatchStream> {
     let mut builder = RecordBatchReceiverStream::builder(schema, 2);

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -144,15 +144,13 @@ impl DiskManager {
 }
 
 /// Ensure local dirs present
-fn create_local_dirs(local_dirs: &Vec<PathBuf>) -> Result<()> {
-    Ok(local_dirs
-        .iter()
-        .try_for_each(|root| -> Result<()> {
-            if !std::path::Path::new(root).exists() {
-                std::fs::create_dir(root)?;
-            }
-            Ok(())
-        })?)
+fn create_local_dirs(local_dirs: &[PathBuf]) -> Result<()> {
+    local_dirs.iter().try_for_each(|root| -> Result<()> {
+        if !std::path::Path::new(root).exists() {
+            std::fs::create_dir(root)?;
+        }
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -268,7 +266,7 @@ mod tests {
         let local_dir1 = TempDir::new()?;
         let local_dir2 = TempDir::new()?;
         let local_dir3 = TempDir::new()?;
-        let local_dirs = vec![local_dir1.path(), local_dir2.path(), local_dir3.path()];
+        let local_dirs = [local_dir1.path(), local_dir2.path(), local_dir3.path()];
         let config = DiskManagerConfig::new_specified(
             local_dirs.iter().map(|p| p.into()).collect(),
         );

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -147,7 +147,7 @@ impl DiskManager {
     }
 }
 
-/// A wrapper around a [`NamedTemporaryFile`] that also contains a reference
+/// A wrapper around a [`NamedTempFile`] that also contains a reference
 #[derive(Debug)]
 pub struct RefCountedTempFile {
     /// directory in which temporary files are created (Arc is held to ensure

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -147,10 +147,11 @@ impl DiskManager {
     }
 }
 
-/// A named temporary file and the directory it lives in, which may be clean up on drop
+/// A wrapper around a [`NamedTemporaryFile`] that also contains a reference
 #[derive(Debug)]
 pub struct RefCountedTempFile {
-    /// directory in which temporary files are created
+    /// directory in which temporary files are created (Arc is held to ensure
+    /// it is not cleaned up prior to the NamedTempFile)
     #[allow(dead_code)]
     parent_temp_dir: Arc<TempDir>,
     tempfile: NamedTempFile,

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -147,11 +147,12 @@ impl DiskManager {
     }
 }
 
-/// A wrapper around a [`NamedTempFile`] that also contains a reference
+/// A wrapper around a [`NamedTempFile`] that also contains
+/// a reference to its parent temporary directory
 #[derive(Debug)]
 pub struct RefCountedTempFile {
-    /// directory in which temporary files are created (Arc is held to ensure
-    /// it is not cleaned up prior to the NamedTempFile)
+    /// The reference to the directory in which temporary files are created to ensure
+    /// it is not cleaned up prior to the NamedTempFile
     #[allow(dead_code)]
     parent_temp_dir: Arc<TempDir>,
     tempfile: NamedTempFile,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7537, 
Closes #7523
Closes https://github.com/apache/arrow-datafusion/issues/7546

## Rationale for this change
This issue seems a potential race condition issue.
To improve the stability, this issue need to be fixed.

## What changes are included in this PR?
This issue happens when the parent directory of spilled files are deleted before being read.
The root cause is `TempDir` of the parent directory can be dropped if [this async block](https://github.com/apache/arrow-datafusion/blob/561e0d7e87825aba224bf2eb9c3b8b5e1b725597/datafusion/core/src/physical_plan/sorts/sort.rs#L870) exits before [the reading task](https://github.com/apache/arrow-datafusion/blob/561e0d7e87825aba224bf2eb9c3b8b5e1b725597/datafusion/core/src/physical_plan/sorts/sort.rs#L618) starts like as follows.

1. Exit the [async block](https://github.com/apache/arrow-datafusion/blob/561e0d7e87825aba224bf2eb9c3b8b5e1b725597/datafusion/core/src/physical_plan/sorts/sort.rs#L870)
2. `sorter` and it's members are dropped including `DiskManager::local_dirs`.
3. `TempFile` in `local_dirs` are dropped then the corresponding temporary directories are deleted recursively.
4. The [reading task](https://github.com/apache/arrow-datafusion/blob/561e0d7e87825aba224bf2eb9c3b8b5e1b725597/datafusion/core/src/physical_plan/sorts/sort.rs#L618) starts

~~To avoid breaking API compatibility, this change proposes to not use `TempDir` and let the DiskManager directly creates temporary spilled file in `local_dirs`.~~

**UPDATE:** After [the discussion](https://github.com/apache/arrow-datafusion/pull/7538#pullrequestreview-1624316842), I prefer the second solution below.

I have another solution but it breaks the API compatibility of `DiskManager::create_tmp_file`, which returns a pair of `Arc<TempDir>` and `NamedTempFile` to ensure `TempDir` lives long enough.

~~Spilled files are represented as `NamedTempFile` and temporary files are deleted when `NamedTempFile::drop` is called.
So, I think not using `TempDir` is not a problem.~~

## Are these changes tested?
Added new test.

## Are there any user-facing changes?
No.