### PR TITLE
Minor: reduce some `#cfg(feature = "parquet")`

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -36,7 +36,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::{JoinHandle, JoinSet};
 
 use crate::datasource::file_format::file_compression_type::FileCompressionType;
-use crate::datasource::statistics::create_max_min_accs;
+use crate::datasource::statistics::{create_max_min_accs, get_col_stats};
 use arrow::datatypes::SchemaRef;
 use arrow::datatypes::{Fields, Schema};
 use bytes::{BufMut, BytesMut};
@@ -63,11 +63,9 @@ use crate::arrow::array::{
 use crate::arrow::datatypes::DataType;
 use crate::config::ConfigOptions;
 
-use crate::datasource::get_col_stats;
 use crate::datasource::physical_plan::{
     FileGroupDisplay, FileMeta, FileSinkConfig, ParquetExec, SchemaAdapter,
 };
-
 use crate::error::Result;
 use crate::execution::context::SessionState;
 use crate::physical_plan::expressions::{MaxAccumulator, MinAccumulator};

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -42,6 +42,4 @@ pub use self::memory::MemTable;
 pub use self::provider::TableProvider;
 pub use self::view::ViewTable;
 pub use crate::logical_expr::TableType;
-#[cfg(feature = "parquet")]
-pub(crate) use statistics::get_col_stats;
 pub use statistics::get_statistics_with_limit;

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -30,8 +30,6 @@ pub(crate) use self::csv::plan_to_csv;
 pub use self::csv::{CsvConfig, CsvExec, CsvOpener};
 pub(crate) use self::json::plan_to_json;
 #[cfg(feature = "parquet")]
-pub(crate) use self::parquet::plan_to_parquet;
-#[cfg(feature = "parquet")]
 pub use self::parquet::{ParquetExec, ParquetFileMetrics, ParquetFileReaderFactory};
 
 pub use arrow_file::ArrowExec;

--- a/datafusion/core/src/execution/context/parquet.rs
+++ b/datafusion/core/src/execution/context/parquet.rs
@@ -17,9 +17,8 @@
 
 use std::sync::Arc;
 
+use crate::datasource::physical_plan::parquet::plan_to_parquet;
 use parquet::file::properties::WriterProperties;
-
-use crate::datasource::physical_plan::plan_to_parquet;
 
 use super::super::options::{ParquetReadOptions, ReadOptions};
 use super::{DataFilePaths, DataFrame, ExecutionPlan, Result, SessionContext};


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/7745

## Rationale for this change
I noticed a few simplifications on https://github.com/apache/arrow-datafusion/pull/7745

## What changes are included in this PR?

1. Remove some `pub use (crate)` that were enabled with `#cfg(feature = "parquet")`

## Are these changes tested?

Existing tests

## Are there any user-facing changes?
No