### PR TITLE
Minor: Clarify Boolean `Interval` handling and verify it with a test

### DIFF
--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -256,11 +256,11 @@ impl Interval {
     /// function ensures they are one of the three valid values:
     ///
     /// 1. An open `false` lower bound is mapped to a `true` closed lower bound.
-    /// 2. an open `true` upper bound is mapped to  `false` closed
+    /// 2. An open `true` upper bound is mapped to  `false` closed
     /// upper bound.
     /// 3. An unbounded lower endpoints is mapped to a `false` closed lower
     /// bound
-    /// 4. An unbounded lower endpoint is mapped to a `true` closed upper bound.
+    /// 4. An unbounded upper endpoint is mapped to a `true` closed upper bound.
     pub fn new(lower: IntervalBound, upper: IntervalBound) -> Interval {
         if let ScalarValue::Boolean(_) = lower.value {
             let standardized_lower = match lower.value {
@@ -1105,7 +1105,7 @@ mod tests {
             expected_open_open: (bool, bool),
             /// expected bounds when lower is open, upper is closed
             expected_open_closed: (bool, bool),
-            /// expected bounds when lower is closes, upper is open
+            /// expected bounds when lower is closed, upper is open
             expected_closed_open: (bool, bool),
             // Not: closed/closed is the same as lower/upper
         }
@@ -1167,7 +1167,6 @@ mod tests {
         }
 
         for case in cases {
-            println!("Case: {case:?}");
             let TestCase {
                 lower,
                 upper,

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -203,7 +203,7 @@ impl Display for IntervalBound {
 /// Given there are only two  boolean values, and they are ordered such that
 /// `false` is less than `true`, there are only three possible valid intervals
 /// for a boolean:
-/// 
+///
 /// 1. `[false, false]`: definitely `false`
 /// 2. `[false, true]`: either `false` or `true`
 /// 3. `[true, true]`: definitely `true`

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -197,10 +197,10 @@ impl Display for IntervalBound {
 /// # Boolean Handling
 ///
 /// Boolean values require special handling. Boolean Intervals NEVER have open
-/// bounds. If you try to and construct one one with open bounds,
+/// bounds. If you try to and construct one with open bounds,
 /// [`Interval::new`] will remap them to one of the three valid values.
 ///
-/// Given there are only two  boolean values, and they are ordered such that
+/// Given there are only two boolean values, and they are ordered such that
 /// `false` is less than `true`, there are only three possible valid intervals
 /// for a boolean:
 ///

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -196,7 +196,9 @@ impl Display for IntervalBound {
 ///
 /// # Boolean Handling
 ///
-/// Boolean values require special handling.
+/// Boolean values require special handling. Boolean Intervals NEVER have open
+/// bounds. If you try to and construct one one with open bounds,
+/// [`Interval::new`] will remap them to one of the three valid values.
 ///
 /// Given there are only two  boolean values, and they are ordered such that
 /// `false` is less than `true`, there are only three possible valid intervals

--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -202,8 +202,11 @@ impl Display for IntervalBound {
 ///
 /// Given there are only two  boolean values, and they are ordered such that
 /// `false` is less than `true`, there are only three possible valid intervals
-/// for a boolean `[false, false]`, `[false, true]` or `[true, true]`, all with
-/// closed bounds.
+/// for a boolean:
+/// 
+/// 1. `[false, false]`: definitely `false`
+/// 2. `[false, true]`: either `false` or `true`
+/// 3. `[true, true]`: definitely `true`
 ///
 /// [`Interval::new`] takes this into account and adjusts any arguments as
 /// needed.


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/7883

## Rationale for this change

I was very confused about what was happening and how open/closed boolean intervals were handled while working on https://github.com/apache/arrow-datafusion/issues/7883

## What changes are included in this PR?

1. Update documentation with some additional rationale
2. Add a test that shows how Boolean intervals are handled with the different combinations of open/closed intervals)

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No functional change is intended