### PR TITLE
Add subtrait support for `IS NULL` and `IS NOT NULL`

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -81,7 +81,7 @@ enum ScalarFunctionType {
     /// [Expr::IsNull]
     IsNull,
     /// [Expr::IsNotNull]
-    IsNotNull
+    IsNotNull,
 }
 
 pub fn name_to_op(name: &str) -> Result<Operator> {
@@ -917,7 +917,9 @@ pub async fn from_substrait_rex(
                                 .clone();
                             Ok(Arc::new(Expr::IsNotNull(Box::new(expr))))
                         }
-                        _ => not_impl_err!("Invalid arguments for IS NOT NULL expression"),
+                        _ => {
+                            not_impl_err!("Invalid arguments for IS NOT NULL expression")
+                        }
                     }
                 }
             }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1025,6 +1025,50 @@ pub fn to_substrait_rex(
             col_ref_offset,
             extension_info,
         ),
+        Expr::IsNull(arg) => {
+            let arguments: Vec<FunctionArgument> = vec![FunctionArgument {
+                arg_type: Some(ArgType::Value(to_substrait_rex(
+                    arg,
+                    schema,
+                    col_ref_offset,
+                    extension_info,
+                )?)),
+            }];
+
+            let function_name = "is_null".to_string();
+            let function_anchor = _register_function(function_name, extension_info);
+            Ok(Expression {
+                rex_type: Some(RexType::ScalarFunction(ScalarFunction {
+                    function_reference: function_anchor,
+                    arguments,
+                    output_type: None,
+                    args: vec![],
+                    options: vec![],
+                })),
+            })
+        },
+        Expr::IsNotNull(arg) => {
+            let arguments: Vec<FunctionArgument> = vec![FunctionArgument {
+                arg_type: Some(ArgType::Value(to_substrait_rex(
+                    arg,
+                    schema,
+                    col_ref_offset,
+                    extension_info,
+                )?)),
+            }];
+
+            let function_name = "is_not_null".to_string();
+            let function_anchor = _register_function(function_name, extension_info);
+            Ok(Expression {
+                rex_type: Some(RexType::ScalarFunction(ScalarFunction {
+                    function_reference: function_anchor,
+                    arguments,
+                    output_type: None,
+                    args: vec![],
+                    options: vec![],
+                })),
+            })
+        }
         _ => not_impl_err!("Unsupported expression: {expr:?}"),
     }
 }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1046,7 +1046,7 @@ pub fn to_substrait_rex(
                     options: vec![],
                 })),
             })
-        },
+        }
         Expr::IsNotNull(arg) => {
             let arguments: Vec<FunctionArgument> = vec![FunctionArgument {
                 arg_type: Some(ArgType::Value(to_substrait_rex(
@@ -1069,7 +1069,9 @@ pub fn to_substrait_rex(
                 })),
             })
         }
-        _ => not_impl_err!("Unsupported expression: {expr:?}"),
+        _ => {
+            not_impl_err!("Unsupported expression: {expr:?}")
+        }
     }
 }
 

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -315,6 +315,16 @@ async fn simple_scalar_function_substr() -> Result<()> {
 }
 
 #[tokio::test]
+async fn simple_scalar_function_is_null() -> Result<()> {
+    roundtrip("SELECT * FROM data WHERE a IS NULL").await
+}
+
+#[tokio::test]
+async fn simple_scalar_function_is_not_null() -> Result<()> {
+    roundtrip("SELECT * FROM data WHERE a IS NOT NULL").await
+}
+
+#[tokio::test]
 async fn case_without_base_expression() -> Result<()> {
     roundtrip("SELECT (CASE WHEN a >= 0 THEN 'positive' ELSE 'negative' END) FROM data")
         .await


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8087.

## What changes are included in this PR?

Support for IS NULL and IS NOT NULL in Substrait producer and consumer. Also includes basic tests for this functionality.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No


