### PR TITLE
fix array_append with null array

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -548,9 +548,7 @@ impl BuiltinScalarFunction {
                         Ok(input_expr_types[0].clone())
                     }
                 } else {
-                    plan_err!(
-                        "The {self} function can only accept list as the first argument"
-                    )
+                    plan_err!("The {self} function expects LIST as the first argument")
                 }
             }
             BuiltinScalarFunction::ArrayConcat => {

--- a/datafusion/physical-expr/src/array_expressions.rs
+++ b/datafusion/physical-expr/src/array_expressions.rs
@@ -227,14 +227,14 @@ fn compute_array_dims(arr: Option<ArrayRef>) -> Result<Option<Vec<Option<u64>>>>
 }
 
 fn check_datatypes(name: &str, args: &[&ArrayRef]) -> Result<()> {
-    let mut data_types = args
+    let data_types = args
         .iter()
         .map(|arg| arg.data_type())
         .collect::<HashSet<_>>();
     match data_types.len() {
         1 => Ok(()),
         2 => {
-            if data_types.remove(&DataType::Null) {
+            if data_types.contains(&DataType::Null) {
                 Ok(())
             } else {
                 let types = args.iter().map(|arg| arg.data_type()).collect::<Vec<_>>();

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1056,16 +1056,16 @@ select make_array(['a','b'], null);
 
 # TODO: array_append with NULLs
 # array_append scalar function #1
-# query ?
-# select array_append(make_array(), 4);
-# ----
-# [4]
+query ?
+select array_append(make_array(), 4);
+----
+[4]
 
 # array_append scalar function #2
-# query ??
-# select array_append(make_array(), make_array()), array_append(make_array(), make_array(4));
-# ----
-# [[]] [[4]]
+query ??
+select array_append(make_array(), make_array()), array_append(make_array(), make_array(4));
+----
+[[]] [[4]]
 
 # array_append scalar function #3
 query ???


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

fix todo in `array.slt`, now we can do `array_append` correctly with null.
```sql
select array_append(make_array(), 4);
```

and fix `fn check_datatypes`, this function contains a bug that when input arrays sequences are different:
* `(DataType::Null, DataType::Int64)` used to return unexcepted array while`(DataType::Int64, DataType::Null)` returns `Ok(())`

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
