### PR TITLE
Minor: Upgrade docs for `PhysicalExpr::{propagate_constraints, evaluate_bounds}`

### DIFF
--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -116,7 +116,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
     ///
     /// If the expression is `a + b`, the current `interval` is `[4, 5] and the
     /// inputs are given [`a: [0, 2], `b: [-∞, 4]]`, then propagation would
-    /// would return `[a: [0, 2], b: [2, 4]]` as `b` must be at least 2 to to
+    /// would return `[a: [0, 2], b: [2, 4]]` as `b` must be at least 2 to
     /// make the output at least `4`.
     fn propagate_constraints(
         &self,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change
While reviewing https://github.com/apache/arrow-datafusion/pull/7804#pullrequestreview-1674090033 I spent time figuring out in more detail what these functions did. I figured I would save myself (and hopefully other future readers) some time in the future

## What changes are included in this PR?

Add doc comments and examples for `PhysicalExpr::{propagate_constraints, evaluate_bounds}`

## Are these changes tested?
Docs
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->