### PR TITLE
fix: failed to create ValuesExec with non-nullable schema

### DIFF
--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -248,6 +248,9 @@ mod tests {
             DataType::UInt32,
             false,
         )]));
-        let _ = ValuesExec::try_new(schema, vec![vec![lit(1u32)]]).unwrap();
+        let _ = ValuesExec::try_new(schema.clone(), vec![vec![lit(1u32)]]).unwrap();
+        // Test that a null value is rejected
+        let _ = ValuesExec::try_new(schema, vec![vec![lit(ScalarValue::UInt32(None))]])
+            .unwrap_err();
     }
 }

--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -27,9 +27,8 @@ use crate::{
     PhysicalExpr,
 };
 
-use arrow::array::new_null_array;
-use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::{internal_err, plan_err, DataFusionError, Result, ScalarValue};
 use datafusion_execution::TaskContext;
 
@@ -53,15 +52,14 @@ impl ValuesExec {
         }
         let n_row = data.len();
         let n_col = schema.fields().len();
-        // we have this single row, null, typed batch as a placeholder to satisfy evaluation argument
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            schema
-                .fields()
-                .iter()
-                .map(|field| new_null_array(field.data_type(), 1))
-                .collect::<Vec<_>>(),
+        // we have this single row batch as a placeholder to satisfy evaluation argument
+        // and generate a single output row
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(1)),
         )?;
+
         let arr = (0..n_col)
             .map(|j| {
                 (0..n_row)
@@ -71,7 +69,7 @@ impl ValuesExec {
                         match r {
                             Ok(ColumnarValue::Scalar(scalar)) => Ok(scalar),
                             Ok(ColumnarValue::Array(a)) if a.len() == 1 => {
-                                Ok(ScalarValue::List(a))
+                                ScalarValue::try_from_array(&a, 0)
                             }
                             Ok(ColumnarValue::Array(a)) => {
                                 plan_err!(
@@ -201,6 +199,7 @@ impl ExecutionPlan for ValuesExec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::expressions::lit;
     use crate::test::{self, make_partition};
 
     use arrow_schema::{DataType, Field, Schema};
@@ -239,5 +238,16 @@ mod tests {
             Field::new("col1", DataType::Utf8, false),
         ]));
         let _ = ValuesExec::try_new_from_batches(invalid_schema, batches).unwrap_err();
+    }
+
+    // Test issue: https://github.com/apache/arrow-datafusion/issues/8763
+    #[test]
+    fn new_exec_with_non_nullable_schema() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col0",
+            DataType::UInt32,
+            false,
+        )]));
+        let _ = ValuesExec::try_new(schema, vec![vec![lit(1u32)]]).unwrap();
     }
 }

--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -172,7 +172,7 @@ impl ExecutionPlan for ValuesExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        // GlobalLimitExec has a single output partition
+        // ValuesExec has a single output partition
         if 0 != partition {
             return internal_err!(
                 "ValuesExec invalid partition {partition} (expected 0)"

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -114,6 +114,14 @@ VALUES (1,2,3,4,5,6,7,8,9,10,11,12,13,NULL,'F',3.5)
 ----
 1 2 3 4 5 6 7 8 9 10 11 12 13 NULL F 3.5
 
+# Test non-literal expressions in VALUES
+query II
+VALUES (1, CASE WHEN RANDOM() > 0.5 THEN 1 ELSE 1 END), 
+       (2, CASE WHEN RANDOM() > 0.5 THEN 2 ELSE 2 END);
+----
+1 1
+2 2
+
 query IT
 SELECT * FROM (VALUES (1,'a'),(2,NULL)) AS t(c1, c2)
 ----


### PR DESCRIPTION
## Which issue does this PR close?
Closes #8763.

## Rationale for this change
In `ValuesExec::try_new`, we use the schema of `ValuesExec` and **null arrays** to construct a placeholder batch. 
https://github.com/apache/arrow-datafusion/blob/dd4263f843e093c807d63edf73a571b1ba2669b5/datafusion/physical-plan/src/values.rs#L56-L64
This batch placeholder is used to evaluate the physical expressions in Values.

But users can define a schema containing non-nullable fields for `ValuesExec` just like issue #8763, which is in conflict with null arrays.
```rust
let field = Field::new("a", DataType::Int32, false);
let schema = Schema::new(vec![field]);
let df_schema = DFSchema::try_from(schema.clone()).unwrap();
let values = vec![vec![Expr::Literal(ScalarValue::Int32(Some(1)))]];
let values_plan = LogicalPlan::Values(Values {
        schema: df_schema.clone().into(),
        values: values.clone(),
})
```
In this case, an ArrowError ‘InvalidArgumentError("Column 'a' is declared as non-nullable but contains null values"))' will be raised.

Since `ValuesExec` has no input, I think the schema for this placeholder batch can be empty, rather than using the schema from `ValuesExec`.

## What changes are included in this PR?
Use correct schema to build the placeholder batch in `ValuesExec::try_new`.

## Are these changes tested?
Yes

## Are there any user-facing changes?

No