### PR TITLE
[CI] Improve windows machine CI test time

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -303,7 +303,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 target-feature=+crt-static"
+          RUSTFLAGS: -Ctarget-feature=+crt-static
           RUST_BACKTRACE: "1"
 
   macos:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -305,7 +305,7 @@ jobs:
           # do not produce debug symbols to keep memory usage down
           RUSTFLAGS: -Ctarget-feature=+crt-static
           RUST_BACKTRACE: "1"
-
+          RUST_MINSTACK: "2384500"
   macos:
     name: cargo test (mac)
     runs-on: macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -309,7 +309,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3 -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -347,7 +347,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,7 +101,9 @@ jobs:
         run: cargo test --lib --tests --bins --features avro,json,backtrace
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C incremental=true -C codegen-units=256"
+          # hardcoding other profile params to avoid profile override values
+          # More on Cargo profiles https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=0 -C incremental=false -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -309,6 +311,9 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
+          # use higher optimization level to overcome Windows rust slowness for tpc-ds
+          # and speed builds: https://github.com/apache/arrow-datafusion/issues/8696
+          # Cargo profile docs https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
           RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C target-feature=+crt-static -C incremental=false -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
@@ -347,6 +352,8 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
+          # hardcoding other profile params to avoid profile override values
+          # More on Cargo profiles https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
           RUSTFLAGS: "-C debuginfo=0 -C opt-level=0 -C incremental=false -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -309,7 +309,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C target-feature=+crt-static -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C target-feature=+crt-static -C incremental=false -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -347,7 +347,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=0 -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=0 -C incremental=false -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,7 +101,7 @@ jobs:
         run: cargo test --lib --tests --bins --features avro,json,backtrace
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -309,7 +309,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3 -C incremental=true"
+          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -347,7 +347,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,12 @@ jobs:
           rust-version: stable
       - name: Run tests (excluding doctests)
         run: cargo test --lib --tests --bins --features avro,json,backtrace
+        env:
+          # do not produce debug symbols to keep memory usage down
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true"
+          RUST_BACKTRACE: "1"
+          # avoid rust stack overflows on tpc-ds tests
+          RUST_MINSTACK: "3000000"
       - name: Verify Working Directory Clean
         run: git diff --exit-code
 
@@ -303,8 +309,9 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3"
+          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3 -C incremental=true"
           RUST_BACKTRACE: "1"
+          # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
   macos:
     name: cargo test (mac)
@@ -328,6 +335,7 @@ jobs:
       # with a OS-dependent path.
       - name: Setup Rust toolchain
         run: |
+          rustup update stable
           rustup toolchain install stable
           rustup default stable
           rustup component add rustfmt
@@ -339,8 +347,10 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true"
           RUST_BACKTRACE: "1"
+          # avoid rust stack overflows on tpc-ds tests
+          RUST_MINSTACK: "3000000"
 
   test-datafusion-pyarrow:
     name: cargo test pyarrow (amd64)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,7 +101,7 @@ jobs:
         run: cargo test --lib --tests --bins --features avro,json,backtrace
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C opt-level=3 -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -309,7 +309,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=1 -C target-feature=+crt-static -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"
@@ -347,7 +347,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0 -C incremental=true -C codegen-units=256"
+          RUSTFLAGS: "-C debuginfo=0 -C opt-level=0 -C incremental=true -C codegen-units=256"
           RUST_BACKTRACE: "1"
           # avoid rust stack overflows on tpc-ds tests
           RUST_MINSTACK: "3000000"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -303,9 +303,9 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: -Ctarget-feature=+crt-static
+          RUSTFLAGS: "-C debuginfo=0 -C target-feature=+crt-static -C opt-level=3"
           RUST_BACKTRACE: "1"
-          RUST_MINSTACK: "2384500"
+          RUST_MINSTACK: "3000000"
   macos:
     name: cargo test (mac)
     runs-on: macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -290,6 +290,7 @@ jobs:
       # with a OS-dependent path.
       - name: Setup Rust toolchain
         run: |
+          rustup update stable
           rustup toolchain install stable
           rustup default stable
           rustup component add rustfmt
@@ -302,7 +303,7 @@ jobs:
           cargo test --lib --tests --bins --all-features
         env:
           # do not produce debug symbols to keep memory usage down
-          RUSTFLAGS: "-C debuginfo=0"
+          RUSTFLAGS: "-C debuginfo=0 target-feature=+crt-static"
           RUST_BACKTRACE: "1"
 
   macos:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8696.

## Rationale for this change

CI tests for windows machines are extremely slow and running 3+ hours now, whereas other architectures are able to finish within 30 mins.

This PR adds more granular build options for each architecture.
With this change windows build time is 60 minutes, which is 2x slower than others OS but still 3x better than current windows run

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
