### PR TITLE
feat: Better large output display in datafusion-cli with --maxrows option

### DIFF
--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -70,17 +70,87 @@ fn print_batches_with_sep(batches: &[RecordBatch], delimiter: u8) -> Result<Stri
     Ok(formatted)
 }
 
+fn keep_only_maxrows(s: &str, maxrows: usize) -> String {
+    let lines: Vec<String> = s.lines().map(String::from).collect();
+
+    assert!(lines.len() >= maxrows + 4); // 4 lines for top and bottom border
+
+    let last_line = &lines[lines.len() - 1]; // bottom border line
+
+    let spaces = last_line.len().saturating_sub(4);
+    let dotted_line = format!("| .{:<spaces$}|", "", spaces = spaces);
+
+    let mut result = lines[0..(maxrows + 3)].to_vec(); // Keep top border and `maxrows` lines
+    result.extend(vec![dotted_line; 3]); // Append ... lines
+    result.push(last_line.clone());
+
+    result.join("\n")
+}
+
+fn format_batches_with_maxrows(
+    batches: &[RecordBatch],
+    maxrows_opt: Option<usize>,
+) -> Result<String> {
+    if let Some(maxrows) = maxrows_opt {
+        // Only format enough batches for maxrows
+        let mut filtered_batches = Vec::new();
+        let mut batches = batches;
+        let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if row_count > maxrows {
+            let mut accumulated_rows = 0;
+
+            for batch in batches {
+                filtered_batches.push(batch.clone());
+                if accumulated_rows + batch.num_rows() > maxrows {
+                    break;
+                }
+                accumulated_rows += batch.num_rows();
+            }
+
+            batches = &filtered_batches;
+        }
+
+        let mut formatted = format!(
+            "{}",
+            pretty_format_batches_with_options(batches, &DEFAULT_FORMAT_OPTIONS)?,
+        );
+
+        if row_count > maxrows {
+            formatted = keep_only_maxrows(&formatted, maxrows);
+        }
+
+        Ok(formatted)
+    } else {
+        // maxrows not specified, print all rows
+        Ok(format!(
+            "{}",
+            pretty_format_batches_with_options(batches, &DEFAULT_FORMAT_OPTIONS)?,
+        ))
+    }
+}
+
 impl PrintFormat {
     /// print the batches to stdout using the specified format
-    pub fn print_batches(&self, batches: &[RecordBatch]) -> Result<()> {
+    /// `maxrows` option is only used for `Table` format:
+    ///     If `maxrows` is Some(n), then at most n rows will be displayed
+    ///     If `maxrows` is None, then every row will be displayed
+    pub fn print_batches(
+        &self,
+        batches: &[RecordBatch],
+        maxrows: Option<usize>,
+    ) -> Result<()> {
+        if batches.is_empty() {
+            return Ok(());
+        }
+
         match self {
             Self::Csv => println!("{}", print_batches_with_sep(batches, b',')?),
             Self::Tsv => println!("{}", print_batches_with_sep(batches, b'\t')?),
             Self::Table => {
-                println!(
-                    "{}",
-                    pretty_format_batches_with_options(batches, &DEFAULT_FORMAT_OPTIONS)?
-                )
+                if maxrows == Some(0) {
+                    return Ok(());
+                }
+                println!("{}", format_batches_with_maxrows(batches, maxrows)?,)
             }
             Self::Json => println!("{}", batches_to_json!(ArrayWriter, batches)),
             Self::NdJson => {
@@ -155,6 +225,74 @@ mod tests {
 
         let r = batches_to_json!(LineDelimitedWriter, &batches);
         assert_eq!("{\"a\":1,\"b\":4,\"c\":7}\n{\"a\":2,\"b\":5,\"c\":8}\n{\"a\":3,\"b\":6,\"c\":9}\n", r);
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_batches_with_maxrows() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+                .unwrap();
+
+        #[rustfmt::skip]
+        let all_rows_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| 2 |",
+            "| 3 |",
+            "+---+",
+        ].join("\n");
+
+        #[rustfmt::skip]
+        let one_row_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| . |",
+            "| . |",
+            "| . |",
+            "+---+",
+        ].join("\n");
+
+        #[rustfmt::skip]
+        let multi_batches_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| 2 |",
+            "| 3 |",
+            "| 1 |",
+            "| 2 |",
+            "| . |",
+            "| . |",
+            "| . |",
+            "+---+",
+        ].join("\n");
+
+        let no_limit = format_batches_with_maxrows(&[batch.clone()], None)?;
+        assert_eq!(all_rows_expected, no_limit);
+
+        let maxrows_less_than_actual =
+            format_batches_with_maxrows(&[batch.clone()], Some(1))?;
+        assert_eq!(one_row_expected, maxrows_less_than_actual);
+        let maxrows_more_than_actual =
+            format_batches_with_maxrows(&[batch.clone()], Some(5))?;
+        assert_eq!(all_rows_expected, maxrows_more_than_actual);
+        let maxrows_equals_actual =
+            format_batches_with_maxrows(&[batch.clone()], Some(3))?;
+        assert_eq!(all_rows_expected, maxrows_equals_actual);
+        let multi_batches = format_batches_with_maxrows(
+            &[batch.clone(), batch.clone(), batch.clone()],
+            Some(5),
+        )?;
+        assert_eq!(multi_batches_expected, multi_batches);
+
         Ok(())
     }
 }

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -75,17 +75,42 @@ USAGE:
     datafusion-cli [OPTIONS]
 
 OPTIONS:
-    -c, --batch-size <BATCH_SIZE>           The batch size of each query, or use DataFusion default
-    -f, --file <FILE>...                    Execute commands from file(s), then exit
-        --format <FORMAT>                   [default: table] [possible values: csv, tsv, table, json,
-                                            nd-json]
-    -h, --help                              Print help information
-    -m, --memory-limit <MEMORY_LIMIT>       The memory pool limitation (e.g. '10g'), default to None (no limit)
-        --mem-pool-type <MEM_POOL_TYPE>     Specify the memory pool type 'greedy' or 'fair', default to 'greedy'
-    -p, --data-path <DATA_PATH>             Path to your data, default to current directory
-    -q, --quiet                             Reduce printing other than the results and work quietly
-    -r, --rc <RC>...                        Run the provided files on startup instead of ~/.datafusionrc
-    -V, --version                           Print version information
+    -b, --batch-size <BATCH_SIZE>
+            The batch size of each query, or use DataFusion default
+
+    -c, --command <COMMAND>...
+            Execute the given command string(s), then exit
+
+    -f, --file <FILE>...
+            Execute commands from file(s), then exit
+
+        --format <FORMAT>
+            [default: table] [possible values: csv, tsv, table, json, nd-json]
+
+    -h, --help
+            Print help information
+
+    -m, --memory-limit <MEMORY_LIMIT>
+            The memory pool limitation (e.g. '10g'), default to None (no limit)
+
+        --maxrows <MAXROWS>
+            The max number of rows to display for 'Table' format
+            [default: 40] [possible values: numbers(0/10/...), inf(no limit)]
+
+        --mem-pool-type <MEM_POOL_TYPE>
+            Specify the memory pool type 'greedy' or 'fair', default to 'greedy'
+
+    -p, --data-path <DATA_PATH>
+            Path to your data, default to current directory
+
+    -q, --quiet
+            Reduce printing other than the results and work quietly
+
+    -r, --rc <RC>...
+            Run the provided files on startup instead of ~/.datafusionrc
+
+    -V, --version
+            Print version information
 ```
 
 ## Querying data from the files directly


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

NA

## Rationale for this change

If a query outputs a large number of lines, currently datafusion-cli will display them all and flood the terminal.
This PR added a `--maxrows` option to limit max number of rows for output display.
```bash
--maxrows <MAXROWS>
            The max number of rows to display for 'Table' format
            [default: 40] [possible values: numbers(0/10/...), inf(no limit)]
```
```
arrow-datafusion/datafusion-cli|cli-large-output🌝| >>> cargo run --release -- --maxrows 5
    Finished release [optimized] target(s) in 0.30s
     Running `target/release/datafusion-cli --maxrows 5`
DataFusion CLI v31.0.0
❯ CREATE EXTERNAL TABLE lineitem STORED AS PARQUET LOCATION '/Users/yongting/Desktop/code/my_datafusion/arrow-datafusion/benchmarks/data/tpch_sf10/lineitem/part-0.parquet';
0 rows in set. Query took 0.041 seconds.

❯ select l_orderkey, l_partkey from lineitem;
+------------+-----------+
| l_orderkey | l_partkey |
+------------+-----------+
| 1          | 1551894   |
| 1          | 673091    |
| 1          | 636998    |
| 1          | 21315     |
| 1          | 240267    |
| .                      |
| .                      |
| .                      |
+------------+-----------+
59986052 rows in set (5 shown). Query took 2.451 seconds.
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

1. Change elapsed time measurement in CLI to (query start -> all result ready in memory in `[RecordBatch]`), before it also counts the time for formatting and printing the results.
2. Add `--maxrows` option, now only `Table` CLI display format is supported.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Unit tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->