### PR TITLE
Remove `Transformed` enum

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -113,7 +113,7 @@ pub trait TreeNode: Sized + Clone {
     /// The default tree traversal direction is transform_up(Postorder Traversal).
     fn transform<F>(self, op: &F) -> Result<Self>
     where
-        F: Fn(Self) -> Result<Transformed<Self>>,
+        F: Fn(Self) -> Result<Self>,
     {
         self.transform_up(op)
     }
@@ -123,9 +123,9 @@ pub trait TreeNode: Sized + Clone {
     /// When the `op` does not apply to a given node, it is left unchanged.
     fn transform_down<F>(self, op: &F) -> Result<Self>
     where
-        F: Fn(Self) -> Result<Transformed<Self>>,
+        F: Fn(Self) -> Result<Self>,
     {
-        let after_op = op(self)?.into();
+        let after_op = op(self)?;
         after_op.map_children(|node| node.transform_down(op))
     }
 
@@ -134,9 +134,9 @@ pub trait TreeNode: Sized + Clone {
     /// When the `op` does not apply to a given node, it is left unchanged.
     fn transform_down_mut<F>(self, op: &mut F) -> Result<Self>
     where
-        F: FnMut(Self) -> Result<Transformed<Self>>,
+        F: FnMut(Self) -> Result<Self>,
     {
-        let after_op = op(self)?.into();
+        let after_op = op(self)?;
         after_op.map_children(|node| node.transform_down_mut(op))
     }
 
@@ -145,11 +145,11 @@ pub trait TreeNode: Sized + Clone {
     /// When the `op` does not apply to a given node, it is left unchanged.
     fn transform_up<F>(self, op: &F) -> Result<Self>
     where
-        F: Fn(Self) -> Result<Transformed<Self>>,
+        F: Fn(Self) -> Result<Self>,
     {
         let after_op_children = self.map_children(|node| node.transform_up(op))?;
 
-        let new_node = op(after_op_children)?.into();
+        let new_node = op(after_op_children)?;
         Ok(new_node)
     }
 
@@ -158,11 +158,11 @@ pub trait TreeNode: Sized + Clone {
     /// When the `op` does not apply to a given node, it is left unchanged.
     fn transform_up_mut<F>(self, op: &mut F) -> Result<Self>
     where
-        F: FnMut(Self) -> Result<Transformed<Self>>,
+        F: FnMut(Self) -> Result<Self>,
     {
         let after_op_children = self.map_children(|node| node.transform_up_mut(op))?;
 
-        let new_node = op(after_op_children)?.into();
+        let new_node = op(after_op_children)?;
         Ok(new_node)
     }
 
@@ -312,29 +312,6 @@ pub enum VisitRecursion {
     Skip,
     /// Stop the visit to this node tree.
     Stop,
-}
-
-pub enum Transformed<T> {
-    /// The item was transformed / rewritten somehow
-    Yes(T),
-    /// The item was not transformed
-    No(T),
-}
-
-impl<T> Transformed<T> {
-    pub fn into(self) -> T {
-        match self {
-            Transformed::Yes(t) => t,
-            Transformed::No(t) => t,
-        }
-    }
-
-    pub fn into_pair(self) -> (T, bool) {
-        match self {
-            Transformed::Yes(t) => (t, true),
-            Transformed::No(t) => (t, false),
-        }
-    }
 }
 
 /// Helper trait for implementing [`TreeNode`] that have children stored as Arc's

--- a/datafusion/core/src/physical_optimizer/coalesce_batches.rs
+++ b/datafusion/core/src/physical_optimizer/coalesce_batches.rs
@@ -27,7 +27,7 @@ use crate::{
         repartition::RepartitionExec, Partitioning,
     },
 };
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use std::sync::Arc;
 
 /// Optimizer rule that introduces CoalesceBatchesExec to avoid overhead with small batches that
@@ -71,12 +71,9 @@ impl PhysicalOptimizerRule for CoalesceBatches {
                     })
                     .unwrap_or(false);
             if wrap_in_coalesce {
-                Ok(Transformed::Yes(Arc::new(CoalesceBatchesExec::new(
-                    plan,
-                    target_batch_size,
-                ))))
+                Ok(Arc::new(CoalesceBatchesExec::new(plan, target_batch_size)))
             } else {
-                Ok(Transformed::No(plan))
+                Ok(plan)
             }
         })
     }

--- a/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
@@ -26,7 +26,7 @@ use crate::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGro
 use crate::physical_plan::ExecutionPlan;
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::{AggregateExpr, PhysicalExpr};
 
@@ -109,9 +109,9 @@ impl PhysicalOptimizerRule for CombinePartialFinalAggregate {
                     });
 
             Ok(if let Some(transformed) = transformed {
-                Transformed::Yes(transformed)
+                transformed
             } else {
-                Transformed::No(plan)
+                plan
             })
         })
     }
@@ -185,9 +185,9 @@ fn discard_column_index(group_expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalEx
                     None => None,
                 };
             Ok(if let Some(normalized_form) = normalized_form {
-                Transformed::Yes(normalized_form)
+                normalized_form
             } else {
-                Transformed::No(expr)
+                expr
             })
         })
         .unwrap_or(group_expr)

--- a/datafusion/core/src/physical_optimizer/output_requirements.rs
+++ b/datafusion/core/src/physical_optimizer/output_requirements.rs
@@ -30,7 +30,7 @@ use crate::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 
 use arrow_schema::SchemaRef;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{Result, Statistics};
 use datafusion_physical_expr::{
     Distribution, LexRequirement, PhysicalSortExpr, PhysicalSortRequirement,
@@ -200,9 +200,9 @@ impl PhysicalOptimizerRule for OutputRequirements {
                 if let Some(sort_req) =
                     plan.as_any().downcast_ref::<OutputRequirementExec>()
                 {
-                    Ok(Transformed::Yes(sort_req.input()))
+                    Ok(sort_req.input())
                 } else {
-                    Ok(Transformed::No(plan))
+                    Ok(plan)
                 }
             }),
         }

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -36,10 +36,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_array::cast::AsArray;
-use datafusion_common::{
-    internal_err, plan_err,
-    tree_node::{Transformed, TreeNode},
-};
+use datafusion_common::{internal_err, plan_err, tree_node::TreeNode};
 use datafusion_common::{plan_datafusion_err, ScalarValue};
 use datafusion_physical_expr::utils::{collect_columns, Guarantee, LiteralGuarantee};
 use datafusion_physical_expr::{expressions as phys_expr, PhysicalExprRef};
@@ -840,11 +837,11 @@ fn rewrite_column_expr(
     e.transform(&|expr| {
         if let Some(column) = expr.as_any().downcast_ref::<phys_expr::Column>() {
             if column == column_old {
-                return Ok(Transformed::Yes(Arc::new(column_new.clone())));
+                return Ok(Arc::new(column_new.clone()));
             }
         }
 
-        Ok(Transformed::No(expr))
+        Ok(expr)
     })
 }
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -27,7 +27,7 @@ use crate::{aggregate_function, ExprSchemable};
 use crate::{built_in_function, BuiltinScalarFunction};
 use crate::{built_in_window_function, udaf};
 use arrow::datatypes::DataType;
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{internal_err, DFSchema, OwnedTableReference};
 use datafusion_common::{plan_err, Column, DataFusionError, Result, ScalarValue};
 use std::collections::HashSet;
@@ -1263,7 +1263,7 @@ impl Expr {
                 rewrite_placeholder(low.as_mut(), expr.as_ref(), schema)?;
                 rewrite_placeholder(high.as_mut(), expr.as_ref(), schema)?;
             }
-            Ok(Transformed::Yes(expr))
+            Ok(expr)
         })
     }
 }

--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -20,7 +20,7 @@
 use crate::expr::{Alias, Sort};
 use crate::expr_rewriter::normalize_col;
 use crate::{Cast, Expr, ExprSchemable, LogicalPlan, TryCast};
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{Column, Result};
 
 /// Rewrite sort on aggregate expressions to sort on the column of aggregate output
@@ -91,7 +91,7 @@ fn rewrite_in_terms_of_projection(
                     .to_field(input.schema())
                     .map(|f| f.qualified_column())?,
             );
-            return Ok(Transformed::Yes(col));
+            return Ok(col);
         }
 
         // if that doesn't work, try to match the expression as an
@@ -103,7 +103,7 @@ fn rewrite_in_terms_of_projection(
             e
         } else {
             // The expr is not based on Aggregate plan output. Skip it.
-            return Ok(Transformed::No(expr));
+            return Ok(expr);
         };
 
         // expr is an actual expr like min(t.c2), but we are looking
@@ -118,7 +118,7 @@ fn rewrite_in_terms_of_projection(
         // look for the column named the same as this expr
         if let Some(found) = proj_exprs.iter().find(|a| expr_match(&search_col, a)) {
             let found = found.clone();
-            return Ok(Transformed::Yes(match normalized_expr {
+            return Ok(match normalized_expr {
                 Expr::Cast(Cast { expr: _, data_type }) => Expr::Cast(Cast {
                     expr: Box::new(found),
                     data_type,
@@ -128,10 +128,10 @@ fn rewrite_in_terms_of_projection(
                     data_type,
                 }),
                 _ => found,
-            }));
+            });
         }
 
-        Ok(Transformed::No(expr))
+        Ok(expr)
     })
 }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -45,8 +45,7 @@ use crate::{
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::tree_node::{
-    RewriteRecursion, Transformed, TreeNode, TreeNodeRewriter, TreeNodeVisitor,
-    VisitRecursion,
+    RewriteRecursion, TreeNode, TreeNodeRewriter, TreeNodeVisitor, VisitRecursion,
 };
 use datafusion_common::{
     aggregate_functional_dependencies, internal_err, plan_err, Column, Constraints,
@@ -1219,17 +1218,17 @@ impl LogicalPlan {
                     let value = param_values
                         .get_placeholders_with_values(id, data_type.as_ref())?;
                     // Replace the placeholder with the value
-                    Ok(Transformed::Yes(Expr::Literal(value)))
+                    Ok(Expr::Literal(value))
                 }
                 Expr::ScalarSubquery(qry) => {
                     let subquery =
                         Arc::new(qry.subquery.replace_params_with_values(param_values)?);
-                    Ok(Transformed::Yes(Expr::ScalarSubquery(Subquery {
+                    Ok(Expr::ScalarSubquery(Subquery {
                         subquery,
                         outer_ref_columns: qry.outer_ref_columns.clone(),
-                    })))
+                    }))
                 }
-                _ => Ok(Transformed::No(expr)),
+                _ => Ok(expr),
             }
         })
     }
@@ -3245,9 +3244,9 @@ digraph {
                         Arc::new(LogicalPlan::TableScan(table)),
                     )
                     .unwrap();
-                    Ok(Transformed::Yes(LogicalPlan::Filter(filter)))
+                    Ok(LogicalPlan::Filter(filter))
                 }
-                x => Ok(Transformed::No(x)),
+                x => Ok(x),
             })
             .unwrap();
 

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::analyzer::AnalyzerRule;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::Result;
 use datafusion_expr::expr::Exists;
 use datafusion_expr::expr::InSubquery;
@@ -50,7 +50,7 @@ impl AnalyzerRule for InlineTableScan {
     }
 }
 
-fn analyze_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+fn analyze_internal(plan: LogicalPlan) -> Result<LogicalPlan> {
     Ok(match plan {
         // Match only on scans without filter / projection / fetch
         // Views and DataFrames won't have those added
@@ -64,33 +64,29 @@ fn analyze_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
         }) if filters.is_empty() && source.get_logical_plan().is_some() => {
             let sub_plan = source.get_logical_plan().unwrap();
             let projection_exprs = generate_projection_expr(&projection, sub_plan)?;
-            let plan = LogicalPlanBuilder::from(sub_plan.clone())
+            LogicalPlanBuilder::from(sub_plan.clone())
                 .project(projection_exprs)?
                 // Ensures that the reference to the inlined table remains the
                 // same, meaning we don't have to change any of the parent nodes
                 // that reference this table.
                 .alias(table_name)?
-                .build()?;
-            Transformed::Yes(plan)
+                .build()?
         }
         LogicalPlan::Filter(filter) => {
             let new_expr = filter.predicate.transform(&rewrite_subquery)?;
-            Transformed::Yes(LogicalPlan::Filter(Filter::try_new(
-                new_expr,
-                filter.input,
-            )?))
+            LogicalPlan::Filter(Filter::try_new(new_expr, filter.input)?)
         }
-        _ => Transformed::No(plan),
+        _ => plan,
     })
 }
 
-fn rewrite_subquery(expr: Expr) -> Result<Transformed<Expr>> {
+fn rewrite_subquery(expr: Expr) -> Result<Expr> {
     match expr {
         Expr::Exists(Exists { subquery, negated }) => {
             let plan = subquery.subquery.as_ref().clone();
             let new_plan = plan.transform_up(&analyze_internal)?;
             let subquery = subquery.with_plan(Arc::new(new_plan));
-            Ok(Transformed::Yes(Expr::Exists(Exists { subquery, negated })))
+            Ok(Expr::Exists(Exists { subquery, negated }))
         }
         Expr::InSubquery(InSubquery {
             expr,
@@ -100,17 +96,15 @@ fn rewrite_subquery(expr: Expr) -> Result<Transformed<Expr>> {
             let plan = subquery.subquery.as_ref().clone();
             let new_plan = plan.transform_up(&analyze_internal)?;
             let subquery = subquery.with_plan(Arc::new(new_plan));
-            Ok(Transformed::Yes(Expr::InSubquery(InSubquery::new(
-                expr, subquery, negated,
-            ))))
+            Ok(Expr::InSubquery(InSubquery::new(expr, subquery, negated)))
         }
         Expr::ScalarSubquery(subquery) => {
             let plan = subquery.subquery.as_ref().clone();
             let new_plan = plan.transform_up(&analyze_internal)?;
             let subquery = subquery.with_plan(Arc::new(new_plan));
-            Ok(Transformed::Yes(Expr::ScalarSubquery(subquery)))
+            Ok(Expr::ScalarSubquery(subquery))
         }
-        _ => Ok(Transformed::No(expr)),
+        _ => Ok(expr),
     }
 }
 

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
-use datafusion_common::tree_node::{Transformed, TreeNode, VisitRecursion};
+use datafusion_common::tree_node::{TreeNode, VisitRecursion};
 use datafusion_common::{
     internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, DataFusionError,
     JoinConstraint, Result,
@@ -1019,11 +1019,11 @@ pub fn replace_cols_by_name(
     e.transform_up(&|expr| {
         Ok(if let Expr::Column(c) = &expr {
             match replace_map.get(&c.flat_name()) {
-                Some(new_c) => Transformed::Yes(new_c.clone()),
-                None => Transformed::No(expr),
+                Some(new_c) => new_c.clone(),
+                None => expr,
             }
         } else {
-            Transformed::No(expr)
+            expr
         })
     })
 }

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -20,9 +20,7 @@ use crate::optimizer::ApplyOrder;
 use crate::utils::replace_qualified_name;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::alias::AliasGenerator;
-use datafusion_common::tree_node::{
-    RewriteRecursion, Transformed, TreeNode, TreeNodeRewriter,
-};
+use datafusion_common::tree_node::{RewriteRecursion, TreeNode, TreeNodeRewriter};
 use datafusion_common::{plan_err, Column, DataFusionError, Result, ScalarValue};
 use datafusion_expr::expr_rewriter::create_col_from_scalar_expr;
 use datafusion_expr::logical_plan::{JoinType, Subquery};
@@ -92,12 +90,12 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                                         if let Some(map_expr) =
                                             expr_check_map.get(&col.name)
                                         {
-                                            Ok(Transformed::Yes(map_expr.clone()))
+                                            Ok(map_expr.clone())
                                         } else {
-                                            Ok(Transformed::No(expr))
+                                            Ok(expr)
                                         }
                                     } else {
-                                        Ok(Transformed::No(expr))
+                                        Ok(expr)
                                     }
                                 })?;
                         }
@@ -147,12 +145,12 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                                                 if let Some(map_expr) =
                                                     expr_check_map.get(&col.name)
                                                 {
-                                                    Ok(Transformed::Yes(map_expr.clone()))
+                                                    Ok(map_expr.clone())
                                                 } else {
-                                                    Ok(Transformed::No(expr))
+                                                    Ok(expr)
                                                 }
                                             } else {
-                                                Ok(Transformed::No(expr))
+                                                Ok(expr)
                                             }
                                         })?;
                                     expr_to_rewrite_expr_map.insert(expr, new_expr);

--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -23,7 +23,7 @@ use crate::{
     PhysicalSortRequirement,
 };
 use datafusion_common::tree_node::TreeNode;
-use datafusion_common::{tree_node::Transformed, JoinType};
+use datafusion_common::JoinType;
 use std::sync::Arc;
 
 /// An `EquivalenceClass` is a set of [`Arc<dyn PhysicalExpr>`]s that are known
@@ -263,10 +263,10 @@ impl EquivalenceGroup {
             .transform(&|expr| {
                 for cls in self.iter() {
                     if cls.contains(&expr) {
-                        return Ok(Transformed::Yes(cls.canonical_expr().unwrap()));
+                        return Ok(cls.canonical_expr().unwrap());
                     }
                 }
-                Ok(Transformed::No(expr))
+                Ok(expr)
             })
             .unwrap_or(expr)
     }

--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -22,7 +22,7 @@ mod properties;
 use crate::expressions::Column;
 use crate::{LexRequirement, PhysicalExpr, PhysicalSortRequirement};
 pub use class::{EquivalenceClass, EquivalenceGroup};
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 pub use ordering::OrderingEquivalenceClass;
 pub use projection::ProjectionMapping;
 pub use properties::{join_equivalence_properties, EquivalenceProperties};
@@ -48,11 +48,8 @@ pub fn add_offset_to_expr(
     offset: usize,
 ) -> Arc<dyn PhysicalExpr> {
     expr.transform_down(&|e| match e.as_any().downcast_ref::<Column>() {
-        Some(col) => Ok(Transformed::Yes(Arc::new(Column::new(
-            col.name(),
-            offset + col.index(),
-        )))),
-        None => Ok(Transformed::No(e)),
+        Some(col) => Ok(Arc::new(Column::new(col.name(), offset + col.index()))),
+        None => Ok(e),
     })
     .unwrap()
     // Note that we can safely unwrap here since our transform always returns

--- a/datafusion/physical-expr/src/equivalence/projection.rs
+++ b/datafusion/physical-expr/src/equivalence/projection.rs
@@ -21,7 +21,7 @@ use crate::expressions::Column;
 use crate::PhysicalExpr;
 
 use arrow::datatypes::SchemaRef;
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::Result;
 
 /// Stores the mapping between source expressions and target expressions for a
@@ -68,9 +68,9 @@ impl ProjectionMapping {
                             let matching_input_field = input_schema.field(idx);
                             let matching_input_column =
                                 Column::new(matching_input_field.name(), idx);
-                            Ok(Transformed::Yes(Arc::new(matching_input_column)))
+                            Ok(Arc::new(matching_input_column))
                         }
-                        None => Ok(Transformed::No(e)),
+                        None => Ok(e),
                     })
                     .map(|source_expr| (source_expr, target_expr))
             })

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -34,7 +34,7 @@ use crate::{
     physical_exprs_contains, LexOrdering, LexOrderingRef, LexRequirement,
     LexRequirementRef, PhysicalExpr, PhysicalSortExpr, PhysicalSortRequirement,
 };
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 
 use super::ordering::collapse_lex_ordering;
 
@@ -798,7 +798,7 @@ impl EquivalenceProperties {
 fn update_ordering(
     mut node: ExprOrdering,
     eq_properties: &EquivalenceProperties,
-) -> Transformed<ExprOrdering> {
+) -> ExprOrdering {
     // We have a Column, which is one of the two possible leaf node types:
     let normalized_expr = eq_properties.eq_group.normalize_expr(node.expr.clone());
     if eq_properties.is_expr_constant(&normalized_expr) {
@@ -815,9 +815,9 @@ fn update_ordering(
         // We have a Literal, which is the other possible leaf node type:
         node.state = node.expr.get_ordering(&[]);
     } else {
-        return Transformed::No(node);
+        return node;
     }
-    Transformed::Yes(node)
+    node
 }
 
 /// This function determines whether the provided expression is constant

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -407,7 +407,7 @@ mod tests {
     use arrow::datatypes::*;
     use datafusion_common::cast::{as_float64_array, as_int32_array};
     use datafusion_common::plan_err;
-    use datafusion_common::tree_node::{Transformed, TreeNode};
+    use datafusion_common::tree_node::TreeNode;
     use datafusion_common::ScalarValue;
     use datafusion_expr::type_coercion::binary::comparison_coercion;
     use datafusion_expr::Operator;
@@ -956,9 +956,9 @@ mod tests {
                         _ => None,
                     };
                 Ok(if let Some(transformed) = transformed {
-                    Transformed::Yes(transformed)
+                    transformed
                 } else {
-                    Transformed::No(e)
+                    e
                 })
             })
             .unwrap();
@@ -977,9 +977,9 @@ mod tests {
                         _ => None,
                     };
                 Ok(if let Some(transformed) = transformed {
-                    Transformed::Yes(transformed)
+                    transformed
                 } else {
-                    Transformed::No(e)
+                    e
                 })
             })
             .unwrap();

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -28,9 +28,7 @@ use crate::{PhysicalExpr, PhysicalSortExpr};
 use arrow::array::{make_array, Array, ArrayRef, BooleanArray, MutableArrayData};
 use arrow::compute::{and_kleene, is_not_null, SlicesIterator};
 use arrow::datatypes::SchemaRef;
-use datafusion_common::tree_node::{
-    Transformed, TreeNode, TreeNodeRewriter, VisitRecursion,
-};
+use datafusion_common::tree_node::{TreeNode, TreeNodeRewriter, VisitRecursion};
 use datafusion_common::Result;
 use datafusion_expr::Operator;
 
@@ -275,12 +273,9 @@ pub fn reassign_predicate_columns(
                 Err(_) if ignore_not_found => usize::MAX,
                 Err(e) => return Err(e.into()),
             };
-            return Ok(Transformed::Yes(Arc::new(Column::new(
-                column.name(),
-                index,
-            ))));
+            return Ok(Arc::new(Column::new(column.name(), index)));
         }
-        Ok(Transformed::No(expr))
+        Ok(expr)
     })
 }
 

--- a/datafusion/physical-plan/src/empty.rs
+++ b/datafusion/physical-plan/src/empty.rs
@@ -165,7 +165,7 @@ mod tests {
         let schema = test::aggr_test_schema();
         let empty = Arc::new(EmptyExec::new(schema.clone()));
 
-        let empty2 = with_new_children_if_necessary(empty.clone(), vec![])?.into();
+        let empty2 = with_new_children_if_necessary(empty.clone(), vec![])?;
         assert_eq!(empty.schema(), empty2.schema());
 
         let too_many_kids = vec![empty2];

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -31,7 +31,7 @@ use arrow::compute::concat_batches;
 use arrow_array::{ArrowPrimitiveType, NativeAdapter, PrimitiveArray, RecordBatch};
 use arrow_buffer::{ArrowNativeType, BooleanBufferBuilder};
 use arrow_schema::{Schema, SchemaRef};
-use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{
     arrow_datafusion_err, plan_datafusion_err, DataFusionError, JoinSide, Result,
     ScalarValue,
@@ -287,8 +287,8 @@ pub fn convert_sort_expr_with_filter_schema(
         let converted_filter_expr = expr.transform_up(&|p| {
             convert_filter_columns(p.as_ref(), &column_map).map(|transformed| {
                 match transformed {
-                    Some(transformed) => Transformed::Yes(transformed),
-                    None => Transformed::No(p),
+                    Some(transformed) => transformed,
+                    None => p,
                 }
             })
         })?;

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -29,7 +29,6 @@ use crate::sorts::sort_preserving_merge::SortPreservingMergeExec;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::tree_node::Transformed;
 use datafusion_common::utils::DataPtr;
 use datafusion_common::{plan_err, DataFusionError, Result};
 use datafusion_execution::TaskContext;
@@ -477,7 +476,7 @@ pub fn need_data_exchange(plan: Arc<dyn ExecutionPlan>) -> bool {
 pub fn with_new_children_if_necessary(
     plan: Arc<dyn ExecutionPlan>,
     children: Vec<Arc<dyn ExecutionPlan>>,
-) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+) -> Result<Arc<dyn ExecutionPlan>> {
     let old_children = plan.children();
     if children.len() != old_children.len() {
         internal_err!("Wrong number of children")
@@ -487,9 +486,9 @@ pub fn with_new_children_if_necessary(
             .zip(old_children.iter())
             .any(|(c1, c2)| !Arc::data_ptr_eq(c1, c2))
     {
-        Ok(Transformed::Yes(plan.with_new_children(children)?))
+        Ok(plan.with_new_children(children)?)
     } else {
-        Ok(Transformed::No(plan))
+        Ok(plan)
     }
 }
 

--- a/datafusion/physical-plan/src/placeholder_row.rs
+++ b/datafusion/physical-plan/src/placeholder_row.rs
@@ -171,8 +171,7 @@ mod tests {
 
         let placeholder = Arc::new(PlaceholderRowExec::new(schema));
 
-        let placeholder_2 =
-            with_new_children_if_necessary(placeholder.clone(), vec![])?.into();
+        let placeholder_2 = with_new_children_if_necessary(placeholder.clone(), vec![])?;
         assert_eq!(placeholder.schema(), placeholder_2.schema());
 
         let too_many_kids = vec![placeholder_2];

--- a/datafusion/physical-plan/src/tree_node.rs
+++ b/datafusion/physical-plan/src/tree_node.rs
@@ -18,7 +18,7 @@
 //! This module provides common traits for visiting or rewriting tree nodes easily.
 
 use crate::{with_new_children_if_necessary, ExecutionPlan};
-use datafusion_common::tree_node::{DynTreeNode, Transformed};
+use datafusion_common::tree_node::DynTreeNode;
 use datafusion_common::Result;
 use std::sync::Arc;
 
@@ -32,6 +32,6 @@ impl DynTreeNode for dyn ExecutionPlan {
         arc_self: Arc<Self>,
         new_children: Vec<Arc<Self>>,
     ) -> Result<Arc<Self>> {
-        with_new_children_if_necessary(arc_self, new_children).map(Transformed::into)
+        with_new_children_if_necessary(arc_self, new_children)
     }
 }

--- a/docs/source/library-user-guide/working-with-exprs.md
+++ b/docs/source/library-user-guide/working-with-exprs.md
@@ -92,7 +92,7 @@ In our example, we'll use rewriting to update our `add_one` UDF, to be rewritten
 
 ### Rewriting with `transform`
 
-To implement the inlining, we'll need to write a function that takes an `Expr` and returns a `Result<Expr>`. If the expression is _not_ to be rewritten `Transformed::No` is used to wrap the original `Expr`. If the expression _is_ to be rewritten, `Transformed::Yes` is used to wrap the new `Expr`.
+To implement the inlining, we'll need to write a function that takes an `Expr` and returns a `Result<Expr>`.
 
 ```rust
 fn rewrite_add_one(expr: Expr) -> Result<Expr> {
@@ -102,9 +102,9 @@ fn rewrite_add_one(expr: Expr) -> Result<Expr> {
                 let input_arg = scalar_fun.args[0].clone();
                 let new_expression = input_arg + lit(1i64);
 
-                Transformed::Yes(new_expression)
+                new_expression
             }
-            _ => Transformed::No(expr),
+            _ => expr,
         })
     })
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

It seems there is no need for the `Transformed` enum so let's try getting rid of it.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
