### PR TITLE
Update code comment for the cases of regularized RANGE frame and add tests for ORDER BY cases with RANGE frame

### DIFF
--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -153,6 +153,7 @@ pub fn regularize(mut frame: WindowFrame, order_bys: usize) -> Result<WindowFram
         // 2. end bound is CURRENT ROW or UNBOUNDED.
         // In these cases, we regularize the RANGE frame to be equivalent to a ROWS
         // frame with the UNBOUNDED bounds.
+        // Note that this follows Postgres behavior.
         if (frame.start_bound.is_unbounded()
             || frame.start_bound == WindowFrameBound::CurrentRow)
             && (frame.end_bound == WindowFrameBound::CurrentRow

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -148,7 +148,8 @@ impl WindowFrame {
 pub fn regularize(mut frame: WindowFrame, order_bys: usize) -> Result<WindowFrame> {
     if frame.units == WindowFrameUnits::Range && order_bys != 1 {
         // Normally, RANGE frames require an ORDER BY clause with exactly one
-        // column. However, an ORDER BY clause may be absent in two edge cases:
+        // column. However, an ORDER BY clause may be absent or present but with
+        // more than one column in two edge cases:
         // 1. start bound is UNBOUNDED or CURRENT ROW
         // 2. end bound is CURRENT ROW or UNBOUNDED.
         // In these cases, we regularize the RANGE frame to be equivalent to a ROWS
@@ -158,11 +159,17 @@ pub fn regularize(mut frame: WindowFrame, order_bys: usize) -> Result<WindowFram
             || frame.start_bound == WindowFrameBound::CurrentRow)
             && (frame.end_bound == WindowFrameBound::CurrentRow
                 || frame.end_bound.is_unbounded())
-            && order_bys == 0
         {
-            frame.units = WindowFrameUnits::Rows;
-            frame.start_bound = WindowFrameBound::Preceding(ScalarValue::UInt64(None));
-            frame.end_bound = WindowFrameBound::Following(ScalarValue::UInt64(None));
+            // If an ORDER BY clause is absent, the frame is equivalent to a ROWS
+            // frame with the UNBOUNDED bounds.
+            // If an ORDER BY clause is present but has more than one column, the
+            // frame is unchanged.
+            if order_bys == 0 {
+                frame.units = WindowFrameUnits::Rows;
+                frame.start_bound =
+                    WindowFrameBound::Preceding(ScalarValue::UInt64(None));
+                frame.end_bound = WindowFrameBound::Following(ScalarValue::UInt64(None));
+            }
         } else {
             plan_err!("RANGE requires exactly one ORDER BY column")?
         }

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3742,20 +3742,18 @@ DROP TABLE score_board;
 query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
 select a,
        rank() over (partition by a order by a, a + 1 RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a union all select 2 a) q
+       from (select 1 a) q
 
 query II
 select a,
        rank() over (partition by a order by a RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a union all select 2 a) q
+       from (select 1 a) q
 ----
 1 1
-2 1
 
 query II
 select a,
        rank() over (partition by a RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a union all select 2 a) q
+       from (select 1 a) q
 ----
 1 1
-2 1

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1080,7 +1080,7 @@ SELECT
 794 95 95
 
 #fn test_window_range_equivalent_frames
-query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
+query IIIIIII
 SELECT
   c9,
   COUNT(*) OVER(ORDER BY c9, c1 RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cnt1,
@@ -1092,22 +1092,12 @@ SELECT
   FROM aggregate_test_100
   ORDER BY c9
   LIMIT 5
-
-query IIII
-SELECT
-  c9,
-  COUNT(*) OVER(RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cnt4,
-  COUNT(*) OVER(RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt5,
-  COUNT(*) OVER(RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt6
-  FROM aggregate_test_100
-  ORDER BY c9
-  LIMIT 5
 ----
-28774375 100 100 100
-63044568 100 100 100
-141047417 100 100 100
-141680161 100 100 100
-145294611 100 100 100
+28774375 1 1 1 100 100 100
+63044568 1 2 1 100 100 100
+141047417 1 3 1 100 100 100
+141680161 1 4 1 100 100 100
+145294611 1 5 1 100 100 100
 
 #fn test_window_cume_dist
 query IRR
@@ -3738,22 +3728,60 @@ FROM score_board s
 statement ok
 DROP TABLE score_board;
 
-# RANGE frame can be regularized to ROWS frame only if empty ORDER BY clause
+# Regularize RANGE frame
 query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
 select a,
-       rank() over (partition by a order by a, a + 1 RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a) q
+       rank() over (order by a, a + 1 RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY a
 
 query II
 select a,
-       rank() over (partition by a order by a RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a) q
+       rank() over (order by a RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY a
 ----
 1 1
+2 2
+
+query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
+select a,
+       rank() over (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY a
 
 query II
 select a,
-       rank() over (partition by a RANGE UNBOUNDED PRECEDING) rnk
-       from (select 1 a) q
+       rank() over (order by a, a + 1 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY a
 ----
 1 1
+2 2
+
+query II
+select a,
+       rank() over (order by a RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY a
+----
+1 1
+2 2
+
+# TODO: this is different to Postgres which returns [1, 1] for `rnk`.
+# Comment it because it is flaky now as it depends on the order of the `a` column.
+# query II
+# select a,
+#       rank() over (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) rnk
+#       from (select 1 a union select 2 a) q ORDER BY rnk
+# ----
+# 1 1
+# 2 2
+
+# TODO: this works in Postgres which returns [1, 1].
+query error DataFusion error: Arrow error: Invalid argument error: must either specify a row count or at least one column
+select rank() over (RANGE between UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) rnk
+       from (select 1 a union select 2 a) q;
+
+# TODO: this is different to Postgres which returns [1, 1] for `rnk`.
+query I
+select rank() over (order by 1 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) rnk
+       from (select 1 a union select 2 a) q ORDER BY rnk
+----
+1
+2

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1080,7 +1080,7 @@ SELECT
 794 95 95
 
 #fn test_window_range_equivalent_frames
-query IIIIIII
+query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
 SELECT
   c9,
   COUNT(*) OVER(ORDER BY c9, c1 RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cnt1,
@@ -1092,12 +1092,22 @@ SELECT
   FROM aggregate_test_100
   ORDER BY c9
   LIMIT 5
+
+query IIII
+SELECT
+  c9,
+  COUNT(*) OVER(RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cnt4,
+  COUNT(*) OVER(RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt5,
+  COUNT(*) OVER(RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt6
+  FROM aggregate_test_100
+  ORDER BY c9
+  LIMIT 5
 ----
-28774375 1 1 1 100 100 100
-63044568 1 2 1 100 100 100
-141047417 1 3 1 100 100 100
-141680161 1 4 1 100 100 100
-145294611 1 5 1 100 100 100
+28774375 100 100 100
+63044568 100 100 100
+141047417 100 100 100
+141680161 100 100 100
+145294611 100 100 100
 
 #fn test_window_cume_dist
 query IRR
@@ -3727,3 +3737,25 @@ FROM score_board s
 
 statement ok
 DROP TABLE score_board;
+
+# RANGE frame with/without (multiple) ORDER BY
+query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
+select a,
+       rank() over (partition by a order by a, a + 1 RANGE UNBOUNDED PRECEDING) rnk
+       from (select 1 a union all select 2 a) q
+
+query II
+select a,
+       rank() over (partition by a order by a RANGE UNBOUNDED PRECEDING) rnk
+       from (select 1 a union all select 2 a) q
+----
+1 1
+2 1
+
+query II
+select a,
+       rank() over (partition by a RANGE UNBOUNDED PRECEDING) rnk
+       from (select 1 a union all select 2 a) q
+----
+1 1
+2 1

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3738,7 +3738,7 @@ FROM score_board s
 statement ok
 DROP TABLE score_board;
 
-# RANGE frame with/without (multiple) ORDER BY
+# RANGE frame can be regularized to ROWS frame only if empty ORDER BY clause
 query error DataFusion error: Error during planning: RANGE requires exactly one ORDER BY column
 select a,
        rank() over (partition by a order by a, a + 1 RANGE UNBOUNDED PRECEDING) rnk


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We have regularized RANGE window frame to ROWS frame if ORDER BY clause is empty under special cases (based on the comment), but the code actually ignores non-empty ORDER BY clause which implicitly allows more than one ORDER BY columns. This case is not reflected in the code comment. This updates code comment to make it more clear.

This also adds a few tests in `sqllogictest` for various `ORDER BY` cases with RANGE frame. By comparing their results with Postgres, there are a few TODOs added for the difference.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Updated code comment and added tests.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added tests to `sqllogictest`.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
