### PR TITLE
Stop using cache for the benchmark job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,17 +226,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./target/
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-benchmark-${{ hashFiles('datafusion/**/Cargo.toml', 'benchmarks/Cargo.toml') }}
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7705 

## Rationale for this change
To recover CI.

## What changes are included in this PR?
#7678 introduces `actions/cache` for two GA jobs but a cache for the benchmark job seems large, and this can take up the space.
So, this PR proposes to stop using the cache for the benchmark job.

## Are these changes tested?
Done by GA.

## Are there any user-facing changes?
No.