### PR TITLE
Minor: avoid a copy in Expr::unalias

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -956,7 +956,7 @@ impl Expr {
     /// Remove an alias from an expression if one exists.
     pub fn unalias(self) -> Expr {
         match self {
-            Expr::Alias(alias) => alias.expr.as_ref().clone(),
+            Expr::Alias(alias) => *alias.expr,
             _ => self,
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
While reviewing the excellent PR from https://github.com/apache/arrow-datafusion/pull/7942 I noticed we can avoid a (deep) copy in the `Expr::unalias` code without an API change

## What changes are included in this PR?
Avoid a copy in `Expr::unalias`

## Are these changes tested?
exisiting tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
