### PR TITLE
Remove unused `AggregateExec::input_schema`

### DIFF
--- a/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
@@ -404,7 +404,6 @@ mod tests {
     async fn test_count_partial_direct_child() -> Result<()> {
         // basic test case with the aggregation applied on a source with exact statistics
         let source = mock_data()?;
-        let schema = source.schema();
         let agg = TestAggregate::new_count_star();
 
         let partial_agg = AggregateExec::try_new(
@@ -414,7 +413,6 @@ mod tests {
             vec![None],
             vec![None],
             source,
-            Arc::clone(&schema),
         )?;
 
         let final_agg = AggregateExec::try_new(
@@ -424,7 +422,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(partial_agg),
-            Arc::clone(&schema),
         )?;
 
         assert_count_optim_success(final_agg, agg).await?;
@@ -446,7 +443,6 @@ mod tests {
             vec![None],
             vec![None],
             source,
-            Arc::clone(&schema),
         )?;
 
         let final_agg = AggregateExec::try_new(
@@ -456,7 +452,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(partial_agg),
-            Arc::clone(&schema),
         )?;
 
         assert_count_optim_success(final_agg, agg).await?;
@@ -467,7 +462,6 @@ mod tests {
     #[tokio::test]
     async fn test_count_partial_indirect_child() -> Result<()> {
         let source = mock_data()?;
-        let schema = source.schema();
         let agg = TestAggregate::new_count_star();
 
         let partial_agg = AggregateExec::try_new(
@@ -477,7 +471,6 @@ mod tests {
             vec![None],
             vec![None],
             source,
-            Arc::clone(&schema),
         )?;
 
         // We introduce an intermediate optimization step between the partial and final aggregtator
@@ -490,7 +483,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(coalesce),
-            Arc::clone(&schema),
         )?;
 
         assert_count_optim_success(final_agg, agg).await?;
@@ -511,7 +503,6 @@ mod tests {
             vec![None],
             vec![None],
             source,
-            Arc::clone(&schema),
         )?;
 
         // We introduce an intermediate optimization step between the partial and final aggregtator
@@ -524,7 +515,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(coalesce),
-            Arc::clone(&schema),
         )?;
 
         assert_count_optim_success(final_agg, agg).await?;
@@ -556,7 +546,6 @@ mod tests {
             vec![None],
             vec![None],
             filter,
-            Arc::clone(&schema),
         )?;
 
         let final_agg = AggregateExec::try_new(
@@ -566,7 +555,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(partial_agg),
-            Arc::clone(&schema),
         )?;
 
         let conf = ConfigOptions::new();
@@ -603,7 +591,6 @@ mod tests {
             vec![None],
             vec![None],
             filter,
-            Arc::clone(&schema),
         )?;
 
         let final_agg = AggregateExec::try_new(
@@ -613,7 +600,6 @@ mod tests {
             vec![None],
             vec![None],
             Arc::new(partial_agg),
-            Arc::clone(&schema),
         )?;
 
         let conf = ConfigOptions::new();

--- a/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
@@ -91,7 +91,6 @@ impl PhysicalOptimizerRule for CombinePartialFinalAggregate {
                                             input_agg_exec.filter_expr().to_vec(),
                                             input_agg_exec.order_by_expr().to_vec(),
                                             input_agg_exec.input().clone(),
-                                            input_agg_exec.input_schema().clone(),
                                         )
                                         .ok()
                                         .map(Arc::new)
@@ -265,7 +264,6 @@ mod tests {
         group_by: PhysicalGroupBy,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     ) -> Arc<dyn ExecutionPlan> {
-        let schema = input.schema();
         Arc::new(
             AggregateExec::try_new(
                 AggregateMode::Partial,
@@ -274,7 +272,6 @@ mod tests {
                 vec![],
                 vec![],
                 input,
-                schema,
             )
             .unwrap(),
         )
@@ -285,7 +282,6 @@ mod tests {
         group_by: PhysicalGroupBy,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     ) -> Arc<dyn ExecutionPlan> {
-        let schema = input.schema();
         Arc::new(
             AggregateExec::try_new(
                 AggregateMode::Final,
@@ -294,7 +290,6 @@ mod tests {
                 vec![],
                 vec![],
                 input,
-                schema,
             )
             .unwrap(),
         )

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -538,7 +538,6 @@ fn reorder_aggregate_keys(
                             agg_exec.filter_expr().to_vec(),
                             agg_exec.order_by_expr().to_vec(),
                             agg_exec.input().clone(),
-                            agg_exec.input_schema.clone(),
                         )?))
                     } else {
                         None
@@ -570,7 +569,6 @@ fn reorder_aggregate_keys(
                         agg_exec.filter_expr().to_vec(),
                         agg_exec.order_by_expr().to_vec(),
                         partial_agg,
-                        agg_exec.input_schema().clone(),
                     )?);
 
                     // Need to create a new projection to change the expr ordering back
@@ -1933,7 +1931,6 @@ mod tests {
         input: Arc<dyn ExecutionPlan>,
         alias_pairs: Vec<(String, String)>,
     ) -> Arc<dyn ExecutionPlan> {
-        let schema = schema();
         let mut group_by_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![];
         for (column, alias) in alias_pairs.iter() {
             group_by_expr
@@ -1969,11 +1966,9 @@ mod tests {
                         vec![],
                         vec![],
                         input,
-                        schema.clone(),
                     )
                     .unwrap(),
                 ),
-                schema,
             )
             .unwrap(),
         )

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -326,7 +326,6 @@ pub fn repartition_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan>
 }
 
 pub fn aggregate_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    let schema = input.schema();
     Arc::new(
         AggregateExec::try_new(
             AggregateMode::Final,
@@ -335,7 +334,6 @@ pub fn aggregate_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
             vec![],
             vec![],
             input,
-            schema,
         )
         .unwrap(),
     )

--- a/datafusion/core/src/physical_optimizer/topk_aggregation.rs
+++ b/datafusion/core/src/physical_optimizer/topk_aggregation.rs
@@ -75,7 +75,6 @@ impl TopKAggregation {
             aggr.filter_expr().to_vec(),
             aggr.order_by_expr().to_vec(),
             aggr.input().clone(),
-            aggr.input_schema().clone(),
         )
         .expect("Unable to copy Aggregate!")
         .with_limit(Some(limit));

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2413,7 +2413,7 @@ mod tests {
         );
         // we need access to the input to the partial aggregate so that other projects can
         // implement serde
-        // assert_eq!("c2", final_hash_agg.input_schema().field(1).name());
+        assert_eq!("c2", final_hash_agg.input().schema().field(1).name());
 
         Ok(())
     }
@@ -2441,7 +2441,7 @@ mod tests {
         );
         // we need access to the input to the partial aggregate so that other projects can
         // implement serde
-        //assert_eq!("c3", final_hash_agg.input_schema().field(2).name());
+        assert_eq!("c3", final_hash_agg.input().schema().field(2).name());
 
         Ok(())
     }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2411,9 +2411,6 @@ mod tests {
             "SUM(aggregate_test_100.c2)",
             final_hash_agg.schema().field(1).name()
         );
-        // we need access to the input to the partial aggregate so that other projects can
-        // implement serde
-        assert_eq!("c2", final_hash_agg.input().schema().field(1).name());
 
         Ok(())
     }
@@ -2439,9 +2436,6 @@ mod tests {
             "SUM(aggregate_test_100.c3)",
             final_hash_agg.schema().field(2).name()
         );
-        // we need access to the input to the partial aggregate so that other projects can
-        // implement serde
-        assert_eq!("c3", final_hash_agg.input().schema().field(2).name());
 
         Ok(())
     }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -802,7 +802,6 @@ impl DefaultPhysicalPlanner {
                         filters.clone(),
                         order_bys,
                         input_exec,
-                        physical_input_schema.clone(),
                     )?);
 
                     // update group column indices based on partial aggregate plan evaluation
@@ -847,7 +846,6 @@ impl DefaultPhysicalPlanner {
                         filters,
                         updated_order_bys,
                         initial_aggr,
-                        physical_input_schema.clone(),
                     )?))
                 }
                 LogicalPlan::Projection(Projection { input, expr, .. }) => {
@@ -2415,7 +2413,7 @@ mod tests {
         );
         // we need access to the input to the partial aggregate so that other projects can
         // implement serde
-        assert_eq!("c2", final_hash_agg.input_schema().field(1).name());
+        // assert_eq!("c2", final_hash_agg.input_schema().field(1).name());
 
         Ok(())
     }
@@ -2443,7 +2441,7 @@ mod tests {
         );
         // we need access to the input to the partial aggregate so that other projects can
         // implement serde
-        assert_eq!("c3", final_hash_agg.input_schema().field(2).name());
+        //assert_eq!("c3", final_hash_agg.input_schema().field(2).name());
 
         Ok(())
     }

--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -116,7 +116,6 @@ async fn run_aggregate_test(input1: Vec<RecordBatch>, group_by_columns: Vec<&str
             vec![None],
             vec![None],
             running_source,
-            schema.clone(),
         )
         .unwrap(),
     ) as Arc<dyn ExecutionPlan>;
@@ -129,7 +128,6 @@ async fn run_aggregate_test(input1: Vec<RecordBatch>, group_by_columns: Vec<&str
             vec![None],
             vec![None],
             usual_source,
-            schema.clone(),
         )
         .unwrap(),
     ) as Arc<dyn ExecutionPlan>;

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -283,10 +283,6 @@ pub struct AggregateExec {
     pub input: Arc<dyn ExecutionPlan>,
     /// Schema after the aggregate is applied
     schema: SchemaRef,
-    /// Input schema before any aggregation is applied. For partial aggregate this will be the
-    /// same as input.schema() but for the final aggregate it will be the same as the input
-    /// to the partial aggregate
-    pub input_schema: SchemaRef,
     /// The columns map used to normalize out expressions like Partitioning and PhysicalSortExpr
     /// The key is the column from the input schema and the values are the columns from the output schema
     columns_map: HashMap<Column, Vec<Column>>,
@@ -612,7 +608,6 @@ impl AggregateExec {
         // Ordering requirement of each aggregate expression
         mut order_by_expr: Vec<Option<LexOrdering>>,
         input: Arc<dyn ExecutionPlan>,
-        input_schema: SchemaRef,
     ) -> Result<Self> {
         let schema = create_schema(
             &input.schema(),
@@ -705,7 +700,6 @@ impl AggregateExec {
             order_by_expr,
             input,
             schema,
-            input_schema,
             columns_map,
             metrics: ExecutionPlanMetricsSet::new(),
             aggregation_ordering,
@@ -754,11 +748,6 @@ impl AggregateExec {
         &self.input
     }
 
-    /// Get the input schema before any aggregates are applied
-    pub fn input_schema(&self) -> SchemaRef {
-        self.input_schema.clone()
-    }
-
     fn execute_typed(
         &self,
         partition: usize,
@@ -798,6 +787,9 @@ impl AggregateExec {
 
     pub fn group_by(&self) -> &PhysicalGroupBy {
         &self.group_by
+    }
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
     }
 }
 
@@ -958,7 +950,7 @@ impl ExecutionPlan for AggregateExec {
     }
 
     fn equivalence_properties(&self) -> EquivalenceProperties {
-        let mut new_properties = EquivalenceProperties::new(self.schema());
+        let mut new_properties = EquivalenceProperties::new(self.schema.clone());
         project_equivalence_properties(
             self.input.equivalence_properties(),
             &self.columns_map,
@@ -982,7 +974,6 @@ impl ExecutionPlan for AggregateExec {
             self.filter_expr.clone(),
             self.order_by_expr.clone(),
             children[0].clone(),
-            self.input_schema.clone(),
         )?;
         me.limit = self.limit;
         Ok(Arc::new(me))
@@ -1532,7 +1523,6 @@ mod tests {
             vec![None],
             vec![None],
             input,
-            input_schema.clone(),
         )?);
 
         let result =
@@ -1611,7 +1601,6 @@ mod tests {
             vec![None],
             vec![None],
             merge,
-            input_schema,
         )?);
 
         let result =
@@ -1677,7 +1666,6 @@ mod tests {
             vec![None],
             vec![None],
             input,
-            input_schema.clone(),
         )?);
 
         let result =
@@ -1725,7 +1713,6 @@ mod tests {
             vec![None],
             vec![None],
             merge,
-            input_schema,
         )?);
 
         let result =
@@ -1988,7 +1975,6 @@ mod tests {
                 vec![None; 3],
                 vec![None; 3],
                 input.clone(),
-                input_schema.clone(),
             )?);
 
             let stream = partial_aggregate.execute_typed(0, task_ctx.clone())?;
@@ -2044,7 +2030,6 @@ mod tests {
             vec![None],
             vec![None],
             blocking_exec,
-            schema,
         )?);
 
         let fut = crate::collect(aggregate_exec, task_ctx);
@@ -2083,7 +2068,6 @@ mod tests {
             vec![None],
             vec![None],
             blocking_exec,
-            schema,
         )?);
 
         let fut = crate::collect(aggregate_exec, task_ctx);
@@ -2185,7 +2169,6 @@ mod tests {
             vec![None],
             vec![Some(ordering_req.clone())],
             memory_exec,
-            schema.clone(),
         )?);
         let coalesce = if use_coalesce_batches {
             let coalesce = Arc::new(CoalescePartitionsExec::new(aggregate_exec));
@@ -2201,7 +2184,6 @@ mod tests {
             vec![None],
             vec![Some(ordering_req)],
             coalesce,
-            schema,
         )?) as Arc<dyn ExecutionPlan>;
 
         let result = crate::collect(aggregate_final, task_ctx).await?;

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -1424,8 +1424,7 @@ message AggregateExecNode {
   PhysicalPlanNode input = 4;
   repeated string group_expr_name = 5;
   repeated string aggr_expr_name = 6;
-  // we need the input schema to the partial aggregate to pass to the final aggregate
-  Schema input_schema = 7;
+  reserved 7; // was input_schema
   repeated PhysicalExprNode null_expr = 8;
   repeated bool groups = 9;
   repeated MaybeFilter filter_expr = 10;

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -24,9 +24,6 @@ impl serde::Serialize for AggregateExecNode {
         if !self.aggr_expr_name.is_empty() {
             len += 1;
         }
-        if self.input_schema.is_some() {
-            len += 1;
-        }
         if !self.null_expr.is_empty() {
             len += 1;
         }
@@ -60,9 +57,6 @@ impl serde::Serialize for AggregateExecNode {
         if !self.aggr_expr_name.is_empty() {
             struct_ser.serialize_field("aggrExprName", &self.aggr_expr_name)?;
         }
-        if let Some(v) = self.input_schema.as_ref() {
-            struct_ser.serialize_field("inputSchema", v)?;
-        }
         if !self.null_expr.is_empty() {
             struct_ser.serialize_field("nullExpr", &self.null_expr)?;
         }
@@ -95,8 +89,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
             "groupExprName",
             "aggr_expr_name",
             "aggrExprName",
-            "input_schema",
-            "inputSchema",
             "null_expr",
             "nullExpr",
             "groups",
@@ -114,7 +106,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
             Input,
             GroupExprName,
             AggrExprName,
-            InputSchema,
             NullExpr,
             Groups,
             FilterExpr,
@@ -146,7 +137,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
                             "input" => Ok(GeneratedField::Input),
                             "groupExprName" | "group_expr_name" => Ok(GeneratedField::GroupExprName),
                             "aggrExprName" | "aggr_expr_name" => Ok(GeneratedField::AggrExprName),
-                            "inputSchema" | "input_schema" => Ok(GeneratedField::InputSchema),
                             "nullExpr" | "null_expr" => Ok(GeneratedField::NullExpr),
                             "groups" => Ok(GeneratedField::Groups),
                             "filterExpr" | "filter_expr" => Ok(GeneratedField::FilterExpr),
@@ -176,7 +166,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
                 let mut input__ = None;
                 let mut group_expr_name__ = None;
                 let mut aggr_expr_name__ = None;
-                let mut input_schema__ = None;
                 let mut null_expr__ = None;
                 let mut groups__ = None;
                 let mut filter_expr__ = None;
@@ -219,12 +208,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
                             }
                             aggr_expr_name__ = Some(map_.next_value()?);
                         }
-                        GeneratedField::InputSchema => {
-                            if input_schema__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("inputSchema"));
-                            }
-                            input_schema__ = map_.next_value()?;
-                        }
                         GeneratedField::NullExpr => {
                             if null_expr__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("nullExpr"));
@@ -258,7 +241,6 @@ impl<'de> serde::Deserialize<'de> for AggregateExecNode {
                     input: input__,
                     group_expr_name: group_expr_name__.unwrap_or_default(),
                     aggr_expr_name: aggr_expr_name__.unwrap_or_default(),
-                    input_schema: input_schema__,
                     null_expr: null_expr__.unwrap_or_default(),
                     groups: groups__.unwrap_or_default(),
                     filter_expr: filter_expr__.unwrap_or_default(),

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2008,9 +2008,6 @@ pub struct AggregateExecNode {
     pub group_expr_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, repeated, tag = "6")]
     pub aggr_expr_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// we need the input schema to the partial aggregate to pass to the final aggregate
-    #[prost(message, optional, tag = "7")]
-    pub input_schema: ::core::option::Option<Schema>,
     #[prost(message, repeated, tag = "8")]
     pub null_expr: ::prost::alloc::vec::Vec<PhysicalExprNode>,
     #[prost(bool, repeated, tag = "9")]

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -405,17 +405,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     vec![]
                 };
 
-                let input_schema = hash_agg
-                    .input_schema
-                    .as_ref()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(
-                            "input_schema in AggregateNode is missing.".to_owned(),
-                        )
-                    })?
-                    .clone();
-                let physical_schema: SchemaRef =
-                    SchemaRef::new((&input_schema).try_into()?);
+                let physical_schema = input.schema();
 
                 let physical_filter_expr = hash_agg
                     .filter_expr
@@ -500,7 +490,6 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     physical_filter_expr,
                     physical_order_by_expr,
                     input,
-                    Arc::new((&input_schema).try_into()?),
                 )?))
             }
             PhysicalPlanType::HashJoin(hashjoin) => {
@@ -1042,7 +1031,6 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     protobuf::AggregateMode::SinglePartitioned
                 }
             };
-            let input_schema = exec.input_schema();
             let input = protobuf::PhysicalPlanNode::try_from_physical_plan(
                 exec.input().to_owned(),
                 extension_codec,
@@ -1073,7 +1061,6 @@ impl AsExecutionPlan for PhysicalPlanNode {
                         aggr_expr_name: agg_names,
                         mode: agg_mode as i32,
                         input: Some(Box::new(input)),
-                        input_schema: Some(input_schema.as_ref().try_into()?),
                         null_expr,
                         groups,
                     },

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -302,7 +302,6 @@ fn rountrip_aggregate() -> Result<()> {
         vec![None],
         vec![None],
         Arc::new(EmptyExec::new(false, schema.clone())),
-        schema,
     )?))
 }
 
@@ -370,7 +369,6 @@ fn roundtrip_aggregate_udaf() -> Result<()> {
             vec![None],
             vec![None],
             Arc::new(EmptyExec::new(false, schema.clone())),
-            schema,
         )?),
         ctx,
     )
@@ -584,7 +582,6 @@ fn roundtrip_distinct_count() -> Result<()> {
         vec![None],
         vec![None],
         Arc::new(EmptyExec::new(false, schema.clone())),
-        schema,
     )?))
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

related to https://github.com/apache/arrow-datafusion/pull/7727

## Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/7727 I was trying to find the location @viirya  was referring to for why `AggregateExec` needed its `input_schema` (when it already has the entire `ExecutionPlan` input)

So I started removing it and it turns out it is not necessary from what I can tell

## What changes are included in this PR?

Remove unused `AggregateExec::input_schema` and all its uses

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->