### PR TITLE
POC: Splitting scalar functions outside Datafusion core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "datafusion-examples",
     "test-utils",
     "benchmarks",
+    "extension/scalar-function/test-func",
 ]
 resolver = "2"
 

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -41,6 +41,7 @@ datafusion-common = { path = "../datafusion/common" }
 datafusion-expr = { path = "../datafusion/expr" }
 datafusion-optimizer = { path = "../datafusion/optimizer" }
 datafusion-sql = { path = "../datafusion/sql" }
+datafusion-extension-test-scalar-func = {path = "../extension/scalar-function/test-func"}
 env_logger = "0.10"
 futures = "0.3"
 log = "0.4"

--- a/datafusion-examples/examples/external_function_package.rs
+++ b/datafusion-examples/examples/external_function_package.rs
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::error::Result;
+use datafusion::prelude::*;
+use datafusion_extension_test_scalar_func::TestFunctionPackage;
+
+/// This example demonstrates executing a simple query against an Arrow data source (CSV) and
+/// fetching results
+#[tokio::main]
+async fn main() -> Result<()> {
+    let ctx = SessionContext::new();
+    let testdata = datafusion::test_util::arrow_test_data();
+    ctx.register_csv(
+        "aggregate_test_100",
+        &format!("{testdata}/csv/aggregate_test_100.csv"),
+        CsvReadOptions::new(),
+    )
+    .await?;
+
+    // Register add_one(x), multiply_two(x) function from `TestFunctionPackage`
+    ctx.register_scalar_function_package(Box::new(TestFunctionPackage));
+
+    let df = ctx
+        .sql("select add_one(1), multiply_two(c3), add_one(multiply_two(c4)) from aggregate_test_100 limit 5").await?;
+    df.show().await?;
+
+    Ok(())
+}

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -77,7 +77,7 @@ pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{Signature, TypeSignature, Volatility};
 pub use table_source::{TableProviderFilterPushDown, TableSource, TableType};
 pub use udaf::AggregateUDF;
-pub use udf::ScalarUDF;
+pub use udf::{ScalarFunctionDef, ScalarFunctionPackage, ScalarUDF};
 pub use udwf::WindowUDF;
 pub use window_frame::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 pub use window_function::{BuiltInWindowFunction, WindowFunction};

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -18,10 +18,29 @@
 //! Udf module contains foundational types that are used to represent UDFs in DataFusion.
 
 use crate::{Expr, ReturnTypeFunction, ScalarFunctionImplementation, Signature};
+use arrow::array::ArrayRef;
+use datafusion_common::Result;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
+
+pub trait ScalarFunctionDef: Sync + Send + std::fmt::Debug {
+    // TODO: support alias
+    fn name(&self) -> &str;
+
+    fn signature(&self) -> Signature;
+
+    // TODO: ReturnTypeFunction -> a ENUM
+    //     most function's return type is either the same as 1st arg or a fixed type
+    fn return_type(&self) -> ReturnTypeFunction;
+
+    fn execute(&self, args: &[ArrayRef]) -> Result<ArrayRef>;
+}
+
+pub trait ScalarFunctionPackage {
+    fn functions(&self) -> Vec<Box<dyn ScalarFunctionDef>>;
+}
 
 /// Logical representation of a UDF.
 #[derive(Clone)]

--- a/extension/scalar-function/test-func/Cargo.toml
+++ b/extension/scalar-function/test-func/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "datafusion-extension-test-scalar-func"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+datafusion = { path = "../../../datafusion/core" }
+datafusion-common = { path = "../../../datafusion/common" }
+datafusion-expr = { path = "../../../datafusion/expr" }
+arrow = { workspace = true }
+#arrow-flight = { workspace = true }
+#arrow-schema = { workspace = true }

--- a/extension/scalar-function/test-func/src/lib.rs
+++ b/extension/scalar-function/test-func/src/lib.rs
@@ -1,0 +1,79 @@
+use arrow::array::{ArrayRef, Float64Array};
+use arrow::datatypes::DataType;
+use datafusion::error::Result;
+use datafusion::logical_expr::Volatility;
+use datafusion_common::cast::as_float64_array;
+use datafusion_expr::{ReturnTypeFunction, Signature};
+use datafusion_expr::{ScalarFunctionDef, ScalarFunctionPackage};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct AddOneFunction;
+
+impl ScalarFunctionDef for AddOneFunction {
+    fn name(&self) -> &str {
+        "add_one"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::exact(vec![DataType::Float64], Volatility::Immutable)
+    }
+
+    fn return_type(&self) -> ReturnTypeFunction {
+        let return_type = Arc::new(DataType::Float64);
+        Arc::new(move |_| Ok(return_type.clone()))
+    }
+
+    fn execute(&self, args: &[ArrayRef]) -> Result<ArrayRef> {
+        assert_eq!(args.len(), 1);
+        let input = as_float64_array(&args[0]).expect("cast failed");
+        let array = input
+            .iter()
+            .map(|value| match value {
+                Some(value) => Some(value + 1.0),
+                _ => None,
+            })
+            .collect::<Float64Array>();
+        Ok(Arc::new(array) as ArrayRef)
+    }
+}
+
+#[derive(Debug)]
+pub struct MultiplyTwoFunction;
+
+impl ScalarFunctionDef for MultiplyTwoFunction {
+    fn name(&self) -> &str {
+        "multiply_two"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::exact(vec![DataType::Float64], Volatility::Immutable)
+    }
+
+    fn return_type(&self) -> ReturnTypeFunction {
+        let return_type = Arc::new(DataType::Float64);
+        Arc::new(move |_| Ok(return_type.clone()))
+    }
+
+    fn execute(&self, args: &[ArrayRef]) -> Result<ArrayRef> {
+        assert_eq!(args.len(), 1);
+        let input = as_float64_array(&args[0]).expect("cast failed");
+        let array = input
+            .iter()
+            .map(|value| match value {
+                Some(value) => Some(value * 2.0),
+                _ => None,
+            })
+            .collect::<Float64Array>();
+        Ok(Arc::new(array) as ArrayRef)
+    }
+}
+
+// Function package declaration
+pub struct TestFunctionPackage;
+
+impl ScalarFunctionPackage for TestFunctionPackage {
+    fn functions(&self) -> Vec<Box<dyn ScalarFunctionDef>> {
+        vec![Box::new(AddOneFunction), Box::new(MultiplyTwoFunction)]
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

POC for https://github.com/apache/arrow-datafusion/issues/7110

## Rationale for this change

This POC PR defined a new interface for `ButinScalarFunction`: `trait ScalarFunctionDef`, to make it possible to define scalar functions outside the core as #7110 stated.
This PR also demonstrated how to define function packages in their own crate and register them into context in `datafusion-examples/examples/external_function_package.rs`

### Background
Currently, there are two ways to define a scalar function in Datafusion
1. built-in functions are defined as `enum BuiltinScalarFunction`: it's a huge enum and there are several large functions like `return_type()` to check every enum variant. This way of implementation is not possible to define functions in other places, so there exist another way to define UDFs.
2. UDFs: currently it uses `struct ScalarUDF` as an internal representation for UDF's logical plan, it's expressive enough to define all builtin functions (almost all, need some minor modifications like supporting aliases). There is an interface `create_udf()` on top of `struct ScalarUDF` for users to define UDFs.
```

 ┌───────────────────────┐  ┌──────────────────────────┐  ┌────────────────────────────────┐
 │                       │  │                          │  │                                │
 │                       │  │ create_udf()             │  │*THIS PR                        │
 │                       │  │ (interface to define UDF)│  │ trait ScalarFunctionDef        │
 │                       │  │                          │  │ (an interface to define        │
 │                       │  │                          │  │  scalar functions outside      │
 │                       │  │                          │  │  datafusion core)              │
 │ BuiltinScalarFunction │  │                          │  │                                │
 │                       │  └──────────────────────────┘  └────────────────────────────────┘
 │                       │
 │                       │  ┌──────────────────────────────────────────────────────────────┐
 │                       │  │ struct ScalarUDF                                             │
 │                       │  │ (internal representation for UDF's logical plan)             │
 │                       │  │                                                              │
 └───────────────────────┘  └──────────────────────────────────────────────────────────────┘
```
### A new interface `trait ScalarFunctionDef`
`ScalarFunctionDef` trait can be used to define scalar functions, and the trait object can be converted into `ScalarUDF`, and reuse UDF infrastructures to register and use the functions.
```rust
pub trait ScalarFunctionDef: Sync + Send + std::fmt::Debug {
    fn name(&self) -> &str;
    fn signature(&self) -> Signature;
    fn return_type(&self) -> ReturnTypeFunction;
    fn execute(&self, args: &[ArrayRef]) -> Result<ArrayRef>;
}
```
One potential concern is why is this new trait needed, can we just use the existing interface `struct ScalarUDF`?
If the function interface is defined as a struct, then a new function should be defined in an imperative way (see `examples/simple_udf.rs`). There might be a lot of functions for function packages to manage, defining them in a declarative way (using trait) is cleaner and more ergonomic.
Besides, `trait ScalarFunctionDef` should cover the same functionality as `struct ScalarUDF` (also the same as `BuiltinScalarFunction`), now it's converted into `ScalarUDF` just because this way can reuse the existing implementation and minimize the patch size, it's possible to replace `ScalarUDF` with `trait ScalarFunctionDef` in the future as a cleanup task.
I think it's also possible to replace `BuitlinScalarFunction` with the new interface, as another cleanup refactor task. Adding a new function into `BuiltinScalarFunction` requires modifications in multiple places/files, the new `ScalarFunctionDef` interface only needs modifying one place, which can be simpler.

## What changes are included in this PR?
### 1. `ScalarFunctionDef` trait as an alternative way to define scalar functions
`Struct ScalarUDF` is currently the internal representation of UDF's logical plan, it should be expressive enough to implement all built-in functions. (with some minor changes like supporting alias)
`ScalarFunctionDef` trait can be used to define scalar functions, and the trait object can be converted into `ScalarUDF`, and reuse UDF infrastructures to register and use the functions.
### 2. Managing extension points
Another issue is how to manage those pluggable crates, possibly with a `extension/` folder under datafusion root?
Recently I saw discussions about pulling parquet reader outside the core, those optional extension points can all be placed inside `extension/` folder
```
.
├── extension
│   ├── data-source
│   │   └── parquet-reader
│   └── scalar-function
│       ├── hash-functions
│       ├── string-functions
│       └── ...

```
For example `arrow-datafusion/extension/scalar-function/hash-functions` is a separate crate defined all hash-related functions.

If this approach is possible I can try to pull some functions from datafusion core into a separate crate after

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->