### PR TITLE
fix: check for precision overflow when parsing float as decimal

### DIFF
--- a/datafusion/sqllogictest/test_files/ddl.slt
+++ b/datafusion/sqllogictest/test_files/ddl.slt
@@ -693,6 +693,34 @@ select arrow_typeof(10000000000000000000.01)
 ----
 Decimal128(22, 2)
 
+query R
+select 99999999999999999999999999999999999999
+----
+99999999999999999999999999999999999999
+
+query T
+select arrow_typeof(99999999999999999999999999999999999999)
+----
+Decimal128(38, 0)
+
+query R
+select 9999999999999999999999999999999999.9999
+----
+9999999999999999999999999999999999.9999
+
+query T
+select arrow_typeof(9999999999999999999999999999999999.9999)
+----
+Decimal128(38, 4)
+
+# precision overflow
+statement error SQL error: ParserError\("Cannot parse 123456789012345678901234567890123456789 as i128 when building decimal: precision overflow"\)
+select 123456789.012345678901234567890123456789
+
+# can not fit in i128
+statement error SQL error: ParserError\("Cannot parse 1234567890123456789012345678901234567890 as i128 when building decimal: number too large to fit in target type"\)
+select 123456789.0123456789012345678901234567890
+
 # Restore those to default value again
 statement ok
 set datafusion.sql_parser.parse_float_as_decimal = false;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7626.

## Rationale for this change
A decimal data could exceed its maximum precision limit without exceeding the maximum value of `i128`.

## What changes are included in this PR?
Check for precision overflow when parsing float as decimal

## Are these changes tested?
Yes

## Are there any user-facing changes?
No