### PR TITLE
minor: add a datatype casting for the updated value

### DIFF
--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -20,7 +20,7 @@
 ##########
 
 statement ok
-create table t1(a int, b varchar, c double);
+create table t1(a int, b varchar, c double, d int);
 
 # Turn off the optimizer to make the logical plan closer to the initial one
 statement ok

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -27,7 +27,7 @@ statement ok
 set datafusion.optimizer.max_passes = 0;
 
 query TT
-explain update t1 set a=1, b=2, c=3.0;
+explain update t1 set a=1, b=2, c=3.0, d=NULL;
 ----
 logical_plan
 Dml: op=[Update] table=[t1]

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -31,7 +31,7 @@ explain update t1 set a=1, b=2, c=3.0, d=NULL;
 ----
 logical_plan
 Dml: op=[Update] table=[t1]
---Projection: CAST(Int64(1) AS Int32) AS a, CAST(Int64(2) AS Utf8) AS b, Float64(3) AS c
+--Projection: CAST(Int64(1) AS Int32) AS a, CAST(Int64(2) AS Utf8) AS b, Float64(3) AS c, CAST(NULL AS Int32) AS d
 ----TableScan: t1
 
 query TT
@@ -39,5 +39,5 @@ explain update t1 set a=c+1, b=a, c=c+1.0, d=b;
 ----
 logical_plan
 Dml: op=[Update] table=[t1]
---Projection: CAST(t1.c + CAST(Int64(1) AS Float64) AS Int32) AS a, CAST(t1.a AS Utf8) AS b, t1.c + Float64(1) AS c
+--Projection: CAST(t1.c + CAST(Int64(1) AS Float64) AS Int32) AS a, CAST(t1.a AS Utf8) AS b, t1.c + Float64(1) AS c,  CAST(t1.b AS Int32) AS d
 ----TableScan: t1

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -35,7 +35,7 @@ Dml: op=[Update] table=[t1]
 ----TableScan: t1
 
 query TT
-explain update t1 set a=c+1, b=a, c=c+1.0;
+explain update t1 set a=c+1, b=a, c=c+1.0, d=b;
 ----
 logical_plan
 Dml: op=[Update] table=[t1]

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Update Tests
+##########
+
+statement ok
+create table t1(a int, b varchar, c double);
+
+# Turn off the optimizer to make the logical plan closer to the initial one
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query TT
+explain update t1 set a=1, b=2, c=3.0;
+----
+logical_plan
+Dml: op=[Update] table=[t1]
+--Projection: CAST(Int64(1) AS Int32) AS a, CAST(Int64(2) AS Utf8) AS b, Float64(3) AS c
+----TableScan: t1
+
+query TT
+explain update t1 set a=c+1, b=a, c=c+1.0;
+----
+logical_plan
+Dml: op=[Update] table=[t1]
+--Projection: CAST(t1.c + CAST(Int64(1) AS Float64) AS Int32) AS a, CAST(t1.a AS Utf8) AS b, t1.c + Float64(1) AS c
+----TableScan: t1


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

Similar to insert:
https://github.com/apache/arrow-datafusion/blob/08c1b69a4ec9e5ddeaefd2810c0624ce9d9a3b9b/datafusion/sql/src/statement.rs#L1149

Add a casting for the updated value to match the data type of the table’s column.

**Current**:
```sh
❯ create table t1(a int, b varchar, c double);
0 rows in set. Query took 0.025 seconds.

❯ explain update t1 set a=1, b=2, c=3.0;
+--------------+-------------------------------------------------------------+
| plan_type    | plan                                                        |
+--------------+-------------------------------------------------------------+
| logical_plan | Dml: op=[Update] table=[t1]                                 |
|              |   Projection: Int64(1) AS a, Int64(2) AS b, Float64(3) AS c |
|              |     TableScan: t1 projection=[a]                            |
+--------------+-------------------------------------------------------------+
```

**After pr:**
```sh
❯ explain update t1 set a=1, b=2, c=3.0;
+--------------+--------------------------------------------------------------+
| plan_type    | plan                                                         |
+--------------+--------------------------------------------------------------+
| logical_plan | Dml: op=[Update] table=[t1]                                  |
|              |   Projection: Int32(1) AS a, Utf8("2") AS b, Float64(3) AS c |
|              |     TableScan: t1 projection=[]                              |
+--------------+--------------------------------------------------------------+
1 row in set. Query took 0.026 seconds.
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

## Are there any user-facing changes?
No