### PR TITLE
Minor/Doc: Add DataFrame::write_table to DataFrame user guide

### DIFF
--- a/docs/source/user-guide/dataframe.md
+++ b/docs/source/user-guide/dataframe.md
@@ -95,6 +95,7 @@ These methods execute the logical plan represented by the DataFrame and either c
 | write_csv                  | Execute this DataFrame and write the results to disk in CSV format.                                                         |
 | write_json                 | Execute this DataFrame and write the results to disk in JSON format.                                                        |
 | write_parquet              | Execute this DataFrame and write the results to disk in Parquet format.                                                     |
+| write_table                | Execute this DataFrame and write the results via the insert_into method of the registered TableProvider                     |
 
 ## Other DataFrame Methods
 


### PR DESCRIPTION
## Which issue does this PR close?

none

## Rationale for this change

The user guide contains a table describing the methods/actions available for DataFrames but currently does not mention write_table.

## What changes are included in this PR?

Add write_table to available actions in DataFrame user guide.

## Are these changes tested?

Via existing tests

## Are there any user-facing changes?

Doc update
