### PR TITLE
Minor: Avoid recomputing compute_array_ndims in align_array_dimensions

### DIFF
--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -1931,8 +1931,8 @@ mod tests {
                 Some(vec![Some(6), Some(7), Some(8)]),
             ]));
 
-        let array2d_1 = Arc::new(wrap_into_list_array(array1d_1.clone())) as ArrayRef;
-        let array2d_2 = Arc::new(wrap_into_list_array(array1d_2.clone())) as ArrayRef;
+        let array2d_1 = Arc::new(array_into_list_array(array1d_1.clone())) as ArrayRef;
+        let array2d_2 = Arc::new(array_into_list_array(array1d_2.clone())) as ArrayRef;
 
         let res =
             align_array_dimensions(vec![array1d_1.to_owned(), array2d_2.to_owned()])
@@ -1946,8 +1946,8 @@ mod tests {
             expected_dim
         );
 
-        let array3d_1 = Arc::new(wrap_into_list_array(array2d_1)) as ArrayRef;
-        let array3d_2 = wrap_into_list_array(array2d_2.to_owned());
+        let array3d_1 = Arc::new(array_into_list_array(array2d_1)) as ArrayRef;
+        let array3d_2 = array_into_list_array(array2d_2.to_owned());
         let res =
             align_array_dimensions(vec![array1d_1, Arc::new(array3d_2.clone())]).unwrap();
 

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -729,9 +729,13 @@ fn align_array_dimensions(args: Vec<ArrayRef>) -> Result<Vec<ArrayRef>> {
     let mut max_ndim = None;
     for arg in args.iter() {
         let ndim = compute_array_ndims(Some(arg.to_owned()))?;
+
         if let Some(ndim) = ndim {
             args_ndim.push(ndim);
-            if max_ndim.is_none() || ndim > max_ndim.unwrap() {
+
+            if let Some(current_max) = max_ndim {
+                max_ndim = Some(std::cmp::max(current_max, ndim));
+            } else {
                 max_ndim = Some(ndim);
             }
         } else {
@@ -739,10 +743,11 @@ fn align_array_dimensions(args: Vec<ArrayRef>) -> Result<Vec<ArrayRef>> {
         }
     }
 
-    if max_ndim.is_none() {
+    let max_ndim = if let Some(max_ndim) = max_ndim {
+        max_ndim
+    } else {
         return internal_err!("args should not be empty");
-    }
-    let max_ndim = max_ndim.unwrap();
+    };
 
     // Align the dimensions of the arrays
     let aligned_args: Result<Vec<ArrayRef>> = args

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -725,35 +725,39 @@ pub fn array_prepend(args: &[ArrayRef]) -> Result<ArrayRef> {
 }
 
 fn align_array_dimensions(args: Vec<ArrayRef>) -> Result<Vec<ArrayRef>> {
-    // Find the maximum number of dimensions
-    let max_ndim: u64 = (*args
-        .iter()
-        .map(|arr| compute_array_ndims(Some(arr.clone())))
-        .collect::<Result<Vec<Option<u64>>>>()?
-        .iter()
-        .max()
-        .unwrap())
-    .unwrap();
+    let mut args_ndim = vec![];
+    for arg in args.iter() {
+        let ndim = compute_array_ndims(Some(arg.to_owned()))?;
+        if let Some(ndim) = ndim {
+            args_ndim.push(ndim);
+        } else {
+            return internal_err!("args should not be empty");
+        }
+    }
+
+    let max_ndim = args_ndim.iter().max();
+    let max_ndim = if let Some(max_ndim) = max_ndim {
+        max_ndim
+    } else {
+        return internal_err!("args_ndim should not be empty");
+    };
 
     // Align the dimensions of the arrays
     let aligned_args: Result<Vec<ArrayRef>> = args
         .into_iter()
-        .map(|array| {
-            let ndim = compute_array_ndims(Some(array.clone()))?.unwrap();
+        .zip(args_ndim.iter())
+        .map(|(array, ndim)| {
             if ndim < max_ndim {
                 let mut aligned_array = array.clone();
                 for _ in 0..(max_ndim - ndim) {
-                    let data_type = aligned_array.as_ref().data_type().clone();
-                    let offsets: Vec<i32> =
-                        (0..downcast_arg!(aligned_array, ListArray).offsets().len())
-                            .map(|i| i as i32)
-                            .collect();
-                    let field = Arc::new(Field::new("item", data_type, true));
+                    let data_type = aligned_array.data_type().to_owned();
+                    let array_lengths = vec![1; aligned_array.len()];
+                    let offsets = OffsetBuffer::<i32>::from_lengths(array_lengths);
 
                     aligned_array = Arc::new(ListArray::try_new(
-                        field,
-                        OffsetBuffer::new(offsets.into()),
-                        Arc::new(aligned_array.clone()),
+                        Arc::new(Field::new("item", data_type, true)),
+                        offsets,
+                        aligned_array,
                         None,
                     )?)
                 }
@@ -1922,6 +1926,47 @@ mod tests {
     use super::*;
     use arrow::datatypes::Int64Type;
     use datafusion_common::cast::as_uint64_array;
+
+    #[test]
+    fn test_align_array_dimensions() {
+        let array1d_1 =
+            Arc::new(ListArray::from_iter_primitive::<Int64Type, _, _>(vec![
+                Some(vec![Some(1), Some(2), Some(3)]),
+                Some(vec![Some(4), Some(5)]),
+            ]));
+        let array1d_2 =
+            Arc::new(ListArray::from_iter_primitive::<Int64Type, _, _>(vec![
+                Some(vec![Some(6), Some(7), Some(8)]),
+            ]));
+
+        let array2d_1 = Arc::new(wrap_into_list_array(array1d_1.clone())) as ArrayRef;
+        let array2d_2 = Arc::new(wrap_into_list_array(array1d_2.clone())) as ArrayRef;
+
+        let res =
+            align_array_dimensions(vec![array1d_1.to_owned(), array2d_2.to_owned()])
+                .expect("should not error");
+
+        let expected = as_list_array(&array2d_1).unwrap();
+        let expected_dim = compute_array_ndims(Some(array2d_1.to_owned())).unwrap();
+        assert_ne!(as_list_array(&res[0]).unwrap(), expected);
+        assert_eq!(
+            compute_array_ndims(Some(res[0].clone())).unwrap(),
+            expected_dim
+        );
+
+        let array3d_1 = Arc::new(wrap_into_list_array(array2d_1)) as ArrayRef;
+        let array3d_2 = wrap_into_list_array(array2d_2.to_owned());
+        let res = align_array_dimensions(vec![array1d_1, Arc::new(array3d_2.clone())])
+            .expect("should not error");
+
+        let expected = as_list_array(&array3d_1).unwrap();
+        let expected_dim = compute_array_ndims(Some(array3d_1.to_owned())).unwrap();
+        assert_ne!(as_list_array(&res[0]).unwrap(), expected);
+        assert_eq!(
+            compute_array_ndims(Some(res[0].clone())).unwrap(),
+            expected_dim
+        );
+    }
 
     #[test]
     fn test_array() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8024.

## Rationale for this change

Main cleanup is to remove the duplicate compute of `compute array ndim`
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->