### PR TITLE
Minor: Remove redundant BuiltinScalarFunction::supports_zero_argument()

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -330,16 +330,7 @@ impl BuiltinScalarFunction {
         note = "please use TypeSignature::supports_zero_argument instead"
     )]
     pub fn supports_zero_argument(&self) -> bool {
-        matches!(
-            self,
-            BuiltinScalarFunction::Pi
-                | BuiltinScalarFunction::Random
-                | BuiltinScalarFunction::Now
-                | BuiltinScalarFunction::CurrentDate
-                | BuiltinScalarFunction::CurrentTime
-                | BuiltinScalarFunction::Uuid
-                | BuiltinScalarFunction::MakeArray
-        )
+        self.signature().type_signature.supports_zero_argument()
     }
 
     /// Returns the [Volatility] of the builtin function.

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -136,7 +136,10 @@ impl PhysicalExpr for ScalarFunctionExpr {
         let inputs = match (self.args.len(), self.name.parse::<BuiltinScalarFunction>()) {
             // MakeArray support zero argument but has the different behavior from the array with one null.
             (0, Ok(scalar_fun))
-                if scalar_fun.supports_zero_argument()
+                if scalar_fun
+                    .signature()
+                    .type_signature
+                    .supports_zero_argument()
                     && scalar_fun != BuiltinScalarFunction::MakeArray =>
             {
                 vec![ColumnarValue::create_null_array(batch.num_rows())]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

A cleanup for https://github.com/apache/arrow-datafusion/issues/8045

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Now built-in functions require a separate function to determine whether it supports 0 arg input during execution, however, this can also be determined using the function `TypeSignature`.
We can remove this redundant method, then the new function interface proposed in https://github.com/apache/arrow-datafusion/issues/8045 can be implemented more easily.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Use `TypeSignature` to determine whether a function supports 0 arg during execution

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Unit test
## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
