### PR TITLE
Fallback on null empty value in ExprBoundaries::try_from_column

### DIFF
--- a/datafusion/physical-expr/src/analysis.rs
+++ b/datafusion/physical-expr/src/analysis.rs
@@ -95,7 +95,8 @@ impl ExprBoundaries {
         col_index: usize,
     ) -> Result<Self> {
         let field = &schema.fields()[col_index];
-        let empty_field = ScalarValue::try_from(field.data_type())?;
+        let empty_field =
+            ScalarValue::try_from(field.data_type()).unwrap_or(ScalarValue::Null);
         let interval = Interval::try_new(
             col_stats
                 .min_value

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -379,3 +379,7 @@ Projection: List([[1, 2, 3], [4, 5, 6]]) AS make_array(make_array(Int64(1),Int64
 physical_plan
 ProjectionExec: expr=[[[1, 2, 3], [4, 5, 6]] as make_array(make_array(Int64(1),Int64(2),Int64(3)),make_array(Int64(4),Int64(5),Int64(6)))]
 --PlaceholderRowExec
+
+# Testing explain on a table with a map filter, registered in test_context.rs.
+statement ok
+explain select * from table_with_map where int_field > 0


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8262 

## Rationale for this change

Previously in https://github.com/apache/arrow-datafusion/commit/c9330bc09e583734aed721a208a0684118b170f1 we changed the default empty value for lower and upper bound from `ScalarValue::Null` to `ScalarValue::try_from(field.data_type())`. but the drawback of this was that for the types that this wasn't implemented (as mentioned in the issue for `Map`), this cause the queries to fail. To fix this we can either implement this for other data types (for map I did a prototype in #8488), or fall back on `Null` which I did in this PR.

## What changes are included in this PR?

Explained above.

## Are these changes tested?

I tested it using the query provided in the issue.


## Are there any user-facing changes?
No