### PR TITLE
Allow default value on lag/lead if they are coerceable to value

### DIFF
--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1153,6 +1153,27 @@ SELECT
 141680161 63044568 63044568 225513085 225513085
 145294611 141047417 141047417 243203849 243203849
 
+# can coerce given default value to lag/lead value type
+query PP
+SELECT
+  LAG(c9::timestamp, 99999999, '2000-11-22T16:17:06.624Z') OVER(ORDER BY c9) as lag_default_coerced,
+  LEAD(c9::timestamp, 99999999, '2023-11-22T16:17:06.624Z') OVER(ORDER BY c9) as lead_default_coerced
+  FROM aggregate_test_100
+  LIMIT 1
+----
+2000-11-22T16:17:06.624 2023-11-22T16:17:06.624
+
+# cannot coerce given default value to lag value type
+query error
+SELECT
+  LAG(c9, 99999999, '2000-11-22T16:17:06.624Z') OVER(ORDER BY c9)
+  FROM aggregate_test_100
+  LIMIT 1
+----
+DataFusion error: Internal error: Cannot coerce default value Utf8("2000-11-22T16:17:06.624Z") Utf8 to UInt64.
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
+
 #fn test_window_frame_first_value_last_value_aggregate
 query IIII
 SELECT

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1170,8 +1170,7 @@ SELECT
   FROM aggregate_test_100
   LIMIT 1
 ----
-DataFusion error: Internal error: Cannot coerce default value Utf8("2000-11-22T16:17:06.624Z") Utf8 to UInt64.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+DataFusion error: Arrow error: Cast error: Cannot cast string '2000-11-22T16:17:06.624Z' to value of UInt64 type
 
 
 #fn test_window_frame_first_value_last_value_aggregate


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8307.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow other default values than Int64 on lag/lead window functions.

## What changes are included in this PR?

If a default value is specified, it is now coerced if possible.
Before this PR only Int64 was allowed.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added some slt tests.

## Are there any user-facing changes?

Yes, more default values are now accepted.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
