### PR TITLE
Add map to ScalarValue::try_from as a list

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -2872,6 +2872,14 @@ impl TryFrom<&DataType> for ScalarValue {
                 ))),
                 1,
             )),
+            DataType::Map(field, _) => ScalarValue::List(new_null_array(
+                &DataType::List(Arc::new(Field::new(
+                    "entries",
+                    field.data_type().clone(),
+                    true,
+                ))),
+                1,
+            )),
             DataType::Struct(fields) => ScalarValue::Struct(None, fields.clone()),
             DataType::Null => ScalarValue::Null,
             _ => {
@@ -4328,6 +4336,19 @@ mod tests {
         assert_eq!(scalar, ScalarValue::Utf8(Some("foo".to_string())));
         let scalar = ScalarValue::from_str("foo").unwrap();
         assert_eq!(scalar, ScalarValue::Utf8(Some("foo".to_string())));
+    }
+
+    #[test]
+    fn test_scalar_map() {
+        let key = Field::new("key", DataType::Int64, false);
+        let value = Field::new("value", DataType::Int64, true);
+        let map_field =
+            Field::new("entries", DataType::Struct(vec![key, value].into()), false);
+
+        let scalar =
+            ScalarValue::try_from(DataType::Map(map_field.into(), false)).unwrap();
+
+        assert!(matches!(scalar, ScalarValue::List(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8262 

## Rationale for this change

To fix the problem mentioned in the issue linked. 

## What changes are included in this PR?

`ScalarValue::try_from` didn't have an implementation for map. So I added it. As described in the description of `DataType::Map`:

    /// A Map is a logical nested type that is represented as
    ///
    /// `List<entries: Struct<key: K, value: V>>`

So I've returned a list of empty list with the same map schema.

## Are these changes tested?

I wrote a test for it. But not sure if is enough

## Are there any user-facing changes?

No