### PR TITLE
fix: fix markdown table in docs

### DIFF
--- a/docs/source/user-guide/sql/write_options.md
+++ b/docs/source/user-guide/sql/write_options.md
@@ -69,9 +69,9 @@ In this example, we write the entirety of `source_table` out to a folder of parq
 The following special options are specific to the `COPY` command.
 
 | Option             | Description                                                                                                                                                                  | Default Value |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --- |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | SINGLE_FILE_OUTPUT | If true, COPY query will write output to a single file. Otherwise, multiple files will be written to a directory in parallel.                                                | true          |
-| FORMAT             | Specifies the file format COPY query will write out. If single_file_output is false or the format cannot be inferred from the file extension, then FORMAT must be specified. | N/A           |     |
+| FORMAT             | Specifies the file format COPY query will write out. If single_file_output is false or the format cannot be inferred from the file extension, then FORMAT must be specified. | N/A           |
 
 ### JSON Format Specific Options
 


### PR DESCRIPTION
## Which issue does this PR close?

Fixes an issue with docs where a markdown table isn't being rendered correctly.

Currently https://arrow.apache.org/datafusion/user-guide/sql/write_options.html... 

<img width="796" alt="image" src="https://github.com/apache/arrow-datafusion/assets/421839/4c448c8a-8cda-49a4-b512-2b0538958c48">

After this PR...

<img width="785" alt="image" src="https://github.com/apache/arrow-datafusion/assets/421839/4064d085-3963-4963-ba7b-27158a8d8292">
