### PR TITLE
Fix #8507: Non-null sub-field on nullable struct-field has wrong nullity

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -559,11 +559,11 @@ mod tests {
     fn test_nested_schema_nullability() {
         let fields = DFField::new(
             Some(TableReference::Bare {
-                table: "nexmark".into(),
+                table: "table_name".into(),
             }),
-            "bid",
+            "parent",
             DataType::Struct(Fields::from(vec![Field::new(
-                "auction",
+                "child",
                 DataType::Int64,
                 false,
             )])),
@@ -572,7 +572,7 @@ mod tests {
 
         let schema = DFSchema::new_with_metadata(vec![fields], HashMap::new()).unwrap();
 
-        let expr = col("bid").field("auction");
+        let expr = col("parent").field("child");
         assert_eq!(expr.nullable(&schema).unwrap(), true);
     }
 

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -573,7 +573,7 @@ mod tests {
         let schema = DFSchema::new_with_metadata(vec![fields], HashMap::new()).unwrap();
 
         let expr = col("parent").field("child");
-        assert_eq!(expr.nullable(&schema).unwrap(), true);
+        assert!(expr.nullable(&schema).unwrap());
     }
 
     #[derive(Debug)]

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -277,6 +277,13 @@ impl ExprSchemable for Expr {
                 "Wildcard expressions are not valid in a logical query plan"
             ),
             Expr::GetIndexedField(GetIndexedField { expr, field }) => {
+                // If schema is nested, check if parent is nullable
+                // if it is, return early
+                if let Expr::Column(col) = expr.as_ref() {
+                    if input_schema.nullable(col)? {
+                        return Ok(true);
+                    }
+                }
                 field_for_index(expr, field, input_schema).map(|x| x.is_nullable())
             }
             Expr::GroupingSet(_) => {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8507.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
If parent struct is nullable; sub-fields should also be.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

As suggested in #8507: 
I added a test to reproduce the bug with the schema described.
Then I introduced a simple guard clause to check if the parent col is nullable; if it is return early.

## Are these changes tested?
Change is tested by `test_nested_schema_nullability`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
