### PR TITLE
[MINOR] CLI error handling on streaming use cases

### DIFF
--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -141,7 +141,8 @@ impl PrintOptions {
         let mut row_count = 0_usize;
         let mut with_header = true;
 
-        while let Some(Ok(batch)) = stream.next().await {
+        while let Some(maybe_batch) = stream.next().await {
+            let batch = maybe_batch?;
             row_count += batch.num_rows();
             self.format.print_batches(
                 &mut writer,


### PR DESCRIPTION
## Which issue does this PR close?



Closes #.

## Rationale for this change

If a streaming execution sends an error, the loop finishes as no error was received, thus this was a bug.

## What changes are included in this PR?

Handling the error if the stream sends an error.

## Are these changes tested?

Yes

## Are there any user-facing changes?

Improved error handling.