### PR TITLE
Minor: improve documentation for IsNotNull, DISTINCT, etc

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -99,21 +99,21 @@ pub enum Expr {
     SimilarTo(Like),
     /// Negation of an expression. The expression's type must be a boolean to make sense.
     Not(Box<Expr>),
-    /// Whether an expression is not Null. This expression is never null.
+    /// True if argument is not NULL, false otherwise. This expression itself is never NULL.
     IsNotNull(Box<Expr>),
-    /// Whether an expression is Null. This expression is never null.
+    /// True if argument is NULL, false otherwise. This expression itself is never NULL.
     IsNull(Box<Expr>),
-    /// Whether an expression is True. Boolean operation
+    /// True if argument is true, false otherwise. This expression itself is never NULL.
     IsTrue(Box<Expr>),
-    /// Whether an expression is False. Boolean operation
+    /// True if argument is  false, false otherwise. This expression itself is never NULL.
     IsFalse(Box<Expr>),
-    /// Whether an expression is Unknown. Boolean operation
+    /// True if argument is NULL, false otherwise. This expression itself is never NULL.
     IsUnknown(Box<Expr>),
-    /// Whether an expression is not True. Boolean operation
+    /// True if argument is FALSE or NULL, false otherwise. This expression itself is never NULL.
     IsNotTrue(Box<Expr>),
-    /// Whether an expression is not False. Boolean operation
+    /// True if argument is TRUE OR NULL, false otherwise. This expression itself is never NULL.
     IsNotFalse(Box<Expr>),
-    /// Whether an expression is not Unknown. Boolean operation
+    /// True if argument is TRUE or FALSE, false otherwise. This expression itself is never NULL.
     IsNotUnknown(Box<Expr>),
     /// arithmetic negation of an expression, the operand must be of a signed numeric data type
     Negative(Box<Expr>),

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -55,11 +55,11 @@ pub enum Operator {
     Or,
     /// `IS DISTINCT FROM` (see [`distinct`])
     ///
-    /// [distinct]: arrow::compute::kernels::cmp::distinct
+    /// [`distinct`]: arrow::compute::kernels::cmp::distinct
     IsDistinctFrom,
     /// `IS NOT DISTINCT FROM` (see [`not_distinct`])
     ///
-    /// [not_distinct]: arrow::compute::kernels::cmp::not_distinct
+    /// [`not_distinct`]: arrow::compute::kernels::cmp::not_distinct
     IsNotDistinctFrom,
     /// Case sensitive regex match
     RegexMatch,

--- a/datafusion/expr/src/operator.rs
+++ b/datafusion/expr/src/operator.rs
@@ -53,9 +53,13 @@ pub enum Operator {
     And,
     /// Logical OR, like `||`
     Or,
-    /// IS DISTINCT FROM
+    /// `IS DISTINCT FROM` (see [`distinct`])
+    ///
+    /// [distinct]: arrow::compute::kernels::cmp::distinct
     IsDistinctFrom,
-    /// IS NOT DISTINCT FROM
+    /// `IS NOT DISTINCT FROM` (see [`not_distinct`])
+    ///
+    /// [not_distinct]: arrow::compute::kernels::cmp::not_distinct
     IsNotDistinctFrom,
     /// Case sensitive regex match
     RegexMatch,


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

The question came up on ASF Slack about what `Expr::IsNotFalse(e)` meant, and since it is subtle I had to look it up in the code, and thus I wanted to save myself (and future people) the trouble of doing that again

## What changes are included in this PR?

Update documentation about the various operator. 

## Are these changes tested?
doctests

## Are there any user-facing changes?
Just Docs