### PR TITLE
Minor: Fix comment typo in table.rs: s/indentical/identical/

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -490,7 +490,7 @@ impl ListingOptions {
 ///
 /// # Features
 ///
-/// 1. Merges schemas if the files have compatible but not indentical schemas
+/// 1. Merges schemas if the files have compatible but not identical schemas
 ///
 /// 2. Hive-style partitioning support, where a path such as
 /// `/files/date=1/1/2022/data.parquet` is injected as a `date` column.


### PR DESCRIPTION
## Which issue does this PR close?

n/a

## Rationale for this change

Fixes a single-character typo.

## What changes are included in this PR?

See above.

## Are these changes tested?

n/a

## Are there any user-facing changes?

No.