### PR TITLE
Refactor of Ordering and Prunability Traversals and States

### DIFF
--- a/datafusion/physical-expr/src/sort_properties.rs
+++ b/datafusion/physical-expr/src/sort_properties.rs
@@ -155,36 +155,36 @@ impl Neg for SortProperties {
 #[derive(Debug)]
 pub struct ExprOrdering {
     pub expr: Arc<dyn PhysicalExpr>,
-    pub state: Option<SortProperties>,
-    pub children_states: Option<Vec<SortProperties>>,
+    pub state: SortProperties,
+    pub children_states: Vec<SortProperties>,
 }
 
 impl ExprOrdering {
+    /// Creates a new [`ExprOrdering`] having [`SortProperties::Unordered`] order, and
+    /// [`SortProperties::Unordered`] orders for its child expressions.
     pub fn new(expr: Arc<dyn PhysicalExpr>) -> Self {
+        let size = expr.children().len();
         Self {
             expr,
-            state: None,
-            children_states: None,
+            state: SortProperties::Unordered,
+            children_states: vec![SortProperties::Unordered; size],
         }
     }
 
-    pub fn children(&self) -> Vec<ExprOrdering> {
+    /// Updates the [`ExprOrdering`]'s children order with the given orderings.
+    pub fn with_new_children(mut self, children_states: Vec<SortProperties>) -> Self {
+        assert_eq!(self.children_states.len(), children_states.len());
+        self.children_states = children_states;
+        self
+    }
+
+    /// Creates new [`ExprOrdering`]'s for each child of an expression.
+    pub fn new_expr_orderings_for_children_exprs(&self) -> Vec<ExprOrdering> {
         self.expr
             .children()
             .into_iter()
             .map(ExprOrdering::new)
             .collect()
-    }
-
-    pub fn new_with_children(
-        children_states: Vec<SortProperties>,
-        parent_expr: Arc<dyn PhysicalExpr>,
-    ) -> Self {
-        Self {
-            expr: parent_expr,
-            state: None,
-            children_states: Some(children_states),
-        }
     }
 }
 
@@ -193,7 +193,7 @@ impl TreeNode for ExprOrdering {
     where
         F: FnMut(&Self) -> Result<VisitRecursion>,
     {
-        for child in self.children() {
+        for child in self.new_expr_orderings_for_children_exprs() {
             match op(&child)? {
                 VisitRecursion::Continue => {}
                 VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
@@ -207,18 +207,22 @@ impl TreeNode for ExprOrdering {
     where
         F: FnMut(Self) -> Result<Self>,
     {
-        let children = self.children();
-        if children.is_empty() {
+        if self.children_states.is_empty() {
             Ok(self)
         } else {
-            Ok(ExprOrdering::new_with_children(
-                children
+            let child_expr_orderings = self.new_expr_orderings_for_children_exprs();
+            Ok(self.with_new_children(
+                child_expr_orderings
                     .into_iter()
+                    // updates the children states after this transformation
                     .map(transform)
-                    .map_ok(|c| c.state.unwrap_or(SortProperties::Unordered))
+                    // extract the state (order) information of the children
+                    .map_ok(|c| c.state)
                     .collect::<Result<Vec<_>>>()?,
-                self.expr,
             ))
+            // after the mapping of children, the children's states are set for
+            // the current node, and the last step of transform_up calculates
+            // the current node's state with update_ordering().
         }
     }
 }
@@ -248,13 +252,13 @@ pub fn update_ordering(
     //       a BinaryExpr like a + b), and there is an ordering equivalence of
     //       it (let's say like c + d), we actually can find it at this step.
     if sort_expr.expr.eq(&node.expr) {
-        node.state = Some(SortProperties::Ordered(sort_expr.options));
+        node.state = SortProperties::Ordered(sort_expr.options);
         return Ok(Transformed::Yes(node));
     }
 
-    if let Some(children_sort_options) = &node.children_states {
+    if !node.expr.children().is_empty() {
         // We have an intermediate (non-leaf) node, account for its children:
-        node.state = Some(node.expr.get_ordering(children_sort_options));
+        node.state = node.expr.get_ordering(&node.children_states);
     } else if let Some(column) = node.expr.as_any().downcast_ref::<Column>() {
         // We have a Column, which is one of the two possible leaf node types:
         node.state = get_indices_of_matching_sort_exprs_with_order_eq(
@@ -268,10 +272,11 @@ pub fn update_ordering(
                 descending: sort_options[0].descending,
                 nulls_first: sort_options[0].nulls_first,
             })
-        });
+        })
+        .unwrap_or(SortProperties::Unordered);
     } else {
         // We have a Literal, which is the other possible leaf node type:
-        node.state = Some(node.expr.get_ordering(&[]));
+        node.state = node.expr.get_ordering(&[]);
     }
     Ok(Transformed::Yes(node))
 }

--- a/datafusion/physical-expr/src/sort_properties.rs
+++ b/datafusion/physical-expr/src/sort_properties.rs
@@ -210,6 +210,8 @@ impl TreeNode for ExprOrdering {
             Ok(self)
         } else {
             let child_expr_orderings = self.children_expr_orderings();
+            // After mapping over the children, the function `F` applies to the
+            // current object and updates its state.
             Ok(self.with_new_children(
                 child_expr_orderings
                     .into_iter()
@@ -219,8 +221,6 @@ impl TreeNode for ExprOrdering {
                     .map_ok(|c| c.state)
                     .collect::<Result<Vec<_>>>()?,
             ))
-            // After mapping over the children, the function `F` applies to the
-            // current object and updates its state.
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`ExprOrdering` implementation has some minor refactors where the code is hard to understand and could be simplified. Comments were added and the algorithm became more clear. A unit test for `find_orderings_of_exprs()` was added.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


`ExprOrdering` struct used for finding the orders of `PhysicalExpr`'s is simplified by eliminating unnecessary `Option<>`'s. The comments are added to clarify how order information is assigned to children nodes and propagated to the main node during the transformation.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->