### PR TITLE
Upgrade apache-avro to 0.16

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -39,7 +39,7 @@ default = ["parquet"]
 pyarrow = ["pyo3", "arrow/pyarrow"]
 
 [dependencies]
-apache-avro = { version = "0.15", default-features = false, features = ["snappy"], optional = true }
+apache-avro = { version = "0.16", default-features = false, features = ["snappy"], optional = true }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 chrono = { workspace = true }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -50,7 +50,7 @@ unicode_expressions = ["datafusion-physical-expr/unicode_expressions", "datafusi
 
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-apache-avro = { version = "0.15", optional = true }
+apache-avro = { version = "0.16", optional = true }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }

--- a/datafusion/core/src/datasource/avro_to_arrow/schema.rs
+++ b/datafusion/core/src/datasource/avro_to_arrow/schema.rs
@@ -90,6 +90,7 @@ fn schema_to_field_with_props(
                 .find_schema_with_known_schemata::<apache_avro::Schema>(
                     &Value::Null,
                     None,
+                    &None,
                 )
                 .is_some();
             let sub_schemas = us.variants();
@@ -158,6 +159,8 @@ fn schema_to_field_with_props(
         AvroSchema::TimeMicros => DataType::Time64(TimeUnit::Microsecond),
         AvroSchema::TimestampMillis => DataType::Timestamp(TimeUnit::Millisecond, None),
         AvroSchema::TimestampMicros => DataType::Timestamp(TimeUnit::Microsecond, None),
+        AvroSchema::LocalTimestampMillis => todo!(),
+        AvroSchema::LocalTimestampMicros => todo!(),
         AvroSchema::Duration => DataType::Duration(TimeUnit::Millisecond),
     };
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7673

## Rationale for this change
Recently, `apache-avro:0.16` was released.
https://github.com/apache/arrow-datafusion/pull/7656 tried to upgrade but some there are some API incompatibility.
So we need upgrade it manaually.

## What changes are included in this PR?
Manual upgrade `apache-avro` to `0.16` and some fixes for API incompatibility.

## Are these changes tested?
Done by CI.

## Are there any user-facing changes?
No.