### PR TITLE
Minor: Document `ExecutionPlan::equivalence_properties` more thoroughly

### DIFF
--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -205,16 +205,16 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
 
     /// Get the [`EquivalenceProperties`] within the plan.
     ///
-    /// Equivalence properties tell DataFsion what columns are known to be
-    /// equal, during various optimization passes. By default, this returns " no
-    /// known equivalances" which is always correct, but may cause DataFusion to
-    /// unecessairly resort data.
+    /// Equivalence properties tell DataFusion what columns are known to be
+    /// equal, during various optimization passes. By default, this returns "no
+    /// known equivalences" which is always correct, but may cause DataFusion to
+    /// unnecessarily resort data.
     ///
     /// If this ExecutionPlan makes no changes to the schema of the rows flowing
-    /// through it or how columns withink each row relate to each other, it
-    /// should should return the equivalence properties of its input. For
+    /// through it or how columns within each row relate to each other, it
+    /// should return the equivalence properties of its input. For
     /// example, since `FilterExec` may remove rows from its input, but does not
-    /// otherwise modify them, it preserves its input equivalece properties.
+    /// otherwise modify them, it preserves its input equivalence properties.
     /// However, since `ProjectionExec` may calculate derived expressions, it
     /// needs special handling.
     ///

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -203,7 +203,23 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
             .collect()
     }
 
-    /// Get the [`EquivalenceProperties`] within the plan
+    /// Get the [`EquivalenceProperties`] within the plan.
+    ///
+    /// Equivalence properties tell DataFsion what columns are known to be
+    /// equal, during various optimization passes. By default, this returns " no
+    /// known equivalances" which is always correct, but may cause DataFusion to
+    /// unecessairly resort data.
+    ///
+    /// If this ExecutionPlan makes no changes to the schema of the rows flowing
+    /// through it or how columns withink each row relate to each other, it
+    /// should should return the equivalence properties of its input. For
+    /// example, since `FilterExec` may remove rows from its input, but does not
+    /// otherwise modify them, it preserves its input equivalece properties.
+    /// However, since `ProjectionExec` may calculate derived expressions, it
+    /// needs special handling.
+    ///
+    /// See also [`Self::maintains_input_order`] and [`Self::output_ordering`]
+    /// for related concepts.
     fn equivalence_properties(&self) -> EquivalenceProperties {
         EquivalenceProperties::new(self.schema())
     }


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/8120

## Rationale for this change

I did not properly set `ExecutionPlan::equivalence_properties` for one of our extension nodes, which took me a non trivial time to debug. 

## What changes are included in this PR?

Add doc comments to `ExecutionPlan::equivalence_properties`

## Are these changes tested?
By doc test

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
