### PR TITLE
feat: Add bloom filter metric to ParquetExec

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -29,9 +29,9 @@ use crate::physical_plan::metrics::{
 pub struct ParquetFileMetrics {
     /// Number of times the predicate could not be evaluated
     pub predicate_evaluation_errors: Count,
-    /// Number of row groups pruned using by statistics
+    /// Number of row groups pruned by statistics
     pub row_groups_pruned_sbbf: Count,
-    /// Number of row groups pruned using by bloom filters
+    /// Number of row groups pruned by bloom filters
     pub row_groups_pruned_statistics: Count,
     /// Total number of bytes scanned
     pub bytes_scanned: Count,

--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -29,8 +29,10 @@ use crate::physical_plan::metrics::{
 pub struct ParquetFileMetrics {
     /// Number of times the predicate could not be evaluated
     pub predicate_evaluation_errors: Count,
-    /// Number of row groups pruned using
-    pub row_groups_pruned: Count,
+    /// Number of row groups pruned using by statistics
+    pub row_groups_pruned_sbbf: Count,
+    /// Number of row groups pruned using by bloom filters
+    pub row_groups_pruned_statistics: Count,
     /// Total number of bytes scanned
     pub bytes_scanned: Count,
     /// Total rows filtered out by predicates pushed into parquet scan
@@ -54,9 +56,13 @@ impl ParquetFileMetrics {
             .with_new_label("filename", filename.to_string())
             .counter("predicate_evaluation_errors", partition);
 
-        let row_groups_pruned = MetricBuilder::new(metrics)
+        let row_groups_pruned_sbbf = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
-            .counter("row_groups_pruned", partition);
+            .counter("row_groups_pruned_sbbf", partition);
+
+        let row_groups_pruned_statistics = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .counter("row_groups_pruned_statistics", partition);
 
         let bytes_scanned = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
@@ -79,7 +85,8 @@ impl ParquetFileMetrics {
 
         Self {
             predicate_evaluation_errors,
-            row_groups_pruned,
+            row_groups_pruned_sbbf,
+            row_groups_pruned_statistics,
             bytes_scanned,
             pushdown_rows_filtered,
             pushdown_eval_time,

--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -30,7 +30,7 @@ pub struct ParquetFileMetrics {
     /// Number of times the predicate could not be evaluated
     pub predicate_evaluation_errors: Count,
     /// Number of row groups pruned by bloom filters
-    pub row_groups_pruned_sbbf: Count,
+    pub row_groups_pruned_bloom_filter: Count,
     /// Number of row groups pruned by statistics
     pub row_groups_pruned_statistics: Count,
     /// Total number of bytes scanned
@@ -56,9 +56,9 @@ impl ParquetFileMetrics {
             .with_new_label("filename", filename.to_string())
             .counter("predicate_evaluation_errors", partition);
 
-        let row_groups_pruned_sbbf = MetricBuilder::new(metrics)
+        let row_groups_pruned_bloom_filter = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
-            .counter("row_groups_pruned_sbbf", partition);
+            .counter("row_groups_pruned_bloom_filter", partition);
 
         let row_groups_pruned_statistics = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
@@ -85,7 +85,7 @@ impl ParquetFileMetrics {
 
         Self {
             predicate_evaluation_errors,
-            row_groups_pruned_sbbf,
+            row_groups_pruned_bloom_filter,
             row_groups_pruned_statistics,
             bytes_scanned,
             pushdown_rows_filtered,

--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -29,9 +29,9 @@ use crate::physical_plan::metrics::{
 pub struct ParquetFileMetrics {
     /// Number of times the predicate could not be evaluated
     pub predicate_evaluation_errors: Count,
-    /// Number of row groups pruned by statistics
-    pub row_groups_pruned_sbbf: Count,
     /// Number of row groups pruned by bloom filters
+    pub row_groups_pruned_sbbf: Count,
+    /// Number of row groups pruned by statistics
     pub row_groups_pruned_statistics: Count,
     /// Total number of bytes scanned
     pub bytes_scanned: Count,

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -290,7 +290,7 @@ impl DisplayAs for ParquetExec {
                                 .join(", ")
                         )
                     })
-                    .unwrap_or("pruning_predicate=None".to_string());
+                    .unwrap_or_default();
 
                 write!(f, "ParquetExec: ")?;
                 self.base_config.fmt_as(t, f)?;

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -51,6 +51,7 @@ use datafusion_physical_expr::{
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{StreamExt, TryStreamExt};
+use itertools::Itertools;
 use log::debug;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -278,8 +279,18 @@ impl DisplayAs for ParquetExec {
                 let pruning_predicate_string = self
                     .pruning_predicate
                     .as_ref()
-                    .map(|pre| format!(", pruning_predicate={}", pre.predicate_expr()))
-                    .unwrap_or_default();
+                    .map(|pre| {
+                        format!(
+                            ", pruning_predicate={} [{}]",
+                            pre.predicate_expr(),
+                            pre.literal_guarantees()
+                                .iter()
+                                .map(|item| format!("{}", item))
+                                .collect_vec()
+                                .join(", ")
+                        )
+                    })
+                    .unwrap_or("pruning_predicate=None".to_string());
 
                 write!(f, "ParquetExec: ")?;
                 self.base_config.fmt_as(t, f)?;

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -281,7 +281,7 @@ impl DisplayAs for ParquetExec {
                     .as_ref()
                     .map(|pre| {
                         format!(
-                            ", pruning_predicate={} [{}]",
+                            ", pruning_predicate={}, required_guarantees=[{}]",
                             pre.predicate_expr(),
                             pre.literal_guarantees()
                                 .iter()

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -159,7 +159,7 @@ pub(crate) async fn prune_row_groups_by_bloom_filters<
         };
 
         if prune_group {
-            metrics.row_groups_pruned_sbbf.add(1);
+            metrics.row_groups_pruned_bloom_filter.add(1);
         } else {
             filtered.push(*idx);
         }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1050,7 +1050,6 @@ mod tests {
 
         let expr = col(r#""String""#).in_list(
             (1..25)
-                .into_iter()
                 .map(|i| lit(format!("Hello_Not_Exists{}", i)))
                 .collect::<Vec<_>>(),
             false,

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -81,7 +81,7 @@ pub(crate) fn prune_row_groups_by_statistics(
                 Ok(values) => {
                     // NB: false means don't scan row group
                     if !values[0] {
-                        metrics.row_groups_pruned.add(1);
+                        metrics.row_groups_pruned_statistics.add(1);
                         continue;
                     }
                 }
@@ -159,7 +159,7 @@ pub(crate) async fn prune_row_groups_by_bloom_filters<
         };
 
         if prune_group {
-            metrics.row_groups_pruned.add(1);
+            metrics.row_groups_pruned_sbbf.add(1);
         } else {
             filtered.push(*idx);
         }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1049,12 +1049,10 @@ mod tests {
         let schema = Schema::new(vec![Field::new("String", DataType::Utf8, false)]);
 
         let expr = col(r#""String""#).in_list(
-            vec![
-                lit("Hello_Not_Exists"),
-                lit("Hello_Not_Exists2"),
-                lit("Hello_Not_Exists3"),
-                lit("Hello_Not_Exist4"),
-            ],
+            (1..25)
+                .into_iter()
+                .map(|i| lit(format!("Hello_Not_Exists{}", i)))
+                .collect::<Vec<_>>(),
             false,
         );
         let expr = logical2physical(&expr, &schema);

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -314,6 +314,11 @@ impl PruningPredicate {
         &self.predicate_expr
     }
 
+    /// Returns a reference to the literal guarantees
+    pub fn literal_guarantees(&self) -> &[LiteralGuarantee] {
+        &self.literal_guarantees
+    }
+
     /// Returns true if this pruning predicate can not prune anything.
     ///
     /// This happens if the predicate is a literal `true`  and

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -63,6 +63,7 @@ enum Scenario {
     Timestamps,
     Dates,
     Int32,
+    Int32Range,
     Float64,
     Decimal,
     DecimalLargePrecision,
@@ -113,14 +114,24 @@ impl TestOutput {
         self.metric_value("predicate_evaluation_errors")
     }
 
-    /// The number of times the pruning predicate evaluation errors
-    fn row_groups_pruned(&self) -> Option<usize> {
+    /// The number of row_groups pruned by bloom filter
+    fn row_groups_pruned_sbbf(&self) -> Option<usize> {
         self.metric_value("row_groups_pruned_sbbf")
-            .zip(self.metric_value("row_groups_pruned_statistics"))
+    }
+
+    /// The number of row_groups pruned by statistics
+    fn row_groups_pruned_statistics(&self) -> Option<usize> {
+        self.metric_value("row_groups_pruned_statistics")
+    }
+
+    /// The number of row_groups pruned
+    fn row_groups_pruned(&self) -> Option<usize> {
+        self.row_groups_pruned_sbbf()
+            .zip(self.row_groups_pruned_statistics())
             .map(|(a, b)| a + b)
     }
 
-    /// The number of times the pruning predicate evaluation errors
+    /// The number of row pages pruned
     fn row_pages_pruned(&self) -> Option<usize> {
         self.metric_value("page_index_rows_filtered")
     }
@@ -147,7 +158,11 @@ impl ContextWithParquet {
         mut config: SessionConfig,
     ) -> Self {
         let file = match unit {
-            Unit::RowGroup => make_test_file_rg(scenario).await,
+            Unit::RowGroup => {
+                let config = config.options_mut();
+                config.execution.parquet.bloom_filter_enabled = true;
+                make_test_file_rg(scenario).await
+            }
             Unit::Page => {
                 let config = config.options_mut();
                 config.execution.parquet.enable_page_index = true;
@@ -362,6 +377,13 @@ fn make_int32_batch(start: i32, end: i32) -> RecordBatch {
     RecordBatch::try_new(schema, vec![array.clone()]).unwrap()
 }
 
+fn make_int32_batch_range(start: i32, end: i32) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, true)]));
+    let v = vec![start, end];
+    let array = Arc::new(Int32Array::from(v)) as ArrayRef;
+    RecordBatch::try_new(schema, vec![array.clone()]).unwrap()
+}
+
 /// Return record batch with f64 vector
 ///
 /// Columns are named
@@ -510,6 +532,12 @@ fn create_data_batch(scenario: Scenario) -> Vec<RecordBatch> {
                 make_int32_batch(5, 10),
             ]
         }
+        Scenario::Int32Range => {
+            vec![
+                make_int32_batch_range(0, 10),
+                make_int32_batch_range(200000, 300000),
+            ]
+        }
         Scenario::Float64 => {
             vec![
                 make_f64_batch(vec![-5.0, -4.0, -3.0, -2.0, -1.0]),
@@ -567,6 +595,7 @@ async fn make_test_file_rg(scenario: Scenario) -> NamedTempFile {
 
     let props = WriterProperties::builder()
         .set_max_row_group_size(5)
+        .set_bloom_filter_enabled(true)
         .build();
 
     let batches = create_data_batch(scenario);

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -115,8 +115,8 @@ impl TestOutput {
     }
 
     /// The number of row_groups pruned by bloom filter
-    fn row_groups_pruned_sbbf(&self) -> Option<usize> {
-        self.metric_value("row_groups_pruned_sbbf")
+    fn row_groups_pruned_bloom_filter(&self) -> Option<usize> {
+        self.metric_value("row_groups_pruned_bloom_filter")
     }
 
     /// The number of row_groups pruned by statistics
@@ -126,7 +126,7 @@ impl TestOutput {
 
     /// The number of row_groups pruned
     fn row_groups_pruned(&self) -> Option<usize> {
-        self.row_groups_pruned_sbbf()
+        self.row_groups_pruned_bloom_filter()
             .zip(self.row_groups_pruned_statistics())
             .map(|(a, b)| a + b)
     }

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -115,7 +115,9 @@ impl TestOutput {
 
     /// The number of times the pruning predicate evaluation errors
     fn row_groups_pruned(&self) -> Option<usize> {
-        self.metric_value("row_groups_pruned")
+        self.metric_value("row_groups_pruned_sbbf")
+            .zip(self.metric_value("row_groups_pruned_statistics"))
+            .map(|(a, b)| a + b)
     }
 
     /// The number of times the pruning predicate evaluation errors

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -377,7 +377,7 @@ fn make_int32_batch(start: i32, end: i32) -> RecordBatch {
     RecordBatch::try_new(schema, vec![array.clone()]).unwrap()
 }
 
-fn make_int32_batch_range(start: i32, end: i32) -> RecordBatch {
+fn make_int32_range(start: i32, end: i32) -> RecordBatch {
     let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, true)]));
     let v = vec![start, end];
     let array = Arc::new(Int32Array::from(v)) as ArrayRef;
@@ -533,10 +533,7 @@ fn create_data_batch(scenario: Scenario) -> Vec<RecordBatch> {
             ]
         }
         Scenario::Int32Range => {
-            vec![
-                make_int32_batch_range(0, 10),
-                make_int32_batch_range(200000, 300000),
-            ]
+            vec![make_int32_range(0, 10), make_int32_range(200000, 300000)]
         }
         Scenario::Float64 => {
             vec![

--- a/datafusion/core/tests/parquet/row_group_pruning.rs
+++ b/datafusion/core/tests/parquet/row_group_pruning.rs
@@ -66,7 +66,7 @@ async fn test_prune_verbose(
     println!("{}", output.description());
     assert_eq!(output.predicate_evaluation_errors(), expected_errors);
     assert_eq!(
-        output.row_groups_pruned_sbbf(),
+        output.row_groups_pruned_bloom_filter(),
         expected_row_group_pruned_sbbf
     );
     assert_eq!(

--- a/datafusion/core/tests/parquet/row_group_pruning.rs
+++ b/datafusion/core/tests/parquet/row_group_pruning.rs
@@ -49,6 +49,7 @@ async fn test_prune(
     );
 }
 
+/// check row group pruning by bloom filter and statistics independently
 async fn test_prune_verbose(
     case_data_type: Scenario,
     sql: &str,

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -738,7 +738,8 @@ async fn parquet_explain_analyze() {
 
     // should contain aggregated stats
     assert_contains!(&formatted, "output_rows=8");
-    assert_contains!(&formatted, "row_groups_pruned=0");
+    assert_contains!(&formatted, "row_groups_pruned_sbbf=0");
+    assert_contains!(&formatted, "row_groups_pruned_statistics=0");
 }
 
 #[tokio::test]
@@ -754,7 +755,8 @@ async fn parquet_explain_analyze_verbose() {
         .to_string();
 
     // should contain the raw per file stats (with the label)
-    assert_contains!(&formatted, "row_groups_pruned{partition=0");
+    assert_contains!(&formatted, "row_groups_pruned_sbbf{partition=0");
+    assert_contains!(&formatted, "row_groups_pruned_statistics{partition=0");
 }
 
 #[tokio::test]

--- a/datafusion/core/tests/sql/explain_analyze.rs
+++ b/datafusion/core/tests/sql/explain_analyze.rs
@@ -738,7 +738,7 @@ async fn parquet_explain_analyze() {
 
     // should contain aggregated stats
     assert_contains!(&formatted, "output_rows=8");
-    assert_contains!(&formatted, "row_groups_pruned_sbbf=0");
+    assert_contains!(&formatted, "row_groups_pruned_bloom_filter=0");
     assert_contains!(&formatted, "row_groups_pruned_statistics=0");
 }
 
@@ -755,7 +755,7 @@ async fn parquet_explain_analyze_verbose() {
         .to_string();
 
     // should contain the raw per file stats (with the label)
-    assert_contains!(&formatted, "row_groups_pruned_sbbf{partition=0");
+    assert_contains!(&formatted, "row_groups_pruned_bloom_filter{partition=0");
     assert_contains!(&formatted, "row_groups_pruned_statistics{partition=0");
 }
 

--- a/datafusion/physical-expr/src/utils/guarantee.rs
+++ b/datafusion/physical-expr/src/utils/guarantee.rs
@@ -722,7 +722,7 @@ mod test {
         );
         // b IN (1,2,3,4...24)
         test_analyze(
-            col("b").in_list((1..25).into_iter().map(|i| lit(i)).collect_vec(), false),
+            col("b").in_list((1..25).map(lit).collect_vec(), false),
             vec![in_guarantee("b", 1..25)],
         );
     }

--- a/datafusion/physical-expr/src/utils/guarantee.rs
+++ b/datafusion/physical-expr/src/utils/guarantee.rs
@@ -23,6 +23,7 @@ use crate::{split_conjunction, PhysicalExpr};
 use datafusion_common::{Column, ScalarValue};
 use datafusion_expr::Operator;
 use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 
 /// Represents a guarantee that must be true for a boolean expression to
@@ -222,6 +223,33 @@ impl LiteralGuarantee {
     }
 }
 
+impl Display for LiteralGuarantee {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.guarantee {
+            Guarantee::In => write!(
+                f,
+                "{} in ({})",
+                self.column.name,
+                self.literals
+                    .iter()
+                    .map(|lit| lit.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Guarantee::NotIn => write!(
+                f,
+                "{} not in ({})",
+                self.column.name,
+                self.literals
+                    .iter()
+                    .map(|lit| lit.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
 /// Combines conjuncts (aka terms `AND`ed together) into [`LiteralGuarantee`]s,
 /// preserving insert order
 #[derive(Debug, Default)]
@@ -398,6 +426,7 @@ mod test {
     use datafusion_common::ToDFSchema;
     use datafusion_expr::expr_fn::*;
     use datafusion_expr::{lit, Expr};
+    use itertools::Itertools;
     use std::sync::OnceLock;
 
     #[test]
@@ -690,6 +719,11 @@ mod test {
         test_analyze(
             col("b").in_list(vec![lit(1), lit(2), lit(3)], true),
             vec![not_in_guarantee("b", [1, 2, 3])],
+        );
+        // b IN (1,2,3,4...24)
+        test_analyze(
+            col("b").in_list((1..25).into_iter().map(|i| lit(i)).collect_vec(), false),
+            vec![in_guarantee("b", 1..25)],
         );
     }
 

--- a/datafusion/sqllogictest/test_files/repartition_scan.slt
+++ b/datafusion/sqllogictest/test_files/repartition_scan.slt
@@ -61,7 +61,7 @@ Filter: parquet_table.column1 != Int32(42)
 physical_plan
 CoalesceBatchesExec: target_batch_size=8192
 --FilterExec: column1@0 != 42
-----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1
+----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
 
 # disable round robin repartitioning
 statement ok
@@ -77,7 +77,7 @@ Filter: parquet_table.column1 != Int32(42)
 physical_plan
 CoalesceBatchesExec: target_batch_size=8192
 --FilterExec: column1@0 != 42
-----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1
+----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
 
 # enable round robin repartitioning again
 statement ok
@@ -102,7 +102,7 @@ SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
 --SortExec: expr=[column1@0 ASC NULLS LAST]
 ----CoalesceBatchesExec: target_batch_size=8192
 ------FilterExec: column1@0 != 42
---------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..200], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:200..394, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..6], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:6..206], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:206..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1
+--------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..200], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:200..394, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..6], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:6..206], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:206..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
 
 
 ## Read the files as though they are ordered
@@ -138,7 +138,7 @@ physical_plan
 SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
 --CoalesceBatchesExec: target_batch_size=8192
 ----FilterExec: column1@0 != 42
-------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..197], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..201], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:201..403], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:197..394]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1
+------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..197], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..201], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:201..403], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:197..394]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
 
 # Cleanup
 statement ok

--- a/datafusion/sqllogictest/test_files/repartition_scan.slt
+++ b/datafusion/sqllogictest/test_files/repartition_scan.slt
@@ -61,7 +61,7 @@ Filter: parquet_table.column1 != Int32(42)
 physical_plan
 CoalesceBatchesExec: target_batch_size=8192
 --FilterExec: column1@0 != 42
-----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
+----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1, required_guarantees=[column1 not in (42)]
 
 # disable round robin repartitioning
 statement ok
@@ -77,7 +77,7 @@ Filter: parquet_table.column1 != Int32(42)
 physical_plan
 CoalesceBatchesExec: target_batch_size=8192
 --FilterExec: column1@0 != 42
-----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
+----ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..101], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:101..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:202..303], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:303..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1, required_guarantees=[column1 not in (42)]
 
 # enable round robin repartitioning again
 statement ok
@@ -102,7 +102,7 @@ SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
 --SortExec: expr=[column1@0 ASC NULLS LAST]
 ----CoalesceBatchesExec: target_batch_size=8192
 ------FilterExec: column1@0 != 42
---------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..200], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:200..394, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..6], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:6..206], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:206..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
+--------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..200], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:200..394, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..6], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:6..206], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:206..403]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1, required_guarantees=[column1 not in (42)]
 
 
 ## Read the files as though they are ordered
@@ -138,7 +138,7 @@ physical_plan
 SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
 --CoalesceBatchesExec: target_batch_size=8192
 ----FilterExec: column1@0 != 42
-------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..197], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..201], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:201..403], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:197..394]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1 [column1 not in (42)]
+------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..197], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..201], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:201..403], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:197..394]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=column1_min@0 != 42 OR 42 != column1_max@1, required_guarantees=[column1 not in (42)]
 
 # Cleanup
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8767, 
Closes #8768

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- I split the `row_groups_pruned` metric into two parts, including `row_groups_pruned_sbbf` and `row_groups_pruned_sbbf`.
-  add an integration test in `row_group_pruning.rs`， by checking value of `row_groups_pruned_sbbf` and `row_groups_pruned_sbbf`
- display `LiteralGuarantees` of  `ParquetExec`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
