### PR TITLE
Make CI fail on any occurrence of rust-tomlfmt failed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -505,12 +505,11 @@ jobs:
 
       - name: Check Cargo.toml formatting
         run: |
-          # if you encounter error, try rerun the command below, finally run 'git diff' to
-          # check which Cargo.toml introduces formatting violation
+          # if you encounter an error, try running 'cargo tomlfmt -p path/to/Cargo.toml' to fix the formatting automatically.
+          # If the error still persists, you need to manually edit the Cargo.toml file, which introduces formatting violation.
           #
           # ignore ./Cargo.toml because putting workspaces in multi-line lists make it easy to read
           ci/scripts/rust_toml_fmt.sh
-          git diff --exit-code
 
   config-docs-check:
     name: check configs.md is up-to-date

--- a/ci/scripts/rust_toml_fmt.sh
+++ b/ci/scripts/rust_toml_fmt.sh
@@ -17,5 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Run cargo-tomlfmt with flag `-d` in dry run to check formatting
+# without overwritng the file. If any error occur, you may want to
+# rerun 'cargo tomlfmt -p path/to/Cargo.toml' without '-d' to fix
+# the formatting automatically.
 set -ex
-find . -mindepth 2 -name 'Cargo.toml' -exec cargo tomlfmt -p {} \;
+for toml in $(find . -mindepth 2 -name 'Cargo.toml'); do
+	cargo tomlfmt -d -p $toml
+done

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -16,46 +16,46 @@
 # under the License.
 
 [package]
-authors.workspace = true
-edition.workspace = true
-homepage.workspace = true
-license.workspace = true
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 name = "datafusion-sqllogictest"
-readme.workspace = true
-repository.workspace = true
-rust-version.workspace = true
-version.workspace = true
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "datafusion_sqllogictest"
 path = "src/lib.rs"
 
 [dependencies]
-arrow = {workspace = true}
+arrow = { workspace = true }
 async-trait = "0.1.41"
 bigdecimal = "0.4.1"
-datafusion = {path = "../core", version = "32.0.0"}
-datafusion-common = {path = "../common", version = "32.0.0", default-features = false}
+bytes = { version = "1.4.0", optional = true }
+chrono = { workspace = true, optional = true }
+datafusion = { path = "../core", version = "32.0.0" }
+datafusion-common = { path = "../common", version = "32.0.0", default-features = false }
+futures = { version = "0.3.28" }
 half = "2.2.1"
 itertools = "0.11"
-object_store = "0.7.0"
-rust_decimal = {version = "1.27.0"}
 log = "^0.4"
+object_store = "0.7.0"
+postgres-protocol = { version = "0.6.4", optional = true }
+postgres-types = { version = "0.2.4", optional = true }
+rust_decimal = { version = "1.27.0" }
 sqllogictest = "0.17.0"
-sqlparser.workspace = true
+sqlparser = { workspace = true }
 tempfile = "3"
 thiserror = "1.0.44"
-tokio = {version = "1.0"}
-bytes = {version = "1.4.0", optional = true}
-futures = {version = "0.3.28"}
-chrono = { workspace = true, optional = true }
-tokio-postgres = {version = "0.7.7", optional = true}
-postgres-types = {version = "0.2.4", optional = true}
-postgres-protocol = {version = "0.6.4", optional = true}
+tokio = { version = "1.0" }
+tokio-postgres = { version = "0.7.7", optional = true }
 
 [features]
-postgres = ["bytes", "chrono", "tokio-postgres", "postgres-types", "postgres-protocol"]
 avro = ["datafusion/avro"]
+postgres = ["bytes", "chrono", "tokio-postgres", "postgres-types", "postgres-protocol"]
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

`ci/scripts/rust_toml_fmt.sh` does not return an error when any occurrence of failed.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Update `cargo-tomlfmt` check script and CI.
- Fix the format of `datafusion/sqllogictest/Cargo.toml`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->