### PR TITLE
Minor: Fix flake in newly added dictionary.slt test

### DIFF
--- a/datafusion/sqllogictest/test_files/dictionary.slt
+++ b/datafusion/sqllogictest/test_files/dictionary.slt
@@ -148,7 +148,7 @@ select count(*) from m1 where tag_id = '1000' and time < '2024-01-03T14:46:35+01
 ----
 10
 
-query RRR
+query RRR rowsort
 select min(f5), max(f5), avg(f5) from m2 where tag_id = '1000' and time < '2024-01-03T14:46:35+01:00' group by type;
 ----
 100 600 350


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/pull/8750 

## Rationale for this change

I added new tests in https://github.com/apache/arrow-datafusion/pull/8750 

I noticed this test failed on main on one CI job and then passes on the next

Here is an example failure https://github.com/apache/arrow-datafusion/actions/runs/7426719857/job/20211097126

## What changes are included in this PR?

Add `rowsort` to the output of a query without an order by to keep it consistent


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
