### PR TITLE
refactor: standardize exec_from funcs arg order

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -51,8 +51,8 @@ use url::Url;
 /// run and execute SQL statements and commands, against a context with the given print options
 pub async fn exec_from_commands(
     ctx: &mut SessionContext,
-    print_options: &PrintOptions,
     commands: Vec<String>,
+    print_options: &PrintOptions,
 ) {
     for sql in commands {
         match exec_and_print(ctx, print_options, sql).await {
@@ -105,8 +105,8 @@ pub async fn exec_from_lines(
 }
 
 pub async fn exec_from_files(
-    files: Vec<String>,
     ctx: &mut SessionContext,
+    files: Vec<String>,
     print_options: &PrintOptions,
 ) {
     let files = files

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -216,7 +216,7 @@ pub async fn main() -> Result<()> {
 
     if commands.is_empty() && files.is_empty() {
         if !rc.is_empty() {
-            exec::exec_from_files(rc, &mut ctx, &print_options).await
+            exec::exec_from_files(&mut ctx, rc, &print_options).await
         }
         // TODO maybe we can have thiserror for cli but for now let's keep it simple
         return exec::exec_from_repl(&mut ctx, &mut print_options)
@@ -225,11 +225,11 @@ pub async fn main() -> Result<()> {
     }
 
     if !files.is_empty() {
-        exec::exec_from_files(files, &mut ctx, &print_options).await;
+        exec::exec_from_files(&mut ctx, files, &print_options).await;
     }
 
     if !commands.is_empty() {
-        exec::exec_from_commands(&mut ctx, &print_options, commands).await;
+        exec::exec_from_commands(&mut ctx, commands, &print_options).await;
     }
 
     Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

Closes #8808

## Rationale for this change

For me the order of 'what does the execing, what's exec'd, then options` makes sense to me, but overally the goal of this PR is to make the order consistent.

## Are these changes tested?

Manual testing of built CLI, open to other options

## Are there any user-facing changes?

Not sure how many are using the CLI code in their own projects, but this could break their code (albeit with an easy fix).