### PR TITLE
Minor: Improve documentation for  `PartitionStream` and `StreamingTableExec`

### DIFF
--- a/datafusion/core/src/datasource/file_format/arrow.rs
+++ b/datafusion/core/src/datasource/file_format/arrow.rs
@@ -105,7 +105,7 @@ impl FileFormat for ArrowFormat {
 const ARROW_MAGIC: [u8; 6] = [b'A', b'R', b'R', b'O', b'W', b'1'];
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
 
-/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs. 
+/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs.
 /// See https://github.com/apache/arrow-rs/issues/5021
 async fn infer_schema_from_file_stream(
     mut stream: BoxStream<'static, object_store::Result<Bytes>>,

--- a/datafusion/physical-plan/src/streaming.rs
+++ b/datafusion/physical-plan/src/streaming.rs
@@ -36,7 +36,7 @@ use log::debug;
 
 /// A partition that can be converted into a [`SendableRecordBatchStream`]
 ///
-/// Combined with [`StreamingTable`], you can use this trait to implement
+/// Combined with [`StreamingTableExec`], you can use this trait to implement
 /// [`ExecutionPlan`] for a custom source with less boiler plate than
 /// implementing `ExecutionPlan` directly for many use cases.
 pub trait PartitionStream: Send + Sync {

--- a/datafusion/physical-plan/src/streaming.rs
+++ b/datafusion/physical-plan/src/streaming.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Execution plan for streaming [`PartitionStream`]
+//! Generic plans for deferred execution: [`StreamingTableExec`] and [`PartitionStream`]
 
 use std::any::Any;
 use std::sync::Arc;
@@ -35,6 +35,10 @@ use futures::stream::StreamExt;
 use log::debug;
 
 /// A partition that can be converted into a [`SendableRecordBatchStream`]
+///
+/// Combined with [`StreamingTable`], you can use this trait to implement
+/// [`ExecutionPlan`] for a custom source with less boiler plate than
+/// implementing `ExecutionPlan` directly for many use cases.
 pub trait PartitionStream: Send + Sync {
     /// Returns the schema of this partition
     fn schema(&self) -> &SchemaRef;
@@ -43,7 +47,10 @@ pub trait PartitionStream: Send + Sync {
     fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream;
 }
 
-/// An [`ExecutionPlan`] for [`PartitionStream`]
+/// An [`ExecutionPlan`] for one or more [`PartitionStream`]s.
+///
+/// If your source can be represented as one or more [`PartitionStream`]s, you can
+/// use this struct to implement [`ExecutionPlan`].
 pub struct StreamingTableExec {
     partitions: Vec<Arc<dyn PartitionStream>>,
     projection: Option<Arc<[usize]>>,


### PR DESCRIPTION


## Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/pull/8021 / https://github.com/apache/arrow-datafusion/issues/7994


## Rationale for this change

I kept getting confused about the usecase of `PartitionStream`. I reviewed it as part of https://github.com/apache/arrow-datafusion/pull/8021 from @tustvold  and hope to encode some of my learning in this PR

## What changes are included in this PR?

Improve doc comments

## Are these changes tested?
N/A
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->