### PR TITLE
Create 2023 Q4 roadmap

### DIFF
--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -24,7 +24,7 @@ A quarterly roadmap will be published to give the DataFusion community visibilit
 ## 2023 Q4
 
 - Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#7079](https://github.com/apache/arrow-datafusion/issues/7079)
-- Implementation of `ARRAY` types and related functions [#6980](https://github.com/apache/arrow-datafusion/issues/6782)
+- Implementation of `ARRAY` types and related functions [#6980](https://github.com/apache/arrow-datafusion/issues/6980)
 - Write an industrial paper about DataFusion for SIGMOD [#6782](https://github.com/apache/arrow-datafusion/issues/6782)
 
 ## 2022 Q2

--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -23,7 +23,7 @@ A quarterly roadmap will be published to give the DataFusion community visibilit
 
 ## 2023 Q4
 
-- Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#7079](https://github.com/apache/arrow-datafusion/issues/7079)
+- Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#6569](https://github.com/apache/arrow-datafusion/issues/6569)
 - Implementation of `ARRAY` types and related functions [#6980](https://github.com/apache/arrow-datafusion/issues/6980)
 - Write an industrial paper about DataFusion for SIGMOD [#6782](https://github.com/apache/arrow-datafusion/issues/6782)
 

--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -23,7 +23,7 @@ A quarterly roadmap will be published to give the DataFusion community visibilit
 
 ## 2023 Q4
 
-- Improve DataFrame write / output capability #7079
+- Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#7079](https://github.com/apache/arrow-datafusion/issues/7079)
 - Implementation of `ARRAY` types #6980
 - Write an academic paper on DataFusion #6782
 

--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -21,6 +21,12 @@
 
 A quarterly roadmap will be published to give the DataFusion community visibility into the priorities of the projects contributors. This roadmap is not binding.
 
+## 2023 Q4
+
+- Improve DataFrame write / output capability #7079
+- Implementation of `ARRAY` types #6980
+- Write an academic paper on DataFusion #6782
+
 ## 2022 Q2
 
 ### DataFusion Core

--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -24,8 +24,8 @@ A quarterly roadmap will be published to give the DataFusion community visibilit
 ## 2023 Q4
 
 - Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#7079](https://github.com/apache/arrow-datafusion/issues/7079)
-- Implementation of `ARRAY` types and related functions #6980
-- Write an industrial paper about DataFusion for SIGMOD #6782
+- Implementation of `ARRAY` types and related functions [#6980](https://github.com/apache/arrow-datafusion/issues/6782)
+- Write an industrial paper about DataFusion for SIGMOD [#6782](https://github.com/apache/arrow-datafusion/issues/6782)
 
 ## 2022 Q2
 

--- a/docs/source/contributor-guide/quarterly_roadmap.md
+++ b/docs/source/contributor-guide/quarterly_roadmap.md
@@ -24,8 +24,8 @@ A quarterly roadmap will be published to give the DataFusion community visibilit
 ## 2023 Q4
 
 - Improve data output (`COPY`, `INSERT` and DataFrame) output capability [#7079](https://github.com/apache/arrow-datafusion/issues/7079)
-- Implementation of `ARRAY` types #6980
-- Write an academic paper on DataFusion #6782
+- Implementation of `ARRAY` types and related functions #6980
+- Write an industrial paper about DataFusion for SIGMOD #6782
 
 ## 2022 Q2
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7535.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

I've added a placeholder for the 2023 Q4 roadmap, with three issues [suggested by @alamb](https://github.com/apache/arrow-datafusion/issues/7535#issuecomment-1717983843) that are currently in progress / top priorities.

I wasn't entirely sure whether the old 2022 Q2 roadmap should be kept or removed, I've left it in for now.