### PR TITLE
Minor: simplify filter statistics code

### DIFF
--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -95,6 +95,7 @@ fn supports_collect_by_size(
     let Ok(stats) = plan.statistics() else {
         return false;
     };
+
     if let Some(size) = stats.total_byte_size.get_value() {
         *size != 0 && *size < collection_size_threshold
     } else if let Some(row_count) = stats.num_rows.get_value() {

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -277,16 +277,11 @@ fn collect_new_statistics(
                         )
                     };
                 ColumnStatistics {
-                    null_count: match input_column_stats[idx].null_count.get_value() {
-                        Some(nc) => Precision::Inexact(*nc),
-                        None => Precision::Absent,
-                    },
+                    // simplify:
+                    null_count: input_column_stats[idx].null_count.clone().to_inexact(),
                     max_value,
                     min_value,
-                    distinct_count: match distinct_count.get_value() {
-                        Some(dc) => Precision::Inexact(*dc),
-                        None => Precision::Absent,
-                    },
+                    distinct_count: distinct_count.to_inexact(),
                 }
             },
         )

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -277,7 +277,6 @@ fn collect_new_statistics(
                         )
                     };
                 ColumnStatistics {
-                    // simplify:
                     null_count: input_column_stats[idx].null_count.clone().to_inexact(),
                     max_value,
                     min_value,


### PR DESCRIPTION
## Which issue does this PR close?
 This is part of https://github.com/apache/arrow-datafusion/issues/8078

## Rationale for this change

I am trying to clean up the existing code's use of `Precision` so that as we change it (as described on https://github.com/apache/arrow-datafusion/issues/8078) it will be easier to do so

## What changes are included in this PR?
Call `into_exact` rather than reimplementing the same logic

## Are these changes tested?
Covered by existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
