### PR TITLE
Minor: Fix bug in `AND` interval analysis tests (not code), and add more coverage

### DIFF
--- a/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
+++ b/datafusion/physical-expr/src/intervals/interval_aritmetic.rs
@@ -1221,21 +1221,29 @@ mod tests {
 
     #[test]
     fn and_test() -> Result<()> {
+        // check that (lhs AND rhs) is equal to result
+        // ((lhs_lower, lhs_upper), (rhs_lower, rhs_upper), lower_result, upper_result))
         let cases = vec![
-            (false, true, false, false, false, false),
-            (false, false, false, true, false, false),
-            (false, true, false, true, false, true),
-            (false, true, true, true, false, true),
-            (false, false, false, false, false, false),
-            (true, true, true, true, true, true),
+            // Note there are only three valid boolean intervals: [false, false], [false, true] and [true, true],
+            ((false, false), (false, false), (false, false)),
+            ((false, false), (false, true), (false, false)),
+            ((false, false), (true, true), (false, false)),
+            ((false, true), (false, false), (false, false)),
+            ((false, true), (false, true), (false, true)),
+            ((false, true), (true, true), (false, true)),
+            ((true, true), (false, false), (false, false)),
+            ((true, true), (false, true), (false, true)),
+            ((true, true), (true, true), (true, true)),
         ];
 
         for case in cases {
-            assert_eq!(
-                open_open(Some(case.0), Some(case.1))
-                    .and(open_open(Some(case.2), Some(case.3)))?,
-                open_open(Some(case.4), Some(case.5))
-            );
+            let (lhs, rhs, expected) = case;
+            println!("case: {:?}", case);
+            let lhs = closed_closed(Some(lhs.0), Some(lhs.1));
+            let rhs = closed_closed(Some(rhs.0), Some(rhs.1));
+            let expected = closed_closed(Some(expected.0), Some(expected.1));
+            println!("lhs: {:?}, rhs: {:?}, expected: {:?}", lhs, rhs, expected);
+            assert_eq!(lhs.and(rhs)?, expected,);
         }
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/pull/7884/files

## Rationale for this change

When I was figuring out how to add `OR` support for interval analysis, I noticed:
1. The tests were using `open_open`, which as shown on https://github.com/apache/arrow-datafusion/pull/7885 means all the cases actually were testing the same
2.  There were three cases  that are not covered. 

## What changes are included in this PR?

1. Fix the test to use `closed_closed`
2. Add coverage of missing cases

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->