### PR TITLE
[Benchmarks] Make `partitions` default to number of cores instead of 2

### DIFF
--- a/benchmarks/src/sort.rs
+++ b/benchmarks/src/sort.rs
@@ -148,8 +148,9 @@ impl RunOpt {
             println!("Executing '{title}' (sorting by: {expr:?})");
             rundata.start_new_case(title);
             for i in 0..self.common.iterations {
-                let config =
-                    SessionConfig::new().with_target_partitions(self.common.partitions);
+                let config = SessionConfig::new().with_target_partitions(
+                    self.common.partitions.unwrap_or(num_cpus::get()),
+                );
                 let ctx = SessionContext::new_with_config(config);
                 let (rows, elapsed) =
                     exec_sort(&ctx, &expr, &test_file, self.common.debug).await?;

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -325,7 +325,7 @@ mod tests {
         let path = get_tpch_data_path()?;
         let common = CommonOpt {
             iterations: 1,
-            partitions: 2,
+            partitions: Some(2),
             batch_size: 8192,
             debug: false,
         };
@@ -357,7 +357,7 @@ mod tests {
         let path = get_tpch_data_path()?;
         let common = CommonOpt {
             iterations: 1,
-            partitions: 2,
+            partitions: Some(2),
             batch_size: 8192,
             debug: false,
         };

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -285,7 +285,7 @@ impl RunOpt {
     }
 
     fn partitions(&self) -> usize {
-        self.common.partitions
+        self.common.partitions.unwrap_or(num_cpus::get())
     }
 }
 

--- a/benchmarks/src/util/options.rs
+++ b/benchmarks/src/util/options.rs
@@ -26,9 +26,9 @@ pub struct CommonOpt {
     #[structopt(short = "i", long = "iterations", default_value = "3")]
     pub iterations: usize,
 
-    /// Number of partitions to process in parallel
-    #[structopt(short = "n", long = "partitions", default_value = "2")]
-    pub partitions: usize,
+    /// Number of partitions to process in parallel. Defaults to number of available cores.
+    #[structopt(short = "n", long = "partitions")]
+    pub partitions: Option<usize>,
 
     /// Batch size when reading CSV or Parquet files
     #[structopt(short = "s", long = "batch-size", default_value = "8192")]
@@ -48,7 +48,7 @@ impl CommonOpt {
     /// Modify the existing config appropriately
     pub fn update_config(&self, config: SessionConfig) -> SessionConfig {
         config
-            .with_target_partitions(self.partitions)
+            .with_target_partitions(self.partitions.unwrap_or(num_cpus::get()))
             .with_batch_size(self.batch_size)
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to discussion in https://github.com/apache/arrow-datafusion/issues/7001

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

By default, the benchmarks have been running with two partitions (i.e., concurrency of two), which is unrealistic given the number of cores on modern laptops. This PR defaults to num cores instead. We can still override this and explicitly set the number of partitions.

This is the difference this makes for me (Threadripper with 24 cores).

```
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      main ┃ bench-default-partitions ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  655.23ms │                 283.37ms │ +2.31x faster │
│ QQuery 2     │  148.53ms │                 160.08ms │  1.08x slower │
│ QQuery 3     │  277.50ms │                 215.95ms │ +1.28x faster │
│ QQuery 4     │  166.20ms │                 131.36ms │ +1.27x faster │
│ QQuery 5     │  334.64ms │                 248.19ms │ +1.35x faster │
│ QQuery 6     │  144.79ms │                  97.53ms │ +1.48x faster │
│ QQuery 7     │  718.12ms │                 367.63ms │ +1.95x faster │
│ QQuery 8     │  385.01ms │                 293.77ms │ +1.31x faster │
│ QQuery 9     │  571.56ms │                 387.59ms │ +1.47x faster │
│ QQuery 10    │  459.09ms │                 388.16ms │ +1.18x faster │
│ QQuery 11    │  143.07ms │                 119.23ms │ +1.20x faster │
│ QQuery 12    │  257.05ms │                 244.25ms │     no change │
│ QQuery 13    │  447.24ms │                 385.33ms │ +1.16x faster │
│ QQuery 14    │  233.90ms │                 126.45ms │ +1.85x faster │
│ QQuery 15    │  192.98ms │                 143.86ms │ +1.34x faster │
│ QQuery 16    │  163.44ms │                 176.92ms │  1.08x slower │
│ QQuery 17    │  335.34ms │                 230.92ms │ +1.45x faster │
│ QQuery 18    │ 1188.63ms │                 678.13ms │ +1.75x faster │
│ QQuery 19    │  360.65ms │                 193.74ms │ +1.86x faster │
│ QQuery 20    │  356.26ms │                 168.59ms │ +2.11x faster │
│ QQuery 21    │  825.86ms │                 491.50ms │ +1.68x faster │
│ QQuery 22    │  163.89ms │                 201.47ms │  1.23x slower │
└──────────────┴───────────┴──────────────────────────┴───────────────┘
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
