### PR TITLE
feat: make RecordBatch generated by ParquetExec carry file source info

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -340,8 +340,14 @@ impl PartitionColumnProjector {
             )
         }
 
+        // The metadata stored in `file_batch` will be discarded here in the
+        // previous impl so we have to set it again.
+        let metadata = file_batch.schema().metadata().clone();
+        let mut schema = Schema::clone(&self.projected_schema);
+        schema.metadata = metadata;
+
         RecordBatch::try_new_with_options(
-            Arc::clone(&self.projected_schema),
+            Arc::new(schema),
             cols,
             &RecordBatchOptions::new().with_row_count(Some(file_batch.num_rows())),
         )


### PR DESCRIPTION
### What does this PR do

1. Store the source file info in `RecordBatch.schema.metadata` so that our `FilterExec` can be aware of this

### Note

1. This is only for `ParquetExec`, not a general implementation, so other formats like JSON or CSV won't have this
2. It is **ONLY guaranteed** that the `RecordBatch`es that **directly** come from a `ParquetExec` will have this info, batches generated from nodes on the top of a `ParquetExec` node may not have this

