### PR TITLE
[CI] Use debug mode for `verify benchmark results` test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Verify that benchmark queries return expected results
         run: |
           export TPCH_DATA=`realpath datafusion/sqllogictest/test_files/tpch/data`
-          cargo test plan_q --package datafusion-benchmarks --profile release-nonlto --features=ci -- --test-threads=1
+          cargo test plan_q --package datafusion-benchmarks --features=ci -- --test-threads=1
           INCLUDE_TPCH=true cargo test --test sqllogictests
       - name: Verify Working Directory Clean
         run: git diff --exit-code


### PR DESCRIPTION
(draft while I test timings)

## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/7709

## Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/7708 from @sarutak I spent time looking into what `plan_q` does and it is not at all clear to me it needs to be built in release mode:

https://github.com/apache/arrow-datafusion/blob/46cdb8c2dc495e8063a0adc5c3f9ac82b136e72e/benchmarks/src/tpch/run.rs#L297-L453

Since the benchmark verifies the plans (rather than actually running them). I think it is ok to use debug mode (rather than release) mode which compiles faster and will have more reuse with the subsequent call to `cargo test --test sqllogictests`


## What changes are included in this PR?
Change to use a debug build

## Are these changes tested?
They are part of CI.

## Test timings: TODO

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->