### PR TITLE
Convert list array and non-list array to scalars

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2041,7 +2041,13 @@ impl ScalarValue {
 
     /// Retrieve `ScalarValue` for each row in `array`
     ///
-    /// Convert `ListArray` to `Vec<Vec<ScalarValue>>`, first `Vec` is for rows, second `Vec` is for elements in the list
+    /// Convert `ListArray` into a 2 dimensional to `Vec<Vec<ScalarValue>>`, first `Vec` is for rows,
+    /// second `Vec` is for elements in the list.
+    ///
+    /// See [`Self::convert_non_list_array_to_scalars`] for converting non Lists
+    ///
+    /// This method is an optimization to unwrap nested ListArrays to nested Rust structures without
+    /// converting them twice
     ///
     /// Return `Err` if `array` is not `ListArray`
     ///

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2057,7 +2057,7 @@ impl ScalarValue {
     ///    Some(vec![Some(4), Some(5)])
     /// ]);
     ///
-    /// let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(&list_arr).unwrap();
+    /// let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(&list_arr).unwrap();
     ///
     /// let expected = vec![
     ///   vec![

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3272,7 +3272,6 @@ mod tests {
         ];
 
         let array = ScalarValue::new_list(scalars.as_slice(), &DataType::Utf8);
-        let result = as_list_array(&array);
 
         let expected = array_into_list_array(Arc::new(StringArray::from(vec![
             "rust",
@@ -3280,6 +3279,7 @@ mod tests {
             "data-fusion",
         ])));
 
+        let result = as_list_array(&array);
         assert_eq!(result, &expected);
     }
 

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -45,13 +45,17 @@ async fn csv_query_array_agg_distinct() -> Result<()> {
     let column = actual[0].column(0);
     assert_eq!(column.len(), 1);
 
-    let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(&column)?;
-    let mut scalars = scalar_vec[0].clone();
+    // 1 row
+    let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(&column)?;
+
     // workaround lack of Ord of ScalarValue
     let cmp = |a: &ScalarValue, b: &ScalarValue| {
         a.partial_cmp(b).expect("Can compare ScalarValues")
     };
+
+    let mut scalars = scalar_vec.first().unwrap().to_owned();
     scalars.sort_by(cmp);
+
     assert_eq!(
         scalars,
         vec![

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -47,13 +47,13 @@ async fn csv_query_array_agg_distinct() -> Result<()> {
 
     // 1 row
     let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(&column)?;
+    let mut scalars = scalar_vec.first().unwrap().to_owned();
 
     // workaround lack of Ord of ScalarValue
     let cmp = |a: &ScalarValue, b: &ScalarValue| {
         a.partial_cmp(b).expect("Can compare ScalarValues")
     };
 
-    let mut scalars = scalar_vec.first().unwrap().to_owned();
     scalars.sort_by(cmp);
 
     assert_eq!(

--- a/datafusion/core/tests/sql/aggregates.rs
+++ b/datafusion/core/tests/sql/aggregates.rs
@@ -45,7 +45,7 @@ async fn csv_query_array_agg_distinct() -> Result<()> {
     let column = actual[0].column(0);
     assert_eq!(column.len(), 1);
 
-    let scalar_vec = ScalarValue::convert_array_to_scalar_vec(&column)?;
+    let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(&column)?;
     let mut scalars = scalar_vec[0].clone();
     // workaround lack of Ord of ScalarValue
     let cmp = |a: &ScalarValue, b: &ScalarValue| {

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -139,7 +139,8 @@ impl Accumulator for DistinctArrayAggAccumulator {
         let array = &values[0];
         match array.data_type() {
             DataType::List(_) => {
-                let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(array)?;
+                let scalar_vec =
+                    ScalarValue::convert_list_array_to_scalar_vec::<i32>(array)?;
                 for scalars in scalar_vec {
                     self.values.extend(scalars);
                 }

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -139,7 +139,7 @@ impl Accumulator for DistinctArrayAggAccumulator {
         let array = &values[0];
         match array.data_type() {
             DataType::List(_) => {
-                let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(array)?;
+                let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(array)?;
                 for scalars in scalar_vec {
                     self.values.extend(scalars);
                 }

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -145,6 +145,13 @@ impl Accumulator for DistinctArrayAggAccumulator {
                     self.values.extend(scalars);
                 }
             }
+            DataType::LargeList(_) => {
+                let scalar_vec =
+                    ScalarValue::convert_list_array_to_scalar_vec::<i64>(array)?;
+                for scalars in scalar_vec {
+                    self.values.extend(scalars);
+                }
+            }
             _ => {
                 let scalars = ScalarValue::convert_non_list_array_to_scalars(array)?;
                 self.values.extend(scalars);

--- a/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
@@ -225,13 +225,13 @@ impl Accumulator for OrderSensitiveArrayAggAccumulator {
             partition_ordering_values.push(self.ordering_values.clone());
 
             let array_agg_res =
-                ScalarValue::convert_list_array_to_scalar_vec(array_agg_values)?;
+                ScalarValue::convert_list_array_to_scalar_vec::<i32>(array_agg_values)?;
 
             for v in array_agg_res.into_iter() {
                 partition_values.push(v);
             }
 
-            let orderings = ScalarValue::convert_list_array_to_scalar_vec(agg_orderings)?;
+            let orderings = ScalarValue::convert_list_array_to_scalar_vec::<i32>(agg_orderings)?;
 
             for partition_ordering_rows in orderings.into_iter() {
                 // Extract value from struct to ordering_rows for each group/partition

--- a/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
@@ -231,7 +231,8 @@ impl Accumulator for OrderSensitiveArrayAggAccumulator {
                 partition_values.push(v);
             }
 
-            let orderings = ScalarValue::convert_list_array_to_scalar_vec::<i32>(agg_orderings)?;
+            let orderings =
+                ScalarValue::convert_list_array_to_scalar_vec::<i32>(agg_orderings)?;
 
             for partition_ordering_rows in orderings.into_iter() {
                 // Extract value from struct to ordering_rows for each group/partition

--- a/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_ordered.rs
@@ -225,13 +225,13 @@ impl Accumulator for OrderSensitiveArrayAggAccumulator {
             partition_ordering_values.push(self.ordering_values.clone());
 
             let array_agg_res =
-                ScalarValue::convert_array_to_scalar_vec(array_agg_values)?;
+                ScalarValue::convert_list_array_to_scalar_vec(array_agg_values)?;
 
             for v in array_agg_res.into_iter() {
                 partition_values.push(v);
             }
 
-            let orderings = ScalarValue::convert_array_to_scalar_vec(agg_orderings)?;
+            let orderings = ScalarValue::convert_list_array_to_scalar_vec(agg_orderings)?;
 
             for partition_ordering_rows in orderings.into_iter() {
                 // Extract value from struct to ordering_rows for each group/partition

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -167,7 +167,7 @@ impl Accumulator for DistinctCountAccumulator {
             return Ok(());
         }
         assert_eq!(states.len(), 1, "array_agg states must be singleton!");
-        let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(&states[0])?;
+        let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(&states[0])?;
         for scalars in scalar_vec.into_iter() {
             self.values.extend(scalars)
         }

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -167,7 +167,8 @@ impl Accumulator for DistinctCountAccumulator {
             return Ok(());
         }
         assert_eq!(states.len(), 1, "array_agg states must be singleton!");
-        let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec::<i32>(&states[0])?;
+        let scalar_vec =
+            ScalarValue::convert_list_array_to_scalar_vec::<i32>(&states[0])?;
         for scalars in scalar_vec.into_iter() {
             self.values.extend(scalars)
         }

--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -167,7 +167,7 @@ impl Accumulator for DistinctCountAccumulator {
             return Ok(());
         }
         assert_eq!(states.len(), 1, "array_agg states must be singleton!");
-        let scalar_vec = ScalarValue::convert_array_to_scalar_vec(&states[0])?;
+        let scalar_vec = ScalarValue::convert_list_array_to_scalar_vec(&states[0])?;
         for scalars in scalar_vec.into_iter() {
             self.values.extend(scalars)
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

`convert_array_to_scalar_vec` can convert well for list array, but we will get `Vec<Vec<ScalarValue>>` for non-list array (primitive array).
It would be nice to have another conversion that returns nicely `Vec<ScalarValue>` for the non-list array. I would need this for #7835 too.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

`convert_list_array_to_scalar_vec` for ListArray
`convert_non_list_array_to_scalar_vec` for non-ListArray

The nested array for DistinctArrayAggAccumulator (update_batch) is removed so as to test.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Doc test

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->