### PR TITLE
Minor: fix typo in GreedyMemoryPool documentation

### DIFF
--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -49,7 +49,7 @@ impl MemoryPool for UnboundedMemoryPool {
 /// A [`MemoryPool`] that implements a greedy first-come first-serve limit.
 ///
 /// This pool works well for queries that do not need to spill or have
-/// a single spillable operator. See [`GreedyMemoryPool`] if there are
+/// a single spillable operator. See [`FairSpillPool`] if there are
 /// multiple spillable operators that all will spill.
 #[derive(Debug)]
 pub struct GreedyMemoryPool {


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

It seems clear from the documentation for `FairSpillPool` that this is what was intended here.

## Are these changes tested?

N/A: documentation change only

## Are there any user-facing changes?

No: Documentation change only