### PR TITLE
Support Interval analysis for `OR` expressions

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -344,8 +344,8 @@ impl PhysicalExpr for BinaryExpr {
         let right_interval = children[1];
 
         let (left, right) = if self.op.is_logic_operator() {
-            // TODO: Currently, this implementation only supports the AND operator
-            //       and does not require any further propagation. In the future,
+            // TODO: Currently, this implementation only supports the AND/OR operator
+            //       and does not require any further propagation (??). In the future,
             //       upon adding support for additional logical operators, this
             //       method will require modification to support propagating the
             //       changes accordingly.

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -345,7 +345,7 @@ impl PhysicalExpr for BinaryExpr {
 
         let (left, right) = if self.op.is_logic_operator() {
             // TODO: Currently, this implementation only supports the AND/OR operator
-            //       and does not require any further propagation (??). In the future,
+            //       and does not require any further propagation. In the future,
             //       upon adding support for additional logical operators, this
             //       method will require modification to support propagating the
             //       changes accordingly.

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -498,22 +498,15 @@ impl ExprIntervalGraph {
     pub fn evaluate_bounds(&mut self) -> Result<&Interval> {
         let mut dfs = DfsPostOrder::new(&self.graph, self.root);
         while let Some(node) = dfs.next(&self.graph) {
-            println!("Considering node: {}", self.graph[node].expr);
             let neighbors = self.graph.neighbors_directed(node, Outgoing);
             let mut children_intervals = neighbors
-                .map(|child| {
-                    println!("  child: {}", self.graph[child].expr);
-                    self.graph[child].interval()
-                })
+                .map(|child| self.graph[child].interval())
                 .collect::<Vec<_>>();
-            println!("  children_intervals: {:?}", children_intervals);
             // If the current expression is a leaf, its interval should already
             // be set externally, just continue with the evaluation procedure:
             if !children_intervals.is_empty() {
                 // Reverse to align with [PhysicalExpr]'s children:
                 children_intervals.reverse();
-                println!("  evaluating bounds with: {:?}", children_intervals);
-
                 self.graph[node].interval =
                     self.graph[node].expr.evaluate_bounds(&children_intervals)?;
             }

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -498,15 +498,22 @@ impl ExprIntervalGraph {
     pub fn evaluate_bounds(&mut self) -> Result<&Interval> {
         let mut dfs = DfsPostOrder::new(&self.graph, self.root);
         while let Some(node) = dfs.next(&self.graph) {
+            println!("Considering node: {}", self.graph[node].expr);
             let neighbors = self.graph.neighbors_directed(node, Outgoing);
             let mut children_intervals = neighbors
-                .map(|child| self.graph[child].interval())
+                .map(|child| {
+                    println!("  child: {}", self.graph[child].expr);
+                    self.graph[child].interval()
+                })
                 .collect::<Vec<_>>();
+            println!("  children_intervals: {:?}", children_intervals);
             // If the current expression is a leaf, its interval should already
             // be set externally, just continue with the evaluation procedure:
             if !children_intervals.is_empty() {
                 // Reverse to align with [PhysicalExpr]'s children:
                 children_intervals.reverse();
+                println!("  evaluating bounds with: {:?}", children_intervals);
+
                 self.graph[node].interval =
                     self.graph[node].expr.evaluate_bounds(&children_intervals)?;
             }

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -1081,12 +1081,9 @@ mod tests {
 
     fn open_open<T>(lower: Option<T>, upper: Option<T>) -> Interval
     where
-        T: std::fmt::Debug,
         ScalarValue: From<Option<T>>,
     {
-        println!("Creating open_open from {:?} to {:?}", lower, upper);
         Interval::make(lower, upper, (true, true))
-
     }
 
     fn open_closed<T>(lower: Option<T>, upper: Option<T>) -> Interval
@@ -1286,16 +1283,15 @@ mod tests {
             (true, true, true, true, true, true),
         ];
 
+        // Something is not right here -- lhs, rhs and expected are always the same Interval
+        //
         for case in cases {
             println!("case: {:?}", case);
             let lhs = open_open(Some(case.0), Some(case.1));
             let rhs = open_open(Some(case.2), Some(case.3));
             let expected = open_open(Some(case.4), Some(case.5));
             println!("lhs: {:?}, rhs: {:?}, expected: {:?}", lhs, rhs, expected);
-            assert_eq!(
-                lhs.or(rhs)?,
-                expected,
-            );
+            assert_eq!(lhs.or(rhs)?, expected,);
         }
         Ok(())
     }

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -436,7 +436,7 @@ impl Interval {
     pub(crate) fn or<T: Borrow<Interval>>(&self, other: T) -> Result<Interval> {
         let rhs = other.borrow();
         if self.get_datatype()? != DataType::Boolean
-            && rhs.get_datatype()? != DataType::Boolean
+            || rhs.get_datatype()? != DataType::Boolean
         {
             return internal_err!(
                 "Incompatible types for logical disjunction: {self:?}, {rhs:?}"

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -1283,8 +1283,9 @@ mod tests {
             (true, true, true, true, true, true),
         ];
 
-        // Something is not right here -- lhs, rhs and expected are always the same Interval
-        //
+        // Something is not right here -- lhs, rhs and expected are always the
+        // same Interval (so the test is useless as it always passes)
+        // Interval { lower: IntervalBound { value: Boolean(true), open: false }, upper: IntervalBound { value: Boolean(false), open: false } }
         for case in cases {
             println!("case: {:?}", case);
             let lhs = open_open(Some(case.0), Some(case.1));


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/7883

## Rationale for this change

See https://github.com/apache/arrow-datafusion/issues/7883

## What changes are included in this PR?

1. Add support for `OR` in interval analysis
2. New tests

## Are these changes tested?

Yes

## Are there any user-facing changes?
Probably not