### PR TITLE
Minor: fix doc and fmt CI check

### DIFF
--- a/datafusion/core/src/datasource/file_format/arrow.rs
+++ b/datafusion/core/src/datasource/file_format/arrow.rs
@@ -105,8 +105,8 @@ impl FileFormat for ArrowFormat {
 const ARROW_MAGIC: [u8; 6] = [b'A', b'R', b'R', b'O', b'W', b'1'];
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
 
-/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs. 
-/// See https://github.com/apache/arrow-rs/issues/5021
+/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs.
+/// See <https://github.com/apache/arrow-rs/issues/5021>
 async fn infer_schema_from_file_stream(
     mut stream: BoxStream<'static, object_store::Result<Bytes>>,
 ) -> Result<SchemaRef> {


### PR DESCRIPTION
## Which issue does this PR close?

Fix bug introduced in https://github.com/apache/arrow-datafusion/pull/7962

## Rationale for this change

I accidentally merged  https://github.com/apache/arrow-datafusion/pull/7962 with a broken CI check (a newly added doc comment tripped up the `cargo doc` check

## What changes are included in this PR?

Fix the failures like: https://github.com/apache/arrow-datafusion/actions/runs/6737064526/job/18313740850

```
cargo fmt --all -- --check
Diff in /__w/arrow-datafusion/arrow-datafusion/datafusion/core/src/datasource/file_format/arrow.rs at line [10](https://github.com/apache/arrow-datafusion/actions/runs/6737064526/job/18313740850#step:5:11)5:
 const ARROW_MAGIC: [u8; 6] = [b'A', b'R', b'R', b'O', b'W', b'1'];
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
 
-/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs. 
+/// Custom implementation of inferring schema. Should eventually be moved upstream to arrow-rs.
 /// See https://github.com/apache/arrow-rs/issues/5021
 async fn infer_schema_from_file_stream(
     mut stream: BoxStream<'static, object_store::Result<Bytes>>,
```

and https://github.com/apache/arrow-datafusion/actions/runs/6737006063/job/18313624675?pr=8035

```
   --> datafusion/core/src/datasource/file_format/arrow.rs:109:9
    |
109 | /// See https://github.com/apache/arrow-rs/issues/5021
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/apache/arrow-rs/issues/5021>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `-D rustdoc::bare-urls` implied by `-D warnings`

error: could not document `datafusion`

``` 



## Are these changes tested?
Yes, by CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->