### PR TITLE
feat: Use bloom filter when reading parquet to skip row groups 

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -600,7 +600,7 @@ impl DefaultParquetFileReaderFactory {
 }
 
 /// Implements [`AsyncFileReader`] for a parquet file in object storage
-struct ParquetFileReader {
+pub(crate) struct ParquetFileReader {
     file_metrics: ParquetFileMetrics,
     inner: ParquetObjectReader,
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -248,7 +248,7 @@ impl ParquetExec {
             .unwrap_or(config_options.execution.parquet.enable_page_index)
     }
 
-    /// If enabled, the reader will read the bloom filter
+    /// If enabled, the reader will read by the bloom filter
     pub fn with_enable_bloom_filter(mut self, enable_bloom_filter: bool) -> Self {
         self.enable_bloom_filter = Some(enable_bloom_filter);
         self

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -514,15 +514,17 @@ impl FileOpener for ParquetOpener {
 
             // Bloom filter pruning: if bloom filters are enabled and then attempt to skip entire row_groups
             // using bloom filters on the row groups
-            if enable_bloom_filter && !row_groups.is_empty() && predicate.is_some() {
-                row_groups = row_groups::prune_row_groups_by_bloom_filters(
-                    &mut builder,
-                    &row_groups,
-                    file_metadata.row_groups(),
-                    predicate.unwrap(),
-                    &file_metrics,
-                )
-                .await;
+            if enable_bloom_filter && !row_groups.is_empty() {
+                if let Some(predicate) = predicate {
+                    row_groups = row_groups::prune_row_groups_by_bloom_filters(
+                        &mut builder,
+                        &row_groups,
+                        file_metadata.row_groups(),
+                        predicate,
+                        &file_metrics,
+                    )
+                    .await;
+                }
             }
 
             // page index pruning: if all data on individual pages can

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -82,6 +82,9 @@ pub struct ParquetExec {
     /// Override for `Self::with_enable_page_index`. If None, uses
     /// values from base_config
     enable_page_index: Option<bool>,
+    /// Override for `Self::with_enable_bloom_filter`. If None, uses
+    /// values from base_config
+    enable_bloom_filter: Option<bool>,
     /// Base configuration for this scan
     base_config: FileScanConfig,
     projected_statistics: Statistics,
@@ -151,6 +154,7 @@ impl ParquetExec {
             pushdown_filters: None,
             reorder_filters: None,
             enable_page_index: None,
+            enable_bloom_filter: None,
             base_config,
             projected_schema,
             projected_statistics,
@@ -242,6 +246,18 @@ impl ParquetExec {
     fn enable_page_index(&self, config_options: &ConfigOptions) -> bool {
         self.enable_page_index
             .unwrap_or(config_options.execution.parquet.enable_page_index)
+    }
+
+    /// If enabled, the reader will read the bloom filter
+    pub fn with_enable_bloom_filter(mut self, enable_bloom_filter: bool) -> Self {
+        self.enable_bloom_filter = Some(enable_bloom_filter);
+        self
+    }
+
+    /// Return the value described in [`Self::with_enable_bloom_filter`]
+    fn enable_bloom_filter(&self, config_options: &ConfigOptions) -> bool {
+        self.enable_bloom_filter
+            .unwrap_or(config_options.execution.parquet.bloom_filter_enabled)
     }
 
     /// Redistribute files across partitions according to their size
@@ -373,6 +389,7 @@ impl ExecutionPlan for ParquetExec {
             pushdown_filters: self.pushdown_filters(config_options),
             reorder_filters: self.reorder_filters(config_options),
             enable_page_index: self.enable_page_index(config_options),
+            enable_bloom_filter: self.enable_bloom_filter(config_options),
         };
 
         let stream =
@@ -406,6 +423,7 @@ struct ParquetOpener {
     pushdown_filters: bool,
     reorder_filters: bool,
     enable_page_index: bool,
+    enable_bloom_filter: bool,
 }
 
 impl FileOpener for ParquetOpener {
@@ -440,6 +458,7 @@ impl FileOpener for ParquetOpener {
             self.enable_page_index,
             &self.page_pruning_predicate,
         );
+        let enable_bloom_filter = self.enable_bloom_filter;
         let limit = self.limit;
 
         Ok(Box::pin(async move {
@@ -482,15 +501,29 @@ impl FileOpener for ParquetOpener {
                 };
             };
 
-            // Row group pruning: attempt to skip entire row_groups
+            // Row group pruning by statistics: attempt to skip entire row_groups
             // using metadata on the row groups
-            let file_metadata = builder.metadata();
-            let row_groups = row_groups::prune_row_groups(
+            let file_metadata = builder.metadata().clone();
+            let predicate = pruning_predicate.as_ref().map(|p| p.as_ref());
+            let mut row_groups = row_groups::prune_row_groups_by_statistics(
                 file_metadata.row_groups(),
                 file_range,
-                pruning_predicate.as_ref().map(|p| p.as_ref()),
+                predicate,
                 &file_metrics,
             );
+
+            // Bloom filter pruning: if bloom filters are enabled and then attempt to skip entire row_groups
+            // using bloom filters on the row groups
+            if enable_bloom_filter && !row_groups.is_empty() && predicate.is_some() {
+                row_groups = row_groups::prune_row_groups_by_bloom_filters(
+                    &mut builder,
+                    &row_groups,
+                    file_metadata.row_groups(),
+                    predicate.unwrap(),
+                    &file_metrics,
+                )
+                .await;
+            }
 
             // page index pruning: if all data on individual pages can
             // be ruled using page metadata, rows from other columns

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1252,7 +1252,7 @@ mod tests {
 
         let metrics = ExecutionPlanMetricsSet::new();
         let file_metrics =
-            ParquetFileMetrics::new(0, &object_meta.location.to_string(), &metrics);
+            ParquetFileMetrics::new(0, object_meta.location.as_ref(), &metrics);
         let reader = ParquetFileReader {
             inner: ParquetObjectReader::new(Arc::new(in_memory), object_meta),
             file_metrics: file_metrics.clone(),
@@ -1263,7 +1263,7 @@ mod tests {
         let pruned_row_group = prune_row_groups_by_bloom_filters(
             &mut builder,
             row_groups,
-            &metadata.row_groups(),
+            metadata.row_groups(),
             pruning_predicate,
             &file_metrics,
         )

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -460,10 +460,14 @@ mod tests {
     use arrow::datatypes::DataType::Decimal128;
     use arrow::datatypes::Schema;
     use arrow::datatypes::{DataType, Field};
-    use datafusion_common::ToDFSchema;
-    use datafusion_expr::{cast, col, lit, Expr};
+    use datafusion_common::{config::ConfigOptions, TableReference, ToDFSchema};
+    use datafusion_expr::{
+        builder::LogicalTableSource, cast, col, lit, AggregateUDF, Expr, ScalarUDF,
+        TableSource, WindowUDF,
+    };
     use datafusion_physical_expr::execution_props::ExecutionProps;
     use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
+    use datafusion_sql::planner::ContextProvider;
     use parquet::arrow::async_reader::ParquetObjectReader;
     use parquet::basic::LogicalType;
     use parquet::data_type::{ByteArray, FixedLenByteArray};
@@ -1174,6 +1178,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_row_group_bloom_filter_pruning_predicate_sql_in() {
+        // load parquet file
+        let testdata = datafusion_common::test_util::parquet_test_data();
+        let file_name = "data_index_bloom_encoding_stats.parquet";
+        let path = format!("{testdata}/{file_name}");
+        let data = bytes::Bytes::from(std::fs::read(path).unwrap());
+
+        // generate pruning predicate
+        let schema = Schema::new(vec![
+            Field::new("String", DataType::Utf8, false),
+            Field::new("String3", DataType::Utf8, false),
+        ]);
+        let sql =
+            "SELECT * FROM tbl WHERE \"String\" IN ('Hello_Not_Exists', 'Hello_Not_Exists2')";
+        let expr = sql_to_physical_plan(sql).unwrap();
+        let pruning_predicate =
+            PruningPredicate::try_new(expr, Arc::new(schema)).unwrap();
+
+        let row_groups = vec![0];
+        let pruned_row_groups = test_row_group_bloom_filter_pruning_predicate(
+            file_name,
+            data,
+            &pruning_predicate,
+            &row_groups,
+        )
+        .await
+        .unwrap();
+        assert!(pruned_row_groups.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_row_group_bloom_filter_pruning_predicate_with_exists_value() {
         // load parquet file
         let testdata = datafusion_common::test_util::parquet_test_data();
@@ -1267,5 +1302,101 @@ mod tests {
         .await;
 
         Ok(pruned_row_group)
+    }
+
+    fn sql_to_physical_plan(sql: &str) -> Result<Arc<dyn PhysicalExpr>> {
+        use datafusion_optimizer::{
+            analyzer::Analyzer, optimizer::Optimizer, OptimizerConfig, OptimizerContext,
+        };
+        use datafusion_sql::{
+            planner::SqlToRel,
+            sqlparser::{ast::Statement, parser::Parser},
+        };
+        use sqlparser::dialect::GenericDialect;
+
+        // parse the SQL
+        let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
+        let ast: Vec<Statement> = Parser::parse_sql(&dialect, sql).unwrap();
+        let statement = &ast[0];
+
+        // create a logical query plan
+        let schema_provider = TestSchemaProvider::new();
+        let sql_to_rel = SqlToRel::new(&schema_provider);
+        let plan = sql_to_rel.sql_statement_to_plan(statement.clone()).unwrap();
+
+        // hard code the return value of now()
+        let config = OptimizerContext::new().with_skip_failing_rules(false);
+        let analyzer = Analyzer::new();
+        let optimizer = Optimizer::new();
+        // analyze and optimize the logical plan
+        let plan = analyzer.execute_and_check(&plan, config.options(), |_, _| {})?;
+        let plan = optimizer.optimize(&plan, &config, |_, _| {})?;
+        // convert the logical plan into a physical plan
+        let exprs = plan.expressions();
+        let expr = &exprs[0];
+        let df_schema = plan.schema().as_ref().to_owned();
+        let tb_schema: Schema = df_schema.into();
+        let execution_props = ExecutionProps::new();
+        create_physical_expr(expr, &df_schema, &tb_schema, &execution_props)
+    }
+
+    struct TestSchemaProvider {
+        options: ConfigOptions,
+        tables: HashMap<String, Arc<dyn TableSource>>,
+    }
+
+    impl TestSchemaProvider {
+        pub fn new() -> Self {
+            let mut tables = HashMap::new();
+            tables.insert(
+                "tbl".to_string(),
+                create_table_source(vec![Field::new(
+                    "String".to_string(),
+                    DataType::Utf8,
+                    false,
+                )]),
+            );
+
+            Self {
+                options: Default::default(),
+                tables,
+            }
+        }
+    }
+
+    impl ContextProvider for TestSchemaProvider {
+        fn get_table_provider(
+            &self,
+            name: TableReference,
+        ) -> Result<Arc<dyn TableSource>> {
+            match self.tables.get(name.table()) {
+                Some(table) => Ok(table.clone()),
+                _ => datafusion_common::plan_err!("Table not found: {}", name.table()),
+            }
+        }
+
+        fn get_function_meta(&self, _name: &str) -> Option<Arc<ScalarUDF>> {
+            None
+        }
+
+        fn get_aggregate_meta(&self, _name: &str) -> Option<Arc<AggregateUDF>> {
+            None
+        }
+
+        fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+            None
+        }
+
+        fn options(&self) -> &ConfigOptions {
+            &self.options
+        }
+
+        fn get_window_meta(&self, _name: &str) -> Option<Arc<WindowUDF>> {
+            None
+        }
+    }
+
+    fn create_table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
+        Arc::new(LogicalTableSource::new(Arc::new(Schema::new(fields))))
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1333,10 +1333,7 @@ mod tests {
     }
 
     impl ContextProvider for TestSchemaProvider {
-        fn get_table_provider(
-            &self,
-            name: TableReference,
-        ) -> Result<Arc<dyn TableSource>> {
+        fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
             match self.tables.get(name.table()) {
                 Some(table) => Ok(table.clone()),
                 _ => datafusion_common::plan_err!("Table not found: {}", name.table()),

--- a/datafusion/sqllogictest/test_files/json.slt
+++ b/datafusion/sqllogictest/test_files/json.slt
@@ -60,8 +60,6 @@ AggregateExec: mode=Final, gby=[], aggr=[COUNT(*)]
 
 query ?
 SELECT mycol FROM single_nan
-----
-NULL
 
 statement ok
 DROP TABLE json_test

--- a/datafusion/sqllogictest/test_files/json.slt
+++ b/datafusion/sqllogictest/test_files/json.slt
@@ -60,6 +60,8 @@ AggregateExec: mode=Final, gby=[], aggr=[COUNT(*)]
 
 query ?
 SELECT mycol FROM single_nan
+----
+NULL
 
 statement ok
 DROP TABLE json_test

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -480,3 +480,43 @@ select * from t where (i & 3) = 1;
 ########
 statement ok
 DROP TABLE t;
+
+
+########
+# Test query with bloom filter
+# Refer to https://github.com/apache/arrow-datafusion/pull/7821#pullrequestreview-1688062599
+########
+
+statement ok
+CREATE EXTERNAL TABLE data_index_bloom_encoding_stats STORED AS PARQUET LOCATION '../../parquet-testing/data/data_index_bloom_encoding_stats.parquet';
+
+statement ok
+set datafusion.execution.parquet.bloom_filter_enabled=true;
+
+query T
+SELECT * FROM data_index_bloom_encoding_stats WHERE "String" = 'foo';
+
+query T
+SELECT * FROM data_index_bloom_encoding_stats WHERE "String" = 'test';
+----
+test
+
+query T
+SELECT * FROM data_index_bloom_encoding_stats WHERE "String" like '%e%';
+----
+Hello
+test
+are you
+the quick
+over
+the lazy
+
+statement ok
+set datafusion.execution.parquet.bloom_filter_enabled=false;
+
+
+########
+# Clean up after the test
+########
+statement ok
+DROP TABLE data_index_bloom_encoding_stats;


### PR DESCRIPTION
## Which issue does this PR close?

Impl #4512  

## Rationale for this change

## What changes are included in this PR?

Implement `bloom filter` support when pruning `row group`.

## Are these changes tested?

- [x] Test with a parquet file that can prune `row group` by  `bloom filter`
- [x] Test with a parquet file that can't prune `row group` by `bloom filter`
- [x] Test with a parquet without `bloom filter`
- [x] Test with SQL  `where col in (a, b)`

## Are there any user-facing changes?

no