### PR TITLE
Minor: use `Expr::alias` in a few places to make the code more concise

### DIFF
--- a/datafusion/optimizer/src/decorrelate.rs
+++ b/datafusion/optimizer/src/decorrelate.rs
@@ -227,8 +227,9 @@ impl TreeNodeRewriter for PullUpCorrelatedExpr {
                     )?;
                     if !expr_result_map_for_count_bug.is_empty() {
                         // has count bug
-                        let un_matched_row = Expr::Literal(ScalarValue::Boolean(Some(true)))
-                            .alias(UN_MATCHED_ROW_INDICATOR);
+                        let un_matched_row =
+                            Expr::Literal(ScalarValue::Boolean(Some(true)))
+                                .alias(UN_MATCHED_ROW_INDICATOR);
                         // add the unmatched rows indicator to the Aggregation's group expressions
                         missing_exprs.push(un_matched_row);
                     }

--- a/datafusion/optimizer/src/decorrelate.rs
+++ b/datafusion/optimizer/src/decorrelate.rs
@@ -227,10 +227,8 @@ impl TreeNodeRewriter for PullUpCorrelatedExpr {
                     )?;
                     if !expr_result_map_for_count_bug.is_empty() {
                         // has count bug
-                        let un_matched_row = Expr::Alias(Alias::new(
-                            Expr::Literal(ScalarValue::Boolean(Some(true))),
-                            UN_MATCHED_ROW_INDICATOR.to_string(),
-                        ));
+                        let un_matched_row = Expr::Literal(ScalarValue::Boolean(Some(true)))
+                            .alias(UN_MATCHED_ROW_INDICATOR);
                         // add the unmatched rows indicator to the Aggregation's group expressions
                         missing_exprs.push(un_matched_row);
                     }

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -25,7 +25,7 @@ use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
 use datafusion_expr::{
     col,
-    expr::{AggregateFunction},
+    expr::AggregateFunction,
     logical_plan::{Aggregate, LogicalPlan},
     Expr,
 };
@@ -169,13 +169,13 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                     );
                                 }
                                 Ok(Expr::AggregateFunction(AggregateFunction::new(
-                                        fun.clone(),
-                                        vec![col(SINGLE_DISTINCT_ALIAS)],
-                                        false, // intentional to remove distinct here
-                                        filter.clone(),
-                                        order_by.clone(),
-                                    )).alias(aggr_expr.display_name()?),
-                                )
+                                    fun.clone(),
+                                    vec![col(SINGLE_DISTINCT_ALIAS)],
+                                    false, // intentional to remove distinct here
+                                    filter.clone(),
+                                    order_by.clone(),
+                                ))
+                                .alias(aggr_expr.display_name()?))
                             }
                             _ => Ok(aggr_expr.clone()),
                         })

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -25,7 +25,7 @@ use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::Result;
 use datafusion_expr::{
     col,
-    expr::{AggregateFunction, Alias},
+    expr::{AggregateFunction},
     logical_plan::{Aggregate, LogicalPlan},
     Expr,
 };
@@ -168,16 +168,14 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                         args[0].clone().alias(SINGLE_DISTINCT_ALIAS),
                                     );
                                 }
-                                Ok(Expr::Alias(Alias::new(
-                                    Expr::AggregateFunction(AggregateFunction::new(
+                                Ok(Expr::AggregateFunction(AggregateFunction::new(
                                         fun.clone(),
                                         vec![col(SINGLE_DISTINCT_ALIAS)],
                                         false, // intentional to remove distinct here
                                         filter.clone(),
                                         order_by.clone(),
-                                    )),
-                                    aggr_expr.display_name()?,
-                                )))
+                                    )).alias(aggr_expr.display_name()?),
+                                )
                             }
                             _ => Ok(aggr_expr.clone()),
                         })

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -373,7 +373,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     &[&[plan.schema()]],
                     &plan.using_columns()?,
                 )?;
-                let expr = Expr::Alias(Alias::new(col, self.normalizer.normalize(alias)));
+                let expr = col.alias(self.normalizer.normalize(alias));
                 Ok(vec![expr])
             }
             SelectItem::Wildcard(options) => {


### PR DESCRIPTION
## Which issue does this PR close?
Follow on to https://github.com/apache/arrow-datafusion/pull/8061

## Rationale for this change

I noticed during review of https://github.com/apache/arrow-datafusion/pull/8061 that we could use `Expr::alias` in a few places to make the code easier to work with

## What changes are included in this PR?
Use `Expr::alias` a few places

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
