### PR TITLE
Minor: Update chrono pin to `0.4.31`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ arrow-flight = { version = "46.0.0", features = ["flight-sql-experimental"] }
 arrow-schema = { version = "46.0.0", default-features = false }
 parquet = { version = "46.0.0", features = ["arrow", "async", "object_store"] }
 sqlparser = { version = "0.37.0", features = ["visitor"] }
+chrono = { version = "0.4.31", default-features = false }
+
 
 [profile.release]
 codegen-units = 1

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -46,7 +46,7 @@ arrow-array = { workspace = true }
 async-compression = { version = "0.4.0", features = ["bzip2", "gzip", "xz", "zstd", "futures-io", "tokio"], optional = true }
 bytes = "1.4"
 bzip2 = { version = "0.4.3", optional = true }
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 flate2 = { version = "1.0.24", optional = true }
 futures = "0.3"
 num_cpus = "1.13.0"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -61,7 +61,7 @@ async-compression = { version = "0.4.0", features = ["bzip2", "gzip", "xz", "zst
 async-trait = "0.1.73"
 bytes = "1.4"
 bzip2 = { version = "0.4.3", optional = true }
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 dashmap = "5.4.0"
 datafusion-common = { path = "../common", version = "31.0.0", features = ["parquet", "object_store"] }
 datafusion-execution = { path = "../execution", version = "31.0.0" }

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -42,7 +42,7 @@ unicode_expressions = ["datafusion-physical-expr/unicode_expressions"]
 [dependencies]
 arrow = { workspace = true }
 async-trait = "0.1.41"
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 datafusion-common = { path = "../common", version = "31.0.0" }
 datafusion-expr = { path = "../expr", version = "31.0.0" }
 datafusion-physical-expr = { path = "../physical-expr", version = "31.0.0", default-features = false }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -51,7 +51,7 @@ arrow-schema = { workspace = true }
 base64 = { version = "0.21", optional = true }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 datafusion-common = { path = "../common", version = "31.0.0" }
 datafusion-expr = { path = "../expr", version = "31.0.0" }
 half = { version = "2.1", default-features = false }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -41,7 +41,7 @@ json = ["pbjson", "serde", "serde_json"]
 
 [dependencies]
 arrow = { workspace = true }
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 datafusion = { path = "../core", version = "31.0.0" }
 datafusion-common = { path = "../common", version = "31.0.0" }
 datafusion-expr = { path = "../expr", version = "31.0.0" }

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -48,7 +48,7 @@ thiserror = "1.0.44"
 tokio = {version = "1.0"}
 bytes = {version = "1.4.0", optional = true}
 futures = {version = "0.3.28"}
-chrono = {version = "0.4.27", optional = true}
+chrono = { workspace = true, optional = true }
 tokio-postgres = {version = "0.7.7", optional = true}
 postgres-types = {version = "0.2.4", optional = true}
 postgres-protocol = {version = "0.6.4", optional = true}

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.70"
 
 [dependencies]
 async-recursion = "1.0"
-chrono = { version = "0.4.27", default-features = false }
+chrono = { workspace = true }
 datafusion = { version = "31.0.0", path = "../core" }
 itertools = "0.11"
 object_store = "0.7.0"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

https://github.com/apache/arrow-datafusion/pull/7572 makes changes to fix clippy with the newest version of chrono, `0.4.31` but to do so it uses new features from that version of chrono (`timestamp_nanos_opt()`). 

Thus we need to make sure DataFusion declares that it requires at least `0.4.31` 

## What changes are included in this PR?

1. Change chrono dependency to a `workspace` dependency and specify at lest `0.4.31` 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->