### PR TITLE
Make schema calculations for `LogicalPlan::Aggregate` and `LogicalPlan::Distinct` consistent with the `HashExec`

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -551,16 +551,16 @@ impl LogicalPlanBuilder {
         let left_plan: LogicalPlan = self.plan;
         let right_plan: LogicalPlan = plan;
 
-        Ok(Self::from(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            union(left_plan, right_plan)?,
-        )))))
+        Ok(Self::from(LogicalPlan::Distinct(Distinct::new_all(
+            Arc::new(union(left_plan, right_plan)?),
+        ))))
     }
 
     /// Apply deduplication: Only distinct (different) values are returned)
     pub fn distinct(self) -> Result<Self> {
-        Ok(Self::from(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            self.plan,
-        )))))
+        Ok(Self::from(LogicalPlan::Distinct(Distinct::new_all(
+            Arc::new(self.plan),
+        ))))
     }
 
     /// Project first values of the specified expression list according to the provided

--- a/datafusion/optimizer/src/eliminate_nested_union.rs
+++ b/datafusion/optimizer/src/eliminate_nested_union.rs
@@ -52,7 +52,7 @@ impl OptimizerRule for EliminateNestedUnion {
                     schema: schema.clone(),
                 })))
             }
-            LogicalPlan::Distinct(Distinct::All(plan)) => match plan.as_ref() {
+            LogicalPlan::Distinct(Distinct::All { input, .. }) => match input.as_ref() {
                 LogicalPlan::Union(Union { inputs, schema }) => {
                     let inputs = inputs
                         .iter()
@@ -60,7 +60,7 @@ impl OptimizerRule for EliminateNestedUnion {
                         .flat_map(extract_plans_from_union)
                         .collect::<Vec<_>>();
 
-                    Ok(Some(LogicalPlan::Distinct(Distinct::All(Arc::new(
+                    Ok(Some(LogicalPlan::Distinct(Distinct::new_all(Arc::new(
                         LogicalPlan::Union(Union {
                             inputs,
                             schema: schema.clone(),
@@ -94,7 +94,7 @@ fn extract_plans_from_union(plan: &Arc<LogicalPlan>) -> Vec<Arc<LogicalPlan>> {
 
 fn extract_plan_from_distinct(plan: &Arc<LogicalPlan>) -> &Arc<LogicalPlan> {
     match plan.as_ref() {
-        LogicalPlan::Distinct(Distinct::All(plan)) => plan,
+        LogicalPlan::Distinct(Distinct::All { input, .. }) => input,
         _ => plan,
     }
 }

--- a/datafusion/optimizer/src/optimize_projections.rs
+++ b/datafusion/optimizer/src/optimize_projections.rs
@@ -150,7 +150,7 @@ fn optimize_projections(
         | LogicalPlan::Explain(_)
         | LogicalPlan::Analyze(_)
         | LogicalPlan::Subquery(_)
-        | LogicalPlan::Distinct(Distinct::All(_)) => {
+        | LogicalPlan::Distinct(Distinct::All { .. }) => {
             // These plans require all their fields, and their children should
             // be treated as final plans -- otherwise, we may have schema a
             // mismatch.

--- a/datafusion/optimizer/src/replace_distinct_aggregate.rs
+++ b/datafusion/optimizer/src/replace_distinct_aggregate.rs
@@ -71,7 +71,7 @@ impl OptimizerRule for ReplaceDistinctWithAggregate {
         _config: &dyn OptimizerConfig,
     ) -> Result<Option<LogicalPlan>> {
         match plan {
-            LogicalPlan::Distinct(Distinct::All(input)) => {
+            LogicalPlan::Distinct(Distinct::All { input, .. }) => {
                 let group_expr = expand_wildcard(input.schema(), input, None)?;
                 let aggregate = LogicalPlan::Aggregate(Aggregate::try_new(
                     input.clone(),

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -20,7 +20,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use super::{displayable, DisplayAs};
+use super::DisplayAs;
 use crate::aggregates::{
     no_grouping::AggregateStream, row_hash::GroupedHashAggregateStream,
     topk_stream::GroupedTopKAggregateStream,
@@ -238,12 +238,6 @@ impl From<StreamType> for SendableRecordBatchStream {
         }
     }
 }
-
-static NEXT_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-fn next_id() -> usize {
-    NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-}
-
 /// Hash aggregate execution plan
 #[derive(Debug)]
 pub struct AggregateExec {
@@ -277,8 +271,6 @@ pub struct AggregateExec {
     input_order_mode: InputOrderMode,
     /// Describe how the output is ordered
     output_ordering: Option<LexOrdering>,
-
-    id: String,
 }
 
 impl AggregateExec {
@@ -391,7 +383,6 @@ impl AggregateExec {
             limit: None,
             input_order_mode,
             output_ordering,
-            id: format!("AggregateExec: {}", next_id()),
         })
     }
 
@@ -431,13 +422,6 @@ impl AggregateExec {
                 contains_null_expr || expr.nullable(&input_schema)?,
             ))
         }
-        println!(
-            "{} input schema: {:?}\n\ninput:\n{}\n\n",
-            self.id,
-            input_schema,
-            displayable(self.input.as_ref()).indent(false)
-        );
-        println!("{} group schema: {:?}", self.id, fields);
         Ok(Arc::new(Schema::new(fields)))
     }
 

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -24,8 +24,7 @@ use std::vec;
 use crate::aggregates::group_values::{new_group_values, GroupValues};
 use crate::aggregates::order::GroupOrderingFull;
 use crate::aggregates::{
-    evaluate_group_by, evaluate_many, evaluate_optional, group_schema, AggregateMode,
-    PhysicalGroupBy,
+    evaluate_group_by, evaluate_many, evaluate_optional, AggregateMode, PhysicalGroupBy,
 };
 use crate::common::IPCWriter;
 use crate::metrics::{BaselineMetrics, RecordOutput};
@@ -273,6 +272,8 @@ pub(crate) struct GroupedHashAggregateStream {
     /// the `GroupedHashAggregateStream` operation immediately switches to
     /// output mode and emits all groups.
     group_values_soft_limit: Option<usize>,
+
+    id: String,
 }
 
 impl GroupedHashAggregateStream {
@@ -326,7 +327,8 @@ impl GroupedHashAggregateStream {
 
         // we need to use original schema so RowConverter in group_values below
         // will do the proper coversion of dictionaries into value types
-        let group_schema = group_schema(&agg.original_schema, agg_group_by.expr.len());
+        //let group_schema = group_schema(&agg.original_schema, agg_group_by.expr.len());
+        let group_schema = agg.group_schema()?;
         let spill_expr = group_schema
             .fields
             .into_iter()
@@ -383,6 +385,7 @@ impl GroupedHashAggregateStream {
             runtime: context.runtime_env(),
             spill_state,
             group_values_soft_limit: agg.limit,
+            id: agg.id.clone(),
         })
     }
 }

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -272,8 +272,6 @@ pub(crate) struct GroupedHashAggregateStream {
     /// the `GroupedHashAggregateStream` operation immediately switches to
     /// output mode and emits all groups.
     group_values_soft_limit: Option<usize>,
-
-    id: String,
 }
 
 impl GroupedHashAggregateStream {
@@ -385,7 +383,6 @@ impl GroupedHashAggregateStream {
             runtime: context.runtime_env(),
             spill_state,
             group_values_soft_limit: agg.limit,
-            id: agg.id.clone(),
         })
     }
 }

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -490,6 +490,8 @@ pub fn can_interleave<T: Borrow<Arc<dyn ExecutionPlan>>>(
 }
 
 fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
+    // all inputs should have the same schema
+
     let fields: Vec<Field> = (0..inputs[0].schema().fields().len())
         .map(|i| {
             inputs


### PR DESCRIPTION
Draft

## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8738

## Rationale for this change
This is a second sketch of how to close https://github.com/apache/arrow-datafusion/issues/8738

https://github.com/apache/arrow-datafusion/pull/8291 / https://github.com/apache/arrow-datafusion/issues/7647 changed DataFusion's Grouping operator so that it never dictionary encoded the output grouping columns. 

Previously, the types of the input grouping expressions were the same as the types of the output group by



The idea I think is that since the values in the group columns are unique, there is no reason to dictionary encode them (as each dictionary entry would have a single value). I actually am not sure about this for reasons I will explain shortly. 

## What changes are included in this PR?

This PR changes `LogicalPlan::Aggregate` and `LogicalPlan::Distinct` (which both use the HashAggregate `ExecutionPlan`) to report a schema that is dictionary unencoded. 

## Are these changes tested?
Yes, there is a regression test added in https://github.com/apache/arrow-datafusion/pull/8750

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
