### PR TITLE
[MINOR]: Generate empty column at placeholder exec

### DIFF
--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3793,3 +3793,9 @@ select a,
 ----
 1 1
 2 1
+
+query I
+select rank() over (order by 1) rnk from (select 1 a union all select 2 a) x
+----
+1
+1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Currently, if there is no column at the place holder exec, it generates at least one dummy column. This causes inconsistency in the subsequent schemas for some edge cases. (Where schema of the `PlaceHolderExec` itself has 0 columns, but generated `RecordBatch` from this schema has single column.) Thanks @comphead for bringing this to my attention.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR fixes above mentioned problem.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes new test is added. Which is the test in the [discussion](https://github.com/apache/arrow-datafusion/issues/8386#issuecomment-1856695669)
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
