### PR TITLE
Minor: improve docstrings on `SessionState`

### DIFF
--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1348,7 +1348,12 @@ impl QueryPlanner for DefaultQueryPlanner {
     }
 }
 
-/// Execution context for registering data sources and executing queries
+/// Execution context for registering data sources and executing queries.
+/// See [`SessionContext`] for a higher level API..
+///
+/// Note that there is no `Default` or `new()` for SessionState,
+/// to avoid accidentally running queries or other operations without passing through
+/// the [`SessionConfig`] or [`RuntimeEnv`]. See [`SessionContext`].
 #[derive(Clone)]
 pub struct SessionState {
     /// A unique UUID that identifies the session

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1349,7 +1349,7 @@ impl QueryPlanner for DefaultQueryPlanner {
 }
 
 /// Execution context for registering data sources and executing queries.
-/// See [`SessionContext`] for a higher level API..
+/// See [`SessionContext`] for a higher level API.
 ///
 /// Note that there is no `Default` or `new()` for SessionState,
 /// to avoid accidentally running queries or other operations without passing through


### PR DESCRIPTION
## Which issue does this PR close?

Related to a discussion with @Ted-Jiang  on https://github.com/apache/arrow-datafusion/pull/7620/files#r1334962930

## Rationale for this change

There is a reason there is no `Default` impl for `SessionState` but that reason is not explicitly documented anywhere. Let's document it.

## What changes are included in this PR?

Add docstrings to `SessionState`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->