### PR TITLE
Doc: Clarify When Limit is Pushed Down to TableProvider::Scan

### DIFF
--- a/datafusion/core/src/datasource/provider.rs
+++ b/datafusion/core/src/datasource/provider.rs
@@ -141,7 +141,11 @@ pub trait TableProvider: Sync + Send {
     /// (though it may return more).  Like Projection Pushdown and Filter
     /// Pushdown, DataFusion pushes `LIMIT`s  as far down in the plan as
     /// possible, called "Limit Pushdown" as some sources can use this
-    /// information to improve their performance.
+    /// information to improve their performance. Note that if there are any
+    /// Inexact filters pushed down, the LIMIT cannot be pushed down. This is
+    /// because inexact filters do not guarentee that every filtered row is
+    /// removed, so applying the limit could lead to too few rows being available
+    /// to return as a final result.
     async fn scan(
         &self,
         state: &SessionState,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8683 

## Rationale for this change

I was recently confused why I was not seeing LIMIT pushed down to my TableProvider when filters were also passed. @Dandandan explained on ASF slack that Inexact filters do not allow the limit to be pushed down. This PR adds to the TableProvider docs to hopefully avoid similar confusion in the future.

## What changes are included in this PR?

Expanded the TableProvider::Scan documentation

## Are these changes tested?
by existin tests

## Are there any user-facing changes?

Just docs
