### PR TITLE
Perf: avoid unnecessary allocations when transforming `Expr`

### DIFF
--- a/datafusion/expr/src/tree_node/expr.rs
+++ b/datafusion/expr/src/tree_node/expr.rs
@@ -17,6 +17,8 @@
 
 //! Tree node implementation for logical expr
 
+use std::mem;
+
 use crate::expr::{
     AggregateFunction, AggregateFunctionDefinition, Alias, Between, BinaryExpr, Case,
     Cast, GetIndexedField, GroupingSet, InList, InSubquery, Like, Placeholder,
@@ -378,15 +380,14 @@ impl TreeNode for Expr {
     }
 }
 
-fn transform_boxed<F>(boxed_expr: Box<Expr>, transform: &mut F) -> Result<Box<Expr>>
+fn transform_boxed<F>(mut boxed_expr: Box<Expr>, transform: &mut F) -> Result<Box<Expr>>
 where
     F: FnMut(Expr) -> Result<Expr>,
 {
-    // TODO:
-    // It might be possible to avoid an allocation (the Box::new) below by reusing the box.
-    let expr: Expr = *boxed_expr;
-    let rewritten_expr = transform(expr)?;
-    Ok(Box::new(rewritten_expr))
+    // We reuse the existing Box to avoid an allocation:
+    let t = mem::replace(&mut *boxed_expr, Expr::Wildcard { qualifier: None });
+    let _ = mem::replace(&mut *boxed_expr, transform(t)?);
+    Ok(boxed_expr)
 }
 
 fn transform_option_box<F>(
@@ -417,9 +418,14 @@ where
 }
 
 /// &mut transform a `Vec` of `Expr`s
-fn transform_vec<F>(v: Vec<Expr>, transform: &mut F) -> Result<Vec<Expr>>
+fn transform_vec<F>(mut v: Vec<Expr>, transform: &mut F) -> Result<Vec<Expr>>
 where
     F: FnMut(Expr) -> Result<Expr>,
 {
-    v.into_iter().map(transform).collect()
+    // Perform an in-place mutation of the Vec to avoid allocation:
+    for expr in v.iter_mut() {
+        let t = mem::replace(expr, Expr::Wildcard { qualifier: None });
+        let _ = mem::replace(expr, transform(t)?);
+    }
+    Ok(v)
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A. Addresses a `TODO` item in `tree_node/expr.rs`

## Rationale for this change

Inspired by #7942: currently, the `Expr` transformer's `transform_box` and `transform_vec` methods allocate a new `Box` and `Vec`, respectively, with potentially harmful performance implications. We can use `std::mem::replace` to avoid this allocation by reusing the existing `Box`/`Vec`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Switch to in-place mutations in the `transform_box` and `transform_vec` methods on `Expr`s.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
