### PR TITLE
Add support for functional dependency for ROW_NUMBER window function.

### DIFF
--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3833,3 +3833,25 @@ from (select 1 a union all select 2 a) x;
 ----
 1 1 1 1 1 1
 2 1 1 2 2 1
+
+query TII
+SELECT *
+FROM (SELECT c1, c2, ROW_NUMBER() OVER() as rn
+    FROM aggregate_test_100
+    LIMIT 5)
+GROUP BY rn
+ORDER BY rn;
+----
+c 2 1
+d 5 2
+b 1 3
+a 1 4
+b 5 5
+
+statement error DataFusion error: Error during planning: Projection references non-aggregate values: Expression aggregate_test_100.c1 could not be resolved from available columns: rn
+SELECT *
+FROM (SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c1) as rn
+    FROM aggregate_test_100
+    LIMIT 5)
+GROUP BY rn
+ORDER BY rn;

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3834,9 +3834,25 @@ from (select 1 a union all select 2 a) x;
 1 1 1 1 1 1
 2 1 1 2 2 1
 
+# when partition by expression is empty row number result will be unique.
 query TII
 SELECT *
 FROM (SELECT c1, c2, ROW_NUMBER() OVER() as rn
+    FROM aggregate_test_100
+    LIMIT 5)
+GROUP BY rn
+ORDER BY rn;
+----
+c 2 1
+d 5 2
+b 1 3
+a 1 4
+b 5 5
+
+# when partition by expression is constant row number result will be unique.
+query TII
+SELECT *
+FROM (SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY 3) as rn
     FROM aggregate_test_100
     LIMIT 5)
 GROUP BY rn


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
For window queries in the form `ROW_NUMBER() OVER(PARTITION BY <empty> ORDER BY <expr>)`, we know that row numbers generated will consists of consecutive numbers across table. Hence result of this expression can be treated as `PRIMARY_KEY`. This enables us to execute queries in the form below
```sql
SELECT *
FROM (SELECT c1, c2, ROW_NUMBER() OVER() as rn
    FROM aggregate_test_100
    LIMIT 5)
GROUP BY rn
ORDER BY rn;
```
without this support query above should be re-written as 
```sql
SELECT *
FROM (SELECT c1, c2, ROW_NUMBER() OVER() as rn
    FROM aggregate_test_100
    LIMIT 5)
GROUP BY rn, c1, c2 -- this line is the difference
ORDER BY rn;
```
to be able to execute.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR adds ROW_NUMBER result as functional dependencies when it known that its result will be unique across rows (when partition by expression is empty).
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
