### PR TITLE
Minor: add githubs start/fork buttons to documentation page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,13 @@ html_static_path = ['_static']
 
 html_logo = "_static/images/DataFusion-Logo-Background-White.png"
 
-html_css_files = ["theme_overrides.css"]
+html_css_files = [
+    "theme_overrides.css"
+]
+
+html_js_files = [
+    ("https://buttons.github.io/buttons.js", {'async': 'true', 'defer': 'true'}),
+]
 
 html_sidebars = {
     "**": ["docs-sidebar.html"],

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,12 +15,29 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
+.. Code from https://buttons.github.io/
+.. raw:: html
+
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+
 .. image:: _static/images/DataFusion-Logo-Background-White.png
   :alt: DataFusion Logo
+
 
 =======================
 Apache Arrow DataFusion
 =======================
+
+.. Code from https://buttons.github.io/
+.. raw:: html
+
+  <p>
+    <!-- Place this tag where you want the button to render. -->
+    <a class="github-button" href="https://github.com/apache/arrow-datafusion" data-size="large" data-show-count="true" aria-label="Star apache/arrow-datafusion on GitHub">Star</a>
+    <!-- Place this tag where you want the button to render. -->
+    <a class="github-button" href="https://github.com/apache/arrow-datafusion/fork" data-size="large" data-show-count="true" aria-label="Fork apache/arrow-datafusion on GitHub">Fork</a>
+  </p>
 
 DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in
 `Rust <http://rustlang.org>`_, using the `Apache Arrow <https://arrow.apache.org>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,15 +15,8 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-.. Code from https://buttons.github.io/
-.. raw:: html
-
-    <!-- Place this tag in your head or just before your close body tag. -->
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
-
 .. image:: _static/images/DataFusion-Logo-Background-White.png
   :alt: DataFusion Logo
-
 
 =======================
 Apache Arrow DataFusion
@@ -36,7 +29,7 @@ Apache Arrow DataFusion
     <!-- Place this tag where you want the button to render. -->
     <a class="github-button" href="https://github.com/apache/arrow-datafusion" data-size="large" data-show-count="true" aria-label="Star apache/arrow-datafusion on GitHub">Star</a>
     <!-- Place this tag where you want the button to render. -->
-    <a class="github-button" href="https://github.com/apache/arrow-datafusion/fork" data-size="large" data-show-count="true" aria-label="Fork apache/arrow-datafusion on GitHub">Fork</a>
+     <a class="github-button" href="https://github.com/apache/arrow-datafusion/fork" data-size="large" data-show-count="true" aria-label="Fork apache/arrow-datafusion on GitHub">Fork</a>
   </p>
 
 DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in


### PR DESCRIPTION
## Which issue does this PR close?

N/a

## Rationale for this change

In the race to get the internets attention, github stars seem to matter. 

It serves both as a marker of use (and thus encourages new users). Thus collecting stars helps a project grow. 

Thus, let's make it easier to catch some wind from people visiting the DataFusion docs site 


## What changes are included in this PR?
Add `star` and `fork` buttons to the main doc site https://arrow.apache.org/datafusion/

Rendered preview
<img width="1564" alt="Screenshot 2023-09-18 at 12 12 02 PM" src="https://github.com/apache/arrow-datafusion/assets/490673/eea03277-f709-485a-b668-cfdb7a3b6fb1">


## Are these changes tested?
I tested it manually locally
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
New badges on the docs page

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->