### PR TITLE
Fix count(null) and count(distinct null)

### DIFF
--- a/datafusion/physical-expr/src/aggregate/count_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct.rs
@@ -152,7 +152,12 @@ impl Accumulator for DistinctCountAccumulator {
         if values.is_empty() {
             return Ok(());
         }
+
         let arr = &values[0];
+        if arr.data_type() == &DataType::Null {
+            return Ok(());
+        }
+
         (0..arr.len()).try_for_each(|index| {
             if !arr.is_null(index) {
                 let scalar = ScalarValue::try_from_array(arr, index)?;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1492,6 +1492,12 @@ SELECT count(c1, c2) FROM test
 ----
 3
 
+# count_null
+query III
+SELECT count(null), count(null, null), count(distinct null) FROM test
+----
+0 0 0
+
 # count_multi_expr_group_by
 query I
 SELECT count(c1, c2) FROM test group by c1 order by c1
@@ -1500,6 +1506,15 @@ SELECT count(c1, c2) FROM test group by c1 order by c1
 1
 2
 0
+
+# count_null_group_by
+query III
+SELECT count(null), count(null, null), count(distinct null) FROM test group by c1 order by c1
+----
+0 0 0
+0 0 0
+0 0 0
+0 0 0
 
 # aggreggte_with_alias
 query II


### PR DESCRIPTION
Use `logical_nulls` when the array data type is `Null`.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8509.

## Rationale for this change

The semantics of `NullArray` in Arrow are confusing: https://github.com/apache/arrow-rs/pull/4838
So we have to handle the `Null` data type in a special way.

## What changes are included in this PR?

Patches in count and count distinct accumulators to handle the `Null` data type or use `logical_nulls` when appropriate.

## Are these changes tested?

Yes, added SQL tests.

## Are there any user-facing changes?

Yes, count and count distinct now behave consistently wrt `null` regardless of the data type.
