### PR TITLE
Minor: Remove unnecessary `#[cfg(feature = "avro")]`

### DIFF
--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -74,7 +74,6 @@ macro_rules! test_expression {
 
 pub mod aggregates;
 pub mod arrow_files;
-#[cfg(feature = "avro")]
 pub mod create_drop;
 pub mod csv_files;
 pub mod describe;


### PR DESCRIPTION
## Rationale for this change
In `datafusion/core/tests/sql/mod.rs`, `#[cfg(feature = "avro")]` is applied to `pub mod create_drop`, but it is not related to Avro.
I guess this is a leftover of d01002c33228a305fdb69d3e6a51465

## What changes are included in this PR?
Removed unnecessary `#[cfg(feature = "avro")]`.

## Are these changes tested?
Done by CI.

## Are there any user-facing changes?
No.