### PR TITLE
refactor(7181): convert into generic ReceiverStream

### DIFF
--- a/datafusion/physical-plan/src/common.rs
+++ b/datafusion/physical-plan/src/common.rs
@@ -18,7 +18,7 @@
 //! Defines common code used in execution plans
 
 use super::SendableRecordBatchStream;
-use crate::stream::RecordBatchReceiverStream;
+use crate::stream::ReceiverStream;
 use crate::{ColumnStatistics, ExecutionPlan, Statistics};
 use arrow::datatypes::Schema;
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
@@ -102,7 +102,7 @@ pub(crate) fn spawn_buffered(
         Ok(handle)
             if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread =>
         {
-            let mut builder = RecordBatchReceiverStream::builder(input.schema(), buffer);
+            let mut builder = ReceiverStream::builder(input.schema(), buffer);
 
             let sender = builder.tx();
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -25,7 +25,7 @@ use crate::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use crate::sorts::merge::streaming_merge;
-use crate::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
+use crate::stream::{ReceiverStream, RecordBatchStreamAdapter};
 use crate::topk::TopK;
 use crate::{
     DisplayAs, DisplayFormatType, Distribution, EmptyRecordBatchStream, ExecutionPlan,
@@ -613,7 +613,7 @@ pub(crate) fn read_spill_as_stream(
     path: RefCountedTempFile,
     schema: SchemaRef,
 ) -> Result<SendableRecordBatchStream> {
-    let mut builder = RecordBatchReceiverStream::builder(schema, 2);
+    let mut builder = ReceiverStream::builder(schema, 2);
     let sender = builder.tx();
 
     builder.spawn_blocking(move || {

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -282,7 +282,7 @@ mod tests {
     use crate::memory::MemoryExec;
     use crate::metrics::{MetricValue, Timestamp};
     use crate::sorts::sort::SortExec;
-    use crate::stream::RecordBatchReceiverStream;
+    use crate::stream::ReceiverStream;
     use crate::test::exec::{assert_strong_count_converges_to_zero, BlockingExec};
     use crate::test::{self, assert_is_pending, make_partition};
     use crate::{collect, common};
@@ -792,10 +792,11 @@ mod tests {
             sorted_partitioned_input(sort.clone(), &[5, 7, 3], task_ctx.clone()).await?;
 
         let partition_count = batches.output_partitioning().partition_count();
-        let mut streams = Vec::with_capacity(partition_count);
+        let mut streams: Vec<SendableRecordBatchStream> =
+            Vec::with_capacity(partition_count);
 
         for partition in 0..partition_count {
-            let mut builder = RecordBatchReceiverStream::builder(schema.clone(), 1);
+            let mut builder = ReceiverStream::<RecordBatch>::builder(schema.clone(), 1);
 
             let sender = builder.tx();
 

--- a/datafusion/physical-plan/src/test/exec.rs
+++ b/datafusion/physical-plan/src/test/exec.rs
@@ -32,8 +32,8 @@ use arrow::{
 use futures::Stream;
 
 use crate::{
-    common, stream::RecordBatchReceiverStream, stream::RecordBatchStreamAdapter,
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
+    common, stream::ReceiverStream, stream::RecordBatchStreamAdapter, DisplayAs,
+    DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
 use datafusion_physical_expr::PhysicalSortExpr;
@@ -211,7 +211,7 @@ impl ExecutionPlan for MockExec {
             .collect();
 
         if self.use_task {
-            let mut builder = RecordBatchReceiverStream::builder(self.schema(), 2);
+            let mut builder = ReceiverStream::builder(self.schema(), 2);
             // send data in order but in a separate task (to ensure
             // the batches are not available without the stream
             // yielding).
@@ -346,7 +346,7 @@ impl ExecutionPlan for BarrierExec {
     ) -> Result<SendableRecordBatchStream> {
         assert!(partition < self.data.len());
 
-        let mut builder = RecordBatchReceiverStream::builder(self.schema(), 2);
+        let mut builder = ReceiverStream::builder(self.schema(), 2);
 
         // task simply sends data in order after barrier is reached
         let data = self.data[partition].clone();


### PR DESCRIPTION
## Which issue does this PR close?

Prerequisite for the cascading merge.

Part of #7181 .

## Rationale for this change

Before this change, the buffered stream abstractions only handled record batch streams (`SendableRecordBatchStream`).
Instead, would like to enable buffering streams of other outputs too. Ideally using the same receiver abstraction. 

Later on, this will be used to buffer the stream of each merge node in the cascaded tree.
Specifically, [this spawn_buffered_merge()](https://github.com/apache/arrow-datafusion/blob/9b1019853fb3d71f6355ab1d850089332592b3d8/datafusion/physical-plan/src/sorts/cascade.rs#L297) will be wrapped around each merge nodes ([here](https://github.com/apache/arrow-datafusion/blob/9b1019853fb3d71f6355ab1d850089332592b3d8/datafusion/physical-plan/src/sorts/cascade.rs#L144) for the leaves and [here](https://github.com/apache/arrow-datafusion/blob/9b1019853fb3d71f6355ab1d850089332592b3d8/datafusion/physical-plan/src/sorts/cascade.rs#L164) for the non-leaves).

## What changes are included in this PR?
* change ReceiverStreamBuilder and ReceiverStream to handle a generic stream of data.
* define an adaptor interface to be used for any input-specific `call()` on the data.
* implement this adaptor for record batches (as needed).

## Are these changes tested?

Is a refactor. Not new functionality.

## Are there any user-facing changes?

No.