### PR TITLE
Fix bug in field level metadata matching code

### DIFF
--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -261,8 +261,7 @@ fn get_field_metadata(
     // column with the same name)
     e.as_any()
         .downcast_ref::<Column>()
-        .map(|column| column.index())
-        .map(|idx| input_schema.field(idx).metadata())
+        .map(|column| input_schema.field(column.index()).metadata())
         .cloned()
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -257,16 +257,12 @@ fn get_field_metadata(
     e: &Arc<dyn PhysicalExpr>,
     input_schema: &Schema,
 ) -> Option<HashMap<String, String>> {
-    let name = if let Some(column) = e.as_any().downcast_ref::<Column>() {
-        column.name()
-    } else {
-        return None;
-    };
-
-    input_schema
-        .field_with_name(name)
-        .ok()
-        .map(|f| f.metadata().clone())
+    // Look up field by index in schema (not NAME)
+    e.as_any()
+        .downcast_ref::<Column>()
+        .map(|column| column.index())
+        .map(|idx| input_schema.field(idx).metadata())
+        .cloned()
 }
 
 fn stats_projection(

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -257,7 +257,8 @@ fn get_field_metadata(
     e: &Arc<dyn PhysicalExpr>,
     input_schema: &Schema,
 ) -> Option<HashMap<String, String>> {
-    // Look up field by index in schema (not NAME)
+    // Look up field by index in schema (not NAME as there can be more than one
+    // column with the same name)
     e.as_any()
         .downcast_ref::<Column>()
         .map(|column| column.index())

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Tests for tables that has both metadata on each field as well as metadata on
+## the schema itself.
+##########
+
+## Note that table_with_metadata is defined using Rust code
+## in the test harness as there is no way to define schema
+## with metadata in SQL.
+
+query IT
+select * from table_with_metadata;
+----
+1 NULL
+NULL bar
+3 baz
+
+query I rowsort
+SELECT (
+  SELECT id FROM table_with_metadata
+  ) UNION (
+  SELECT id FROM table_with_metadata
+  );
+----
+1
+3
+NULL
+
+query I rowsort
+SELECT "data"."id"
+FROM
+  (
+    (SELECT "id" FROM "table_with_metadata")
+      UNION
+    (SELECT "id" FROM "table_with_metadata")
+  ) as "data",
+  (
+    SELECT "id" FROM "table_with_metadata"
+  ) as "samples"
+WHERE "data"."id" = "samples"."id";
+----
+1
+3
+
+statement ok
+drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8285


## Rationale for this change

Bug fix

## What changes are included in this PR?

What was happening is that the input to a join has metadata on one side, but not the other. When the inputs were reordered then metadata was not properly reordered as well

Specifically:
```
OutputRequirementExec
  ProjectionExec: expr=[id@0 as id]
    HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, id@0)]
      AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[]  <--******** this does not have metadata
        AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[]
          UnionExec
            MemoryExec: partitions=1, partition_sizes=[1]
            MemoryExec: partitions=1, partition_sizes=[1]
      MemoryExec: partitions=1, partition_sizes=[1]                    <--******** this has metadata
```

So the output schema looks like:
```
  id (metadata)    <-- first input
  id (no metadata) <-- second input
```

When the join reorders the inputs, the result had the metadata incorrectly set:

```
  id (no metadata) <-- first input *** Metadata is switched ***
  id (metadata)    <-- second input
```

There is code in the join reordering that tries to remap the output so the schema is the same, however
it had a bug (was looking up field by name, not column index), so it picked the wrong column. 




## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
