### PR TITLE
Minor: fix comment on SortExec::with_fetch method

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -735,7 +735,13 @@ impl SortExec {
         self
     }
 
-    /// Whether this `SortExec` preserves partitioning of the children
+    /// Modify how many rows to include in the result
+    ///
+    /// If None, then all rows will be returned, in sorted order.
+    /// If Some, then only the top `fetch` rows will be returned.
+    /// This can reduce the memory pressure required by the sort
+    /// operation since rows that are not going to be included
+    /// can be dropped.
     pub fn with_fetch(mut self, fetch: Option<usize>) -> Self {
         self.fetch = fetch;
         self


### PR DESCRIPTION
## Which issue does this PR close?

I can create an issue if needed.  However, this is a fairly minor comment-only change.

## Rationale for this change
The previous description for this method was confusing, and I suspect a copy/paste error from `with_preserve_partitioning`

## What changes are included in this PR?

Comment is replaced

## Are these changes tested?

No change to code that can be tested.

## Are there any user-facing changes?

No