### PR TITLE
Minor: update pbjson_dependency

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -47,7 +47,7 @@ datafusion = { path = "../core", version = "33.0.0" }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 object_store = { workspace = true }
-pbjson = { version = "0.5", optional = true }
+pbjson = { version = "0.6.0", optional = true }
 prost = "0.12.0"
 serde = { version = "1.0", optional = true }
 serde_json = { workspace = true, optional = true }


### PR DESCRIPTION
Let's keep dependencies up to date

Especially since other parts of the system use `pbjson 0.6.0` already: https://github.com/apache/arrow-datafusion/blob/34b0445b778c503f4e65b384ee9ec119ec90044a/datafusion/proto/gen/Cargo.toml#L34

I am not sure why this one did not