### PR TITLE
fix misplaced statements in sqllogictest

### DIFF
--- a/datafusion/sqllogictest/test_files/encoding.slt
+++ b/datafusion/sqllogictest/test_files/encoding.slt
@@ -40,9 +40,7 @@ select decode(12, 'hex')
 query error DataFusion error: Error during planning: There is no built\-in encoding named 'non_encoding', currently supported encodings are: base64, hex
 select decode(hex_field, 'non_encoding') from test;
 
-query error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: Candidate"\)
-	Candidate functions:
-	to_hex\(Int64\)
+query error DataFusion error: Error during planning: No function matches the given name and argument types 'to_hex\(Utf8\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tto_hex\(Int64\)
 select to_hex(hex_field) from test;
 
 # Arrays tests

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -46,9 +46,7 @@ statement error DataFusion error: Arrow error: Cast error: Cannot cast string 'c
 SELECT CAST(c1 AS INT) FROM aggregate_test_100
 
 # aggregation_with_bad_arguments
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: Candidate"\)
-	Candidate functions:
-	COUNT\(Any, \.\., Any\)
+statement error DataFusion error: Error during planning: No function matches the given name and argument types 'COUNT\(\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tCOUNT\(Any, .., Any\)
 SELECT COUNT(DISTINCT) FROM aggregate_test_100
 
 # query_cte_incorrect

--- a/datafusion/sqllogictest/test_files/set_variable.slt
+++ b/datafusion/sqllogictest/test_files/set_variable.slt
@@ -93,14 +93,10 @@ datafusion.execution.coalesce_batches false
 statement ok
 set datafusion.catalog.information_schema = true
 
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: caused"\)
-caused by
-External error: provided string was not `true` or `false`
+statement error DataFusion error: Error parsing 1 as bool
 SET datafusion.execution.coalesce_batches to 1
 
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: caused"\)
-caused by
-External error: provided string was not `true` or `false`
+statement error DataFusion error: Error parsing abc as bool
 SET datafusion.execution.coalesce_batches to abc
 
 # set u64 variable
@@ -136,19 +132,13 @@ datafusion.execution.batch_size 2
 statement ok
 set datafusion.catalog.information_schema = true
 
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: caused"\)
-caused by
-External error: invalid digit found in string
+statement error DataFusion error: Error parsing -1 as usize
 SET datafusion.execution.batch_size to -1
 
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: caused"\)
-caused by
-External error: invalid digit found in string
+statement error DataFusion error: Error parsing abc as usize
 SET datafusion.execution.batch_size to abc
 
-statement error DataFusion error: SQL error: ParserError\("Expected an SQL statement, found: caused"\)
-caused by
-External error: invalid digit found in string
+statement error External error: invalid digit found in string
 SET datafusion.execution.batch_size to 0.1
 
 # set time zone


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change
In the following example, sqllogictest will parse 'caused by' as an SQL statement, execute it, and then encounter a `ParserError`.  This is because`caused by` is the first new line after `statement error`.

The statement we really wanted to test `SET datafusion.execution.coalesce_batches to 1
` was ignored and not executed.

https://github.com/apache/arrow-datafusion/blob/678d27af3c2e800153c20da5c737a255e1450cc1/datafusion/sqllogictest/test_files/set_variable.slt#L96-L99

This could be a bug in the complete mode of sqllogictest where it generates incorrect statements for multi-line errors.

## What changes are included in this PR?
Quickly fix the misplaced statements manually.

## Are these changes tested?
N/A

## Are there any user-facing changes?
No