### PR TITLE
GroupedHashAggregateStream should register spillable consumer

### DIFF
--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -328,7 +328,9 @@ impl GroupedHashAggregateStream {
             .collect();
 
         let name = format!("GroupedHashAggregateStream[{partition}]");
-        let reservation = MemoryConsumer::new(name).register(context.memory_pool());
+        let reservation = MemoryConsumer::new(name)
+            .with_can_spill(true)
+            .register(context.memory_pool());
 
         let group_ordering = agg
             .aggregation_ordering


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8001.

## Rationale for this change

It is expected for this operator to register spillable consumer as it can spill

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->