### PR TITLE
fix: DataFusion suggests invalid functions

### DIFF
--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -418,13 +418,13 @@ mod tests {
     use strum::IntoEnumIterator;
 
     #[test]
-    // Test for AggregateFuncion's name() and from_str() implementations.
-    // For each variant in AggregateFuncion, it converts the variant's name
-    // back to a variant. The test asserts that the original variant and
+    // Test for AggregateFuncion's Display and from_str() implementations.
+    // For each variant in AggregateFuncion, it converts the variant to a string
+    // and then back to a variant. The test asserts that the original variant and
     // the reconstructed variant are the same.
-    fn test_name_and_from_str() {
+    fn test_display_and_from_str() {
         for func_original in AggregateFunction::iter() {
-            let func_name = func_original.name();
+            let func_name = func_original.to_string();
             let func_from_str =
                 AggregateFunction::from_str(func_name.to_lowercase().as_str()).unwrap();
             assert_eq!(func_from_str, func_original);

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -116,13 +116,13 @@ impl AggregateFunction {
             ArrayAgg => "ARRAY_AGG",
             FirstValue => "FIRST_VALUE",
             LastValue => "LAST_VALUE",
-            Variance => "VARIANCE",
-            VariancePop => "VARIANCE_POP",
+            Variance => "VAR",
+            VariancePop => "VAR_POP",
             Stddev => "STDDEV",
             StddevPop => "STDDEV_POP",
-            Covariance => "COVARIANCE",
-            CovariancePop => "COVARIANCE_POP",
-            Correlation => "CORRELATION",
+            Covariance => "COVAR",
+            CovariancePop => "COVAR_POP",
+            Correlation => "CORR",
             RegrSlope => "REGR_SLOPE",
             RegrIntercept => "REGR_INTERCEPT",
             RegrCount => "REGR_COUNT",
@@ -408,6 +408,26 @@ impl AggregateFunction {
                     .collect(),
                 Volatility::Immutable,
             ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    // Test for AggregateFuncion's name() and from_str() implementations.
+    // For each variant in AggregateFuncion, it converts the variant's name
+    // back to a variant. The test asserts that the original variant and
+    // the reconstructed variant are the same.
+    fn test_name_and_from_str() {
+        for func_original in AggregateFunction::iter() {
+            let func_name = func_original.name();
+            let func_from_str =
+                AggregateFunction::from_str(func_name.to_lowercase().as_str()).unwrap();
+            assert_eq!(func_from_str, func_original);
         }
     }
 }

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -421,7 +421,8 @@ mod tests {
     // Test for AggregateFuncion's Display and from_str() implementations.
     // For each variant in AggregateFuncion, it converts the variant to a string
     // and then back to a variant. The test asserts that the original variant and
-    // the reconstructed variant are the same.
+    // the reconstructed variant are the same. This assertion is also necessary for
+    // function suggestion. See https://github.com/apache/arrow-datafusion/issues/8082
     fn test_display_and_from_str() {
         for func_original in AggregateFunction::iter() {
             let func_name = func_original.to_string();

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -1621,7 +1621,8 @@ mod tests {
     // Test for BuiltinScalarFunction's Display and from_str() implementations.
     // For each variant in BuiltinScalarFunction, it converts the variant to a string
     // and then back to a variant. The test asserts that the original variant and
-    // the reconstructed variant are the same.
+    // the reconstructed variant are the same. This assertion is also necessary for
+    // function suggestion. See https://github.com/apache/arrow-datafusion/issues/8082
     fn test_display_and_from_str() {
         for (_, func_original) in name_to_function().iter() {
             let func_name = func_original.to_string();

--- a/datafusion/expr/src/window_function.rs
+++ b/datafusion/expr/src/window_function.rs
@@ -281,6 +281,7 @@ impl BuiltInWindowFunction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strum::IntoEnumIterator;
 
     #[test]
     fn test_count_return_type() -> Result<()> {
@@ -446,5 +447,19 @@ mod tests {
             ))
         );
         assert_eq!(find_df_window_func("not_exist"), None)
+    }
+
+    #[test]
+    // Test for BuiltInWindowFunction's Display and from_str() implementations.
+    // For each variant in BuiltInWindowFunction, it converts the variant to a string
+    // and then back to a variant. The test asserts that the original variant and
+    // the reconstructed variant are the same. This assertion is also necessary for
+    // function suggestion. See https://github.com/apache/arrow-datafusion/issues/8082
+    fn test_display_and_from_str() {
+        for func_original in BuiltInWindowFunction::iter() {
+            let func_name = func_original.to_string();
+            let func_from_str = BuiltInWindowFunction::from_str(&func_name).unwrap();
+            assert_eq!(func_from_str, func_original);
+        }
     }
 }

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -494,6 +494,10 @@ SELECT counter(*) from test;
 statement error Did you mean 'STDDEV'?
 SELECT STDEV(v1) from test;
 
+# Aggregate function
+statement error Did you mean 'COVAR'?
+SELECT COVARIA(1,1);
+
 # Window function
 statement error Did you mean 'SUM'?
 SELECT v1, v2, SUMM(v2) OVER(ORDER BY v1) from test;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8082.

## Rationale for this change
DataFusion use the `name()` method to generate suggestions for aggregate functions.
 https://github.com/apache/arrow-datafusion/blob/f3c9009e50fdb5811c522bfb07ba29ac04cd1d22/datafusion/expr/src/function.rs#L91-L91
https://github.com/apache/arrow-datafusion/blob/f3c9009e50fdb5811c522bfb07ba29ac04cd1d22/datafusion/expr/src/aggregate_function.rs#L148-L152

We need to ensure that the `name()` method returns valid SQL function names.

## What changes are included in this PR?


## Are these changes tested?
Yes
## Are there any user-facing changes?
No