### PR TITLE
Move source repartitioning into `ExecutionPlan::repartition`

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -892,11 +892,8 @@ mod tests {
                         None,
                     );
 
-                    let actual = file_groups_to_vec(repartition_with_size(
-                        &parquet_exec,
-                        n_partition,
-                        10,
-                    ));
+                    let actual =
+                        repartition_with_size_to_vec(&parquet_exec, n_partition, 10);
 
                     assert_eq!(expected, &actual);
                 }
@@ -924,7 +921,7 @@ mod tests {
                 None,
             );
 
-            let actual = file_groups_to_vec(repartition_with_size(&parquet_exec, 4, 10));
+            let actual = repartition_with_size_to_vec(&parquet_exec, 4, 10);
             let expected = vec![
                 (0, "a".to_string(), 0, 31),
                 (1, "a".to_string(), 31, 62),
@@ -955,7 +952,7 @@ mod tests {
                 None,
             );
 
-            let actual = file_groups_to_vec(repartition_with_size(&parquet_exec, 96, 5));
+            let actual = repartition_with_size_to_vec(&parquet_exec, 96, 5);
             let expected = vec![
                 (0, "a".to_string(), 0, 1),
                 (1, "a".to_string(), 1, 2),
@@ -992,7 +989,7 @@ mod tests {
                 None,
             );
 
-            let actual = file_groups_to_vec(repartition_with_size(&parquet_exec, 3, 10));
+            let actual = repartition_with_size_to_vec(&parquet_exec, 3, 10);
             let expected = vec![
                 (0, "a".to_string(), 0, 34),
                 (1, "a".to_string(), 34, 40),
@@ -1025,7 +1022,7 @@ mod tests {
                 None,
             );
 
-            let actual = file_groups_to_vec(repartition_with_size(&parquet_exec, 2, 10));
+            let actual = repartition_with_size_to_vec(&parquet_exec, 2, 10);
             let expected = vec![
                 (0, "a".to_string(), 0, 40),
                 (0, "b".to_string(), 0, 10),
@@ -1088,11 +1085,43 @@ mod tests {
             assert_eq!(1, actual.len());
         }
 
-        /// Convert a set of file groups into a vector of tuples:
+        /// Calls `ParquetExec.repartitioned` with the  specified
+        /// `target_partitions` and `repartition_file_min_size`, returning the
+        /// resulting `PartitionedFile`s
+        fn repartition_with_size(
+            parquet_exec: &ParquetExec,
+            target_partitions: usize,
+            repartition_file_min_size: usize,
+        ) -> Vec<Vec<PartitionedFile>> {
+            let mut config = ConfigOptions::new();
+            config.optimizer.repartition_file_min_size = repartition_file_min_size;
+
+            parquet_exec
+                .repartitioned(target_partitions, &config)
+                .unwrap() // unwrap Result
+                .unwrap() // unwrap Option
+                .as_any()
+                .downcast_ref::<ParquetExec>()
+                .unwrap()
+                .base_config()
+                .file_groups
+                .clone()
+        }
+
+        /// Calls `repartition_with_size` and returns a tuple for each output `PartitionedFile`:
+        ///
         /// `(partition index, file path, start, end)`
-        fn file_groups_to_vec(
-            file_groups: Vec<Vec<PartitionedFile>>,
+        fn repartition_with_size_to_vec(
+            parquet_exec: &ParquetExec,
+            target_partitions: usize,
+            repartition_file_min_size: usize,
         ) -> Vec<(usize, String, i64, i64)> {
+            let file_groups = repartition_with_size(
+                parquet_exec,
+                target_partitions,
+                repartition_file_min_size,
+            );
+
             file_groups
                 .iter()
                 .enumerate()
@@ -1111,28 +1140,5 @@ mod tests {
                 })
                 .collect_vec()
         }
-    }
-
-    /// Calls `ParquetExec.repartitioned` with the  specified
-    /// `target_partitions` and `repartition_file_min_size`, returning the
-    /// resulting `PartitionedFile`s
-    fn repartition_with_size(
-        parquet_exec: &ParquetExec,
-        target_partitions: usize,
-        repartition_file_min_size: usize,
-    ) -> Vec<Vec<PartitionedFile>> {
-        let mut config = ConfigOptions::new();
-        config.optimizer.repartition_file_min_size = repartition_file_min_size;
-
-        parquet_exec
-            .repartitioned(target_partitions, &config)
-            .unwrap() // unwrap Result
-            .unwrap() // unwrap Option
-            .as_any()
-            .downcast_ref::<ParquetExec>()
-            .unwrap()
-            .base_config()
-            .file_groups
-            .clone()
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -529,6 +529,7 @@ mod tests {
     };
     use arrow_schema::Field;
     use chrono::Utc;
+    use datafusion_common::config::ConfigOptions;
 
     use crate::physical_plan::{DefaultDisplay, VerboseDisplay};
 
@@ -831,7 +832,7 @@ mod tests {
             );
 
             let partitioned_file = parquet_exec
-                .get_repartitioned(4, 0)
+                .repartitioned(4, &config_with_size(0))
                 .base_config()
                 .file_groups
                 .clone();
@@ -897,7 +898,7 @@ mod tests {
 
                     let actual = file_groups_to_vec(
                         parquet_exec
-                            .get_repartitioned(n_partition, 10)
+                            .repartitioned(n_partition, &config_with_size(10))
                             .base_config()
                             .file_groups
                             .clone(),
@@ -931,7 +932,7 @@ mod tests {
 
             let actual = file_groups_to_vec(
                 parquet_exec
-                    .get_repartitioned(4, 10)
+                    .repartitioned(4, &config_with_size(10))
                     .base_config()
                     .file_groups
                     .clone(),
@@ -968,7 +969,7 @@ mod tests {
 
             let actual = file_groups_to_vec(
                 parquet_exec
-                    .get_repartitioned(96, 5)
+                    .repartitioned(96, &config_with_size(5))
                     .base_config()
                     .file_groups
                     .clone(),
@@ -1011,7 +1012,7 @@ mod tests {
 
             let actual = file_groups_to_vec(
                 parquet_exec
-                    .get_repartitioned(3, 10)
+                    .repartitioned(3, &config_with_size(10))
                     .base_config()
                     .file_groups
                     .clone(),
@@ -1050,7 +1051,7 @@ mod tests {
 
             let actual = file_groups_to_vec(
                 parquet_exec
-                    .get_repartitioned(2, 10)
+                    .repartitioned(2, &config_with_size(10))
                     .base_config()
                     .file_groups
                     .clone(),
@@ -1089,7 +1090,7 @@ mod tests {
             );
 
             let actual = parquet_exec
-                .get_repartitioned(65, 10)
+                .repartitioned(65, &config_with_size(10))
                 .base_config()
                 .file_groups
                 .clone();
@@ -1118,7 +1119,7 @@ mod tests {
             );
 
             let actual = parquet_exec
-                .get_repartitioned(65, 500)
+                .repartitioned(65, &config_with_size(500))
                 .base_config()
                 .file_groups
                 .clone();
@@ -1146,5 +1147,12 @@ mod tests {
                 })
                 .collect_vec()
         }
+    }
+
+    /// Returns a new ConfigOptions with the specified `repartition_file_min_size`
+    fn config_with_size(repartition_file_min_size: usize) -> ConfigOptions {
+        let mut config = ConfigOptions::new();
+        config.optimizer.repartition_file_min_size = repartition_file_min_size;
+        config
     }
 }

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -1628,7 +1628,6 @@ mod tests {
     use crate::datasource::file_format::file_compression_type::FileCompressionType;
     use crate::datasource::listing::PartitionedFile;
     use crate::datasource::object_store::ObjectStoreUrl;
-    use crate::datasource::physical_plan::FileScanConfig;
     use crate::datasource::physical_plan::ParquetExec;
     use crate::datasource::physical_plan::{CsvExec, FileScanConfig};
     use crate::physical_optimizer::enforce_sorting::EnforceSorting;

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -26,9 +26,6 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use crate::config::ConfigOptions;
-use crate::datasource::physical_plan::CsvExec;
-#[cfg(feature = "parquet")]
-use crate::datasource::physical_plan::ParquetExec;
 use crate::error::Result;
 use crate::physical_optimizer::utils::{
     add_sort_above, get_children_exectrees, get_plan_string, is_coalesce_partitions,
@@ -1188,7 +1185,6 @@ fn ensure_distribution(
     // When `false`, round robin repartition will not be added to increase parallelism
     let enable_round_robin = config.optimizer.enable_round_robin_repartition;
     let repartition_file_scans = config.optimizer.repartition_file_scans;
-    let repartition_file_min_size = config.optimizer.repartition_file_min_size;
     let batch_size = config.execution.batch_size;
     let is_unbounded = unbounded_output(&dist_context.plan);
     // Use order preserving variants either of the conditions true
@@ -1630,9 +1626,9 @@ mod tests {
     use crate::datasource::file_format::file_compression_type::FileCompressionType;
     use crate::datasource::listing::PartitionedFile;
     use crate::datasource::object_store::ObjectStoreUrl;
-    use crate::datasource::physical_plan::FileScanConfig;
     #[cfg(feature = "parquet")]
     use crate::datasource::physical_plan::ParquetExec;
+    use crate::datasource::physical_plan::{CsvExec, FileScanConfig};
     use crate::physical_optimizer::enforce_sorting::EnforceSorting;
     use crate::physical_optimizer::output_requirements::OutputRequirements;
     use crate::physical_plan::aggregates::{

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -210,17 +210,23 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
-    /// If supported, changes the partitioning of this `ExecutionPlan` to
+    /// If supported, attempt to increase the partitioning of this `ExecutionPlan` to
     /// produce `target_partitions` partitions.
     ///
     /// If the `ExecutionPlan` does not support changing its partitioning,
     /// returns `Ok(None)` (the default).
     ///
+    /// It is the `ExecutionPlan` can increase its partitioning, but not to the
+    /// `target_partitions`, it may return an ExecutionPlan with fewer
+    /// partitions. This might happen, for example, if each new partition would
+    /// be too small to be efficiently processed individually.
+    ///
     /// The DataFusion optimizer attempts to use as many threads as possible by
     /// repartitioning its inputs to match the target number of threads
     /// available (`target_partitions`). Some data sources, such as the built in
-    /// CSV and Parquet readers, are able to read from their input files in
-    /// parallel, regardless of how the source data is split amongst files.
+    /// CSV and Parquet readers, implement this method as they are able to read
+    /// from their input files in parallel, regardless of how the source data is
+    /// split amongst files.
     fn repartitioned(
         &self,
         _target_partitions: usize,


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/7935

## Rationale for this change

Inspired by PR https://github.com/apache/arrow-datafusion/pull/7745, the repartition input code as it is now is both a bit messy (needs a `#cfg`) but also only works for `ParquetExec` and `CsvExec`, where the code is general for any ExecutionPlan.

## What changes are included in this PR?

1. Extract the `repartition` code to a trait on ExecutionPlan, which also allows other (user defined) table sources to benefit from this optimization
2. Document what is happening in more detail
3. Move implementation code for Parquet and CSV



## Are these changes tested?

Covered by existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->