### PR TITLE
fix: make `ntile` work in some corner cases

### DIFF
--- a/datafusion/expr/src/window_function.rs
+++ b/datafusion/expr/src/window_function.rs
@@ -268,7 +268,20 @@ impl BuiltInWindowFunction {
             BuiltInWindowFunction::FirstValue | BuiltInWindowFunction::LastValue => {
                 Signature::any(1, Volatility::Immutable)
             }
-            BuiltInWindowFunction::Ntile => Signature::any(1, Volatility::Immutable),
+            BuiltInWindowFunction::Ntile => Signature::uniform(
+                1,
+                vec![
+                    DataType::UInt64,
+                    DataType::UInt32,
+                    DataType::UInt16,
+                    DataType::UInt8,
+                    DataType::Int64,
+                    DataType::Int32,
+                    DataType::Int16,
+                    DataType::Int8,
+                ],
+                Volatility::Immutable,
+            ),
             BuiltInWindowFunction::NthValue => Signature::any(2, Volatility::Immutable),
         }
     }

--- a/datafusion/physical-expr/src/window/ntile.rs
+++ b/datafusion/physical-expr/src/window/ntile.rs
@@ -96,8 +96,12 @@ impl PartitionEvaluator for NtileEvaluator {
     ) -> Result<ArrayRef> {
         let num_rows = num_rows as u64;
         let mut vec: Vec<u64> = Vec::new();
+        let mut n = self.n;
+        if n > num_rows {
+            n = num_rows;
+        }
         for i in 0..num_rows {
-            let res = i * self.n / num_rows;
+            let res = i * n / num_rows;
             vec.push(res + 1)
         }
         Ok(Arc::new(UInt64Array::from(vec)))

--- a/datafusion/physical-expr/src/window/ntile.rs
+++ b/datafusion/physical-expr/src/window/ntile.rs
@@ -96,10 +96,7 @@ impl PartitionEvaluator for NtileEvaluator {
     ) -> Result<ArrayRef> {
         let num_rows = num_rows as u64;
         let mut vec: Vec<u64> = Vec::new();
-        let mut n = self.n;
-        if n > num_rows {
-            n = num_rows;
-        }
+        let n = u64::min(self.n, num_rows);
         for i in 0..num_rows {
             let res = i * n / num_rows;
             vec.push(res + 1)

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -189,15 +189,26 @@ fn create_built_in_window_expr(
         BuiltInWindowFunction::PercentRank => Arc::new(percent_rank(name)),
         BuiltInWindowFunction::CumeDist => Arc::new(cume_dist(name)),
         BuiltInWindowFunction::Ntile => {
-            let n: i64 = get_scalar_value_from_args(args, 0)?
-                .ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "NTILE requires at least 1 argument".to_string(),
-                    )
-                })?
-                .try_into()?;
-            let n: u64 = n as u64;
-            Arc::new(Ntile::new(name, n))
+            let n = get_scalar_value_from_args(args, 0)?.ok_or_else(|| {
+                DataFusionError::Execution(
+                    "NTILE requires at least 1 argument".to_string(),
+                )
+            })?;
+
+            if n.is_null() {
+                return exec_err!("NTILE requires a positive integer, but finds NULL");
+            }
+
+            if n.is_unsigned() {
+                let n: u64 = n.try_into()?;
+                Arc::new(Ntile::new(name, n))
+            } else {
+                let n: i64 = n.try_into()?;
+                if n <= 0 {
+                    return exec_err!("NTILE requires a positive integer");
+                }
+                Arc::new(Ntile::new(name, n as u64))
+            }
         }
         BuiltInWindowFunction::Lag => {
             let arg = args[0].clone();

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -191,7 +191,7 @@ fn create_built_in_window_expr(
         BuiltInWindowFunction::Ntile => {
             let n = get_scalar_value_from_args(args, 0)?.ok_or_else(|| {
                 DataFusionError::Execution(
-                    "NTILE requires at least 1 argument".to_string(),
+                    "NTILE requires a positive integer".to_string(),
                 )
             })?;
 

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3607,40 +3607,40 @@ DROP TABLE t;
 
 # NTILE with PARTITION BY, those tests from duckdb: https://github.com/duckdb/duckdb/blob/main/test/sql/window/test_ntile.test
 statement ok
-CREATE TABLE Scoreboard(TeamName VARCHAR, Player VARCHAR, Score INTEGER);
+CREATE TABLE score_board(team_name VARCHAR, player VARCHAR, score INTEGER);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Mongrels', 'Apu', 350);
+INSERT INTO score_board VALUES ('Mongrels', 'Apu', 350);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Mongrels', 'Ned', 666);
+INSERT INTO score_board VALUES ('Mongrels', 'Ned', 666);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Mongrels', 'Meg', 1030);
+INSERT INTO score_board VALUES ('Mongrels', 'Meg', 1030);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Mongrels', 'Burns', 1270);
+INSERT INTO score_board VALUES ('Mongrels', 'Burns', 1270);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Simpsons', 'Homer', 1);
+INSERT INTO score_board VALUES ('Simpsons', 'Homer', 1);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Simpsons', 'Lisa', 710);
+INSERT INTO score_board VALUES ('Simpsons', 'Lisa', 710);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Simpsons', 'Marge', 990);
+INSERT INTO score_board VALUES ('Simpsons', 'Marge', 990);
 
 statement ok
-INSERT INTO Scoreboard VALUES ('Simpsons', 'Bart', 2010);
+INSERT INTO score_board VALUES ('Simpsons', 'Bart', 2010);
 
 query TTII
 SELECT
-  TeamName,
-  Player,
-  Score,
-  NTILE(2) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
-ORDER BY TeamName, Score;
+  team_name,
+  player,
+  score,
+  NTILE(2) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
+ORDER BY team_name, score;
 ----
 Mongrels	Apu	350	1
 Mongrels	Ned	666	1
@@ -3653,12 +3653,12 @@ Simpsons	Bart	2010	2
 
 query TTII
 SELECT
-  TeamName,
-  Player,
-  Score,
-  NTILE(2) OVER (ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
-ORDER BY Score;
+  team_name,
+  player,
+  score,
+  NTILE(2) OVER (ORDER BY score ASC) AS NTILE
+FROM score_board s
+ORDER BY score;
 ----
 Simpsons	Homer	1	1
 Mongrels	Apu	350	1
@@ -3671,12 +3671,12 @@ Simpsons	Bart	2010	2
 
 query TTII
 SELECT
-  TeamName,
-  Player,
-  Score,
-  NTILE(1000) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
-ORDER BY TeamName, Score;
+  team_name,
+  player,
+  score,
+  NTILE(1000) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
+ORDER BY team_name, score;
 ----
 Mongrels	Apu	350	1
 Mongrels	Ned	666	2
@@ -3689,12 +3689,12 @@ Simpsons	Bart	2010	4
 
 query TTII
 SELECT
-  TeamName,
-  Player,
-  Score,
-  NTILE(1) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
-ORDER BY TeamName, Score;
+  team_name,
+  player,
+  score,
+  NTILE(1) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
+ORDER BY team_name, score;
 ----
 Mongrels	Apu	350	1
 Mongrels	Ned	666	1
@@ -3708,38 +3708,38 @@ Simpsons	Bart	2010	1
 # incorrect number of parameters for ntile
 query error DataFusion error: Execution error: NTILE requires a positive integer, but finds NULL
 SELECT
-  NTILE(NULL) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(NULL) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 query error DataFusion error: Execution error: NTILE requires a positive integer
 SELECT
-  NTILE(-1) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(-1) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 query error DataFusion error: Execution error: NTILE requires a positive integer
 SELECT
-  NTILE(0) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(0) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 statement error
 SELECT
-  NTILE() OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE() OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 statement error
 SELECT
-  NTILE(1,2) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(1,2) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 statement error
 SELECT
-  NTILE(1,2,3) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(1,2,3) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 statement error
 SELECT
-  NTILE(1,2,3,4) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
-FROM ScoreBoard s
+  NTILE(1,2,3,4) OVER (PARTITION BY team_name ORDER BY score ASC) AS NTILE
+FROM score_board s
 
 statement ok
-DROP TABLE Scoreboard;
+DROP TABLE score_board;

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3607,31 +3607,15 @@ DROP TABLE t;
 
 # NTILE with PARTITION BY, those tests from duckdb: https://github.com/duckdb/duckdb/blob/main/test/sql/window/test_ntile.test
 statement ok
-CREATE TABLE score_board(team_name VARCHAR, player VARCHAR, score INTEGER);
-
-statement ok
-INSERT INTO score_board VALUES ('Mongrels', 'Apu', 350);
-
-statement ok
-INSERT INTO score_board VALUES ('Mongrels', 'Ned', 666);
-
-statement ok
-INSERT INTO score_board VALUES ('Mongrels', 'Meg', 1030);
-
-statement ok
-INSERT INTO score_board VALUES ('Mongrels', 'Burns', 1270);
-
-statement ok
-INSERT INTO score_board VALUES ('Simpsons', 'Homer', 1);
-
-statement ok
-INSERT INTO score_board VALUES ('Simpsons', 'Lisa', 710);
-
-statement ok
-INSERT INTO score_board VALUES ('Simpsons', 'Marge', 990);
-
-statement ok
-INSERT INTO score_board VALUES ('Simpsons', 'Bart', 2010);
+CREATE TABLE score_board (team_name VARCHAR, player VARCHAR, score INTEGER) as VALUES
+          ('Mongrels', 'Apu', 350),
+          ('Mongrels', 'Ned', 666),
+          ('Mongrels', 'Meg', 1030),
+          ('Mongrels', 'Burns', 1270),
+          ('Simpsons', 'Homer', 1),
+          ('Simpsons', 'Lisa', 710),
+          ('Simpsons', 'Marge', 990),
+          ('Simpsons', 'Bart', 2010)
 
 query TTII
 SELECT

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3581,3 +3581,165 @@ CREATE TABLE new_table AS SELECT NTILE(2) OVER(ORDER BY c1) AS ntile_2 FROM aggr
 
 statement ok
 DROP TABLE new_table;
+
+statement ok
+CREATE TABLE t1 (a int) AS VALUES (1), (2), (3);
+
+query I
+SELECT NTILE(9223377) OVER(ORDER BY a) FROM t1;
+----
+1
+2
+3
+
+query I
+SELECT NTILE(9223372036854775809) OVER(ORDER BY a) FROM t1;
+----
+1
+2
+3
+
+query error DataFusion error: Execution error: NTILE requires a positive integer
+SELECT NTILE(-922337203685477580) OVER(ORDER BY a) FROM t1;
+
+query error DataFusion error: Execution error: Table 't' doesn't exist\.
+DROP TABLE t;
+
+# NTILE with PARTITION BY, those tests from duckdb: https://github.com/duckdb/duckdb/blob/main/test/sql/window/test_ntile.test
+statement ok
+CREATE TABLE Scoreboard(TeamName VARCHAR, Player VARCHAR, Score INTEGER);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Mongrels', 'Apu', 350);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Mongrels', 'Ned', 666);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Mongrels', 'Meg', 1030);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Mongrels', 'Burns', 1270);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Simpsons', 'Homer', 1);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Simpsons', 'Lisa', 710);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Simpsons', 'Marge', 990);
+
+statement ok
+INSERT INTO Scoreboard VALUES ('Simpsons', 'Bart', 2010);
+
+query TTII
+SELECT
+  TeamName,
+  Player,
+  Score,
+  NTILE(2) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+ORDER BY TeamName, Score;
+----
+Mongrels	Apu	350	1
+Mongrels	Ned	666	1
+Mongrels	Meg	1030	2
+Mongrels	Burns	1270	2
+Simpsons	Homer	1	1
+Simpsons	Lisa	710	1
+Simpsons	Marge	990	2
+Simpsons	Bart	2010	2
+
+query TTII
+SELECT
+  TeamName,
+  Player,
+  Score,
+  NTILE(2) OVER (ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+ORDER BY Score;
+----
+Simpsons	Homer	1	1
+Mongrels	Apu	350	1
+Mongrels	Ned	666	1
+Simpsons	Lisa	710	1
+Simpsons	Marge	990	2
+Mongrels	Meg	1030	2
+Mongrels	Burns	1270	2
+Simpsons	Bart	2010	2
+
+query TTII
+SELECT
+  TeamName,
+  Player,
+  Score,
+  NTILE(1000) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+ORDER BY TeamName, Score;
+----
+Mongrels	Apu	350	1
+Mongrels	Ned	666	2
+Mongrels	Meg	1030	3
+Mongrels	Burns	1270	4
+Simpsons	Homer	1	1
+Simpsons	Lisa	710	2
+Simpsons	Marge	990	3
+Simpsons	Bart	2010	4
+
+query TTII
+SELECT
+  TeamName,
+  Player,
+  Score,
+  NTILE(1) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+ORDER BY TeamName, Score;
+----
+Mongrels	Apu	350	1
+Mongrels	Ned	666	1
+Mongrels	Meg	1030	1
+Mongrels	Burns	1270	1
+Simpsons	Homer	1	1
+Simpsons	Lisa	710	1
+Simpsons	Marge	990	1
+Simpsons	Bart	2010	1
+
+# incorrect number of parameters for ntile
+query error DataFusion error: Execution error: NTILE requires a positive integer, but finds NULL
+SELECT
+  NTILE(NULL) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+query error DataFusion error: Execution error: NTILE requires a positive integer
+SELECT
+  NTILE(-1) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+query error DataFusion error: Execution error: NTILE requires a positive integer
+SELECT
+  NTILE(0) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+statement error
+SELECT
+  NTILE() OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+statement error
+SELECT
+  NTILE(1,2) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+statement error
+SELECT
+  NTILE(1,2,3) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+statement error
+SELECT
+  NTILE(1,2,3,4) OVER (PARTITION BY TeamName ORDER BY Score ASC) AS NTILE
+FROM ScoreBoard s
+
+statement ok
+DROP TABLE Scoreboard;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8284

## Rationale for this change
fix #8284
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add parameter type checking using `Signature`, 
before
```
❯ select ntile('1') OVER(ORDER BY a) from t1;
Internal error: Cannot convert Utf8("1") to i64.
This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
❯ select ntile([]) OVER(ORDER BY a) from t1;
Internal error: Cannot convert List([NullArray(0)]) to i64.
This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```
after 
```
❯ select ntile([]) OVER(ORDER BY a) from t1;
Error during planning: No function matches the given name and argument types 'NTILE(List(Field { name: "item", data_type: Null, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }))'. You might need to add explicit type casts.
        Candidate functions:
        NTILE(UInt64/UInt32/UInt16/UInt8/Int64/Int32/Int16/Int8)
❯ select ntile('1') OVER(ORDER BY a) from t1;
Error during planning: No function matches the given name and argument types 'NTILE(Utf8)'. You might need to add explicit type casts.
        Candidate functions:
        NTILE(UInt64/UInt32/UInt16/UInt8/Int64/Int32/Int16/Int8)
```
make `ntile` work properly, when parameter greater than table's row number

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes, add more test 

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
