### PR TITLE
Minor: error on unsupported RESPECT NULLs syntax

### DIFF
--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -142,7 +142,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             // next, aggregate built-ins
             if let Ok(fun) = AggregateFunction::from_str(&name) {
-                let distinct = distinct;
                 let order_by =
                     self.order_by_to_sort_expr(&order_by, schema, planner_context)?;
                 let order_by = (!order_by.is_empty()).then_some(order_by);

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1288,6 +1288,17 @@ fn select_simple_aggregate_repeated_aggregate_with_unique_aliases() {
 }
 
 #[test]
+fn select_simple_aggregate_respect_nulls() {
+    let sql = "SELECT MIN(age) RESPECT NULLS FROM person";
+    let err = logical_plan(sql).expect_err("query should have failed");
+
+    // HashSet doesn't guarantee order
+    assert_contains!(
+        err.strip_backtrace(),
+        "This feature is not implemented: Null treatment in aggregate functions is not supported: RESPECT NULLS"
+    );
+}
+#[test]
 fn select_from_typed_string_values() {
     quick_test(
             "SELECT col1, col2 FROM (VALUES (TIMESTAMP '2021-06-10 17:01:00Z', DATE '2004-04-09')) as t (col1, col2)",

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1292,7 +1292,6 @@ fn select_simple_aggregate_respect_nulls() {
     let sql = "SELECT MIN(age) RESPECT NULLS FROM person";
     let err = logical_plan(sql).expect_err("query should have failed");
 
-    // HashSet doesn't guarantee order
     assert_contains!(
         err.strip_backtrace(),
         "This feature is not implemented: Null treatment in aggregate functions is not supported: RESPECT NULLS"


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/7983 from @jackwener 

## Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/7983 I noticed there was a newly introduced field in SQLParser's `Function` struct that is ignored by DataFusion

## What changes are included in this PR?
1. If the unsupported syntax is included, return a not yet implemented error

## Are these changes tested?
Yes, with a new test

## Are there any user-facing changes?
Will not silently accept (and ignore) unsupported syntax

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->