### PR TITLE
Add Apache attribution to site footer

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -3,3 +3,24 @@
 {# Silence the navbar #}
 {% block docs_navbar %}
 {% endblock %}
+
+<!--
+    Custom footer
+-->
+{% block footer %}
+<!-- Based on pydata_sphinx_theme/footer.html -->
+<footer class="footer mt-5 mt-md-0">
+  <div class="container">
+    {% for footer_item in theme_footer_items %}
+    <div class="footer-item">
+      {% include footer_item %}
+    </div>
+    {% endfor %}
+    <div class="footer-item">
+      <p>Apache Arrow DataFusion, Arrow DataFusion, Apache, the Apache feather logo, and the Apache Arrow DataFusion project logo</p>
+      <p>are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+    </div>
+  </div>
+</footer>
+
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,9 +33,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Arrow DataFusion'
-copyright = '2023, Apache Software Foundation'
-author = 'Arrow DataFusion Authors'
+project = 'Apache Arrow DataFusion'
+copyright = '2019-2024, Apache Software Foundation'
+author = 'Apache Software Foundation'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8755

## Rationale for this change

Comply with ASF branding guidelines

## What changes are included in this PR?

Add a footer to https://arrow.apache.org/datafusion/

<img width="1728" alt="Screenshot 2024-01-05 at 7 25 56 AM" src="https://github.com/apache/arrow-datafusion/assets/490673/1fee1036-f346-4768-ba14-c5b8f0797eef">

## Are these changes tested?
I tested them locally

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Website change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
