### PR TITLE
reduce clones of LogicalPlan in planner

### DIFF
--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -193,11 +193,11 @@ impl RunOpt {
             println!("=== Logical plan ===\n{plan:?}\n");
         }
 
-        let plan = state.optimize(&plan)?;
+        let plan = state.optimize(plan)?;
         if debug {
             println!("=== Optimized logical plan ===\n{plan:?}\n");
         }
-        let physical_plan = state.create_physical_plan(&plan).await?;
+        let physical_plan = state.create_physical_plan(plan).await?;
         if debug {
             println!(
                 "=== Physical plan ===\n{}\n",

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -59,7 +59,7 @@ pub fn main() -> Result<()> {
 
     // then run the optimizer with our custom rule
     let optimizer = Optimizer::with_rules(vec![Arc::new(MyOptimizerRule {})]);
-    let optimized_plan = optimizer.optimize(&analyzed_plan, &config, observe)?;
+    let optimized_plan = optimizer.optimize(analyzed_plan, &config, observe)?;
     println!(
         "Optimized Logical Plan:\n\n{}\n",
         optimized_plan.display_indent()

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -51,7 +51,7 @@ pub fn main() -> Result<()> {
     let config = OptimizerContext::default().with_skip_failing_rules(false);
     let analyzer = Analyzer::with_rules(vec![Arc::new(MyAnalyzerRule {})]);
     let analyzed_plan =
-        analyzer.execute_and_check(&logical_plan, config.options(), |_, _| {})?;
+        analyzer.execute_and_check(logical_plan, config.options(), |_, _| {})?;
     println!(
         "Analyzed Logical Plan:\n\n{}\n",
         analyzed_plan.display_indent()

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -369,7 +369,7 @@ impl From<DataFusionError> for io::Error {
 }
 
 impl DataFusionError {
-    const BACK_TRACE_SEP: &str = "\n\nbacktrace: ";
+    const BACK_TRACE_SEP: &'static str = "\n\nbacktrace: ";
 
     /// Get deepest underlying [`DataFusionError`]
     ///

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -1613,8 +1613,8 @@ mod tests {
 
     #[tokio::test]
     async fn registry() -> Result<()> {
-        let mut ctx = SessionContext::new();
-        register_aggregate_csv(&mut ctx, "aggregate_test_100").await?;
+        let ctx = SessionContext::new();
+        register_aggregate_csv(&ctx, "aggregate_test_100").await?;
 
         // declare the udf
         let my_fn: ScalarFunctionImplementation =
@@ -1747,14 +1747,14 @@ mod tests {
 
     /// Create a logical plan from a SQL query
     async fn create_plan(sql: &str) -> Result<LogicalPlan> {
-        let mut ctx = SessionContext::new();
-        register_aggregate_csv(&mut ctx, "aggregate_test_100").await?;
+        let ctx = SessionContext::new();
+        register_aggregate_csv(&ctx, "aggregate_test_100").await?;
         Ok(ctx.sql(sql).await?.into_unoptimized_plan())
     }
 
     async fn test_table_with_name(name: &str) -> Result<DataFrame> {
-        let mut ctx = SessionContext::new();
-        register_aggregate_csv(&mut ctx, name).await?;
+        let ctx = SessionContext::new();
+        register_aggregate_csv(&ctx, name).await?;
         ctx.table(name).await
     }
 
@@ -1763,7 +1763,7 @@ mod tests {
     }
 
     async fn register_aggregate_csv(
-        ctx: &mut SessionContext,
+        ctx: &SessionContext,
         table_name: &str,
     ) -> Result<()> {
         let schema = test_util::aggr_test_schema();
@@ -2011,9 +2011,9 @@ mod tests {
                 "datafusion.sql_parser.enable_ident_normalization".to_owned(),
                 "false".to_owned(),
             )]))?;
-        let mut ctx = SessionContext::new_with_config(config);
+        let ctx = SessionContext::new_with_config(config);
         let name = "aggregate_test_100";
-        register_aggregate_csv(&mut ctx, name).await?;
+        register_aggregate_csv(&ctx, name).await?;
         let df = ctx.table(name);
 
         let df = df

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -152,7 +152,7 @@ impl DataFrame {
 
     /// Create a physical plan
     pub async fn create_physical_plan(self) -> Result<Arc<dyn ExecutionPlan>> {
-        self.session_state.create_physical_plan(&self.plan).await
+        self.session_state.create_physical_plan(self.plan).await
     }
 
     /// Filter the DataFrame by column. Returns a new DataFrame only containing the
@@ -891,7 +891,7 @@ impl DataFrame {
     /// operations may take place against a different state
     pub fn into_optimized_plan(self) -> Result<LogicalPlan> {
         // Optimize the plan first for better UX
-        self.session_state.optimize(&self.plan)
+        self.session_state.optimize(self.plan)
     }
 
     /// Converts this [`DataFrame`] into a [`TableProvider`] that can be registered
@@ -1302,7 +1302,7 @@ impl TableProvider for DataFrameTableProvider {
             expr = expr.limit(0, Some(l))?
         }
         let plan = expr.build()?;
-        state.create_physical_plan(&plan).await
+        state.create_physical_plan(plan).await
     }
 }
 

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1942,7 +1942,7 @@ mod tests {
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
-            .create_physical_plan(&insert_into_table)
+            .create_physical_plan(insert_into_table.clone())
             .await?;
 
         // Execute the physical plan and collect the results
@@ -1986,7 +1986,7 @@ mod tests {
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
-            .create_physical_plan(&insert_into_table)
+            .create_physical_plan(insert_into_table)
             .await?;
 
         // Again, execute the physical plan and collect the results
@@ -2155,7 +2155,7 @@ mod tests {
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
-            .create_physical_plan(&insert_into_table)
+            .create_physical_plan(insert_into_table.clone())
             .await?;
         // Execute the physical plan and collect the results
         let res = collect(plan, session_ctx.task_ctx()).await?;
@@ -2195,7 +2195,7 @@ mod tests {
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
-            .create_physical_plan(&insert_into_table)
+            .create_physical_plan(insert_into_table)
             .await?;
 
         // Again, execute the physical plan and collect the results

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -558,7 +558,7 @@ mod tests {
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
-            .create_physical_plan(&insert_into_table)
+            .create_physical_plan(insert_into_table)
             .await?;
 
         // Execute the physical plan and collect the results

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -141,7 +141,7 @@ impl TableProvider for ViewTable {
             plan = plan.limit(0, Some(limit))?;
         }
 
-        state.create_physical_plan(&plan.build()?).await
+        state.create_physical_plan(plan.build()?).await
     }
 }
 

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1115,7 +1115,7 @@ impl DefaultPhysicalPlanner {
                             let filter_df_schema = DFSchema::new_with_metadata(filter_df_fields, HashMap::new())?;
                             let filter_schema = Schema::new_with_metadata(filter_fields, HashMap::new());
                             let filter_expr = create_physical_expr(
-                                &expr,
+                                expr,
                                 &filter_df_schema,
                                 &filter_schema,
                                 session_state.execution_props(),
@@ -1139,7 +1139,7 @@ impl DefaultPhysicalPlanner {
                             physical_left,
                             physical_right,
                             join_filter,
-                            &join_type,
+                            join_type,
                         )?))
                     } else if session_state.config().target_partitions() > 1
                         && session_state.config().repartition_joins()
@@ -1176,7 +1176,7 @@ impl DefaultPhysicalPlanner {
                             physical_right,
                             join_on,
                             join_filter,
-                            &join_type,
+                            join_type,
                             partition_mode,
                             *null_equals_null,
                         )?))
@@ -1186,7 +1186,7 @@ impl DefaultPhysicalPlanner {
                             physical_right,
                             join_on,
                             join_filter,
-                            &join_type,
+                            join_type,
                             PartitionMode::CollectLeft,
                             *null_equals_null,
                         )?))
@@ -1280,7 +1280,7 @@ impl DefaultPhysicalPlanner {
                     "Unsupported logical plan: Analyze must be root of the plan"
                 ),
                 LogicalPlan::Extension(e) => {
-                    let physical_inputs = self.create_initial_plan_multi(e.node.inputs().into_iter().map(|plan| plan.clone()).collect::<Vec<LogicalPlan>>(), session_state).await?;
+                    let physical_inputs = self.create_initial_plan_multi(e.node.inputs().into_iter().cloned().collect::<Vec<LogicalPlan>>(), session_state).await?;
 
                     let mut maybe_plan = None;
                     for planner in &self.extension_planners {

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -216,10 +216,10 @@ impl ContextWithParquet {
         let pretty_input = pretty_format_batches(&input).unwrap().to_string();
 
         let state = self.ctx.state();
-        let logical_plan = state.optimize(&logical_plan).expect("optimizing plan");
+        let logical_plan = state.optimize(logical_plan).expect("optimizing plan");
 
         let physical_plan = state
-            .create_physical_plan(&logical_plan)
+            .create_physical_plan(logical_plan)
             .await
             .expect("creating physical plan");
 

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -788,8 +788,8 @@ async fn aggregate_with_alias() -> Result<()> {
         .project(vec![col("c1"), sum(col("c2")).alias("total_salary")])?
         .build()?;
 
-    let plan = state.optimize(&plan)?;
-    let physical_plan = state.create_physical_plan(&Arc::new(plan)).await?;
+    let plan = state.optimize(plan)?;
+    let physical_plan = state.create_physical_plan(plan).await?;
     assert_eq!("c1", physical_plan.schema().field(0).name().as_str());
     assert_eq!(
         "total_salary",

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -178,7 +178,7 @@ async fn csv_explain_plans() {
     let msg = format!("Creating logical plan for '{sql}'");
     let dataframe = ctx.sql(sql).await.expect(&msg);
     let logical_schema = dataframe.schema();
-    let plan = dataframe.logical_plan();
+    let plan = dataframe.logical_plan().to_owned();
 
     //
     println!("SQL: {sql}");
@@ -326,7 +326,7 @@ async fn csv_explain_plans() {
     // Physical plan
     // Create plan
     let msg = format!("Creating physical plan for '{sql}': {plan:?}");
-    let plan = state.create_physical_plan(&plan).await.expect(&msg);
+    let plan = state.create_physical_plan(plan).await.expect(&msg);
     //
     // Execute plan
     let msg = format!("Executing physical plan for '{sql}': {plan:?}");
@@ -473,7 +473,7 @@ async fn csv_explain_verbose_plans() {
     // Optimized logical plan
     let msg = format!("Optimizing logical plan for '{sql}': {dataframe:?}");
     let (state, plan) = dataframe.into_parts();
-    let plan = state.optimize(&plan).expect(&msg);
+    let plan = state.optimize(plan).expect(&msg);
     let optimized_logical_schema = plan.schema();
     // Both schema has to be the same
     assert_eq!(&logical_schema, optimized_logical_schema.as_ref());
@@ -547,7 +547,7 @@ async fn csv_explain_verbose_plans() {
     // Physical plan
     // Create plan
     let msg = format!("Creating physical plan for '{sql}': {plan:?}");
-    let plan = state.create_physical_plan(&plan).await.expect(&msg);
+    let plan = state.create_physical_plan(plan).await.expect(&msg);
     //
     // Execute plan
     let msg = format!("Executing physical plan for '{sql}': {plan:?}");

--- a/datafusion/core/tests/sql/order.rs
+++ b/datafusion/core/tests/sql/order.rs
@@ -200,7 +200,7 @@ ORDER BY 1, 2;
     // check phys. plan
     let dataframe = ctx.sql(sql).await.unwrap();
     let plan = dataframe.into_optimized_plan().unwrap();
-    let plan = ctx.state().create_physical_plan(&plan).await.unwrap();
+    let plan = ctx.state().create_physical_plan(plan).await.unwrap();
     let expected = vec![
         "SortPreservingMergeExec: [m@0 ASC NULLS LAST,t@1 ASC NULLS LAST]",
         "  SortExec: expr=[m@0 ASC NULLS LAST,t@1 ASC NULLS LAST]",

--- a/datafusion/core/tests/sql/projection.rs
+++ b/datafusion/core/tests/sql/projection.rs
@@ -171,7 +171,7 @@ async fn projection_on_table_scan() -> Result<()> {
         .build()?;
 
     let state = ctx.state();
-    let optimized_plan = state.optimize(&logical_plan)?;
+    let optimized_plan = state.optimize(logical_plan)?;
     match &optimized_plan {
         LogicalPlan::TableScan(TableScan {
             source,
@@ -187,7 +187,7 @@ async fn projection_on_table_scan() -> Result<()> {
     let expected = "TableScan: test projection=[c2]";
     assert_eq!(format!("{optimized_plan:?}"), expected);
 
-    let physical_plan = state.create_physical_plan(&optimized_plan).await?;
+    let physical_plan = state.create_physical_plan(optimized_plan).await?;
 
     assert_eq!(1, physical_plan.schema().fields().len());
     assert_eq!("c2", physical_plan.schema().field(0).name().as_str());
@@ -281,7 +281,7 @@ async fn projection_on_memory_scan() -> Result<()> {
 
     let ctx = SessionContext::new();
     let state = ctx.state();
-    let optimized_plan = state.optimize(&plan)?;
+    let optimized_plan = state.optimize(plan)?;
     match &optimized_plan {
         LogicalPlan::TableScan(TableScan {
             source,
@@ -297,7 +297,7 @@ async fn projection_on_memory_scan() -> Result<()> {
     let expected = format!("TableScan: {UNNAMED_TABLE} projection=[b]");
     assert_eq!(format!("{optimized_plan:?}"), expected);
 
-    let physical_plan = state.create_physical_plan(&optimized_plan).await?;
+    let physical_plan = state.create_physical_plan(optimized_plan).await?;
 
     assert_eq!(1, physical_plan.schema().fields().len());
     assert_eq!("b", physical_plan.schema().field(0).name().as_str());

--- a/datafusion/core/tests/sql/sql_api.rs
+++ b/datafusion/core/tests/sql/sql_api.rs
@@ -108,7 +108,7 @@ async fn ddl_can_not_be_planned_by_session_state() {
     // can not create a logical plan for catalog DDL
     let sql = "drop table test";
     let plan = state.create_logical_plan(sql).await.unwrap();
-    let physical_plan = state.create_physical_plan(&plan).await;
+    let physical_plan = state.create_physical_plan(plan).await;
     assert_eq!(
         physical_plan.unwrap_err().strip_backtrace(),
         "This feature is not implemented: Unsupported logical plan: DropTable"

--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -1063,9 +1063,9 @@ async fn regression_test(query_no: u8, create_physical: bool) -> Result<()> {
     for sql in &sql {
         let df = ctx.sql(sql).await?;
         let (state, plan) = df.into_parts();
-        let plan = state.optimize(&plan)?;
+        let plan = state.optimize(plan)?;
         if create_physical {
-            let _ = state.create_physical_plan(&plan).await?;
+            let _ = state.create_physical_plan(plan).await?;
         }
     }
 

--- a/datafusion/core/tests/user_defined/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined/user_defined_plan.rs
@@ -263,7 +263,7 @@ impl QueryPlanner for TopKQueryPlanner {
     /// `ExecutionPlan` suitable for execution
     async fn create_physical_plan(
         &self,
-        logical_plan: &LogicalPlan,
+        logical_plan: LogicalPlan,
         session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Teach the default physical planner how to plan TopK nodes.

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -87,7 +87,7 @@ impl Analyzer {
     /// do necessary check and fail the invalid plans
     pub fn execute_and_check<F>(
         &self,
-        plan: &LogicalPlan,
+        plan: LogicalPlan,
         config: &ConfigOptions,
         mut observer: F,
     ) -> Result<LogicalPlan>
@@ -95,7 +95,7 @@ impl Analyzer {
         F: FnMut(&LogicalPlan, &dyn AnalyzerRule),
     {
         let start_time = Instant::now();
-        let mut new_plan = plan.clone();
+        let mut new_plan = plan;
 
         // TODO add common rule executor for Analyzer and Optimizer
         for rule in &self.rules {

--- a/datafusion/optimizer/src/eliminate_limit.rs
+++ b/datafusion/optimizer/src/eliminate_limit.rs
@@ -120,7 +120,7 @@ mod tests {
             Arc::new(EliminateLimit::new()),
         ]);
         let optimized_plan = optimizer
-            .optimize(plan, &config, observe)
+            .optimize(plan.clone(), &config, observe)
             .expect("failed to optimize plan");
         let formatted_plan = format!("{optimized_plan:?}");
         assert_eq!(formatted_plan, expected);

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -215,7 +215,7 @@ mod tests {
             .with_max_passes(1)
             .with_skip_failing_rules(false);
         let optimized_plan = optimizer
-            .optimize(plan, config, observe)
+            .optimize(plan.clone(), config, observe)
             .expect("failed to optimize plan");
         let formatted_plan = format!("{optimized_plan:?}");
         assert_eq!(formatted_plan, expected);

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -114,8 +114,11 @@ pub fn assert_analyzed_plan_eq(
     expected: &str,
 ) -> Result<()> {
     let options = ConfigOptions::default();
-    let analyzed_plan =
-        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &options, |_, _| {})?;
+    let analyzed_plan = Analyzer::with_rules(vec![rule]).execute_and_check(
+        plan.to_owned(),
+        &options,
+        |_, _| {},
+    )?;
     let formatted_plan = format!("{analyzed_plan:?}");
     assert_eq!(formatted_plan, expected);
 
@@ -127,8 +130,11 @@ pub fn assert_analyzed_plan_eq_display_indent(
     expected: &str,
 ) -> Result<()> {
     let options = ConfigOptions::default();
-    let analyzed_plan =
-        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &options, |_, _| {})?;
+    let analyzed_plan = Analyzer::with_rules(vec![rule]).execute_and_check(
+        plan.to_owned(),
+        &options,
+        |_, _| {},
+    )?;
     let formatted_plan = analyzed_plan.display_indent_schema().to_string();
     assert_eq!(formatted_plan, expected);
 
@@ -141,8 +147,11 @@ pub fn assert_analyzer_check_err(
     expected: &str,
 ) {
     let options = ConfigOptions::default();
-    let analyzed_plan =
-        Analyzer::with_rules(rules).execute_and_check(plan, &options, |_, _| {});
+    let analyzed_plan = Analyzer::with_rules(rules).execute_and_check(
+        plan.to_owned(),
+        &options,
+        |_, _| {},
+    );
     match analyzed_plan {
         Ok(plan) => assert_eq!(format!("{}", plan.display_indent()), "An error"),
         Err(e) => {

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -352,7 +352,7 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
     let analyzer = Analyzer::new();
     let optimizer = Optimizer::new();
     // analyze and optimize the logical plan
-    let plan = analyzer.execute_and_check(&plan, config.options(), |_, _| {})?;
+    let plan = analyzer.execute_and_check(plan, config.options(), |_, _| {})?;
     optimizer.optimize(&plan, &config, |_, _| {})
 }
 

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -353,7 +353,7 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
     let optimizer = Optimizer::new();
     // analyze and optimize the logical plan
     let plan = analyzer.execute_and_check(plan, config.options(), |_, _| {})?;
-    optimizer.optimize(&plan, &config, |_, _| {})
+    optimizer.optimize(plan, &config, |_, _| {})
 }
 
 #[derive(Default)]

--- a/datafusion/proto/README.md
+++ b/datafusion/proto/README.md
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
         .await
         ?;
     let logical_plan = ctx.table("t1").await?.into_optimized_plan()?;
-    let physical_plan = ctx.create_physical_plan(&logical_plan).await?;
+    let physical_plan = ctx.create_physical_plan(logical_plan).await?;
     let bytes = physical_plan_to_bytes(physical_plan.clone())?;
     let physical_round_trip = physical_plan_from_bytes(&bytes, &ctx)?;
     assert_eq!(format!("{:?}", physical_plan), format!("{:?}", physical_round_trip));

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -27,7 +27,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         id: Ident,
         schema: &DFSchema,
-        planner_context: &mut PlannerContext,
+        planner_context: &PlannerContext,
     ) -> Result<Expr> {
         if id.value.starts_with('@') {
             // TODO: figure out if ScalarVariables should be insensitive.
@@ -87,7 +87,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         ids: Vec<Ident>,
         schema: &DFSchema,
-        planner_context: &mut PlannerContext,
+        planner_context: &PlannerContext,
     ) -> Result<Expr> {
         if ids.len() < 2 {
             return internal_err!("Not a compound identifier: {ids:?}");

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -626,7 +626,7 @@ async fn assert_expected_plan(sql: &str, expected_plan_str: &str) -> Result<()> 
     let plan = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan, &ctx)?;
     let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
-    let plan2 = ctx.state().optimize(&plan2)?;
+    let plan2 = ctx.state().optimize(plan2)?;
     let plan2str = format!("{plan2:?}");
     assert_eq!(expected_plan_str, &plan2str);
     Ok(())
@@ -638,7 +638,7 @@ async fn roundtrip_fill_na(sql: &str) -> Result<()> {
     let plan1 = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan1, &ctx)?;
     let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
-    let plan2 = ctx.state().optimize(&plan2)?;
+    let plan2 = ctx.state().optimize(plan2)?;
 
     // Format plan string and replace all None's with 0
     let plan1str = format!("{plan1:?}").replace("None", "0");
@@ -677,7 +677,7 @@ async fn roundtrip(sql: &str) -> Result<()> {
     let plan = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan, &ctx)?;
     let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
-    let plan2 = ctx.state().optimize(&plan2)?;
+    let plan2 = ctx.state().optimize(plan2)?;
 
     println!("{plan:#?}");
     println!("{plan2:#?}");
@@ -694,7 +694,7 @@ async fn roundtrip_all_types(sql: &str) -> Result<()> {
     let plan = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan, &ctx)?;
     let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
-    let plan2 = ctx.state().optimize(&plan2)?;
+    let plan2 = ctx.state().optimize(plan2)?;
 
     println!("{plan:#?}");
     println!("{plan2:#?}");


### PR DESCRIPTION
## Rationale for this change
To reduce clone of the logical plan. This pr may have some relation with #5637 
And the clone of input plan will be reduced after #4628 closed.

## What changes are included in this PR?
Speedup the planner but make some tests slower than before because of some more clones.

## Are these changes tested?
yes.

## Are there any user-facing changes?
no.