### PR TITLE
Convert Null to Int32(None) for MakeArray at type coercion step

### DIFF
--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -349,7 +349,17 @@ pub fn wrap_into_list_array(arr: ArrayRef) -> ListArray {
     )
 }
 
-/// Get the base type of a data type. For example, the base type of `List<Int32>` is `Int32`.
+/// Get the base type of a data type.
+///
+/// Example
+/// ```
+/// use arrow::datatypes::{DataType, Field};
+/// use datafusion_common::utils::base_type;
+/// use std::sync::Arc;
+///
+/// let data_type = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+/// let base_type = base_type(&data_type).unwrap();
+/// assert_eq!(base_type, DataType::Int32);
 pub fn base_type(data_type: &DataType) -> Result<DataType> {
     match data_type {
         DataType::List(field) => match field.data_type() {
@@ -361,8 +371,17 @@ pub fn base_type(data_type: &DataType) -> Result<DataType> {
 }
 
 /// Coerced only the base type.
-/// For example, if the data type is `List<Int32>` and the base type is `Float64`,
-/// the result would be `List<Float64>`.
+///
+/// Example
+/// ```
+/// use arrow::datatypes::{DataType, Field};
+/// use datafusion_common::utils::coerced_type_with_base_type_only;
+/// use std::sync::Arc;
+///
+/// let data_type = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+/// let base_type = DataType::Float64;
+/// let coerced_type = coerced_type_with_base_type_only(&data_type, &base_type).unwrap();
+/// assert_eq!(coerced_type, DataType::List(Arc::new(Field::new("item", DataType::Float64, true))));
 pub fn coerced_type_with_base_type_only(
     data_type: &DataType,
     base_type: &DataType,

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -609,7 +609,7 @@ impl BuiltinScalarFunction {
                             if !input_expr_type.equals_datatype(&Null) {
                                 expr_type = input_expr_type.clone();
                             }
-                        // For nested list cases, since Null is already converted to other primitive types after evalute(),
+                        // For nested list cases, since Null is already converted to other primitive types after evalua te(),
                         // we can only find the return type based on whether input_expr_type is List.
                         } else if let DataType::List(_) = input_expr_type {
                             expr_type = input_expr_type.clone();

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -605,9 +605,14 @@ impl BuiltinScalarFunction {
                 _ => {
                     let mut expr_type = Null;
                     for input_expr_type in input_expr_types {
-                        if !input_expr_type.equals_datatype(&Null) {
+                        if expr_type.equals_datatype(&Null) {
+                            if !input_expr_type.equals_datatype(&Null) {
+                                expr_type = input_expr_type.clone();
+                            }
+                        // For nested list cases, since Null is already converted to other primitive types after evalute(),
+                        // we can only find the return type based on whether input_expr_type is List.
+                        } else if let DataType::List(_) = input_expr_type {
                             expr_type = input_expr_type.clone();
-                            break;
                         }
                     }
 

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -562,10 +562,6 @@ fn coerce_arguments_for_fun(
 
     let mut expressions: Vec<Expr> = expressions.to_vec();
 
-    if *fun == BuiltinScalarFunction::ArrayConcat {
-        println!("expressions: {:?}", expressions);
-    }
-
     // Cast Fixedsizelist to List for array functions
     if *fun == BuiltinScalarFunction::MakeArray {
         expressions = expressions
@@ -596,7 +592,6 @@ fn coerce_arguments_for_fun(
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        // println!("expressions: {:?}", expressions);
     }
 
     // Casting type to make data type consistent for array functions
@@ -606,8 +601,6 @@ fn coerce_arguments_for_fun(
             .iter()
             .map(|e| e.get_type(schema))
             .collect::<Result<Vec<_>>>()?;
-
-        // println!("current_types: {:?}", current_types);
 
         let new_type = current_types
             .iter()

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -326,9 +326,6 @@ fn array_array(args: &[ArrayRef], data_type: DataType) -> Result<ArrayRef> {
                 let mut array_lengths = vec![];
                 let mut valid = BooleanBufferBuilder::new(column_count);
                 for arg in args {
-                    // For debug purposes, there should not be NullArray anymore
-                    assert!(arg.as_any().downcast_ref::<NullArray>().is_none());
-
                     if arg.is_null(index) {
                         array_lengths.push(0);
                         valid.append(false);
@@ -808,13 +805,6 @@ fn concat_internal(args: &[ArrayRef]) -> Result<ArrayRef> {
             // Get all the arrays on i-th row
             let values = list_arrays
                 .iter()
-                // .map(|arr| {
-                //     let res = arr.value(i);
-                //     let res2 = arr.value_length(i);
-                //     println!("res2: {:?}", res2);
-                //     res
-                // })
-                // .filter(|arr| arr.len() > 0)
                 .map(|arr| arr.value(i))
                 .collect::<Vec<_>>();
 
@@ -830,8 +820,6 @@ fn concat_internal(args: &[ArrayRef]) -> Result<ArrayRef> {
             valid.append(true);
         }
     }
-
-    println!("arrays: {:?}", arrays);
 
     // Assume all arrays have the same data type
     let data_type = list_arrays[0].value_type();
@@ -988,7 +976,6 @@ macro_rules! general_repeat_list {
 
 /// Array_empty SQL function
 pub fn array_empty(args: &[ArrayRef]) -> Result<ArrayRef> {
-    println!("args: {:?}", args);
     if args[0].as_any().downcast_ref::<NullArray>().is_some() {
         // Make sure to return Boolean type.
         return Ok(Arc::new(BooleanArray::new_null(args[0].len())));
@@ -1945,15 +1932,7 @@ pub fn string_to_array<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef
 mod tests {
     use super::*;
     use arrow::datatypes::Int64Type;
-    use datafusion_common::{cast::as_uint64_array, utils::wrap_into_list_array};
-
-    #[test]
-    fn testaa() {
-        let array = new_null_array(&DataType::Null, 1);
-        let p = Arc::new(wrap_into_list_array(array));
-        let res = array_empty(&[p]).unwrap();
-        println!("a: {:?}", res);
-    }
+    use datafusion_common::cast::as_uint64_array;
 
     #[test]
     fn test_array() {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -751,7 +751,7 @@ select array_pop_back(make_array(make_array(1, 2, 3), make_array(2, 9, 1), make_
 query ?
 select array_pop_back(make_array(make_array(1, 2, 3), make_array(2, 9, 1), make_array(7, 8, 9), NULL, make_array(1, 7, 4)));
 ----
-[[1, 2, 3], [2, 9, 1], [7, 8, 9], ]
+[[1, 2, 3], [2, 9, 1], [7, 8, 9], []]
 
 # array_pop_back scalar function #8 (after array_pop_back, nested array is empty)
 query ?
@@ -935,20 +935,20 @@ select make_array(make_array('a','b'), null),
        make_array([1,2,3], null, make_array(4,5,6,7)),
        make_array(null, 1, null, 2, null, 3, null, null, 4, 5);
 ----
-[[a, b], ] [[a, b], , [c, d]] [, [a, b], ] [, [a, b], , , [c, d]] [[a, bc, def], , [rust]] [[1, 2, 3], , [4, 5, 6, 7]] [, 1, , 2, , 3, , , 4, 5]
+[[a, b], []] [[a, b], [], [c, d]] [[], [a, b], []] [[], [a, b], [], [], [c, d]] [[a, bc, def], [], [rust]] [[1, 2, 3], [], [4, 5, 6, 7]] [, 1, , 2, , 3, , , 4, 5]
 
 query ?
 select make_array(column5, null, column5) from arrays_values_without_nulls;
 ----
-[[2, 3], , [2, 3]]
-[[4, 5], , [4, 5]]
-[[6, 7], , [6, 7]]
-[[8, 9], , [8, 9]]
+[[2, 3], [], [2, 3]]
+[[4, 5], [], [4, 5]]
+[[6, 7], [], [6, 7]]
+[[8, 9], [], [8, 9]]
 
 query ?
 select make_array(['a','b'], null);
 ----
-[[a, b], ]
+[[a, b], []]
 
 ## array_append (aliases: `list_append`, `array_push_back`, `list_push_back`)
 

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -751,7 +751,7 @@ select array_pop_back(make_array(make_array(1, 2, 3), make_array(2, 9, 1), make_
 query ?
 select array_pop_back(make_array(make_array(1, 2, 3), make_array(2, 9, 1), make_array(7, 8, 9), NULL, make_array(1, 7, 4)));
 ----
-[[1, 2, 3], [2, 9, 1], [7, 8, 9], []]
+[[1, 2, 3], [2, 9, 1], [7, 8, 9], ]
 
 # array_pop_back scalar function #8 (after array_pop_back, nested array is empty)
 query ?
@@ -935,20 +935,20 @@ select make_array(make_array('a','b'), null),
        make_array([1,2,3], null, make_array(4,5,6,7)),
        make_array(null, 1, null, 2, null, 3, null, null, 4, 5);
 ----
-[[a, b], []] [[a, b], [], [c, d]] [[], [a, b], []] [[], [a, b], [], [], [c, d]] [[a, bc, def], [], [rust]] [[1, 2, 3], [], [4, 5, 6, 7]] [, 1, , 2, , 3, , , 4, 5]
+[[a, b], ] [[a, b], , [c, d]] [, [a, b], ] [, [a, b], , , [c, d]] [[a, bc, def], , [rust]] [[1, 2, 3], , [4, 5, 6, 7]] [, 1, , 2, , 3, , , 4, 5]
 
 query ?
 select make_array(column5, null, column5) from arrays_values_without_nulls;
 ----
-[[2, 3], [], [2, 3]]
-[[4, 5], [], [4, 5]]
-[[6, 7], [], [6, 7]]
-[[8, 9], [], [8, 9]]
+[[2, 3], , [2, 3]]
+[[4, 5], , [4, 5]]
+[[6, 7], , [6, 7]]
+[[8, 9], , [8, 9]]
 
 query ?
 select make_array(['a','b'], null);
 ----
-[[a, b], []]
+[[a, b], ]
 
 ## array_append (aliases: `list_append`, `array_push_back`, `list_push_back`)
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ref #7142.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Convert null to int32(none) in type coercion, only make_array is supported now.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->


