### PR TITLE
Minor/Doc: Clarify DataFrame::write_table Documentation

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1015,7 +1015,7 @@ impl DataFrame {
 
     /// Write this DataFrame to the referenced table by name.
     /// This method uses on the same underlying implementation
-    /// as the SQL Insert Into statement. Unlike most other DataFrame methods, 
+    /// as the SQL Insert Into statement. Unlike most other DataFrame methods,
     /// this method executes eagerly. Data is written to the table using an
     /// execution plan returned by the [TableProvider]'s insert_into method.
     /// Refer to the documentation of the specific [TableProvider] to determine

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1013,11 +1013,16 @@ impl DataFrame {
         ))
     }
 
-    /// Write this DataFrame to the referenced table
+    /// Write this DataFrame to the referenced table by name.
     /// This method uses on the same underlying implementation
-    /// as the SQL Insert Into statement.
-    /// Unlike most other DataFrame methods, this method executes
-    /// eagerly, writing data, and returning the count of rows written.
+    /// as the SQL Insert Into statement. Unlike most other DataFrame methods, 
+    /// this method executes eagerly. Data is written to the table using an
+    /// execution plan returned by the [TableProvider]'s insert_into method.
+    /// Refer to the documentation of the specific [TableProvider] to determine
+    /// the expected data returned by the insert_into plan via this method.
+    /// For the built in ListingTable provider, a single [RecordBatch] containing
+    /// a single column and row representing the count of total rows written
+    /// is returned.
     pub async fn write_table(
         self,
         table_name: &str,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8487

## Rationale for this change

Aims to clarify some confusion around DataFrame::write_table and its return type.

## What changes are included in this PR?

Updated Doc comment for DataFrame::write_table

## Are these changes tested?

na

## Are there any user-facing changes?

Updated docs
