### PR TITLE
Fix PartialOrd for ScalarValue::List/FixSizeList/LargeList

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -3497,7 +3497,6 @@ impl ScalarType<i64> for TimestampNanosecondType {
 }
 
 #[cfg(test)]
-#[cfg(feature = "parquet")]
 mod tests {
     use std::cmp::Ordering;
     use std::sync::Arc;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Bugs in #8221 

FixedsizeList should converted by `as_fixed_size_list` not `as_list_array`. However, I just found we can get the child data so we dont need to downcast array via their type.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Existing test `test_list_partial_cmp`
I removed test that array length is greater than 1 since ScalarValue::List should contains length 1 array.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
