### PR TITLE
Exactness Indicator of Parameters: Precision

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -267,3 +267,118 @@ impl ColumnStatistics {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_value() {
+        let exact_sharpness = Sharpness::Exact(42);
+        let inexact_sharpness = Sharpness::Inexact(23);
+        let absent_sharpness = Sharpness::<i32>::Absent;
+
+        assert_eq!(*exact_sharpness.get_value().unwrap(), 42);
+        assert_eq!(*inexact_sharpness.get_value().unwrap(), 23);
+        assert_eq!(absent_sharpness.get_value(), None);
+    }
+
+    #[test]
+    fn test_map() {
+        let exact_sharpness = Sharpness::Exact(42);
+        let inexact_sharpness = Sharpness::Inexact(23);
+        let absent_sharpness = Sharpness::Absent;
+
+        let squared = |x| x * x;
+
+        assert_eq!(exact_sharpness.map(squared), Sharpness::Exact(1764));
+        assert_eq!(inexact_sharpness.map(squared), Sharpness::Inexact(529));
+        assert_eq!(absent_sharpness.map(squared), Sharpness::Absent);
+    }
+
+    #[test]
+    fn test_is_exact() {
+        let exact_sharpness = Sharpness::Exact(42);
+        let inexact_sharpness = Sharpness::Inexact(23);
+        let absent_sharpness = Sharpness::<i32>::Absent;
+
+        assert_eq!(exact_sharpness.is_exact(), Some(true));
+        assert_eq!(inexact_sharpness.is_exact(), Some(false));
+        assert_eq!(absent_sharpness.is_exact(), None);
+    }
+
+    #[test]
+    fn test_max() {
+        let sharpness1 = Sharpness::Exact(42);
+        let sharpness2 = Sharpness::Inexact(23);
+        let sharpness3 = Sharpness::Exact(30);
+        let absent_sharpness = Sharpness::Absent;
+
+        assert_eq!(sharpness1.max(&sharpness2), Sharpness::Inexact(42));
+        assert_eq!(sharpness1.max(&sharpness3), Sharpness::Exact(42));
+        assert_eq!(sharpness2.max(&sharpness3), Sharpness::Inexact(30));
+        assert_eq!(sharpness1.max(&absent_sharpness), Sharpness::Absent);
+    }
+
+    #[test]
+    fn test_min() {
+        let sharpness1 = Sharpness::Exact(42);
+        let sharpness2 = Sharpness::Inexact(23);
+        let sharpness3 = Sharpness::Exact(30);
+        let absent_sharpness = Sharpness::Absent;
+
+        assert_eq!(sharpness1.min(&sharpness2), Sharpness::Inexact(23));
+        assert_eq!(sharpness1.min(&sharpness3), Sharpness::Exact(30));
+        assert_eq!(sharpness2.min(&sharpness3), Sharpness::Inexact(23));
+        assert_eq!(sharpness1.min(&absent_sharpness), Sharpness::Absent);
+    }
+
+    #[test]
+    fn test_to_inexact() {
+        let exact_sharpness = Sharpness::Exact(42);
+        let inexact_sharpness = Sharpness::Inexact(23);
+        let absent_sharpness = Sharpness::<i32>::Absent;
+
+        assert_eq!(exact_sharpness.clone().to_inexact(), inexact_sharpness);
+        assert_eq!(inexact_sharpness.clone().to_inexact(), inexact_sharpness);
+        assert_eq!(absent_sharpness.clone().to_inexact(), absent_sharpness);
+    }
+
+    #[test]
+    fn test_add() {
+        let sharpness1 = Sharpness::Exact(42);
+        let sharpness2 = Sharpness::Inexact(23);
+        let sharpness3 = Sharpness::Exact(30);
+        let absent_sharpness = Sharpness::Absent;
+
+        assert_eq!(sharpness1.add(&sharpness2), Sharpness::Inexact(65));
+        assert_eq!(sharpness1.add(&sharpness3), Sharpness::Exact(72));
+        assert_eq!(sharpness2.add(&sharpness3), Sharpness::Inexact(53));
+        assert_eq!(sharpness1.add(&absent_sharpness), Sharpness::Absent);
+    }
+
+    #[test]
+    fn test_sub() {
+        let sharpness1 = Sharpness::Exact(42);
+        let sharpness2 = Sharpness::Inexact(23);
+        let sharpness3 = Sharpness::Exact(30);
+        let absent_sharpness = Sharpness::Absent;
+
+        assert_eq!(sharpness1.sub(&sharpness2), Sharpness::Inexact(19));
+        assert_eq!(sharpness1.sub(&sharpness3), Sharpness::Exact(12));
+        assert_eq!(sharpness1.sub(&absent_sharpness), Sharpness::Absent);
+    }
+
+    #[test]
+    fn test_multiply() {
+        let sharpness1 = Sharpness::Exact(6);
+        let sharpness2 = Sharpness::Inexact(3);
+        let sharpness3 = Sharpness::Exact(5);
+        let absent_sharpness = Sharpness::Absent;
+
+        assert_eq!(sharpness1.multiply(&sharpness2), Sharpness::Inexact(18));
+        assert_eq!(sharpness1.multiply(&sharpness3), Sharpness::Exact(30));
+        assert_eq!(sharpness2.multiply(&sharpness3), Sharpness::Inexact(15));
+        assert_eq!(sharpness1.multiply(&absent_sharpness), Sharpness::Absent);
+    }
+}

--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_to_inexact() {
         let exact_sharpness = Sharpness::Exact(42);
-        let inexact_sharpness = Sharpness::Inexact(23);
+        let inexact_sharpness = Sharpness::Inexact(42);
         let absent_sharpness = Sharpness::<i32>::Absent;
 
         assert_eq!(exact_sharpness.clone().to_inexact(), inexact_sharpness);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Some parameters need to be carried along with their exactness information. That exactness information can be provided by the source, or it can be set during the execution. This implementation which will initially be useful in statistics can also be used in different areas in the future.

If this approach makes sense and is approved by the community, I will subsequently open a new [PR](https://github.com/apache/arrow-datafusion/pull/7793) where its importance on statistics will be seen and some optimizations will be possible.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

An enumeration, named Precision, is implemented to define 3 types of exactness variants: Exact, Inexact, and Absent. The enum can be used in a generic way, and some utilities on usize and ScalarValue have also been added.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, unit tests are added.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->