### PR TITLE
Simplify physical expression creation API (not require schema)

### DIFF
--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -254,5 +254,5 @@ pub fn physical_expr(schema: &Schema, expr: Expr) -> Result<Arc<dyn PhysicalExpr
     // apply type coercion here to ensure types match
     let expr = simplifier.coerce(expr, df_schema.clone())?;
 
-    create_physical_expr(&expr, df_schema.as_ref(), schema, &props)
+    create_physical_expr(&expr, df_schema.as_ref(), &props)
 }

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -285,7 +285,7 @@ async fn prune_partitions(
 
     // Applies `filter` to `batch` returning `None` on error
     let do_filter = |filter| -> Option<ArrayRef> {
-        let expr = create_physical_expr(filter, &df_schema, &schema, &props).ok()?;
+        let expr = create_physical_expr(filter, &df_schema, &props).ok()?;
         expr.evaluate(&batch)
             .ok()?
             .into_array(partitions.len())

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -662,12 +662,8 @@ impl TableProvider for ListingTable {
         let filters = if let Some(expr) = conjunction(filters.to_vec()) {
             // NOTE: Use the table schema (NOT file schema) here because `expr` may contain references to partition columns.
             let table_df_schema = self.table_schema.as_ref().clone().to_dfschema()?;
-            let filters = create_physical_expr(
-                &expr,
-                &table_df_schema,
-                &self.table_schema,
-                state.execution_props(),
-            )?;
+            let filters =
+                create_physical_expr(&expr, &table_df_schema, state.execution_props())?;
             Some(filters)
         } else {
             None

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -2134,6 +2134,6 @@ mod tests {
     fn logical2physical(expr: &Expr, schema: &Schema) -> Arc<dyn PhysicalExpr> {
         let df_schema = schema.clone().to_dfschema().unwrap();
         let execution_props = ExecutionProps::new();
-        create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
+        create_physical_expr(expr, &df_schema, &execution_props).unwrap()
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
@@ -487,6 +487,6 @@ mod test {
     fn logical2physical(expr: &Expr, schema: &Schema) -> Arc<dyn PhysicalExpr> {
         let df_schema = schema.clone().to_dfschema().unwrap();
         let execution_props = ExecutionProps::new();
-        create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
+        create_physical_expr(expr, &df_schema, &execution_props).unwrap()
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1010,7 +1010,7 @@ mod tests {
     fn logical2physical(expr: &Expr, schema: &Schema) -> Arc<dyn PhysicalExpr> {
         let df_schema = schema.clone().to_dfschema().unwrap();
         let execution_props = ExecutionProps::new();
-        create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
+        create_physical_expr(expr, &df_schema, &execution_props).unwrap()
     }
 
     #[tokio::test]

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -2124,7 +2124,6 @@ mod tests {
     use crate::test;
     use crate::test_util::{plan_and_collect, populate_csv_partitions};
     use crate::variable::VarType;
-    use arrow_schema::Schema;
     use async_trait::async_trait;
     use datafusion_expr::Expr;
     use std::env;
@@ -2504,7 +2503,6 @@ mod tests {
             &self,
             _expr: &Expr,
             _input_dfschema: &crate::common::DFSchema,
-            _input_schema: &Schema,
             _session_state: &SessionState,
         ) -> Result<Arc<dyn crate::physical_plan::PhysicalExpr>> {
             unimplemented!()

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3144,6 +3144,6 @@ mod tests {
     fn logical2physical(expr: &Expr, schema: &Schema) -> Arc<dyn PhysicalExpr> {
         let df_schema = schema.clone().to_dfschema().unwrap();
         let execution_props = ExecutionProps::new();
-        create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
+        create_physical_expr(expr, &df_schema, &execution_props).unwrap()
     }
 }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -401,13 +401,10 @@ pub trait PhysicalPlanner: Send + Sync {
     /// `expr`: the expression to convert
     ///
     /// `input_dfschema`: the logical plan schema for evaluating `expr`
-    ///
-    /// `input_schema`: the physical schema for evaluating `expr`
     fn create_physical_expr(
         &self,
         expr: &Expr,
         input_dfschema: &DFSchema,
-        input_schema: &Schema,
         session_state: &SessionState,
     ) -> Result<Arc<dyn PhysicalExpr>>;
 }
@@ -467,21 +464,13 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
     /// `e`: the expression to convert
     ///
     /// `input_dfschema`: the logical plan schema for evaluating `e`
-    ///
-    /// `input_schema`: the physical schema for evaluating `e`
     fn create_physical_expr(
         &self,
         expr: &Expr,
         input_dfschema: &DFSchema,
-        input_schema: &Schema,
         session_state: &SessionState,
     ) -> Result<Arc<dyn PhysicalExpr>> {
-        create_physical_expr(
-            expr,
-            input_dfschema,
-            input_schema,
-            session_state.execution_props(),
-        )
+        create_physical_expr(expr, input_dfschema, session_state.execution_props())
     }
 }
 
@@ -654,7 +643,6 @@ impl DefaultPhysicalPlanner {
                                 self.create_physical_expr(
                                     expr,
                                     schema,
-                                    &exec_schema,
                                     session_state,
                                 )
                             })
@@ -694,7 +682,6 @@ impl DefaultPhysicalPlanner {
                                 self.create_physical_expr(
                                     e,
                                     input.schema(),
-                                    &input_exec.schema(),
                                     session_state,
                                 )
                             })
@@ -884,7 +871,6 @@ impl DefaultPhysicalPlanner {
                                 self.create_physical_expr(
                                     e,
                                     input_schema,
-                                    &input_exec.schema(),
                                     session_state,
                                 ),
                                 physical_name,
@@ -899,13 +885,11 @@ impl DefaultPhysicalPlanner {
                 }
                 LogicalPlan::Filter(filter) => {
                     let physical_input = self.create_initial_plan(&filter.input, session_state).await?;
-                    let input_schema = physical_input.as_ref().schema();
                     let input_dfschema = filter.input.schema();
 
                     let runtime_expr = self.create_physical_expr(
                         &filter.predicate,
                         input_dfschema,
-                        &input_schema,
                         session_state,
                     )?;
                     let selectivity = session_state.config().options().optimizer.default_filter_selectivity;
@@ -922,7 +906,6 @@ impl DefaultPhysicalPlanner {
                     partitioning_scheme,
                 }) => {
                     let physical_input = self.create_initial_plan(input, session_state).await?;
-                    let input_schema = physical_input.schema();
                     let input_dfschema = input.as_ref().schema();
                     let physical_partitioning = match partitioning_scheme {
                         LogicalPartitioning::RoundRobinBatch(n) => {
@@ -935,7 +918,6 @@ impl DefaultPhysicalPlanner {
                                     self.create_physical_expr(
                                         e,
                                         input_dfschema,
-                                        &input_schema,
                                         session_state,
                                     )
                                 })
@@ -953,14 +935,12 @@ impl DefaultPhysicalPlanner {
                 }
                 LogicalPlan::Sort(Sort { expr, input, fetch, .. }) => {
                     let physical_input = self.create_initial_plan(input, session_state).await?;
-                    let input_schema = physical_input.as_ref().schema();
                     let input_dfschema = input.as_ref().schema();
                     let sort_expr = expr
                         .iter()
                         .map(|e| create_physical_sort_expr(
                             e,
                             input_dfschema,
-                            &input_schema,
                             session_state.execution_props(),
                         ))
                         .collect::<Result<Vec<_>>>()?;
@@ -1107,7 +1087,6 @@ impl DefaultPhysicalPlanner {
                             let filter_expr = create_physical_expr(
                                 expr,
                                 &filter_df_schema,
-                                &filter_schema,
                                 session_state.execution_props(),
                             )?;
                             let column_indices = join_utils::JoinFilter::build_column_indices(left_field_indices, right_field_indices);
@@ -1348,12 +1327,7 @@ impl DefaultPhysicalPlanner {
                     )
                 }
                 expr => Ok(PhysicalGroupBy::new_single(vec![tuple_err((
-                    self.create_physical_expr(
-                        expr,
-                        input_dfschema,
-                        input_schema,
-                        session_state,
-                    ),
+                    self.create_physical_expr(expr, input_dfschema, session_state),
                     physical_name(expr),
                 ))?])),
             }
@@ -1363,12 +1337,7 @@ impl DefaultPhysicalPlanner {
                     .iter()
                     .map(|e| {
                         tuple_err((
-                            self.create_physical_expr(
-                                e,
-                                input_dfschema,
-                                input_schema,
-                                session_state,
-                            ),
+                            self.create_physical_expr(e, input_dfschema, session_state),
                             physical_name(e),
                         ))
                     })
@@ -1406,7 +1375,6 @@ fn merge_grouping_set_physical_expr(
             grouping_set_expr.push(get_physical_expr_pair(
                 expr,
                 input_dfschema,
-                input_schema,
                 session_state,
             )?);
 
@@ -1461,12 +1429,7 @@ fn create_cube_physical_expr(
             session_state,
         )?);
 
-        all_exprs.push(get_physical_expr_pair(
-            expr,
-            input_dfschema,
-            input_schema,
-            session_state,
-        )?)
+        all_exprs.push(get_physical_expr_pair(expr, input_dfschema, session_state)?)
     }
 
     let mut groups: Vec<Vec<bool>> = Vec::with_capacity(num_groups);
@@ -1509,12 +1472,7 @@ fn create_rollup_physical_expr(
             session_state,
         )?);
 
-        all_exprs.push(get_physical_expr_pair(
-            expr,
-            input_dfschema,
-            input_schema,
-            session_state,
-        )?)
+        all_exprs.push(get_physical_expr_pair(expr, input_dfschema, session_state)?)
     }
 
     for total in 0..=num_of_exprs {
@@ -1541,12 +1499,8 @@ fn get_null_physical_expr_pair(
     input_schema: &Schema,
     session_state: &SessionState,
 ) -> Result<(Arc<dyn PhysicalExpr>, String)> {
-    let physical_expr = create_physical_expr(
-        expr,
-        input_dfschema,
-        input_schema,
-        session_state.execution_props(),
-    )?;
+    let physical_expr =
+        create_physical_expr(expr, input_dfschema, session_state.execution_props())?;
     let physical_name = physical_name(&expr.clone())?;
 
     let data_type = physical_expr.data_type(input_schema)?;
@@ -1559,15 +1513,10 @@ fn get_null_physical_expr_pair(
 fn get_physical_expr_pair(
     expr: &Expr,
     input_dfschema: &DFSchema,
-    input_schema: &Schema,
     session_state: &SessionState,
 ) -> Result<(Arc<dyn PhysicalExpr>, String)> {
-    let physical_expr = create_physical_expr(
-        expr,
-        input_dfschema,
-        input_schema,
-        session_state.execution_props(),
-    )?;
+    let physical_expr =
+        create_physical_expr(expr, input_dfschema, session_state.execution_props())?;
     let physical_name = physical_name(expr)?;
     Ok((physical_expr, physical_name))
 }
@@ -1611,35 +1560,16 @@ pub fn create_window_expr_with_name(
         }) => {
             let args = args
                 .iter()
-                .map(|e| {
-                    create_physical_expr(
-                        e,
-                        logical_input_schema,
-                        physical_input_schema,
-                        execution_props,
-                    )
-                })
+                .map(|e| create_physical_expr(e, logical_input_schema, execution_props))
                 .collect::<Result<Vec<_>>>()?;
             let partition_by = partition_by
                 .iter()
-                .map(|e| {
-                    create_physical_expr(
-                        e,
-                        logical_input_schema,
-                        physical_input_schema,
-                        execution_props,
-                    )
-                })
+                .map(|e| create_physical_expr(e, logical_input_schema, execution_props))
                 .collect::<Result<Vec<_>>>()?;
             let order_by = order_by
                 .iter()
                 .map(|e| {
-                    create_physical_sort_expr(
-                        e,
-                        logical_input_schema,
-                        physical_input_schema,
-                        execution_props,
-                    )
+                    create_physical_sort_expr(e, logical_input_schema, execution_props)
                 })
                 .collect::<Result<Vec<_>>>()?;
             if !is_window_valid(window_frame) {
@@ -1711,20 +1641,12 @@ pub fn create_aggregate_expr_with_name_and_maybe_filter(
         }) => {
             let args = args
                 .iter()
-                .map(|e| {
-                    create_physical_expr(
-                        e,
-                        logical_input_schema,
-                        physical_input_schema,
-                        execution_props,
-                    )
-                })
+                .map(|e| create_physical_expr(e, logical_input_schema, execution_props))
                 .collect::<Result<Vec<_>>>()?;
             let filter = match filter {
                 Some(e) => Some(create_physical_expr(
                     e,
                     logical_input_schema,
-                    physical_input_schema,
                     execution_props,
                 )?),
                 None => None,
@@ -1736,7 +1658,6 @@ pub fn create_aggregate_expr_with_name_and_maybe_filter(
                             create_physical_sort_expr(
                                 expr,
                                 logical_input_schema,
-                                physical_input_schema,
                                 execution_props,
                             )
                         })
@@ -1804,7 +1725,6 @@ pub fn create_aggregate_expr_and_maybe_filter(
 pub fn create_physical_sort_expr(
     e: &Expr,
     input_dfschema: &DFSchema,
-    input_schema: &Schema,
     execution_props: &ExecutionProps,
 ) -> Result<PhysicalSortExpr> {
     if let Expr::Sort(expr::Sort {
@@ -1814,12 +1734,7 @@ pub fn create_physical_sort_expr(
     }) = e
     {
         Ok(PhysicalSortExpr {
-            expr: create_physical_expr(
-                expr,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?,
+            expr: create_physical_expr(expr, input_dfschema, execution_props)?,
             options: SortOptions {
                 descending: !asc,
                 nulls_first: *nulls_first,
@@ -2180,7 +2095,6 @@ mod tests {
         let expr = planner.create_physical_expr(
             &col("a").not(),
             &dfschema,
-            &schema,
             &make_session_state(),
         )?;
         let expected = expressions::not(expressions::col("a", &schema)?)?;

--- a/datafusion/core/src/test_util/parquet.rs
+++ b/datafusion/core/src/test_util/parquet.rs
@@ -166,12 +166,8 @@ impl TestParquetFile {
         if let Some(filter) = maybe_filter {
             let simplifier = ExprSimplifier::new(context);
             let filter = simplifier.coerce(filter, df_schema.clone()).unwrap();
-            let physical_filter_expr = create_physical_expr(
-                &filter,
-                &df_schema,
-                self.schema.as_ref(),
-                &ExecutionProps::default(),
-            )?;
+            let physical_filter_expr =
+                create_physical_expr(&filter, &df_schema, &ExecutionProps::default())?;
             let parquet_exec = Arc::new(ParquetExec::new(
                 scan_config,
                 Some(physical_filter_expr.clone()),

--- a/datafusion/core/tests/parquet/page_pruning.rs
+++ b/datafusion/core/tests/parquet/page_pruning.rs
@@ -67,8 +67,7 @@ async fn get_parquet_exec(state: &SessionState, filter: Expr) -> ParquetExec {
 
     let df_schema = schema.clone().to_dfschema().unwrap();
     let execution_props = ExecutionProps::new();
-    let predicate =
-        create_physical_expr(&filter, &df_schema, &schema, &execution_props).unwrap();
+    let predicate = create_physical_expr(&filter, &df_schema, &execution_props).unwrap();
 
     let parquet_exec = ParquetExec::new(
         FileScanConfig {

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -381,12 +381,8 @@ impl<'a> ConstEvaluator<'a> {
             return Ok(s);
         }
 
-        let phys_expr = create_physical_expr(
-            &expr,
-            &self.input_schema,
-            &self.input_batch.schema(),
-            self.execution_props,
-        )?;
+        let phys_expr =
+            create_physical_expr(&expr, &self.input_schema, self.execution_props)?;
         let col_val = phys_expr.evaluate(&self.input_batch)?;
         match col_val {
             ColumnarValue::Array(a) => {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -43,14 +43,17 @@ use std::sync::Arc;
 /// * `e` - The logical expression
 /// * `input_dfschema` - The DataFusion schema for the input, used to resolve `Column` references
 ///                      to qualified or unqualified fields by name.
-/// * `input_schema` - The Arrow schema for the input, used for determining expression data types
-///                    when performing type coercion.
 pub fn create_physical_expr(
     e: &Expr,
     input_dfschema: &DFSchema,
-    input_schema: &Schema,
     execution_props: &ExecutionProps,
 ) -> Result<Arc<dyn PhysicalExpr>> {
+    // dbg!(&input_dfschema);
+    // dbg!(&input_schema);
+    let input_schema: &Schema = &input_dfschema.into();
+    //let input_dfschema: &DFSchema = &DFSchema::try_from(input_schema.clone())?;
+    //let input_dfschema: &DFSchema = &DFSchema::try_from_qualified_schema(input_schema.clone())?;
+
     if input_schema.fields.len() != input_dfschema.fields().len() {
         return internal_err!(
             "create_physical_expr expected same number of fields, got \
@@ -60,12 +63,9 @@ pub fn create_physical_expr(
         );
     }
     match e {
-        Expr::Alias(Alias { expr, .. }) => Ok(create_physical_expr(
-            expr,
-            input_dfschema,
-            input_schema,
-            execution_props,
-        )?),
+        Expr::Alias(Alias { expr, .. }) => {
+            Ok(create_physical_expr(expr, input_dfschema, execution_props)?)
+        }
         Expr::Column(c) => {
             let idx = input_dfschema.index_of_column(c)?;
             Ok(Arc::new(Column::new(&c.name, idx)))
@@ -96,12 +96,7 @@ pub fn create_physical_expr(
                 Operator::IsNotDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(Some(true))),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::IsNotTrue(expr) => {
             let binary_op = binary_expr(
@@ -109,12 +104,7 @@ pub fn create_physical_expr(
                 Operator::IsDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(Some(true))),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::IsFalse(expr) => {
             let binary_op = binary_expr(
@@ -122,12 +112,7 @@ pub fn create_physical_expr(
                 Operator::IsNotDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(Some(false))),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::IsNotFalse(expr) => {
             let binary_op = binary_expr(
@@ -135,12 +120,7 @@ pub fn create_physical_expr(
                 Operator::IsDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(Some(false))),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::IsUnknown(expr) => {
             let binary_op = binary_expr(
@@ -148,12 +128,7 @@ pub fn create_physical_expr(
                 Operator::IsNotDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(None)),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::IsNotUnknown(expr) => {
             let binary_op = binary_expr(
@@ -161,27 +136,12 @@ pub fn create_physical_expr(
                 Operator::IsDistinctFrom,
                 Expr::Literal(ScalarValue::Boolean(None)),
             );
-            create_physical_expr(
-                &binary_op,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )
+            create_physical_expr(&binary_op, input_dfschema, execution_props)
         }
         Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
             // Create physical expressions for left and right operands
-            let lhs = create_physical_expr(
-                left,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
-            let rhs = create_physical_expr(
-                right,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
+            let lhs = create_physical_expr(left, input_dfschema, execution_props)?;
+            let rhs = create_physical_expr(right, input_dfschema, execution_props)?;
             // Note that the logical planner is responsible
             // for type coercion on the arguments (e.g. if one
             // argument was originally Int32 and one was
@@ -201,18 +161,10 @@ pub fn create_physical_expr(
             if escape_char.is_some() {
                 return exec_err!("LIKE does not support escape_char");
             }
-            let physical_expr = create_physical_expr(
-                expr,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
-            let physical_pattern = create_physical_expr(
-                pattern,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
+            let physical_expr =
+                create_physical_expr(expr, input_dfschema, execution_props)?;
+            let physical_pattern =
+                create_physical_expr(pattern, input_dfschema, execution_props)?;
             like(
                 *negated,
                 *case_insensitive,
@@ -226,7 +178,6 @@ pub fn create_physical_expr(
                 Some(create_physical_expr(
                     e.as_ref(),
                     input_dfschema,
-                    input_schema,
                     execution_props,
                 )?)
             } else {
@@ -236,24 +187,14 @@ pub fn create_physical_expr(
                 .when_then_expr
                 .iter()
                 .map(|(w, _)| {
-                    create_physical_expr(
-                        w.as_ref(),
-                        input_dfschema,
-                        input_schema,
-                        execution_props,
-                    )
+                    create_physical_expr(w.as_ref(), input_dfschema, execution_props)
                 })
                 .collect::<Result<Vec<_>>>()?;
             let then_expr = case
                 .when_then_expr
                 .iter()
                 .map(|(_, t)| {
-                    create_physical_expr(
-                        t.as_ref(),
-                        input_dfschema,
-                        input_schema,
-                        execution_props,
-                    )
+                    create_physical_expr(t.as_ref(), input_dfschema, execution_props)
                 })
                 .collect::<Result<Vec<_>>>()?;
             let when_then_expr: Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> =
@@ -267,7 +208,6 @@ pub fn create_physical_expr(
                     Some(create_physical_expr(
                         e.as_ref(),
                         input_dfschema,
-                        input_schema,
                         execution_props,
                     )?)
                 } else {
@@ -276,35 +216,30 @@ pub fn create_physical_expr(
             Ok(expressions::case(expr, when_then_expr, else_expr)?)
         }
         Expr::Cast(Cast { expr, data_type }) => expressions::cast(
-            create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
+            create_physical_expr(expr, input_dfschema, execution_props)?,
             input_schema,
             data_type.clone(),
         ),
         Expr::TryCast(TryCast { expr, data_type }) => expressions::try_cast(
-            create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
+            create_physical_expr(expr, input_dfschema, execution_props)?,
             input_schema,
             data_type.clone(),
         ),
-        Expr::Not(expr) => expressions::not(create_physical_expr(
-            expr,
-            input_dfschema,
-            input_schema,
-            execution_props,
-        )?),
+        Expr::Not(expr) => {
+            expressions::not(create_physical_expr(expr, input_dfschema, execution_props)?)
+        }
         Expr::Negative(expr) => expressions::negative(
-            create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
+            create_physical_expr(expr, input_dfschema, execution_props)?,
             input_schema,
         ),
         Expr::IsNull(expr) => expressions::is_null(create_physical_expr(
             expr,
             input_dfschema,
-            input_schema,
             execution_props,
         )?),
         Expr::IsNotNull(expr) => expressions::is_not_null(create_physical_expr(
             expr,
             input_dfschema,
-            input_schema,
             execution_props,
         )?),
         Expr::GetIndexedField(GetIndexedField { expr, field }) => {
@@ -313,37 +248,25 @@ pub fn create_physical_expr(
                     GetFieldAccessExpr::NamedStructField { name: name.clone() }
                 }
                 GetFieldAccess::ListIndex { key } => GetFieldAccessExpr::ListIndex {
-                    key: create_physical_expr(
-                        key,
-                        input_dfschema,
-                        input_schema,
-                        execution_props,
-                    )?,
+                    key: create_physical_expr(key, input_dfschema, execution_props)?,
                 },
                 GetFieldAccess::ListRange { start, stop } => {
                     GetFieldAccessExpr::ListRange {
                         start: create_physical_expr(
                             start,
                             input_dfschema,
-                            input_schema,
                             execution_props,
                         )?,
                         stop: create_physical_expr(
                             stop,
                             input_dfschema,
-                            input_schema,
                             execution_props,
                         )?,
                     }
                 }
             };
             Ok(Arc::new(GetIndexedFieldExpr::new(
-                create_physical_expr(
-                    expr,
-                    input_dfschema,
-                    input_schema,
-                    execution_props,
-                )?,
+                create_physical_expr(expr, input_dfschema, execution_props)?,
                 field,
             )))
         }
@@ -351,9 +274,7 @@ pub fn create_physical_expr(
         Expr::ScalarFunction(ScalarFunction { func_def, args }) => {
             let mut physical_args = args
                 .iter()
-                .map(|e| {
-                    create_physical_expr(e, input_dfschema, input_schema, execution_props)
-                })
+                .map(|e| create_physical_expr(e, input_dfschema, execution_props))
                 .collect::<Result<Vec<_>>>()?;
             match func_def {
                 ScalarFunctionDefinition::BuiltIn(fun) => {
@@ -386,20 +307,9 @@ pub fn create_physical_expr(
             low,
             high,
         }) => {
-            let value_expr = create_physical_expr(
-                expr,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
-            let low_expr =
-                create_physical_expr(low, input_dfschema, input_schema, execution_props)?;
-            let high_expr = create_physical_expr(
-                high,
-                input_dfschema,
-                input_schema,
-                execution_props,
-            )?;
+            let value_expr = create_physical_expr(expr, input_dfschema, execution_props)?;
+            let low_expr = create_physical_expr(low, input_dfschema, execution_props)?;
+            let high_expr = create_physical_expr(high, input_dfschema, execution_props)?;
 
             // rewrite the between into the two binary operators
             let binary_expr = binary(
@@ -424,22 +334,13 @@ pub fn create_physical_expr(
                 Ok(expressions::lit(ScalarValue::Boolean(None)))
             }
             _ => {
-                let value_expr = create_physical_expr(
-                    expr,
-                    input_dfschema,
-                    input_schema,
-                    execution_props,
-                )?;
+                let value_expr =
+                    create_physical_expr(expr, input_dfschema, execution_props)?;
 
                 let list_exprs = list
                     .iter()
                     .map(|expr| {
-                        create_physical_expr(
-                            expr,
-                            input_dfschema,
-                            input_schema,
-                            execution_props,
-                        )
+                        create_physical_expr(expr, input_dfschema, execution_props)
                     })
                     .collect::<Result<Vec<_>>>()?;
                 expressions::in_list(value_expr, list_exprs, negated, input_schema)
@@ -465,7 +366,7 @@ mod tests {
 
         let schema = Schema::new(vec![Field::new("letter", DataType::Utf8, false)]);
         let df_schema = DFSchema::try_from_qualified_schema("data", &schema)?;
-        let p = create_physical_expr(&expr, &df_schema, &schema, &ExecutionProps::new())?;
+        let p = create_physical_expr(&expr, &df_schema, &ExecutionProps::new())?;
 
         let batch = RecordBatch::try_new(
             Arc::new(schema),

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -50,14 +50,6 @@ pub fn create_physical_expr(
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let input_schema: &Schema = &input_dfschema.into();
 
-    if input_schema.fields.len() != input_dfschema.fields().len() {
-        return internal_err!(
-            "create_physical_expr expected same number of fields, got \
-                     Arrow schema with {}  and DataFusion schema with {}",
-            input_schema.fields.len(),
-            input_dfschema.fields().len()
-        );
-    }
     match e {
         Expr::Alias(Alias { expr, .. }) => {
             Ok(create_physical_expr(expr, input_dfschema, execution_props)?)

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -48,11 +48,7 @@ pub fn create_physical_expr(
     input_dfschema: &DFSchema,
     execution_props: &ExecutionProps,
 ) -> Result<Arc<dyn PhysicalExpr>> {
-    // dbg!(&input_dfschema);
-    // dbg!(&input_schema);
     let input_schema: &Schema = &input_dfschema.into();
-    //let input_dfschema: &DFSchema = &DFSchema::try_from(input_schema.clone())?;
-    //let input_dfschema: &DFSchema = &DFSchema::try_from_qualified_schema(input_schema.clone())?;
 
     if input_schema.fields.len() != input_dfschema.fields().len() {
         return internal_err!(

--- a/datafusion/physical-expr/src/utils/guarantee.rs
+++ b/datafusion/physical-expr/src/utils/guarantee.rs
@@ -871,7 +871,7 @@ mod test {
     fn logical2physical(expr: &Expr, schema: &Schema) -> Arc<dyn PhysicalExpr> {
         let df_schema = schema.clone().to_dfschema().unwrap();
         let execution_props = ExecutionProps::new();
-        create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
+        create_physical_expr(expr, &df_schema, &execution_props).unwrap()
     }
 
     // Schema for testing


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
To create physical expression we require 2 sets of schemas:
- logical
- physical

Having 2 schemas is confusing in some sense, this PR is to create physical expression based on logical schema only.
The reason the logical schema was chosen is the schema contains more information than physical schema, for instance qualifier information.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Signature simplified for bunch of methods creating the physical expressions.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
The signature for pub `create_physical_expr` changed
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
