### PR TITLE
`WIP` Prototype new DFSchema implementation

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -233,7 +233,7 @@ impl DFSchema {
         let (new_field_qualifiers, new_fields) = self
             .iter()
             .chain(other.qualified_field_iter())
-            .map(|qualifier, field| (qualifier.as_ref().clone(), field.clone()))
+            .map(|q, f| (q.as_ref().clone(), f.clone()))
             .unzip();
 
         for field in other.fields() {

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -43,7 +43,7 @@ pub mod utils;
 /// Reexport arrow crate
 pub use arrow;
 pub use column::Column;
-pub use dfschema::{DFField, DFSchema, DFSchemaRef, ExprSchema, SchemaExt, ToDFSchema};
+pub use dfschema::{DFSchema, DFSchemaRef, ExprSchema, SchemaExt, ToDFSchema};
 pub use error::{
     field_not_found, unqualified_field_not_found, DataFusionError, Result, SchemaError,
     SharedResult,


### PR DESCRIPTION
I have long been bothered by the amount of copying required in DFSchema and how akward it is to use and how much duplication (e.g. metadata handling) there is between it and Schema

The current setup also makes adding additional indexes such as described on https://github.com/apache/arrow-datafusion/issues/7698 very hard 

This PR is part of a plan to review the current implementation and possibly  simplify it / prepare for faster DataFusion planning