### PR TITLE
Change the unbounded_output API default

### DIFF
--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -224,6 +224,10 @@ impl ExecutionPlan for FileSinkExec {
         }))
     }
 
+    fn unbounded_output(&self, _children: &[bool]) -> Result<bool> {
+        Ok(_children[0])
+    }
+
     /// Execute the plan and return a stream of `RecordBatch`es for
     /// the specified partition.
     fn execute(

--- a/datafusion/physical-plan/src/limit.rs
+++ b/datafusion/physical-plan/src/limit.rs
@@ -154,6 +154,10 @@ impl ExecutionPlan for GlobalLimitExec {
         )))
     }
 
+    fn unbounded_output(&self, _children: &[bool]) -> Result<bool> {
+        Ok(false)
+    }
+
     fn execute(
         &self,
         partition: usize,
@@ -318,6 +322,10 @@ impl ExecutionPlan for LocalLimitExec {
 
     fn ordering_equivalence_properties(&self) -> OrderingEquivalenceProperties {
         self.input.ordering_equivalence_properties()
+    }
+
+    fn unbounded_output(&self, _children: &[bool]) -> Result<bool> {
+        Ok(false)
     }
 
     fn with_new_children(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

When dealing with unbounded data sources, the default implementation of `Ok(false)` can lead to silent errors.

## What changes are included in this PR?

If a plan does not implement `unbounded_output`, it cannot support unbounded outputs as default.

## Are these changes tested?

With existing tests.

## Are there any user-facing changes?

No