### PR TITLE
Drop single quotes to make warnings for parquet options not confusing

### DIFF
--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -342,7 +342,7 @@ pub(crate) fn parse_version_string(str_setting: &str) -> Result<WriterVersion> {
         "2.0" => Ok(WriterVersion::PARQUET_2_0),
         _ => Err(DataFusionError::Configuration(format!(
             "Unknown or unsupported parquet writer version {str_setting} \
-            valid options are '1.0' and '2.0'"
+            valid options are 1.0 and 2.0"
         ))),
     }
 }
@@ -355,7 +355,7 @@ pub(crate) fn parse_statistics_string(str_setting: &str) -> Result<EnabledStatis
         "page" => Ok(EnabledStatistics::Page),
         _ => Err(DataFusionError::Configuration(format!(
             "Unknown or unsupported parquet statistics setting {str_setting} \
-            valid options are 'none', 'page', and 'chunk'"
+            valid options are none, page, and chunk"
         ))),
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7867

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Previous warnings could be confusing and it was decided to drop single quotes to fix this.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Warnings were fixed

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tested with `cargo test` locally.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Minor change in warnings

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->