### PR TITLE
Add examples of DataFrame::write* methods without S3 dependency

### DIFF
--- a/datafusion-examples/README.md
+++ b/datafusion-examples/README.md
@@ -47,7 +47,8 @@ cargo run --example csv_sql
 - [`catalog.rs`](examples/external_dependency/catalog.rs): Register the table into a custom catalog
 - [`custom_datasource.rs`](examples/custom_datasource.rs): Run queries against a custom datasource (TableProvider)
 - [`dataframe.rs`](examples/dataframe.rs): Run a query using a DataFrame against a local parquet file
-- [`dataframe-to-s3.rs`](examples/external_dependency/dataframe-to-s3.rs): Run a query using a DataFrame against a parquet file from s3
+- [`dataframe-to-s3.rs`](examples/external_dependency/dataframe-to-s3.rs): Run a query using a DataFrame against a parquet file from s3 and writing back to s3
+- [`dataframe_output.rs`](examples/dataframe_output.rs): Examples of methods which write data out from a DataFrame
 - [`dataframe_in_memory.rs`](examples/dataframe_in_memory.rs): Run a query using a DataFrame against data in memory
 - [`deserialize_to_struct.rs`](examples/deserialize_to_struct.rs): Convert query results into rust structs using serde
 - [`expr_api.rs`](examples/expr_api.rs): Create, execute, simplify and anaylze `Expr`s

--- a/datafusion-examples/examples/dataframe_output.rs
+++ b/datafusion-examples/examples/dataframe_output.rs
@@ -1,0 +1,58 @@
+use datafusion::{dataframe::DataFrameWriteOptions, prelude::*};
+use datafusion_common::DataFusionError;
+use object_store::local::LocalFileSystem;
+use std::sync::Arc;
+use url::Url;
+
+/// This example demonstrates the various methods to write out a DataFrame
+#[tokio::main]
+async fn main() -> Result<(), DataFusionError> {
+    let ctx = SessionContext::new();
+    let local = Arc::new(LocalFileSystem::new_with_prefix("./").unwrap());
+    let local_url = Url::parse("file://local").unwrap();
+    ctx.runtime_env().register_object_store(&local_url, local);
+
+    let mut df = ctx.sql(
+        "values ('a'), ('b'), ('c')"
+    ).await
+    .unwrap();
+
+    // Ensure the column names and types match the target table
+    df = df.with_column_renamed("column1", "tablecol1").unwrap();
+
+    ctx.sql(
+        "create external table 
+    test(tablecol1 varchar)
+    stored as parquet 
+    location './datafusion-examples/test_table/'",
+    )
+    .await?
+    .collect()
+    .await?;
+
+    df.clone()
+        .write_table("test", DataFrameWriteOptions::new())
+        .await?;
+
+    df.clone()
+        .write_parquet("file://local/datafusion-examples/test_parquet/", 
+        DataFrameWriteOptions::new(),
+        None,
+    )
+        .await?;
+
+    df.clone()
+        .write_csv("file://local/datafusion-examples/test_csv/", 
+        DataFrameWriteOptions::new(),
+        None,
+    )
+        .await?;
+
+    df.clone()
+        .write_json("file://local/datafusion-examples/test_json/", 
+        DataFrameWriteOptions::new(),
+    )
+        .await?;
+
+    Ok(())
+}

--- a/datafusion-examples/examples/dataframe_output.rs
+++ b/datafusion-examples/examples/dataframe_output.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use datafusion::{dataframe::DataFrameWriteOptions, prelude::*};
 use datafusion_common::DataFusionError;
 use object_store::local::LocalFileSystem;

--- a/datafusion-examples/examples/dataframe_output.rs
+++ b/datafusion-examples/examples/dataframe_output.rs
@@ -29,10 +29,7 @@ async fn main() -> Result<(), DataFusionError> {
     let local_url = Url::parse("file://local").unwrap();
     ctx.runtime_env().register_object_store(&local_url, local);
 
-    let mut df = ctx.sql(
-        "values ('a'), ('b'), ('c')"
-    ).await
-    .unwrap();
+    let mut df = ctx.sql("values ('a'), ('b'), ('c')").await.unwrap();
 
     // Ensure the column names and types match the target table
     df = df.with_column_renamed("column1", "tablecol1").unwrap();
@@ -52,23 +49,26 @@ async fn main() -> Result<(), DataFusionError> {
         .await?;
 
     df.clone()
-        .write_parquet("file://local/datafusion-examples/test_parquet/", 
-        DataFrameWriteOptions::new(),
-        None,
-    )
+        .write_parquet(
+            "file://local/datafusion-examples/test_parquet/",
+            DataFrameWriteOptions::new(),
+            None,
+        )
         .await?;
 
     df.clone()
-        .write_csv("file://local/datafusion-examples/test_csv/", 
-        DataFrameWriteOptions::new(),
-        None,
-    )
+        .write_csv(
+            "file://local/datafusion-examples/test_csv/",
+            DataFrameWriteOptions::new(),
+            None,
+        )
         .await?;
 
     df.clone()
-        .write_json("file://local/datafusion-examples/test_json/", 
-        DataFrameWriteOptions::new(),
-    )
+        .write_json(
+            "file://local/datafusion-examples/test_json/",
+            DataFrameWriteOptions::new(),
+        )
         .await?;
 
     Ok(())

--- a/datafusion-examples/examples/dataframe_output.rs
+++ b/datafusion-examples/examples/dataframe_output.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use datafusion::{dataframe::DataFrameWriteOptions, prelude::*};
-use datafusion_common::DataFusionError;
+use datafusion_common::{parsers::CompressionTypeVariant, DataFusionError};
 
 /// This example demonstrates the various methods to write out a DataFrame to local storage.
 /// See datafusion-examples/examples/external_dependency/dataframe-to-s3.rs for an example
@@ -58,7 +58,9 @@ async fn main() -> Result<(), DataFusionError> {
     df.clone()
         .write_csv(
             "./datafusion-examples/test_csv/",
-            DataFrameWriteOptions::new(),
+            // DataFrameWriteOptions contains options which control how data is written
+            // such as compression codec
+            DataFrameWriteOptions::new().with_compression(CompressionTypeVariant::GZIP),
             None,
         )
         .await?;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8551 

## Rationale for this change

We currently do not have an example of DataFrame::write_table, nor other DataFrame::write* methods which do not depend on an external S3 bucket.

## What changes are included in this PR?

Adds examples of DataFrame::write_table and other write* methods using LocalFileSystem object store.

## Are these changes tested?

Via existing tests

## Are there any user-facing changes?

No
