### PR TITLE
Support Partitioning Data by Dictionary Encoded String Array Types

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -420,6 +420,17 @@ impl DFSchema {
                 Self::datatype_is_semantically_equal(k1.as_ref(), k2.as_ref())
                     && Self::datatype_is_semantically_equal(v1.as_ref(), v2.as_ref())
             }
+            // The next two cases allow for the possibility that one schema has a dictionary encoded array
+            // and the other has an equivalent non dictionary encoded array of the same type
+            // E.g. Dictionary(_, Utf8) is semantically equivalent to Utf8 since both represent an array of strings
+            (DataType::Dictionary(_, v1), othertype) => {
+                println!("Comparting {} to {}", v1, othertype);
+                v1.as_ref() == othertype
+            }
+            (othertype, DataType::Dictionary(_, v1)) => {
+                println!("Comparting {} to {}", v1, othertype);
+                v1.as_ref() == othertype
+            }
             (DataType::List(f1), DataType::List(f2))
             | (DataType::LargeList(f1), DataType::LargeList(f2))
             | (DataType::FixedSizeList(f1, _), DataType::FixedSizeList(f2, _))

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -424,11 +424,9 @@ impl DFSchema {
             // and the other has an equivalent non dictionary encoded array of the same type
             // E.g. Dictionary(_, Utf8) is semantically equivalent to Utf8 since both represent an array of strings
             (DataType::Dictionary(_, v1), othertype) => {
-                println!("Comparting {} to {}", v1, othertype);
                 v1.as_ref() == othertype
             }
             (othertype, DataType::Dictionary(_, v1)) => {
-                println!("Comparting {} to {}", v1, othertype);
                 v1.as_ref() == othertype
             }
             (DataType::List(f1), DataType::List(f2))

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -423,12 +423,8 @@ impl DFSchema {
             // The next two cases allow for the possibility that one schema has a dictionary encoded array
             // and the other has an equivalent non dictionary encoded array of the same type
             // E.g. Dictionary(_, Utf8) is semantically equivalent to Utf8 since both represent an array of strings
-            (DataType::Dictionary(_, v1), othertype) => {
-                v1.as_ref() == othertype
-            }
-            (othertype, DataType::Dictionary(_, v1)) => {
-                v1.as_ref() == othertype
-            }
+            (DataType::Dictionary(_, v1), othertype) => v1.as_ref() == othertype,
+            (othertype, DataType::Dictionary(_, v1)) => v1.as_ref() == othertype,
             (DataType::List(f1), DataType::List(f2))
             | (DataType::LargeList(f1), DataType::LargeList(f2))
             | (DataType::FixedSizeList(f1, _), DataType::FixedSizeList(f2, _))

--- a/datafusion/core/src/datasource/file_format/write/demux.rs
+++ b/datafusion/core/src/datasource/file_format/write/demux.rs
@@ -28,9 +28,8 @@ use crate::error::Result;
 use crate::physical_plan::SendableRecordBatchStream;
 
 use arrow_array::builder::UInt64Builder;
-use arrow_array::cast::{as_dictionary_array, AsArray};
-use arrow_array::types::{Int32Type, UInt16Type};
-use arrow_array::{RecordBatch, StringArray, StructArray};
+use arrow_array::cast::AsArray;
+use arrow_array::{downcast_dictionary_array, RecordBatch, StringArray, StructArray};
 use arrow_schema::{DataType, Schema};
 use datafusion_common::cast::as_string_array;
 use datafusion_common::DataFusionError;
@@ -311,37 +310,23 @@ fn compute_partition_keys_by_row<'a>(
                 for i in 0..rb.num_rows() {
                     partition_values.push(array.value(i));
                 }
-            },
-            DataType::Dictionary(key_type, _) => {
-                match **key_type{
-                    DataType::UInt16 => {
-                        let dict_array = as_dictionary_array::<UInt16Type>(col_array);
-                        let array = dict_array.downcast_dict::<StringArray>()
-                            .ok_or(DataFusionError::NotImplemented(format!("It is not yet supported to write to hive partitioned with datatype {}", dtype)))?;
-                        for val in array.into_iter() {
+            }
+            DataType::Dictionary(_, _) => {
+                downcast_dictionary_array!(
+                    col_array =>  {
+                        let array = col_array.downcast_dict::<StringArray>()
+                            .ok_or(DataFusionError::Execution(format!("it is not yet supported to write to hive partitions with datatype {}",
+                            dtype)))?;
+
+                        for val in array.values() {
                             partition_values.push(
-                                val.ok_or(DataFusionError::Execution("Partition values cannot be null!".into()))?
+                                val.ok_or(DataFusionError::Execution(format!("Cannot partition by null value for column {}", col)))?
                             );
                         }
                     },
-                    DataType::Int32 => {
-                        let dict_array = as_dictionary_array::<Int32Type>(col_array);
-                        let array = dict_array.downcast_dict::<StringArray>()
-                            .ok_or(DataFusionError::NotImplemented(format!("It is not yet supported to write to hive partitioned with datatype {}", dtype)))?;
-                        for val in array.into_iter() {
-                            partition_values.push(
-                                val.ok_or(DataFusionError::Execution("Partition values cannot be null!".into()))?
-                            );
-                        }
-                    },
-                    _ => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "It is not yet supported to write to hive partitions with datatype {}",
-                            dtype
-                        )))
-                    }
-                }
-            },
+                    _ => unreachable!(),
+                )
+            }
             _ => {
                 return Err(DataFusionError::NotImplemented(format!(
                 "it is not yet supported to write to hive partitions with datatype {}",

--- a/datafusion/core/src/datasource/file_format/write/demux.rs
+++ b/datafusion/core/src/datasource/file_format/write/demux.rs
@@ -28,8 +28,9 @@ use crate::error::Result;
 use crate::physical_plan::SendableRecordBatchStream;
 
 use arrow_array::builder::UInt64Builder;
-use arrow_array::cast::AsArray;
-use arrow_array::{RecordBatch, StructArray};
+use arrow_array::cast::{as_dictionary_array, AsArray};
+use arrow_array::types::{Int32Type, UInt16Type};
+use arrow_array::{RecordBatch, StringArray, StructArray};
 use arrow_schema::{DataType, Schema};
 use datafusion_common::cast::as_string_array;
 use datafusion_common::DataFusionError;
@@ -310,7 +311,37 @@ fn compute_partition_keys_by_row<'a>(
                 for i in 0..rb.num_rows() {
                     partition_values.push(array.value(i));
                 }
-            }
+            },
+            DataType::Dictionary(key_type, _) => {
+                match **key_type{
+                    DataType::UInt16 => {
+                        let dict_array = as_dictionary_array::<UInt16Type>(col_array);
+                        let array = dict_array.downcast_dict::<StringArray>()
+                            .ok_or(DataFusionError::NotImplemented(format!("It is not yet supported to write to hive partitioned with datatype {}", dtype)))?;
+                        for val in array.into_iter() {
+                            partition_values.push(
+                                val.ok_or(DataFusionError::Execution("Partition values cannot be null!".into()))?
+                            );
+                        }
+                    },
+                    DataType::Int32 => {
+                        let dict_array = as_dictionary_array::<Int32Type>(col_array);
+                        let array = dict_array.downcast_dict::<StringArray>()
+                            .ok_or(DataFusionError::NotImplemented(format!("It is not yet supported to write to hive partitioned with datatype {}", dtype)))?;
+                        for val in array.into_iter() {
+                            partition_values.push(
+                                val.ok_or(DataFusionError::Execution("Partition values cannot be null!".into()))?
+                            );
+                        }
+                    },
+                    _ => {
+                        return Err(DataFusionError::NotImplemented(format!(
+                            "It is not yet supported to write to hive partitions with datatype {}",
+                            dtype
+                        )))
+                    }
+                }
+            },
             _ => {
                 return Err(DataFusionError::NotImplemented(format!(
                 "it is not yet supported to write to hive partitions with datatype {}",

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -830,7 +830,10 @@ impl TableProvider for ListingTable {
         overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
-        if !self.schema().equivalent_names_and_types(&input.schema()) {
+        if !self
+            .schema()
+            .logically_equivalent_names_and_types(&input.schema())
+        {
             return plan_err!(
                 // Return an error if schema of the input query does not match with the table schema.
                 "Inserting query must have the same schema with the table."

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -830,8 +830,6 @@ impl TableProvider for ListingTable {
         overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
-        println!("table schema: {}", self.schema());
-        println!("incoming schema: {}", input.schema());
         if !self.schema().equivalent_names_and_types(&input.schema()) {
             return plan_err!(
                 // Return an error if schema of the input query does not match with the table schema.

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -830,6 +830,8 @@ impl TableProvider for ListingTable {
         overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
+        println!("table schema: {}", self.schema());
+        println!("incoming schema: {}", input.schema());
         if !self.schema().equivalent_names_and_types(&input.schema()) {
             return plan_err!(
                 // Return an error if schema of the input query does not match with the table schema.

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -209,7 +209,10 @@ impl TableProvider for MemTable {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Create a physical plan from the logical plan.
         // Check that the schema of the plan matches the schema of this table.
-        if !self.schema().equivalent_names_and_types(&input.schema()) {
+        if !self
+            .schema()
+            .logically_equivalent_names_and_types(&input.schema())
+        {
             return plan_err!(
                 "Inserting query must have the same schema with the table."
             );

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -40,8 +40,73 @@ STORED AS CSV
 WITH HEADER ROW
 LOCATION '../../testing/data/csv/aggregate_test_100.csv'
 
-# test_insert_into
 
+statement ok
+CREATE EXTERNAL TABLE dictionary_encoded_parquet
+STORED AS parquet
+LOCATION '../../parquet-testing/data/alltypes_dictionary.parquet';
+
+query TTT
+describe dictionary_encoded_parquet;
+----
+id Int32 YES
+bool_col Boolean YES
+tinyint_col Int32 YES
+smallint_col Int32 YES
+int_col Int32 YES
+bigint_col Int64 YES
+float_col Float32 YES
+double_col Float64 YES
+date_string_col Binary YES
+string_col Binary YES
+timestamp_col Timestamp(Nanosecond, None) YES
+
+statement ok
+CREATE EXTERNAL TABLE dictionary_encoded_parquet_partitioned(
+  id int,
+  bool_col bool,
+  tinyint_col int,
+  smallint_col int,
+  int_col int,
+  bigint_col bigint,
+  float_col float,
+  double_col double,
+  date_string_col varchar,
+  string_col varchar,
+  timestamp_col varchar
+) 
+STORED AS parquet
+LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned'
+PARTITIONED BY (date_string_col, string_col, timestamp_col)
+OPTIONS(
+create_local_path 'true',
+insert_mode 'append_new_files',
+);
+
+query IBIIIIRRTTT
+insert into dictionary_encoded_parquet_partitioned 
+select 
+  id, 
+  bool_col, 
+  tinyint_col,
+  smallint_col,
+  int_col,
+  bigint_col,
+  float_col,
+  double_col,
+  date_string_col,
+  string_col,
+  timestamp_col::TEXT from dictionary_encoded_parquet;
+----
+2
+
+query IBIIIIRRTTT
+select * from dictionary_encoded_parquet_partitioned order by (id);
+----
+0 true 0 0 0 0 0 0 01%2F01%2F09 0 2009-01-01T00:00:00
+1 false 1 1 1 10 1.1 10.1 01%2F01%2F09 1 2009-01-01T00:01:00
+
+# test_insert_into
 statement ok
 set datafusion.execution.target_partitions = 8;
 

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -42,69 +42,40 @@ LOCATION '../../testing/data/csv/aggregate_test_100.csv'
 
 
 statement ok
-CREATE EXTERNAL TABLE dictionary_encoded_parquet
-STORED AS parquet
-LOCATION '../../parquet-testing/data/alltypes_dictionary.parquet';
+create table dictionary_encoded_values as values 
+('a', arrow_cast('foo', 'Dictionary(Int32, Utf8)')), ('b', arrow_cast('bar', 'Dictionary(Int32, Utf8)'));
 
 query TTT
-describe dictionary_encoded_parquet;
+describe dictionary_encoded_values;
 ----
-id Int32 YES
-bool_col Boolean YES
-tinyint_col Int32 YES
-smallint_col Int32 YES
-int_col Int32 YES
-bigint_col Int64 YES
-float_col Float32 YES
-double_col Float64 YES
-date_string_col Binary YES
-string_col Binary YES
-timestamp_col Timestamp(Nanosecond, None) YES
+column1 Utf8 YES
+column2 Dictionary(Int32, Utf8) YES
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_parquet_partitioned(
-  id int,
-  bool_col bool,
-  tinyint_col int,
-  smallint_col int,
-  int_col int,
-  bigint_col bigint,
-  float_col float,
-  double_col double,
-  date_string_col varchar,
-  string_col varchar,
-  timestamp_col varchar
+  a varchar,
+  b varchar,
 ) 
 STORED AS parquet
 LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned'
-PARTITIONED BY (date_string_col, string_col, timestamp_col)
+PARTITIONED BY (b)
 OPTIONS(
 create_local_path 'true',
 insert_mode 'append_new_files',
 );
 
-query IBIIIIRRTTT
+query TT
 insert into dictionary_encoded_parquet_partitioned 
-select 
-  id, 
-  bool_col, 
-  tinyint_col,
-  smallint_col,
-  int_col,
-  bigint_col,
-  float_col,
-  double_col,
-  date_string_col,
-  string_col,
-  timestamp_col::TEXT from dictionary_encoded_parquet;
+select * from dictionary_encoded_values
 ----
 2
 
-query IBIIIIRRTTT
-select * from dictionary_encoded_parquet_partitioned order by (id);
+query TT
+select * from dictionary_encoded_parquet_partitioned order by (a);
 ----
-0 true 0 0 0 0 0 0 01%2F01%2F09 0 2009-01-01T00:00:00
-1 false 1 1 1 10 1.1 10.1 01%2F01%2F09 1 2009-01-01T00:01:00
+a foo
+b bar
+
 
 # test_insert_into
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7891 

## Rationale for this change

The initial implementation of hive style partition demux code only supported plain UTF8 arrays. This PR adds support for dictionary encoded `UTF8` arrays. 

## What changes are included in this PR?

- Extracts string values from dictionary encoded `UTF8` arrays to determine hive partitions
- Adds additional cases to schema semantic equivalence checking: `Dictionary(_, dtype)` is now considered semantically equivalent to `dtype`. 

## Are these changes tested?

Yes using dictionary encoded values from parquet-testing submodule

## Are there any user-facing changes?

No, just (hopefully) more robust support for inserting inferred schema string data as a partition column.