### PR TITLE
Serialize function signature simplifications

### DIFF
--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -423,9 +423,8 @@ impl CsvSerializer {
     }
 }
 
-#[async_trait]
 impl BatchSerializer for CsvSerializer {
-    async fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes> {
+    fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes> {
         let mut buffer = Vec::with_capacity(4096);
         let builder = self.builder.clone();
         let header = self.header && initial;
@@ -829,7 +828,7 @@ mod tests {
             .await?;
         let batch = concat_batches(&batches[0].schema(), &batches)?;
         let serializer = CsvSerializer::new();
-        let bytes = serializer.serialize(batch, true).await?;
+        let bytes = serializer.serialize(batch, true)?;
         assert_eq!(
             "c2,c3\n2,1\n5,-40\n1,29\n1,-85\n5,-82\n4,-111\n3,104\n3,13\n1,38\n4,-38\n",
             String::from_utf8(bytes.into()).unwrap()
@@ -853,7 +852,7 @@ mod tests {
             .await?;
         let batch = concat_batches(&batches[0].schema(), &batches)?;
         let serializer = CsvSerializer::new().with_header(false);
-        let bytes = serializer.serialize(batch, true).await?;
+        let bytes = serializer.serialize(batch, true)?;
         assert_eq!(
             "2,1\n5,-40\n1,29\n1,-85\n5,-82\n4,-111\n3,104\n3,13\n1,38\n4,-38\n",
             String::from_utf8(bytes.into()).unwrap()

--- a/datafusion/core/src/datasource/file_format/json.rs
+++ b/datafusion/core/src/datasource/file_format/json.rs
@@ -204,9 +204,8 @@ impl JsonSerializer {
     }
 }
 
-#[async_trait]
 impl BatchSerializer for JsonSerializer {
-    async fn serialize(&self, batch: RecordBatch, _initial: bool) -> Result<Bytes> {
+    fn serialize(&self, batch: RecordBatch, _initial: bool) -> Result<Bytes> {
         let mut buffer = Vec::with_capacity(4096);
         let mut writer = json::LineDelimitedWriter::new(&mut buffer);
         writer.write(&batch)?;

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -29,7 +29,6 @@ use crate::error::Result;
 use arrow_array::RecordBatch;
 use datafusion_common::DataFusionError;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use object_store::path::Path;

--- a/datafusion/core/src/datasource/file_format/write/mod.rs
+++ b/datafusion/core/src/datasource/file_format/write/mod.rs
@@ -144,12 +144,11 @@ impl<W: AsyncWrite + Unpin + Send> AsyncWrite for AbortableWrite<W> {
 }
 
 /// A trait that defines the methods required for a RecordBatch serializer.
-#[async_trait]
 pub trait BatchSerializer: Sync + Send {
     /// Asynchronously serializes a `RecordBatch` and returns the serialized bytes.
     /// Parameter `initial` signals whether the given batch is the first batch.
     /// This distinction is important for certain serializers (like CSV).
-    async fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes>;
+    fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes>;
 }
 
 /// Returns an [`AbortableWrite`] which writes to the given object store location

--- a/datafusion/core/src/datasource/file_format/write/orchestration.rs
+++ b/datafusion/core/src/datasource/file_format/write/orchestration.rs
@@ -58,7 +58,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
         let mut initial = true;
         while let Some(batch) = data_rx.recv().await {
             let serializer_clone = serializer.clone();
-            let handle = tokio::task::spawn_blocking(move ||{
+            let handle = tokio::task::spawn_blocking(move || {
                 let num_rows = batch.num_rows();
                 let bytes = serializer_clone.serialize(batch, initial)?;
                 Ok((num_rows, bytes))

--- a/datafusion/core/src/datasource/file_format/write/orchestration.rs
+++ b/datafusion/core/src/datasource/file_format/write/orchestration.rs
@@ -58,7 +58,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
         let mut initial = true;
         while let Some(batch) = data_rx.recv().await {
             let serializer_clone = serializer.clone();
-            let handle = tokio::task::spawn_blocking(move || {
+            let handle = tokio::spawn(async move {
                 let num_rows = batch.num_rows();
                 let bytes = serializer_clone.serialize(batch, initial)?;
                 Ok((num_rows, bytes))

--- a/datafusion/core/src/datasource/file_format/write/orchestration.rs
+++ b/datafusion/core/src/datasource/file_format/write/orchestration.rs
@@ -58,9 +58,9 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
         let mut initial = true;
         while let Some(batch) = data_rx.recv().await {
             let serializer_clone = serializer.clone();
-            let handle = tokio::spawn(async move {
+            let handle = tokio::task::spawn_blocking(move ||{
                 let num_rows = batch.num_rows();
-                let bytes = serializer_clone.serialize(batch, initial).await?;
+                let bytes = serializer_clone.serialize(batch, initial)?;
                 Ok((num_rows, bytes))
             });
             if initial {

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -989,9 +989,8 @@ mod tests {
         bytes: Bytes,
     }
 
-    #[async_trait]
     impl BatchSerializer for TestSerializer {
-        async fn serialize(&self, _batch: RecordBatch, _initial: bool) -> Result<Bytes> {
+        fn serialize(&self, _batch: RecordBatch, _initial: bool) -> Result<Bytes> {
             Ok(self.bytes.clone())
         }
     }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -535,7 +535,6 @@ mod tests {
     use arrow_schema::Schema;
     use datafusion_common::{internal_err, DataFusionError, Statistics};
 
-    use async_trait::async_trait;
     use bytes::Bytes;
     use futures::StreamExt;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change


> In general, issuing a blocking call or performing a lot of compute in a future without yielding is problematic, as it may prevent the executor from driving other futures forward.

~~https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html~~

~~Previously, the serialization process was always asynchronous, even if there were no asynchronous calls involved, which was a CPU-bound operation. This is an anti-pattern.~~

This PR simplifies function signatures in `BatchSerializer`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make `BatchSerializer` sync ~~, and use it with `tokio::task::spawn_blocking`~~.

## Are these changes tested?

With existing tests.

## Are there any user-facing changes?

No.
