### PR TITLE
Support for `extract(x from time)` / `date_part` from time types

### DIFF
--- a/datafusion/common/src/cast.rs
+++ b/datafusion/common/src/cast.rs
@@ -24,17 +24,18 @@ use crate::{downcast_value, DataFusionError, Result};
 use arrow::{
     array::{
         Array, BinaryArray, BooleanArray, Date32Array, Date64Array, Decimal128Array,
-        DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array,
-        Float64Array, GenericBinaryArray, GenericListArray, GenericStringArray,
-        Int32Array, Int64Array, IntervalDayTimeArray, IntervalMonthDayNanoArray,
-        IntervalYearMonthArray, LargeListArray, ListArray, MapArray, NullArray,
-        OffsetSizeTrait, PrimitiveArray, StringArray, StructArray,
-        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-        TimestampSecondArray, UInt32Array, UInt64Array, UInt8Array, UnionArray,
+        Decimal256Array, DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray,
+        Float32Array, Float64Array, GenericBinaryArray, GenericListArray,
+        GenericStringArray, Int32Array, Int64Array, IntervalDayTimeArray,
+        IntervalMonthDayNanoArray, IntervalYearMonthArray, LargeListArray, ListArray,
+        MapArray, NullArray, OffsetSizeTrait, PrimitiveArray, StringArray, StructArray,
+        Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+        Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampNanosecondArray, TimestampSecondArray, UInt32Array, UInt64Array,
+        UInt8Array, UnionArray,
     },
     datatypes::{ArrowDictionaryKeyType, ArrowPrimitiveType},
 };
-use arrow_array::Decimal256Array;
 
 // Downcast ArrayRef to Date32Array
 pub fn as_date32_array(array: &dyn Array) -> Result<&Date32Array> {
@@ -152,6 +153,26 @@ pub fn as_null_array(array: &dyn Array) -> Result<&NullArray> {
 // Downcast ArrayRef to NullArray
 pub fn as_union_array(array: &dyn Array) -> Result<&UnionArray> {
     Ok(downcast_value!(array, UnionArray))
+}
+
+// Downcast ArrayRef to Time32SecondArray
+pub fn as_time32_second_array(array: &dyn Array) -> Result<&Time32SecondArray> {
+    Ok(downcast_value!(array, Time32SecondArray))
+}
+
+// Downcast ArrayRef to Time32MillisecondArray
+pub fn as_time32_millisecond_array(array: &dyn Array) -> Result<&Time32MillisecondArray> {
+    Ok(downcast_value!(array, Time32MillisecondArray))
+}
+
+// Downcast ArrayRef to Time64MicrosecondArray
+pub fn as_time64_microsecond_array(array: &dyn Array) -> Result<&Time64MicrosecondArray> {
+    Ok(downcast_value!(array, Time64MicrosecondArray))
+}
+
+// Downcast ArrayRef to Time64NanosecondArray
+pub fn as_time64_nanosecond_array(array: &dyn Array) -> Result<&Time64NanosecondArray> {
+    Ok(downcast_value!(array, Time64NanosecondArray))
 }
 
 // Downcast ArrayRef to TimestampNanosecondArray

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -948,7 +948,17 @@ SELECT date_part('hour', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 23
 
 query R
+SELECT extract(hour from arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+23
+
+query R
 SELECT date_part('minute', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+32
+
+query R
+SELECT extract(minute from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 32
 
@@ -958,7 +968,17 @@ SELECT date_part('second', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 50
 
 query R
+SELECT extract(second from arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50
+
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000
+
+query R
+SELECT extract(millisecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000
 
@@ -968,12 +988,27 @@ SELECT date_part('microsecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 50000000
 
 query R
+SELECT extract(microsecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000000
+
+query R
 SELECT date_part('nanosecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000000000
 
 query R
+SELECT extract(nanosecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000000000
+
+query R
 SELECT date_part('epoch', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+84770
+
+query R
+SELECT extract(epoch from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 84770
 
@@ -984,7 +1019,17 @@ SELECT date_part('hour', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)')
 23
 
 query R
+SELECT extract(hour from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+23
+
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+32
+
+query R
+SELECT extract(minute from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 32
 
@@ -994,7 +1039,17 @@ SELECT date_part('second', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)
 50.123
 
 query R
+SELECT extract(second from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50.123
+
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123
+
+query R
+SELECT extract(millisecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123
 
@@ -1004,12 +1059,27 @@ SELECT date_part('microsecond', arrow_cast('23:32:50.123'::time, 'Time32(Millise
 50123000
 
 query R
+SELECT extract(microsecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123000
+
+query R
 SELECT date_part('nanosecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123000000
 
 query R
+SELECT extract(nanosecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123000000
+
+query R
 SELECT date_part('epoch', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+84770.123
+
+query R
+SELECT extract(epoch from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 84770.123
 
@@ -1020,7 +1090,17 @@ SELECT date_part('hour', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond
 23
 
 query R
+SELECT extract(hour from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+23
+
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+32
+
+query R
+SELECT extract(minute from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 32
 
@@ -1030,7 +1110,17 @@ SELECT date_part('second', arrow_cast('23:32:50.123456'::time, 'Time64(Microseco
 50.123456
 
 query R
+SELECT extract(second from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50.123456
+
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123.456
+
+query R
+SELECT extract(millisecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123.456
 
@@ -1040,12 +1130,27 @@ SELECT date_part('microsecond', arrow_cast('23:32:50.123456'::time, 'Time64(Micr
 50123456
 
 query R
+SELECT extract(microsecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123456
+
+query R
 SELECT date_part('nanosecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123456000
 
 query R
+SELECT extract(nanosecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123456000
+
+query R
 SELECT date_part('epoch', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+84770.123456
+
+query R
+SELECT extract(epoch from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 84770.123456
 
@@ -1056,7 +1161,17 @@ SELECT date_part('hour', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanoseco
 23
 
 query R
+SELECT extract(hour from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+23
+
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+32
+
+query R
+SELECT extract(minute from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 32
 
@@ -1066,7 +1181,17 @@ SELECT date_part('second', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanose
 50.123456789
 
 query R
+SELECT extract(second from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50.123456789
+
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123.456789
+
+query R
+SELECT extract(millisecond from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123.456789
 
@@ -1077,12 +1202,27 @@ SELECT date_part('microsecond', arrow_cast('23:32:50.123456789'::time, 'Time64(N
 50123456.789000005
 
 query R
+SELECT extract(microsecond from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123456.789000005
+
+query R
 SELECT date_part('nanosecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123456789
 
 query R
+SELECT extract(nanosecond from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123456789
+
+query R
 SELECT date_part('epoch', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+84770.123456789
+
+query R
+SELECT extract(epoch from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 84770.123456789
 

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -939,6 +939,153 @@ SELECT date_part('nanosecond', '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
+# test_date_part_time
+
+## time32 seconds
+query R
+SELECT date_part('hour', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+23
+
+query R
+SELECT date_part('minute', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+32
+
+query R
+SELECT date_part('second', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50
+
+query R
+SELECT date_part('millisecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000
+
+query R
+SELECT date_part('microsecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000000
+
+query R
+SELECT date_part('nanosecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+50000000000
+
+query R
+SELECT date_part('epoch', arrow_cast('23:32:50'::time, 'Time32(Second)'))
+----
+84770
+
+## time32 milliseconds
+query R
+SELECT date_part('hour', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+23
+
+query R
+SELECT date_part('minute', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+32
+
+query R
+SELECT date_part('second', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50.123
+
+query R
+SELECT date_part('millisecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123
+
+query R
+SELECT date_part('microsecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123000
+
+query R
+SELECT date_part('nanosecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+50123000000
+
+query R
+SELECT date_part('epoch', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
+----
+84770.123
+
+## time64 microseconds
+query R
+SELECT date_part('hour', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+23
+
+query R
+SELECT date_part('minute', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+32
+
+query R
+SELECT date_part('second', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50.123456
+
+query R
+SELECT date_part('millisecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123.456
+
+query R
+SELECT date_part('microsecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123456
+
+query R
+SELECT date_part('nanosecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+50123456000
+
+query R
+SELECT date_part('epoch', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
+----
+84770.123456
+
+## time64 nanoseconds
+query R
+SELECT date_part('hour', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+23
+
+query R
+SELECT date_part('minute', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+32
+
+query R
+SELECT date_part('second', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50.123456789
+
+query R
+SELECT date_part('millisecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123.456789
+
+# just some floating point stuff happening in the result here
+query R
+SELECT date_part('microsecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123456.789000005
+
+query R
+SELECT date_part('nanosecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+50123456789
+
+query R
+SELECT date_part('epoch', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
+----
+84770.123456789
+
 # test_extract_epoch
 
 query R

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1624,34 +1624,19 @@ _Alias of [date_part](#date_part)._
 ### `extract`
 
 Returns a sub-field from a time value as an integer.
-Similar to `date_part`, but with different arguments.
 
 ```
 extract(field FROM source)
 ```
 
-#### Arguments
+Equivalent to calling `date_part('field', source)`. For example, these are equivalent:
 
-- **field**: Part or field of the date to return.
-  The following date fields are supported:
+```sql
+extract(day FROM '2024-04-13'::date)
+date_part('day', '2024-04-13'::date)
+```
 
-  - year
-  - quarter _(emits value in inclusive range [1, 4] based on which quartile of the year the date is in)_
-  - month
-  - week _(week of the year)_
-  - day _(day of the month)_
-  - hour
-  - minute
-  - second
-  - millisecond
-  - microsecond
-  - nanosecond
-  - dow _(day of the week)_
-  - doy _(day of the year)_
-  - epoch _(seconds since Unix epoch)_
-
-- **source**: Source time expression to operate on.
-  Can be a constant, column, or function.
+See [date_part](#date_part).
 
 ### `make_date`
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8692

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Extend support for `extract` and `date_part` to `Time32` and `Time64` types, for relevant precisions (hours, minutes, seconds, etc.)

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
