### PR TITLE
ci: upgrade node to version 20

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "20"
       - name: Prettier check
         run: |
           # if you encounter error, rerun the command below and commit the changes

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -527,7 +527,7 @@ jobs:
           rust-version: stable
       - uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "20"
       - name: Check if configs.md has been modified
         run: |
           # If you encounter an error, run './dev/update_config_docs.sh' and commit


### PR DESCRIPTION
## Which issue does this PR close?
\-

## Rationale for this change
Mostly to keep the CI up-to-date, triggered by #7915.

## What changes are included in this PR?
Upgrade node version to 20.

## Are these changes tested?
CI passes.

## Are there any user-facing changes?
\-