### PR TITLE
Support `Binary`/`LargeBinary` --> `Utf8`/`LargeUtf8` in ilike and string functions

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -1523,16 +1523,29 @@ impl FromStr for BuiltinScalarFunction {
     }
 }
 
+/// Creates a function that returns the return type of a string function given
+/// the type of its first argument.
+///
+/// If the input type is `LargeUtf8` or `LargeBinary` the return type is
+/// `$largeUtf8Type`,
+///
+/// If the input type is `Utf8` or `Binary` the return type is `$utf8Type`,
 macro_rules! make_utf8_to_return_type {
     ($FUNC:ident, $largeUtf8Type:expr, $utf8Type:expr) => {
         fn $FUNC(arg_type: &DataType, name: &str) -> Result<DataType> {
             Ok(match arg_type {
-                DataType::LargeUtf8 => $largeUtf8Type,
-                DataType::Utf8 => $utf8Type,
+                DataType::LargeUtf8  => $largeUtf8Type,
+                // LargeBinary inputs are automatically coerced to Utf8
+                DataType::LargeBinary => $largeUtf8Type,
+                DataType::Utf8  => $utf8Type,
+                // Binary inputs are automatically coerced to Utf8
+                DataType::Binary => $utf8Type,
                 DataType::Null => DataType::Null,
                 DataType::Dictionary(_, value_type) => match **value_type {
-                    DataType::LargeUtf8 => $largeUtf8Type,
+                    DataType::LargeUtf8  => $largeUtf8Type,
+                    DataType::LargeBinary => $largeUtf8Type,
                     DataType::Utf8 => $utf8Type,
+                    DataType::Binary => $utf8Type,
                     DataType::Null => DataType::Null,
                     _ => {
                         return plan_err!(
@@ -1553,8 +1566,10 @@ macro_rules! make_utf8_to_return_type {
         }
     };
 }
-
+// `utf8_to_str_type`: returns either a Utf8 or LargeUtf8 based on the input type size.
 make_utf8_to_return_type!(utf8_to_str_type, DataType::LargeUtf8, DataType::Utf8);
+
+// `utf8_to_str_type`: returns either a Int32 or Int64 based on the input type size.
 make_utf8_to_return_type!(utf8_to_int_type, DataType::Int64, DataType::Int32);
 
 fn utf8_or_binary_to_binary_type(arg_type: &DataType, name: &str) -> Result<DataType> {

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -46,6 +46,8 @@ pub fn data_types(
         return Ok(current_types.to_vec());
     }
 
+    // Try and coerce the argument types to match the signature, returning the
+    // coerced types from the first matching signature.
     for valid_types in valid_types {
         if let Some(types) = maybe_data_types(&valid_types, current_types) {
             return Ok(types);
@@ -60,6 +62,7 @@ pub fn data_types(
     )
 }
 
+/// Returns a Vec of all possible valid argument types for the given signature.
 fn get_valid_types(
     signature: &TypeSignature,
     current_types: &[DataType],
@@ -104,7 +107,12 @@ fn get_valid_types(
     Ok(valid_types)
 }
 
-/// Try to coerce current_types into valid_types.
+/// Try to coerce the current argument types to match the given `valid_types`.
+///
+/// For example, if a function `func` accepts arguments of  `(int64, int64)`,
+/// but was called with `(int32, int64)`, this function could match the
+/// valid_types by by coercing the first argument to `int64`, and would return
+/// `Some([int64, int64])`.
 fn maybe_data_types(
     valid_types: &[DataType],
     current_types: &[DataType],
@@ -220,6 +228,7 @@ fn coerced_from<'a>(
             Some(type_into.clone())
         }
         Interval(_) if matches!(type_from, Utf8 | LargeUtf8) => Some(type_into.clone()),
+        // Any type can be coerced into strings
         Utf8 | LargeUtf8 => Some(type_into.clone()),
         Null if can_cast_types(type_from, type_into) => Some(type_into.clone()),
 

--- a/datafusion/sqllogictest/test_files/binary.slt
+++ b/datafusion/sqllogictest/test_files/binary.slt
@@ -217,30 +217,51 @@ SELECT largebinary FROM t ORDER BY largebinary;
 NULL
 
 # LIKE
-# https://github.com/apache/arrow-datafusion/issues/7342
-query error DataFusion error: type_coercion
-SELECT binary FROM t where binary LIKE '%F';
+query ?
+SELECT binary FROM t where binary LIKE '%F%';
+----
+466f6f
+466f6f426172
 
-query error DataFusion error: type_coercion
-SELECT largebinary FROM t where largebinary LIKE '%F';
-
+query ?
+SELECT largebinary FROM t where largebinary LIKE '%F%';
+----
+466f6f
+466f6f426172
 
 # character_length function
-# https://github.com/apache/arrow-datafusion/issues/7344
-query error DataFusion error: Error during planning: The "character_length" function can only accept strings, but got Binary\.
+query TITI
 SELECT
   cast(binary as varchar) as str,
   character_length(binary) as binary_len,
   cast(largebinary as varchar) as large_str,
   character_length(binary) as largebinary_len
 from t;
+----
+Foo 3 Foo 3
+NULL NULL NULL NULL
+Bar 3 Bar 3
+FooBar 6 FooBar 6
+
+query I
+SELECT character_length(X'20');
+----
+1
+
+# still errors on values that can not be coerced to utf8
+query error Encountered non UTF\-8 data: invalid utf\-8 sequence of 1 bytes from index 0
+SELECT character_length(X'c328');
 
 # regexp_replace
-# https://github.com/apache/arrow-datafusion/issues/7345
-query error DataFusion error: Error during planning: The "regexp_replace" function can only accept strings, but got Binary\.
+query TTTT
 SELECT
   cast(binary as varchar) as str,
   regexp_replace(binary, 'F', 'f') as binary_replaced,
   cast(largebinary as varchar) as large_str,
   regexp_replace(largebinary, 'F', 'f') as large_binary_replaced
 from t;
+----
+Foo foo Foo foo
+NULL NULL NULL NULL
+Bar Bar Bar Bar
+FooBar fooBar FooBar fooBar


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/7342
Closes https://github.com/apache/arrow-datafusion/issues/7345
Closes https://github.com/apache/arrow-datafusion/issues/7344

It also closes several draft / PRs:
Closes https://github.com/apache/arrow-datafusion/pull/7349
Closes https://github.com/apache/arrow-datafusion/pull/7350
Closes https://github.com/apache/arrow-datafusion/pull/7365


## Rationale for this change
Some of the clickbench queries have this pattern

## What changes are included in this PR?
1. Add a bunch of comments
1. Add automatic coercion rules from `Binary` and `LargeBinary` to the appropriate `Utf8` (string) variants for `LIKE` and `ILIKE`
2. Add appropriate binary --> string logic in return type calculation for functions

## Are these changes tested?
Yes, new tests

## Are there any user-facing changes?

Yes now some queries will not error