### PR TITLE
Minor: Move `Monotonicity` to `expr` crate

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -21,8 +21,8 @@ use crate::nullif::SUPPORTED_NULLIF_TYPES;
 use crate::signature::TIMEZONE_WILDCARD;
 use crate::type_coercion::functions::data_types;
 use crate::{
-    conditional_expressions, struct_expressions, utils, Signature, TypeSignature,
-    Volatility,
+    conditional_expressions, struct_expressions, utils, FuncMonotonicity, Signature,
+    TypeSignature, Volatility,
 };
 use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
 use datafusion_common::{internal_err, plan_err, DataFusionError, Result};
@@ -1281,6 +1281,47 @@ impl BuiltinScalarFunction {
                     self.volatility(),
                 )
             }
+        }
+    }
+
+    /// This function specifies monotonicity behaviors for built-in scalar functions.
+    /// The list can be extended, only mathematical and datetime functions are
+    /// considered for the initial implementation of this feature.
+    pub fn monotonicity(&self) -> Option<FuncMonotonicity> {
+        if matches!(
+            &self,
+            BuiltinScalarFunction::Atan
+                | BuiltinScalarFunction::Acosh
+                | BuiltinScalarFunction::Asinh
+                | BuiltinScalarFunction::Atanh
+                | BuiltinScalarFunction::Ceil
+                | BuiltinScalarFunction::Degrees
+                | BuiltinScalarFunction::Exp
+                | BuiltinScalarFunction::Factorial
+                | BuiltinScalarFunction::Floor
+                | BuiltinScalarFunction::Ln
+                | BuiltinScalarFunction::Log10
+                | BuiltinScalarFunction::Log2
+                | BuiltinScalarFunction::Radians
+                | BuiltinScalarFunction::Round
+                | BuiltinScalarFunction::Signum
+                | BuiltinScalarFunction::Sinh
+                | BuiltinScalarFunction::Sqrt
+                | BuiltinScalarFunction::Cbrt
+                | BuiltinScalarFunction::Tanh
+                | BuiltinScalarFunction::Trunc
+                | BuiltinScalarFunction::Pi
+        ) {
+            Some(vec![Some(true)])
+        } else if matches!(
+            &self,
+            BuiltinScalarFunction::DateTrunc | BuiltinScalarFunction::DateBin
+        ) {
+            Some(vec![None, Some(true)])
+        } else if *self == BuiltinScalarFunction::Log {
+            Some(vec![Some(true), Some(false)])
+        } else {
+            None
         }
     }
 }

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -74,7 +74,10 @@ pub use logical_plan::*;
 pub use nullif::SUPPORTED_NULLIF_TYPES;
 pub use operator::Operator;
 pub use partition_evaluator::PartitionEvaluator;
-pub use signature::{Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD};
+pub use signature::{
+    get_func_monotonicity, FuncMonotonicity, Signature, TypeSignature, Volatility,
+    TIMEZONE_WILDCARD,
+};
 pub use table_source::{TableProviderFilterPushDown, TableSource, TableType};
 pub use udaf::AggregateUDF;
 pub use udf::ScalarUDF;

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -75,8 +75,7 @@ pub use nullif::SUPPORTED_NULLIF_TYPES;
 pub use operator::Operator;
 pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{
-    get_func_monotonicity, FuncMonotonicity, Signature, TypeSignature, Volatility,
-    TIMEZONE_WILDCARD,
+    FuncMonotonicity, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,
 };
 pub use table_source::{TableProviderFilterPushDown, TableSource, TableType};
 pub use udaf::AggregateUDF;

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -18,7 +18,6 @@
 //! Signature module contains foundational types that are used to represent signatures, types,
 //! and return types of functions in DataFusion.
 
-use crate::BuiltinScalarFunction;
 use arrow::datatypes::DataType;
 
 /// Constant that is used as a placeholder for any valid timezone.
@@ -235,44 +234,3 @@ impl Signature {
 /// - `Some(true)` indicates that the function is monotonically increasing w.r.t. the argument in question.
 /// - Some(false) indicates that the function is monotonically decreasing w.r.t. the argument in question.
 pub type FuncMonotonicity = Vec<Option<bool>>;
-
-/// This function specifies monotonicity behaviors for built-in scalar functions.
-/// The list can be extended, only mathematical and datetime functions are
-/// considered for the initial implementation of this feature.
-pub fn get_func_monotonicity(fun: &BuiltinScalarFunction) -> Option<FuncMonotonicity> {
-    if matches!(
-        fun,
-        BuiltinScalarFunction::Atan
-            | BuiltinScalarFunction::Acosh
-            | BuiltinScalarFunction::Asinh
-            | BuiltinScalarFunction::Atanh
-            | BuiltinScalarFunction::Ceil
-            | BuiltinScalarFunction::Degrees
-            | BuiltinScalarFunction::Exp
-            | BuiltinScalarFunction::Factorial
-            | BuiltinScalarFunction::Floor
-            | BuiltinScalarFunction::Ln
-            | BuiltinScalarFunction::Log10
-            | BuiltinScalarFunction::Log2
-            | BuiltinScalarFunction::Radians
-            | BuiltinScalarFunction::Round
-            | BuiltinScalarFunction::Signum
-            | BuiltinScalarFunction::Sinh
-            | BuiltinScalarFunction::Sqrt
-            | BuiltinScalarFunction::Cbrt
-            | BuiltinScalarFunction::Tanh
-            | BuiltinScalarFunction::Trunc
-            | BuiltinScalarFunction::Pi
-    ) {
-        Some(vec![Some(true)])
-    } else if matches!(
-        fun,
-        BuiltinScalarFunction::DateTrunc | BuiltinScalarFunction::DateBin
-    ) {
-        Some(vec![None, Some(true)])
-    } else if *fun == BuiltinScalarFunction::Log {
-        Some(vec![Some(true), Some(false)])
-    } else {
-        None
-    }
-}

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -46,7 +46,8 @@ use arrow::{
 };
 use datafusion_common::{internal_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
-    BuiltinScalarFunction, ColumnarValue, ScalarFunctionImplementation,
+    get_func_monotonicity, BuiltinScalarFunction, ColumnarValue, FuncMonotonicity,
+    ScalarFunctionImplementation,
 };
 use std::ops::Neg;
 use std::sync::Arc;
@@ -903,14 +904,6 @@ pub fn create_physical_fun(
     })
 }
 
-/// Monotonicity of the `ScalarFunctionExpr` with respect to its arguments.
-/// Each element of this vector corresponds to an argument and indicates whether
-/// the function's behavior is monotonic, or non-monotonic/unknown for that argument, namely:
-/// - `None` signifies unknown monotonicity or non-monotonicity.
-/// - `Some(true)` indicates that the function is monotonically increasing w.r.t. the argument in question.
-/// - Some(false) indicates that the function is monotonically decreasing w.r.t. the argument in question.
-pub type FuncMonotonicity = Vec<Option<bool>>;
-
 /// Determines a [`ScalarFunctionExpr`]'s monotonicity for the given arguments
 /// and the function's behavior depending on its arguments.
 pub fn out_ordering(
@@ -961,47 +954,6 @@ fn func_order_in_one_dimension(
                 }
             }
         }
-    }
-}
-
-/// This function specifies monotonicity behaviors for built-in scalar functions.
-/// The list can be extended, only mathematical and datetime functions are
-/// considered for the initial implementation of this feature.
-pub fn get_func_monotonicity(fun: &BuiltinScalarFunction) -> Option<FuncMonotonicity> {
-    if matches!(
-        fun,
-        BuiltinScalarFunction::Atan
-            | BuiltinScalarFunction::Acosh
-            | BuiltinScalarFunction::Asinh
-            | BuiltinScalarFunction::Atanh
-            | BuiltinScalarFunction::Ceil
-            | BuiltinScalarFunction::Degrees
-            | BuiltinScalarFunction::Exp
-            | BuiltinScalarFunction::Factorial
-            | BuiltinScalarFunction::Floor
-            | BuiltinScalarFunction::Ln
-            | BuiltinScalarFunction::Log10
-            | BuiltinScalarFunction::Log2
-            | BuiltinScalarFunction::Radians
-            | BuiltinScalarFunction::Round
-            | BuiltinScalarFunction::Signum
-            | BuiltinScalarFunction::Sinh
-            | BuiltinScalarFunction::Sqrt
-            | BuiltinScalarFunction::Cbrt
-            | BuiltinScalarFunction::Tanh
-            | BuiltinScalarFunction::Trunc
-            | BuiltinScalarFunction::Pi
-    ) {
-        Some(vec![Some(true)])
-    } else if matches!(
-        fun,
-        BuiltinScalarFunction::DateTrunc | BuiltinScalarFunction::DateBin
-    ) {
-        Some(vec![None, Some(true)])
-    } else if *fun == BuiltinScalarFunction::Log {
-        Some(vec![Some(true), Some(false)])
-    } else {
-        None
     }
 }
 

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -45,9 +45,9 @@ use arrow::{
     datatypes::{DataType, Int32Type, Int64Type, Schema},
 };
 use datafusion_common::{internal_err, DataFusionError, Result, ScalarValue};
+pub use datafusion_expr::FuncMonotonicity;
 use datafusion_expr::{
-    get_func_monotonicity, BuiltinScalarFunction, ColumnarValue, FuncMonotonicity,
-    ScalarFunctionImplementation,
+    BuiltinScalarFunction, ColumnarValue, ScalarFunctionImplementation,
 };
 use std::ops::Neg;
 use std::sync::Arc;
@@ -181,7 +181,7 @@ pub fn create_physical_expr(
         _ => create_physical_fun(fun, execution_props)?,
     };
 
-    let monotonicity = get_func_monotonicity(fun);
+    let monotonicity = fun.monotonicity();
 
     Ok(Arc::new(ScalarFunctionExpr::new(
         &format!("{fun}"),
@@ -902,6 +902,14 @@ pub fn create_physical_fun(
             );
         }
     })
+}
+
+#[deprecated(
+    since = "32.0.0",
+    note = "Moved to `expr` crate. Please use `BuiltinScalarFunction::monotonicity()` instead"
+)]
+pub fn get_func_monotonicity(fun: &BuiltinScalarFunction) -> Option<FuncMonotonicity> {
+    fun.monotonicity()
 }
 
 /// Determines a [`ScalarFunctionExpr`]'s monotonicity for the given arguments

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -30,7 +30,6 @@
 //! to a function that supports f64, it is coerced to f64.
 
 use crate::functions::out_ordering;
-use crate::functions::FuncMonotonicity;
 use crate::physical_expr::down_cast_any_ref;
 use crate::sort_properties::SortProperties;
 use crate::utils::expr_list_eq_strict_order;
@@ -41,6 +40,7 @@ use datafusion_common::Result;
 use datafusion_expr::expr_vec_fmt;
 use datafusion_expr::BuiltinScalarFunction;
 use datafusion_expr::ColumnarValue;
+use datafusion_expr::FuncMonotonicity;
 use datafusion_expr::ScalarFunctionImplementation;
 use std::any::Any;
 use std::fmt::Debug;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

NA

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I'm working on something related to functions and would like to use `Monotonicity` inside `expr` crate.
But now `Monotonicity` is defined in `physical-expr` crate, which depends on `expr`
Since it should be part of the function definition, it's better to move it into `expr` crate.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->