### PR TITLE
feat: make FSL scalar also an arrayref

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -763,6 +763,7 @@ fn coerce_case_expression(case: Case, schema: &DFSchemaRef) -> Result<Case> {
 mod test {
     use std::sync::Arc;
 
+    use arrow::array::{FixedSizeListArray, Int32Array};
     use arrow::datatypes::{DataType, TimeUnit};
 
     use arrow::datatypes::Field;
@@ -1237,15 +1238,14 @@ mod test {
 
     #[test]
     fn test_casting_for_fixed_size_list() -> Result<()> {
-        let val = lit(ScalarValue::Fixedsizelist(
-            Some(vec![
-                ScalarValue::from(1i32),
-                ScalarValue::from(2i32),
-                ScalarValue::from(3i32),
-            ]),
-            Arc::new(Field::new("item", DataType::Int32, true)),
-            3,
-        ));
+        let val = lit(ScalarValue::FixedSizeList(Arc::new(
+            FixedSizeListArray::new(
+                Arc::new(Field::new("item", DataType::Int32, true)),
+                3,
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                None,
+            ),
+        )));
         let expr = Expr::ScalarFunction(ScalarFunction {
             fun: BuiltinScalarFunction::MakeArray,
             args: vec![val.clone()],

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1134,7 +1134,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     Value::LargeUtf8Value(s.to_owned())
                 })
             }
-            ScalarValue::Fixedsizelist(..) => Err(Error::General(
+            ScalarValue::FixedSizeList(..) => Err(Error::General(
                 "Proto serialization error: ScalarValue::Fixedsizelist not supported"
                     .to_string(),
             )),


### PR DESCRIPTION
## Which issue does this PR close?

Changes `ScalarValue::FixedSizeList()` to wrap an `ArrayRef`. This is an API breaking change, so while I did this I also fixed the capitalization of the name `Fixedsizelist` to `FixedSizeList`, so it's consistent with the data and array type in arrow-rs.

Closes #8218.

## Rationale for this change

We can re-use a lot of functions with `ScalarValue::List`, and this representation leaves less room for invalid state (for example, previously one could create a scalar that contained scalar values of varying data type).

## What changes are included in this PR?

* Rename `ScalarValue::Fixedsizelist` to `ScalarValue::FixedSizeList`.
* Change `ScalarValue::FixedSizeList` to wrap an array ref.

## Are these changes tested?

There's not much testing for this type. I can work on adding more tests in #8220.

## Are there any user-facing changes?

Yes, this is a breaking API change.
