### PR TITLE
fix: incorrect set preserve_partitioning in SortExec

### DIFF
--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -454,7 +454,8 @@ fn try_swapping_with_sort(
 
     Ok(Some(Arc::new(
         SortExec::new(updated_exprs, make_with_child(projection, sort.input())?)
-            .with_fetch(sort.fetch()),
+            .with_fetch(sort.fetch())
+            .with_preserve_partitioning(sort.preserve_partitioning()),
     )))
 }
 

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -604,7 +604,8 @@ CREATE TABLE t2(a text, b int) AS VALUES ('Alice', 2), ('Alice', 1);
 
 # the current query results are incorrect, becuase the query was incorrectly rewritten as:
 # SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t1.b;
-# after https://github.com/apache/arrow-datafusion/issues/8374 fixed, the result should be:
+# the difference is ORDER BY clause rewrite from t2.b to t1.b, it is incorrect.
+# after https://github.com/apache/arrow-datafusion/issues/8374 fixed, the correct result should be:
 # Alice 50
 # Alice 100
 # Alice 50

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -594,3 +594,39 @@ drop table IF EXISTS full_join_test;
 # batch size
 statement ok
 set datafusion.execution.batch_size = 8192;
+
+# related to: https://github.com/apache/arrow-datafusion/issues/8374
+statement ok
+CREATE TABLE t1(a text, b int) AS VALUES ('Alice', 50), ('Alice', 100);
+
+statement ok
+CREATE TABLE t2(a text, b int) AS VALUES ('Alice', 2), ('Alice', 1);
+
+# the current query results are incorrect, becuase the query was incorrectly rewritten as:
+# SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t1.b;
+# after https://github.com/apache/arrow-datafusion/issues/8374 fixed, the result should be:
+# Alice 50
+# Alice 100
+# Alice 50
+# Alice 100
+query TI
+SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t2.b;
+----
+Alice 50
+Alice 50
+Alice 100
+Alice 100
+
+query TITI
+SELECT t1.a, t1.b, t2.a, t2.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t2.b;
+----
+Alice 50 Alice 1
+Alice 100 Alice 1
+Alice 50 Alice 2
+Alice 100 Alice 2
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;


### PR DESCRIPTION
## Which issue does this PR close?

related to #8374

## Rationale for this change

In #8374, we find `ProjectionPushdown` will incorrectly push projection down and rewrite order by column, 
before
```sql
select t1.* from t1 join t2 on t1.a = t2.a order by t1.a, t2.b;
```
after
```sql
select t1.* from t1 join t2 on t1.a = t2.a order by t1.a, t1.b;
```
the sort column change from `t1.a, t2.b` to `t1.a, t1.b`.

However, even if we find the root case, we can still not explain why setting the order by column incorrectly results in an empty output. After doing some tests, I discovered that we did not set the `preserve_partitioning` in `SortExec`. As a result, `SortExec` only run one partition(instead of all partition), leading to an empty output.



## What changes are included in this PR?

make `SortExec`'s `preserve_patitioning` consistent before and after projection_pushdown


## Are these changes tested?
yes, add `.slt` test


## Are there any user-facing changes?


