### PR TITLE
Make the BatchSerializer behind Arc to avoid unnecessary struct creation

### DIFF
--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicBool, Ordering};
+
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -206,15 +206,11 @@ impl JsonSerializationSchema {
 
 #[async_trait]
 impl SerializationSchema for JsonSerializationSchema {
-    async fn serialize(&self, batch: RecordBatch) -> Result<Bytes> {
+    async fn serialize(&self, batch: RecordBatch, _initial: bool) -> Result<Bytes> {
         let mut buffer = Vec::with_capacity(4096);
         let mut writer = json::LineDelimitedWriter::new(&mut buffer);
         writer.write(&batch)?;
         Ok(Bytes::from(buffer))
-    }
-
-    fn duplicate_headerless(&self) -> Arc<dyn SerializationSchema> {
-        Arc::new(JsonSerializationSchema::new()) as _
     }
 }
 

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -149,15 +149,11 @@ impl<W: AsyncWrite + Unpin + Send> AsyncWrite for AbortableWrite<W> {
 
 /// A trait that defines the methods required for a RecordBatch serializer.
 #[async_trait]
-pub trait BatchSerializer: Unpin + Send {
+pub trait SerializationSchema: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
-    async fn serialize(&mut self, batch: RecordBatch) -> Result<Bytes>;
-    /// Duplicates self to support serializing multiple batches in parallel on multiple cores
-    fn duplicate(&mut self) -> Result<Box<dyn BatchSerializer>> {
-        Err(DataFusionError::NotImplemented(
-            "Parallel serialization is not implemented for this file type".into(),
-        ))
-    }
+    async fn serialize(&self, batch: RecordBatch) -> Result<Bytes>;
+
+    fn create_headless_serializer(&self) -> Arc<dyn SerializationSchema>;
 }
 
 /// Returns an [`AbortableWrite`] which writes to the given object store location

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -24,20 +24,16 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::datasource::file_format::file_compression_type::FileCompressionType;
-
 use crate::error::Result;
 
 use arrow_array::RecordBatch;
-
 use datafusion_common::DataFusionError;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-
 use futures::future::BoxFuture;
 use object_store::path::Path;
 use object_store::{MultipartId, ObjectStore};
-
 use tokio::io::AsyncWrite;
 
 pub(crate) mod demux;
@@ -153,9 +149,10 @@ pub trait SerializationSchema: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
     async fn serialize(&self, batch: RecordBatch) -> Result<Bytes>;
 
-    /// Creates itself without header to support serializing multiple batches in parallel on multiple cores.
-    /// Unless it is CSV, this method is no op.
-    fn create_headless_serializer(&self) -> Arc<dyn SerializationSchema>;
+    /// Duplicates itself (sans header configuration) to support serializing
+    /// multiple batches in parallel on multiple cores. Unless we are serializing
+    /// a CSV file, this method is no-op.
+    fn duplicate_headerless(&self) -> Arc<dyn SerializationSchema>;
 }
 
 /// Returns an [`AbortableWrite`] which writes to the given object store location

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -145,7 +145,7 @@ impl<W: AsyncWrite + Unpin + Send> AsyncWrite for AbortableWrite<W> {
 
 /// A trait that defines the methods required for a RecordBatch serializer.
 #[async_trait]
-pub trait SerializationSchema: Sync + Send {
+pub trait BatchSerializer: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
     /// Parameter `initial` signals whether the given batch is the first batch.
     /// This distinction is important for certain serializers (like CSV).

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -153,6 +153,8 @@ pub trait SerializationSchema: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
     async fn serialize(&self, batch: RecordBatch) -> Result<Bytes>;
 
+    /// Creates itself without header to support serializing multiple batches in parallel on multiple cores.
+    /// Unless it is CSV, this method is no op.
     fn create_headless_serializer(&self) -> Arc<dyn SerializationSchema>;
 }
 

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -147,12 +147,9 @@ impl<W: AsyncWrite + Unpin + Send> AsyncWrite for AbortableWrite<W> {
 #[async_trait]
 pub trait SerializationSchema: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
-    async fn serialize(&self, batch: RecordBatch) -> Result<Bytes>;
-
-    /// Duplicates itself (sans header configuration) to support serializing
-    /// multiple batches in parallel on multiple cores. Unless we are serializing
-    /// a CSV file, this method is no-op.
-    fn duplicate_headerless(&self) -> Arc<dyn SerializationSchema>;
+    /// Parameter `initial` signals whether the given batch is the first batch.
+    /// This distinction is important for certain serializers (like CSV).
+    async fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes>;
 }
 
 /// Returns an [`AbortableWrite`] which writes to the given object store location

--- a/datafusion/core/src/datasource/file_format/write/orchestration.rs
+++ b/datafusion/core/src/datasource/file_format/write/orchestration.rs
@@ -21,25 +21,22 @@
 
 use std::sync::Arc;
 
+use super::demux::start_demuxer_task;
+use super::{create_writer, AbortableWrite, SerializationSchema};
 use crate::datasource::file_format::file_compression_type::FileCompressionType;
 use crate::datasource::physical_plan::FileSinkConfig;
 use crate::error::Result;
 use crate::physical_plan::SendableRecordBatchStream;
 
 use arrow_array::RecordBatch;
-
-use datafusion_common::DataFusionError;
-
-use bytes::Bytes;
+use datafusion_common::{internal_datafusion_err, internal_err, DataFusionError};
 use datafusion_execution::TaskContext;
 
+use bytes::Bytes;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::try_join;
-
-use super::demux::start_demuxer_task;
-use super::{create_writer, AbortableWrite, SerializationSchema};
 
 type WriterType = AbortableWrite<Box<dyn AsyncWrite + Send + Unpin>>;
 type SerializerType = Arc<dyn SerializationSchema>;
@@ -55,8 +52,8 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
 ) -> std::result::Result<(WriterType, u64), (WriterType, DataFusionError)> {
     let (tx, mut rx) =
         mpsc::channel::<JoinHandle<Result<(usize, Bytes), DataFusionError>>>(100);
-    // Initially, has_header can be true for CSV use cases. Then, we must turn into false to keep integrity
-    // of the writing process.
+    // Initially, has_header can be true for CSV use cases. Then, we must turn
+    // it off to maintain the integrity of the writing process.
     let serialize_task = tokio::spawn(async move {
         let mut initial = true;
         while let Some(batch) = data_rx.recv().await {
@@ -67,11 +64,11 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
                 Ok((num_rows, bytes))
             });
             if initial {
-                serializer = serializer.create_headless_serializer() as _;
+                serializer = serializer.duplicate_headerless();
                 initial = false;
             }
             tx.send(handle).await.map_err(|_| {
-                DataFusionError::Internal("Unknown error writing to object store".into())
+                internal_datafusion_err!("Unknown error writing to object store")
             })?;
         }
         Ok(())
@@ -116,7 +113,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
         Err(_) => {
             return Err((
                 writer,
-                DataFusionError::Internal("Unknown error writing to object store".into()),
+                internal_datafusion_err!("Unknown error writing to object store"),
             ))
         }
     };
@@ -167,9 +164,9 @@ pub(crate) async fn stateless_serialize_and_write_files(
                 // this thread, so we cannot clean it up (hence any_abort_errors is true)
                 any_errors = true;
                 any_abort_errors = true;
-                triggering_error = Some(DataFusionError::Internal(format!(
+                triggering_error = Some(internal_datafusion_err!(
                     "Unexpected join error while serializing file {e}"
-                )));
+                ));
             }
         }
     }
@@ -186,24 +183,24 @@ pub(crate) async fn stateless_serialize_and_write_files(
             false => {
                 writer.shutdown()
                     .await
-                    .map_err(|_| DataFusionError::Internal("Error encountered while finalizing writes! Partial results may have been written to ObjectStore!".into()))?;
+                    .map_err(|_| internal_datafusion_err!("Error encountered while finalizing writes! Partial results may have been written to ObjectStore!"))?;
             }
         }
     }
 
     if any_errors {
         match any_abort_errors{
-            true => return Err(DataFusionError::Internal("Error encountered during writing to ObjectStore and failed to abort all writers. Partial result may have been written.".into())),
+            true => return internal_err!("Error encountered during writing to ObjectStore and failed to abort all writers. Partial result may have been written."),
             false => match triggering_error {
                 Some(e) => return Err(e),
-                None => return Err(DataFusionError::Internal("Unknown Error encountered during writing to ObjectStore. All writers succesfully aborted.".into()))
+                None => return internal_err!("Unknown Error encountered during writing to ObjectStore. All writers succesfully aborted.")
             }
         }
     }
 
     tx.send(row_count).map_err(|_| {
-        DataFusionError::Internal(
-            "Error encountered while sending row count back to file sink!".into(),
+        internal_datafusion_err!(
+            "Error encountered while sending row count back to file sink!"
         )
     })?;
     Ok(())
@@ -260,8 +257,8 @@ pub(crate) async fn stateless_multipart_put(
             .send((rb_stream, serializer, writer))
             .await
             .map_err(|_| {
-                DataFusionError::Internal(
-                    "Writer receive file bundle channel closed unexpectedly!".into(),
+                internal_datafusion_err!(
+                    "Writer receive file bundle channel closed unexpectedly!"
                 )
             })?;
     }
@@ -284,9 +281,7 @@ pub(crate) async fn stateless_multipart_put(
     }
 
     let total_count = rx_row_cnt.await.map_err(|_| {
-        DataFusionError::Internal(
-            "Did not receieve row count from write coordinater".into(),
-        )
+        internal_datafusion_err!("Did not receieve row count from write coordinater")
     })?;
 
     Ok(total_count)

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -524,7 +524,7 @@ mod tests {
     use datafusion_common::Statistics;
 
     use super::*;
-    use crate::datasource::file_format::write::BatchSerializer;
+    use crate::datasource::file_format::write::SerializationSchema;
     use crate::datasource::object_store::ObjectStoreUrl;
     use crate::datasource::physical_plan::FileMeta;
     use crate::physical_plan::metrics::ExecutionPlanMetricsSet;
@@ -992,9 +992,13 @@ mod tests {
     }
 
     #[async_trait]
-    impl BatchSerializer for TestSerializer {
-        async fn serialize(&mut self, _batch: RecordBatch) -> Result<Bytes> {
+    impl SerializationSchema for TestSerializer {
+        async fn serialize(&self, _batch: RecordBatch) -> Result<Bytes> {
             Ok(self.bytes.clone())
+        }
+
+        fn create_headless_serializer(&self) -> Arc<dyn SerializationSchema> {
+            unimplemented!()
         }
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -991,12 +991,8 @@ mod tests {
 
     #[async_trait]
     impl SerializationSchema for TestSerializer {
-        async fn serialize(&self, _batch: RecordBatch) -> Result<Bytes> {
+        async fn serialize(&self, _batch: RecordBatch, _initial: bool) -> Result<Bytes> {
             Ok(self.bytes.clone())
-        }
-
-        fn duplicate_headerless(&self) -> Arc<dyn SerializationSchema> {
-            unimplemented!()
         }
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -522,7 +522,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::datasource::file_format::write::SerializationSchema;
+    use crate::datasource::file_format::write::BatchSerializer;
     use crate::datasource::object_store::ObjectStoreUrl;
     use crate::datasource::physical_plan::FileMeta;
     use crate::physical_plan::metrics::ExecutionPlanMetricsSet;
@@ -990,7 +990,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SerializationSchema for TestSerializer {
+    impl BatchSerializer for TestSerializer {
         async fn serialize(&self, _batch: RecordBatch, _initial: bool) -> Result<Bytes> {
             Ok(self.bytes.clone())
         }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -518,10 +518,8 @@ impl<F: FileOpener> RecordBatchStream for FileStream<F> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_schema::Schema;
-    use datafusion_common::internal_err;
-    use datafusion_common::DataFusionError;
-    use datafusion_common::Statistics;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     use super::*;
     use crate::datasource::file_format::write::SerializationSchema;
@@ -534,8 +532,8 @@ mod tests {
         test::{make_partition, object_store::register_test_store},
     };
 
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use arrow_schema::Schema;
+    use datafusion_common::{internal_err, DataFusionError, Statistics};
 
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -997,7 +995,7 @@ mod tests {
             Ok(self.bytes.clone())
         }
 
-        fn create_headless_serializer(&self) -> Arc<dyn SerializationSchema> {
+        fn duplicate_headerless(&self) -> Arc<dyn SerializationSchema> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Currently, the serializer is re-created for each RecordBatch, which degrades the performance while dealing with small batch sizes.

The `duplicate()` method is called here

https://github.com/apache/arrow-datafusion/blob/1737d49185e9e37c15aa432342604ee559a1069d/datafusion/core/src/datasource/file_format/write/orchestration.rs#L51-L82

where it is defined as (for CSV it is used for header, for JSON it is just a deep clone.)

https://github.com/apache/arrow-datafusion/blob/1737d49185e9e37c15aa432342604ee559a1069d/datafusion/core/src/datasource/file_format/csv.rs#L432-L450

Also, this makes the internal buffer useless since it is re-created for each batch in this setup.

## What changes are included in this PR?

- Renamed the `BatchSerializer`.
- Make the trait methods take immutable references.
- Make the `type SerializerType = Arc<dyn SerializationSchema>`
- Handle the making CSV header false for the batches after the first batch.

## Are these changes tested?

Existing tests.

## Are there any user-facing changes?

No.
