### PR TITLE
Determine causal window frames to produce early results.

### DIFF
--- a/datafusion-examples/examples/advanced_udwf.rs
+++ b/datafusion-examples/examples/advanced_udwf.rs
@@ -219,7 +219,7 @@ async fn main() -> Result<()> {
         vec![col("speed")],                 // smooth_it(speed)
         vec![col("car")],                   // PARTITION BY car
         vec![col("time").sort(true, true)], // ORDER BY time ASC
-        WindowFrame::new(false),
+        WindowFrame::new(None),
     );
     let df = ctx.table("cars").await?.window(vec![window_expr])?;
 

--- a/datafusion-examples/examples/simple_udwf.rs
+++ b/datafusion-examples/examples/simple_udwf.rs
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
         vec![col("speed")],                 // smooth_it(speed)
         vec![col("car")],                   // PARTITION BY car
         vec![col("time").sort(true, true)], // ORDER BY time ASC
-        WindowFrame::new(false),
+        WindowFrame::new(None),
     );
     let df = ctx.table("cars").await?.window(vec![window_expr])?;
 

--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -792,7 +792,6 @@ impl ScalarValue {
 
     /// Create a zero value in the given type.
     pub fn new_zero(datatype: &DataType) -> Result<ScalarValue> {
-        assert!(datatype.is_primitive());
         Ok(match datatype {
             DataType::Boolean => ScalarValue::Boolean(Some(false)),
             DataType::Int8 => ScalarValue::Int8(Some(0)),

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1531,7 +1531,7 @@ mod tests {
             vec![col("aggregate_test_100.c1")],
             vec![col("aggregate_test_100.c2")],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let t2 = t.select(vec![col("c1"), first_row])?;
         let plan = t2.plan.clone();

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -239,7 +239,7 @@ pub fn bounded_window_exec(
                 &[col(col_name, &schema).unwrap()],
                 &[],
                 &sort_exprs,
-                Arc::new(WindowFrame::new(true)),
+                Arc::new(WindowFrame::new(Some(false))),
                 schema.as_ref(),
             )
             .unwrap()],

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -174,11 +174,11 @@ async fn test_count_wildcard_on_window() -> Result<()> {
             vec![wildcard()],
             vec![],
             vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-            WindowFrame::try_new(
+            WindowFrame::new_frame(
                 WindowFrameUnits::Range,
                 WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
                 WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
-            )?,
+            ),
         ))])?
         .explain(false, false)?
         .collect()

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -174,11 +174,11 @@ async fn test_count_wildcard_on_window() -> Result<()> {
             vec![wildcard()],
             vec![],
             vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-            WindowFrame {
-                units: WindowFrameUnits::Range,
-                start_bound: WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
-                end_bound: WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
-            },
+            WindowFrame::try_new(
+                WindowFrameUnits::Range,
+                WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
+                WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
+            )?,
         ))])?
         .explain(false, false)?
         .collect()

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -174,7 +174,7 @@ async fn test_count_wildcard_on_window() -> Result<()> {
             vec![wildcard()],
             vec![],
             vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-            WindowFrame::new_frame(
+            WindowFrame::new_bounds(
                 WindowFrameUnits::Range,
                 WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
                 WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -170,11 +170,11 @@ async fn bounded_window_causal_non_causal() -> Result<()> {
                 // end_bound FOLLOWING
                 WindowFrameBound::Following(ScalarValue::UInt64(Some(end_bound)))
             };
-            let window_frame = WindowFrame::try_new(
+            let window_frame = WindowFrame::new_frame(
                 WindowFrameUnits::Rows,
                 start_bound.clone(),
                 end_bound,
-            )?;
+            );
 
             let search_mode = InputOrderMode::Linear;
             // BoundedWindowAggExec(Count(x) OVER(ROW BETWEEN UNBOUNDED PRECEDING AND <end bound> PRECEDING/FOLLOWING))
@@ -428,8 +428,7 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
             } else {
                 WindowFrameBound::Following(ScalarValue::Int32(Some(end_bound.val)))
             };
-            let mut window_frame =
-                WindowFrame::try_new(units, start_bound, end_bound).unwrap();
+            let mut window_frame = WindowFrame::new_frame(units, start_bound, end_bound);
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =
@@ -457,8 +456,7 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
                     end_bound.val as u64,
                 )))
             };
-            let mut window_frame =
-                WindowFrame::try_new(units, start_bound, end_bound).unwrap();
+            let mut window_frame = WindowFrame::new_frame(units, start_bound, end_bound);
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -343,11 +343,8 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
             } else {
                 WindowFrameBound::Following(ScalarValue::Int32(Some(end_bound.val)))
             };
-            let mut window_frame = WindowFrame {
-                units,
-                start_bound,
-                end_bound,
-            };
+            let mut window_frame =
+                WindowFrame::try_new(units, start_bound, end_bound).unwrap();
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =
@@ -375,11 +372,8 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
                     end_bound.val as u64,
                 )))
             };
-            let mut window_frame = WindowFrame {
-                units,
-                start_bound,
-                end_bound,
-            };
+            let mut window_frame =
+                WindowFrame::try_new(units, start_bound, end_bound).unwrap();
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -139,7 +139,7 @@ async fn window_bounded_window_random_comparison() -> Result<()> {
     Ok(())
 }
 
-// This tests whether we cna generate bounded window results for each input batch immediately for causal window frames.
+// This tests whether we can generate bounded window results for each input batch immediately for causal window frames.
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn bounded_window_causal_non_causal() -> Result<()> {
     let session_config = SessionConfig::new();

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -139,67 +139,64 @@ async fn window_bounded_window_random_comparison() -> Result<()> {
     Ok(())
 }
 
-// This tests whether we can generate bounded window results for each input batch immediately for causal window frames.
+// This tests whether we can generate bounded window results for each input
+// batch immediately for causal window frames.
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn bounded_window_causal_non_causal() -> Result<()> {
     let session_config = SessionConfig::new();
     let ctx = SessionContext::new_with_config(session_config);
     let mut batches = make_staggered_batches::<true>(1000, 10, 23_u64);
-    // Remove empty batches
+    // Remove empty batches:
     batches.retain(|batch| batch.num_rows() > 0);
     let schema = batches[0].schema();
     let memory_exec = Arc::new(MemoryExec::try_new(
         &[batches.clone()],
         schema.clone(),
         None,
-    )?) as Arc<dyn ExecutionPlan>;
+    )?);
     let window_fn = WindowFunctionDefinition::AggregateFunction(AggregateFunction::Count);
-    let fn_name = "count".to_string();
+    let fn_name = "COUNT".to_string();
     let args = vec![col("x", &schema)?];
     let partitionby_exprs = vec![];
     let orderby_exprs = vec![];
-    // unbounded preceding
+    // Window frame starts with "UNBOUNDED PRECEDING":
     let start_bound = WindowFrameBound::Preceding(ScalarValue::UInt64(None));
 
+    // Simulate cases of the following form:
+    // COUNT(x) OVER (
+    //     ROWS BETWEEN UNBOUNDED PRECEDING AND <end_bound> PRECEDING/FOLLOWING
+    // )
     for is_preceding in [false, true] {
         for end_bound in [0, 1, 2, 3] {
             let end_bound = if is_preceding {
-                // end_bound PRECEDING
                 WindowFrameBound::Preceding(ScalarValue::UInt64(Some(end_bound)))
             } else {
-                // end_bound FOLLOWING
                 WindowFrameBound::Following(ScalarValue::UInt64(Some(end_bound)))
             };
-            let window_frame = WindowFrame::new_frame(
+            let window_frame = WindowFrame::new_bounds(
                 WindowFrameUnits::Rows,
                 start_bound.clone(),
                 end_bound,
             );
+            let causal = window_frame.is_causal();
 
-            let search_mode = InputOrderMode::Linear;
-            // BoundedWindowAggExec(Count(x) OVER(ROW BETWEEN UNBOUNDED PRECEDING AND <end bound> PRECEDING/FOLLOWING))
-            let running_window_exec = Arc::new(
-                BoundedWindowAggExec::try_new(
-                    vec![create_window_expr(
-                        &window_fn,
-                        fn_name.clone(),
-                        &args,
-                        &partitionby_exprs,
-                        &orderby_exprs,
-                        Arc::new(window_frame.clone()),
-                        schema.as_ref(),
-                    )
-                    .unwrap()],
-                    memory_exec.clone(),
-                    vec![],
-                    search_mode,
-                )
-                .unwrap(),
-            ) as Arc<dyn ExecutionPlan>;
+            let window_expr = create_window_expr(
+                &window_fn,
+                fn_name.clone(),
+                &args,
+                &partitionby_exprs,
+                &orderby_exprs,
+                Arc::new(window_frame),
+                schema.as_ref(),
+            )?;
+            let running_window_exec = Arc::new(BoundedWindowAggExec::try_new(
+                vec![window_expr],
+                memory_exec.clone(),
+                vec![],
+                InputOrderMode::Linear,
+            )?);
             let task_ctx = ctx.task_ctx();
-            let mut collected_results = collect(running_window_exec, task_ctx.clone())
-                .await
-                .unwrap();
+            let mut collected_results = collect(running_window_exec, task_ctx).await?;
             collected_results.retain(|batch| batch.num_rows() > 0);
             let input_batch_sizes = batches
                 .iter()
@@ -209,13 +206,14 @@ async fn bounded_window_causal_non_causal() -> Result<()> {
                 .iter()
                 .map(|batch| batch.num_rows())
                 .collect::<Vec<_>>();
-            if window_frame.is_causal() {
-                // For causal window frames, for each input batch we can generate result immediately
-                // Hence batch sizes should match
+            if causal {
+                // For causal window frames, we can generate results immediately
+                // for each input batch. Hence, batch sizes should match.
                 assert_eq!(input_batch_sizes, result_batch_sizes);
             } else {
-                // For non-causal window frames, for each input batch we cannot generate result immediately
-                // Hence batch sizes shouldn't match
+                // For non-causal window frames, we cannot generate results
+                // immediately for each input batch. Hence, batch sizes shouldn't
+                // match.
                 assert_ne!(input_batch_sizes, result_batch_sizes);
             }
         }
@@ -428,7 +426,7 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
             } else {
                 WindowFrameBound::Following(ScalarValue::Int32(Some(end_bound.val)))
             };
-            let mut window_frame = WindowFrame::new_frame(units, start_bound, end_bound);
+            let mut window_frame = WindowFrame::new_bounds(units, start_bound, end_bound);
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =
@@ -456,7 +454,7 @@ fn get_random_window_frame(rng: &mut StdRng, is_linear: bool) -> WindowFrame {
                     end_bound.val as u64,
                 )))
             };
-            let mut window_frame = WindowFrame::new_frame(units, start_bound, end_bound);
+            let mut window_frame = WindowFrame::new_bounds(units, start_bound, end_bound);
             // with 10% use unbounded preceding in tests
             if rng.gen_range(0..10) == 0 {
                 window_frame.start_bound =

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -233,7 +233,7 @@ where
 ///     vec![col("speed")],                 // smooth_it(speed)
 ///     vec![col("car")],                   // PARTITION BY car
 ///     vec![col("time").sort(true, true)], // ORDER BY time ASC
-///     WindowFrame::new(false),
+///     WindowFrame::new(None),
 /// );
 /// ```
 pub trait WindowUDFImpl {

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1252,28 +1252,28 @@ mod tests {
             vec![col("name")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let max2 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Max),
             vec![col("name")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let min3 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Min),
             vec![col("name")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let sum4 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Sum),
             vec![col("age")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let exprs = &[max1.clone(), max2.clone(), min3.clone(), sum4.clone()];
         let result = group_window_expr_by_sort_keys(exprs.to_vec())?;
@@ -1295,28 +1295,28 @@ mod tests {
             vec![col("name")],
             vec![],
             vec![age_asc.clone(), name_desc.clone()],
-            WindowFrame::new(true),
+            WindowFrame::new(Some(false)),
         ));
         let max2 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Max),
             vec![col("name")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let min3 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Min),
             vec![col("name")],
             vec![],
             vec![age_asc.clone(), name_desc.clone()],
-            WindowFrame::new(true),
+            WindowFrame::new(Some(false)),
         ));
         let sum4 = Expr::WindowFunction(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateFunction(AggregateFunction::Sum),
             vec![col("age")],
             vec![],
             vec![name_desc.clone(), age_asc.clone(), created_at_desc.clone()],
-            WindowFrame::new(true),
+            WindowFrame::new(Some(false)),
         ));
         // FIXME use as_ref
         let exprs = &[max1.clone(), max2.clone(), min3.clone(), sum4.clone()];
@@ -1350,7 +1350,7 @@ mod tests {
                     Expr::Sort(expr::Sort::new(Box::new(col("age")), true, true)),
                     Expr::Sort(expr::Sort::new(Box::new(col("name")), false, true)),
                 ],
-                WindowFrame::new(true),
+                WindowFrame::new(Some(false)),
             )),
             Expr::WindowFunction(expr::WindowFunction::new(
                 WindowFunctionDefinition::AggregateFunction(AggregateFunction::Sum),
@@ -1361,7 +1361,7 @@ mod tests {
                     Expr::Sort(expr::Sort::new(Box::new(col("age")), true, true)),
                     Expr::Sort(expr::Sort::new(Box::new(col("created_at")), false, true)),
                 ],
-                WindowFrame::new(true),
+                WindowFrame::new(Some(false)),
             )),
         ];
         let expected = vec![

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -201,7 +201,6 @@ impl WindowFrame {
 ///
 /// As an example following window frame is causal where window frame
 /// range refers to past and current values.
-///
 ///                +--------------+
 ///      Future    |              |
 ///         |      |              |
@@ -217,7 +216,6 @@ impl WindowFrame {
 ///
 /// Similarly, following window frame is causal also
 /// where window frame refers past values
-///
 ///                +--------------+
 ///      Future    |              |
 ///         |      |              |
@@ -232,7 +230,6 @@ impl WindowFrame {
 ///                +--------------+
 ///
 /// However, following is not where window frame refers values from future.
-///
 ///                +--------------+
 ///      Future    |              |
 ///         |      |              |

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -157,6 +157,19 @@ impl WindowFrame {
             end_bound,
         }
     }
+
+    /// Check whether frame end is exact or can change with new data.
+    pub fn is_frame_end_exact(&self) -> bool {
+        match &self.units {
+            WindowFrameUnits::Rows => {
+                matches!(
+                    self.end_bound,
+                    WindowFrameBound::Preceding(_) | WindowFrameBound::CurrentRow
+                )
+            }
+            WindowFrameUnits::Range | WindowFrameUnits::Groups => false,
+        }
+    }
 }
 
 /// Regularizes ORDER BY clause for window definition for implicit corner cases.

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -114,6 +114,21 @@ impl WindowFrame {
         }
     }
 
+    /// Creates a new window frame for OVER(ORDER BY <expr, ..>) cases.
+    pub fn new_with_primary_key_ordering() -> Self {
+        // This window frame covers the table (or partition if `PARTITION BY` is used)
+        // from beginning to the `CURRENT ROW`. It is used
+        // when the `OVER` clause
+        // - contains an `ORDER BY` clause
+        // - doesn't contain a window frame.
+        // - ordering expression contains a PRIMARY KEY (e.g one of the expressions is unique)
+        WindowFrame {
+            units: WindowFrameUnits::Rows,
+            start_bound: WindowFrameBound::Preceding(ScalarValue::Null),
+            end_bound: WindowFrameBound::CurrentRow,
+        }
+    }
+
     /// Get reversed window frame. For example
     /// `3 ROWS PRECEDING AND 2 ROWS FOLLOWING` -->
     /// `2 ROWS PRECEDING AND 3 ROWS FOLLOWING`

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -46,7 +46,8 @@ pub struct WindowFrame {
     pub start_bound: WindowFrameBound,
     /// An ending frame boundary
     pub end_bound: WindowFrameBound,
-    /// Flag indicates whether window frame is causal.
+    /// Flag indicates whether window frame is causal
+    /// See documentation for [is_frame_causal] for what causal means in this context and how it is calculated.
     is_causal: bool,
 }
 
@@ -193,7 +194,57 @@ impl WindowFrame {
     }
 }
 
-/// Calculate whether window frame is causal or not.
+/// Calculates whether window frame is causal or not given window frame unit, and end bound of the
+/// window frame.
+///
+/// Causal window frames refer to data only from past or present.
+///
+/// As an example following window frame is causal where window frame
+/// range refers to past and current values.
+///
+///                +--------------+
+///      Future    |              |
+///         |      |              |
+///         |      |              |
+///    Current Row |+------------+|  ---
+///         |      |              |   |
+///         |      |              |   |
+///         |      |              |   |  Window Frame Range
+///       Past     |              |   |
+///                |              |   |
+///                |              |  ---
+///                +--------------+
+///
+/// Similarly, following window frame is causal also
+/// where window frame refers past values
+///
+///                +--------------+
+///      Future    |              |
+///         |      |              |
+///         |      |              |
+///    Current Row |+------------+|
+///         |      |              |
+///         |      |              | ---
+///         |      |              |  |
+///       Past     |              |  |  Window Frame Range
+///                |              |  |
+///                |              | ---
+///                +--------------+
+///
+/// However, following is not where window frame refers values from future.
+///
+///                +--------------+
+///      Future    |              |
+///         |      |              |
+///         |      |              | ---
+///    Current Row |+------------+|  |
+///         |      |              |  |  Window Frame Range
+///         |      |              |  |
+///         |      |              | ---
+///       Past     |              |
+///                |              |
+///                |              |
+///                +--------------+
 fn is_frame_causal(
     frame_units: &WindowFrameUnits,
     end_bound: &WindowFrameBound,

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -205,8 +205,14 @@ fn is_frame_causal(
         ),
         WindowFrameUnits::Range | WindowFrameUnits::Groups => match end_bound {
             WindowFrameBound::Preceding(val) => {
-                let zero = ScalarValue::new_zero(&val.data_type())?;
-                val.gt(&zero)
+                // val can be either numeric type or Utf8 type (which is initial type after parsing)
+                // In subsequent stages, Utf8 type converted to the appropriate types.
+                if let ScalarValue::Utf8(Some(val)) = val {
+                    val != "0"
+                } else {
+                    let zero = ScalarValue::new_zero(&val.data_type())?;
+                    val.gt(&zero)
+                }
             }
             _ => false,
         },

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -249,7 +249,10 @@ fn is_frame_causal(
     Ok(match frame_units {
         WindowFrameUnits::Rows => match end_bound {
             WindowFrameBound::Following(val) => {
-                if let ScalarValue::Utf8(Some(val)) = val {
+                if val.is_null() {
+                    // unbounded following
+                    false
+                } else if let ScalarValue::Utf8(Some(val)) = val {
                     val == "0"
                 } else {
                     let zero = ScalarValue::new_zero(&val.data_type())?;
@@ -262,7 +265,10 @@ fn is_frame_causal(
             WindowFrameBound::Preceding(val) => {
                 // val can be either numeric type or Utf8 type (which is initial type after parsing)
                 // In subsequent stages, Utf8 type converted to the appropriate types.
-                if let ScalarValue::Utf8(Some(val)) = val {
+                if val.is_null() {
+                    // unbounded preceding
+                    true
+                } else if let ScalarValue::Utf8(Some(val)) = val {
                     val != "0"
                 } else {
                     let zero = ScalarValue::new_zero(&val.data_type())?;

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -682,11 +682,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::try_new(
+        let window_frame = Arc::new(WindowFrame::new_frame(
             WindowFrameUnits::Groups,
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
             WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
-        )?);
+        ));
         let expected_results = vec![
             (Range { start: 0, end: 2 }, 0),
             (Range { start: 0, end: 4 }, 1),
@@ -703,11 +703,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_following() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::try_new(
+        let window_frame = Arc::new(WindowFrame::new_frame(
             WindowFrameUnits::Groups,
             WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
             WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-        )?);
+        ));
         let expected_results = vec![
             (Range::<usize> { start: 1, end: 4 }, 0),
             (Range::<usize> { start: 2, end: 5 }, 1),
@@ -724,11 +724,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_preceding() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::try_new(
+        let window_frame = Arc::new(WindowFrame::new_frame(
             WindowFrameUnits::Groups,
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
-        )?);
+        ));
         let expected_results = vec![
             (Range::<usize> { start: 0, end: 0 }, 0),
             (Range::<usize> { start: 0, end: 1 }, 1),

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -682,11 +682,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame {
-            units: WindowFrameUnits::Groups,
-            start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
-            end_bound: WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
-        });
+        let window_frame = Arc::new(WindowFrame::try_new(
+            WindowFrameUnits::Groups,
+            WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
+            WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
+        )?);
         let expected_results = vec![
             (Range { start: 0, end: 2 }, 0),
             (Range { start: 0, end: 4 }, 1),
@@ -703,11 +703,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_following() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame {
-            units: WindowFrameUnits::Groups,
-            start_bound: WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
-            end_bound: WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-        });
+        let window_frame = Arc::new(WindowFrame::try_new(
+            WindowFrameUnits::Groups,
+            WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
+            WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
+        )?);
         let expected_results = vec![
             (Range::<usize> { start: 1, end: 4 }, 0),
             (Range::<usize> { start: 2, end: 5 }, 1),
@@ -724,11 +724,11 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_preceding() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame {
-            units: WindowFrameUnits::Groups,
-            start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
-            end_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
-        });
+        let window_frame = Arc::new(WindowFrame::try_new(
+            WindowFrameUnits::Groups,
+            WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
+            WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
+        )?);
         let expected_results = vec![
             (Range::<usize> { start: 0, end: 0 }, 0),
             (Range::<usize> { start: 0, end: 1 }, 1),

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -682,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::new_frame(
+        let window_frame = Arc::new(WindowFrame::new_bounds(
             WindowFrameUnits::Groups,
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),
             WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
@@ -703,7 +703,7 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_following() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::new_frame(
+        let window_frame = Arc::new(WindowFrame::new_bounds(
             WindowFrameUnits::Groups,
             WindowFrameBound::Following(ScalarValue::UInt64(Some(1))),
             WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn test_window_frame_group_boundaries_both_preceding() -> Result<()> {
-        let window_frame = Arc::new(WindowFrame::new_frame(
+        let window_frame = Arc::new(WindowFrame::new_bounds(
             WindowFrameUnits::Groups,
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
             WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1))),

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -346,7 +346,7 @@ mod tests {
                 vec![wildcard()],
                 vec![],
                 vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-                WindowFrame::new_frame(
+                WindowFrame::new_bounds(
                     WindowFrameUnits::Range,
                     WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
                     WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -346,11 +346,11 @@ mod tests {
                 vec![wildcard()],
                 vec![],
                 vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-                WindowFrame::try_new(
+                WindowFrame::new_frame(
                     WindowFrameUnits::Range,
                     WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
                     WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
-                )?,
+                ),
             ))])?
             .project(vec![count(wildcard())])?
             .build()?;

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -346,13 +346,11 @@ mod tests {
                 vec![wildcard()],
                 vec![],
                 vec![Expr::Sort(Sort::new(Box::new(col("a")), false, true))],
-                WindowFrame {
-                    units: WindowFrameUnits::Range,
-                    start_bound: WindowFrameBound::Preceding(ScalarValue::UInt32(Some(
-                        6,
-                    ))),
-                    end_bound: WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
-                },
+                WindowFrame::try_new(
+                    WindowFrameUnits::Range,
+                    WindowFrameBound::Preceding(ScalarValue::UInt32(Some(6))),
+                    WindowFrameBound::Following(ScalarValue::UInt32(Some(2))),
+                )?,
             ))])?
             .project(vec![count(wildcard())])?
             .build()?;

--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -586,7 +586,7 @@ mod tests {
             vec![col("test.a")],
             vec![col("test.b")],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
 
         let max2 = Expr::WindowFunction(expr::WindowFunction::new(
@@ -594,7 +594,7 @@ mod tests {
             vec![col("test.b")],
             vec![],
             vec![],
-            WindowFrame::new(false),
+            WindowFrame::new(None),
         ));
         let col1 = col(max1.display_name()?);
         let col2 = col(max2.display_name()?);

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -230,7 +230,8 @@ impl WindowExpr for BuiltInWindowExpr {
                 }?;
 
                 // Exit if the range extends all the way and not exact:
-                if (frame_range.end == num_rows && !is_end_exact)
+                if frame_range.end == num_rows
+                    && !is_end_exact
                     && !partition_batch_state.is_end
                 {
                     break;

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -229,7 +229,7 @@ impl WindowExpr for BuiltInWindowExpr {
                     evaluator.get_range(idx, num_rows)
                 }?;
 
-                // Exit if the range extends all the way and not exact:
+                // Exit if the range is non-causal and extends all the way:
                 if frame_range.end == num_rows
                     && !is_causal
                     && !partition_batch_state.is_end

--- a/datafusion/physical-expr/src/window/built_in.rs
+++ b/datafusion/physical-expr/src/window/built_in.rs
@@ -206,7 +206,7 @@ impl WindowExpr for BuiltInWindowExpr {
             let record_batch = &partition_batch_state.record_batch;
             let num_rows = record_batch.num_rows();
             let mut row_wise_results: Vec<ScalarValue> = vec![];
-            let mut is_end_exact = self.window_frame.is_frame_end_exact();
+            let mut is_causal = self.window_frame.is_causal();
             for idx in state.last_calculated_index..num_rows {
                 let frame_range = if evaluator.uses_window_frame() {
                     state
@@ -225,13 +225,13 @@ impl WindowExpr for BuiltInWindowExpr {
                             idx,
                         )
                 } else {
-                    is_end_exact = false;
+                    is_causal = false;
                     evaluator.get_range(idx, num_rows)
                 }?;
 
                 // Exit if the range extends all the way and not exact:
                 if frame_range.end == num_rows
-                    && !is_end_exact
+                    && !is_causal
                     && !partition_batch_state.is_end
                 {
                     break;

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -231,12 +231,13 @@ pub trait AggregateWindowExpr: WindowExpr {
         // We iterate on each row to perform a running calculation.
         let length = values[0].len();
         let mut row_wise_results: Vec<ScalarValue> = vec![];
+        let is_end_exact = self.get_window_frame().is_frame_end_exact();
         while idx < length {
             // Start search from the last_range. This squeezes searched range.
             let cur_range =
                 window_frame_ctx.calculate_range(&order_bys, last_range, length, idx)?;
-            // Exit if the range extends all the way:
-            if cur_range.end == length && not_end {
+            // Exit if the range extends all the way and end point is not exact:
+            if (cur_range.end == length && !is_end_exact) && not_end {
                 break;
             }
             let value = self.get_aggregate_result_inside_range(

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -237,7 +237,7 @@ pub trait AggregateWindowExpr: WindowExpr {
             let cur_range =
                 window_frame_ctx.calculate_range(&order_bys, last_range, length, idx)?;
             // Exit if the range extends all the way and end point is not exact:
-            if (cur_range.end == length && !is_end_exact) && not_end {
+            if cur_range.end == length && !is_end_exact && not_end {
                 break;
             }
             let value = self.get_aggregate_result_inside_range(

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -231,13 +231,13 @@ pub trait AggregateWindowExpr: WindowExpr {
         // We iterate on each row to perform a running calculation.
         let length = values[0].len();
         let mut row_wise_results: Vec<ScalarValue> = vec![];
-        let is_end_exact = self.get_window_frame().is_frame_end_exact();
+        let is_causal = self.get_window_frame().is_causal();
         while idx < length {
             // Start search from the last_range. This squeezes searched range.
             let cur_range =
                 window_frame_ctx.calculate_range(&order_bys, last_range, length, idx)?;
             // Exit if the range extends all the way and end point is not exact:
-            if cur_range.end == length && !is_end_exact && not_end {
+            if cur_range.end == length && !is_causal && not_end {
                 break;
             }
             let value = self.get_aggregate_result_inside_range(

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -236,7 +236,7 @@ pub trait AggregateWindowExpr: WindowExpr {
             // Start search from the last_range. This squeezes searched range.
             let cur_range =
                 window_frame_ctx.calculate_range(&order_bys, last_range, length, idx)?;
-            // Exit if the range extends all the way and end point is not exact:
+            // Exit if the range is non-causal and extends all the way:
             if cur_range.end == length && !is_causal && not_end {
                 break;
             }

--- a/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
@@ -1170,7 +1170,7 @@ mod tests {
                 last_value_func,
                 &[],
                 &[],
-                Arc::new(WindowFrame::new_frame(
+                Arc::new(WindowFrame::new_bounds(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,
@@ -1181,7 +1181,7 @@ mod tests {
                 nth_value_func1,
                 &[],
                 &[],
-                Arc::new(WindowFrame::new_frame(
+                Arc::new(WindowFrame::new_bounds(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,
@@ -1192,7 +1192,7 @@ mod tests {
                 nth_value_func2,
                 &[],
                 &[],
-                Arc::new(WindowFrame::new_frame(
+                Arc::new(WindowFrame::new_bounds(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,

--- a/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
@@ -1170,33 +1170,33 @@ mod tests {
                 last_value_func,
                 &[],
                 &[],
-                Arc::new(WindowFrame::try_new(
+                Arc::new(WindowFrame::new_frame(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,
-                )?),
+                )),
             )) as _,
             // NTH_VALUE(a, -1)
             Arc::new(BuiltInWindowExpr::new(
                 nth_value_func1,
                 &[],
                 &[],
-                Arc::new(WindowFrame::try_new(
+                Arc::new(WindowFrame::new_frame(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,
-                )?),
+                )),
             )) as _,
             // NTH_VALUE(a, -2)
             Arc::new(BuiltInWindowExpr::new(
                 nth_value_func2,
                 &[],
                 &[],
-                Arc::new(WindowFrame::try_new(
+                Arc::new(WindowFrame::new_frame(
                     WindowFrameUnits::Rows,
                     WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
                     WindowFrameBound::CurrentRow,
-                )?),
+                )),
             )) as _,
         ];
         let physical_plan = BoundedWindowAggExec::try_new(

--- a/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
@@ -1170,33 +1170,33 @@ mod tests {
                 last_value_func,
                 &[],
                 &[],
-                Arc::new(WindowFrame {
-                    units: WindowFrameUnits::Rows,
-                    start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
-                    end_bound: WindowFrameBound::CurrentRow,
-                }),
+                Arc::new(WindowFrame::try_new(
+                    WindowFrameUnits::Rows,
+                    WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                    WindowFrameBound::CurrentRow,
+                )?),
             )) as _,
             // NTH_VALUE(a, -1)
             Arc::new(BuiltInWindowExpr::new(
                 nth_value_func1,
                 &[],
                 &[],
-                Arc::new(WindowFrame {
-                    units: WindowFrameUnits::Rows,
-                    start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
-                    end_bound: WindowFrameBound::CurrentRow,
-                }),
+                Arc::new(WindowFrame::try_new(
+                    WindowFrameUnits::Rows,
+                    WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                    WindowFrameBound::CurrentRow,
+                )?),
             )) as _,
             // NTH_VALUE(a, -2)
             Arc::new(BuiltInWindowExpr::new(
                 nth_value_func2,
                 &[],
                 &[],
-                Arc::new(WindowFrame {
-                    units: WindowFrameUnits::Rows,
-                    start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
-                    end_bound: WindowFrameBound::CurrentRow,
-                }),
+                Arc::new(WindowFrame::try_new(
+                    WindowFrameUnits::Rows,
+                    WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                    WindowFrameBound::CurrentRow,
+                )?),
             )) as _,
         ];
         let physical_plan = BoundedWindowAggExec::try_new(

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -654,7 +654,7 @@ mod tests {
                 &[col("a", &schema)?],
                 &[],
                 &[],
-                Arc::new(WindowFrame::new(false)),
+                Arc::new(WindowFrame::new(None)),
                 schema.as_ref(),
             )?],
             blocking_exec,

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -871,7 +871,7 @@ impl TryFrom<protobuf::WindowFrame> for WindowFrame {
             })
             .transpose()?
             .unwrap_or(WindowFrameBound::CurrentRow);
-        Ok(WindowFrame::try_new(units, start_bound, end_bound)?)
+        Ok(WindowFrame::new_frame(units, start_bound, end_bound))
     }
 }
 

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -871,11 +871,7 @@ impl TryFrom<protobuf::WindowFrame> for WindowFrame {
             })
             .transpose()?
             .unwrap_or(WindowFrameBound::CurrentRow);
-        Ok(Self {
-            units,
-            start_bound,
-            end_bound,
-        })
+        Ok(WindowFrame::try_new(units, start_bound, end_bound)?)
     }
 }
 

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -871,7 +871,7 @@ impl TryFrom<protobuf::WindowFrame> for WindowFrame {
             })
             .transpose()?
             .unwrap_or(WindowFrameBound::CurrentRow);
-        Ok(WindowFrame::new_frame(units, start_bound, end_bound))
+        Ok(WindowFrame::new_bounds(units, start_bound, end_bound))
     }
 }
 

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1671,7 +1671,7 @@ fn roundtrip_window() {
         vec![],
         vec![col("col1")],
         vec![col("col2")],
-        WindowFrame::new(true),
+        WindowFrame::new(Some(false)),
     ));
 
     // 2. with default window_frame
@@ -1682,7 +1682,7 @@ fn roundtrip_window() {
         vec![],
         vec![col("col1")],
         vec![col("col2")],
-        WindowFrame::new(true),
+        WindowFrame::new(Some(false)),
     ));
 
     // 3. with window_frame with row numbers

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1686,7 +1686,7 @@ fn roundtrip_window() {
     ));
 
     // 3. with window_frame with row numbers
-    let range_number_frame = WindowFrame::new_frame(
+    let range_number_frame = WindowFrame::new_bounds(
         WindowFrameUnits::Range,
         WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
         WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
@@ -1703,7 +1703,7 @@ fn roundtrip_window() {
     ));
 
     // 4. test with AggregateFunction
-    let row_number_frame = WindowFrame::new_frame(
+    let row_number_frame = WindowFrame::new_bounds(
         WindowFrameUnits::Rows,
         WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
         WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1686,11 +1686,12 @@ fn roundtrip_window() {
     ));
 
     // 3. with window_frame with row numbers
-    let range_number_frame = WindowFrame {
-        units: WindowFrameUnits::Range,
-        start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
-        end_bound: WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-    };
+    let range_number_frame = WindowFrame::try_new(
+        WindowFrameUnits::Range,
+        WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
+        WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
+    )
+    .unwrap();
 
     let test_expr3 = Expr::WindowFunction(expr::WindowFunction::new(
         WindowFunctionDefinition::BuiltInWindowFunction(
@@ -1703,11 +1704,12 @@ fn roundtrip_window() {
     ));
 
     // 4. test with AggregateFunction
-    let row_number_frame = WindowFrame {
-        units: WindowFrameUnits::Rows,
-        start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
-        end_bound: WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-    };
+    let row_number_frame = WindowFrame::try_new(
+        WindowFrameUnits::Rows,
+        WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
+        WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
+    )
+    .unwrap();
 
     let test_expr4 = Expr::WindowFunction(expr::WindowFunction::new(
         WindowFunctionDefinition::AggregateFunction(AggregateFunction::Max),

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1686,12 +1686,11 @@ fn roundtrip_window() {
     ));
 
     // 3. with window_frame with row numbers
-    let range_number_frame = WindowFrame::try_new(
+    let range_number_frame = WindowFrame::new_frame(
         WindowFrameUnits::Range,
         WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
         WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-    )
-    .unwrap();
+    );
 
     let test_expr3 = Expr::WindowFunction(expr::WindowFunction::new(
         WindowFunctionDefinition::BuiltInWindowFunction(
@@ -1704,12 +1703,11 @@ fn roundtrip_window() {
     ));
 
     // 4. test with AggregateFunction
-    let row_number_frame = WindowFrame::try_new(
+    let row_number_frame = WindowFrame::new_frame(
         WindowFrameUnits::Rows,
         WindowFrameBound::Preceding(ScalarValue::UInt64(Some(2))),
         WindowFrameBound::Following(ScalarValue::UInt64(Some(2))),
-    )
-    .unwrap();
+    );
 
     let test_expr4 = Expr::WindowFunction(expr::WindowFunction::new(
         WindowFunctionDefinition::AggregateFunction(AggregateFunction::Max),

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -255,7 +255,7 @@ fn roundtrip_window() -> Result<()> {
     let field_b = Field::new("b", DataType::Int64, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
 
-    let window_frame = WindowFrame::new_frame(
+    let window_frame = WindowFrame::new_bounds(
         datafusion_expr::WindowFrameUnits::Range,
         WindowFrameBound::Preceding(ScalarValue::Int64(None)),
         WindowFrameBound::CurrentRow,
@@ -289,7 +289,7 @@ fn roundtrip_window() -> Result<()> {
         Arc::new(WindowFrame::new(None)),
     ));
 
-    let window_frame = WindowFrame::new_frame(
+    let window_frame = WindowFrame::new_bounds(
         datafusion_expr::WindowFrameUnits::Range,
         WindowFrameBound::CurrentRow,
         WindowFrameBound::Preceding(ScalarValue::Int64(None)),

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -255,11 +255,11 @@ fn roundtrip_window() -> Result<()> {
     let field_b = Field::new("b", DataType::Int64, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
 
-    let window_frame = WindowFrame {
-        units: datafusion_expr::WindowFrameUnits::Range,
-        start_bound: WindowFrameBound::Preceding(ScalarValue::Int64(None)),
-        end_bound: WindowFrameBound::CurrentRow,
-    };
+    let window_frame = WindowFrame::try_new(
+        datafusion_expr::WindowFrameUnits::Range,
+        WindowFrameBound::Preceding(ScalarValue::Int64(None)),
+        WindowFrameBound::CurrentRow,
+    )?;
 
     let builtin_window_expr = Arc::new(BuiltInWindowExpr::new(
         Arc::new(NthValue::first(
@@ -289,11 +289,11 @@ fn roundtrip_window() -> Result<()> {
         Arc::new(WindowFrame::new(None)),
     ));
 
-    let window_frame = WindowFrame {
-        units: datafusion_expr::WindowFrameUnits::Range,
-        start_bound: WindowFrameBound::CurrentRow,
-        end_bound: WindowFrameBound::Preceding(ScalarValue::Int64(None)),
-    };
+    let window_frame = WindowFrame::try_new(
+        datafusion_expr::WindowFrameUnits::Range,
+        WindowFrameBound::CurrentRow,
+        WindowFrameBound::Preceding(ScalarValue::Int64(None)),
+    )?;
 
     let sliding_aggr_window_expr = Arc::new(SlidingAggregateWindowExpr::new(
         Arc::new(Sum::new(

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -255,11 +255,11 @@ fn roundtrip_window() -> Result<()> {
     let field_b = Field::new("b", DataType::Int64, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
 
-    let window_frame = WindowFrame::try_new(
+    let window_frame = WindowFrame::new_frame(
         datafusion_expr::WindowFrameUnits::Range,
         WindowFrameBound::Preceding(ScalarValue::Int64(None)),
         WindowFrameBound::CurrentRow,
-    )?;
+    );
 
     let builtin_window_expr = Arc::new(BuiltInWindowExpr::new(
         Arc::new(NthValue::first(
@@ -289,11 +289,11 @@ fn roundtrip_window() -> Result<()> {
         Arc::new(WindowFrame::new(None)),
     ));
 
-    let window_frame = WindowFrame::try_new(
+    let window_frame = WindowFrame::new_frame(
         datafusion_expr::WindowFrameUnits::Range,
         WindowFrameBound::CurrentRow,
         WindowFrameBound::Preceding(ScalarValue::Int64(None)),
-    )?;
+    );
 
     let sliding_aggr_window_expr = Arc::new(SlidingAggregateWindowExpr::new(
         Arc::new(Sum::new(

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -286,7 +286,7 @@ fn roundtrip_window() -> Result<()> {
         )),
         &[],
         &[],
-        Arc::new(WindowFrame::new(false)),
+        Arc::new(WindowFrame::new(None)),
     ));
 
     let window_frame = WindowFrame {

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -17,7 +17,8 @@
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{
-    not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Result,
+    not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Dependency,
+    Result,
 };
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::function::suggest_valid_function;
@@ -108,9 +109,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 if let Expr::Sort(sort_expr) = orderby_expr {
                     if let Expr::Column(col) = sort_expr.expr.as_ref() {
                         let idx = schema.index_of_column(col).unwrap();
-                        return func_deps
-                            .iter()
-                            .any(|dep| dep.source_indices == vec![idx]);
+                        return func_deps.iter().any(|dep| {
+                            dep.source_indices == vec![idx]
+                                && dep.mode == Dependency::Single
+                        });
                     }
                 }
                 false

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -132,9 +132,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 regularize_window_order_by(&window_frame, &mut order_by)?;
                 window_frame
             } else if is_ordering_stable {
-                WindowFrame::new_with_primary_key_ordering()
+                WindowFrame::new(Some(true))
             } else {
-                WindowFrame::new(!order_by.is_empty())
+                WindowFrame::new((!order_by.is_empty()).then_some(false))
             };
 
             if let Ok(fun) = self.find_window_func(&name) {

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -105,23 +105,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             )?;
 
             let func_deps = schema.functional_dependencies();
-            // Strict ordering means that there is no tie among ordering expressions.
-            // e.g after sorting final indices of all rows are determined by ordering expression.
-            // As an example for the following table:
-            // | a | b |
-            // | 0 | 0 |
-            // | 1 | 1 |
-            // | 4 | 4 |
-            // | 3 | 3 |
-            // | 2 | 3 |
-            // ordering `a ASC` determines a strict ordering after sorting original rows will be mapped as following
-            // (where first index is original index second index is index after sorting.)
-            // [0->0, 1->1, 2->4, 3->3, 4->2], and there is no other possibility.
-            //
-            // However, ordering `b ASC` doesn't determine a strict ordering; because after sorting original rows will be mapped as either
-            // [0->0, 1->1, 2->4, 3->2, 4->3] or
-            // [0->0, 1->1, 2->4, 3->3, 4->2]
-            // where both mappings are valid for the ordering `b ASC`.
+            // Find whether ties are possible in the given ordering:
             let is_ordering_strict = order_by.iter().any(|orderby_expr| {
                 if let Expr::Sort(sort_expr) = orderby_expr {
                     if let Expr::Column(col) = sort_expr.expr.as_ref() {

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -104,7 +104,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             )?;
 
             let func_deps = schema.functional_dependencies();
-            let is_ordering_deterministic = order_by.iter().any(|orderby_expr| {
+            let is_ordering_stable = order_by.iter().any(|orderby_expr| {
                 if let Expr::Sort(sort_expr) = orderby_expr {
                     if let Expr::Column(col) = sort_expr.expr.as_ref() {
                         let idx = schema.index_of_column(col).unwrap();
@@ -129,7 +129,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             let window_frame = if let Some(window_frame) = window_frame {
                 regularize_window_order_by(&window_frame, &mut order_by)?;
                 window_frame
-            } else if is_ordering_deterministic {
+            } else if is_ordering_stable {
                 WindowFrame::new_with_primary_key_ordering()
             } else {
                 WindowFrame::new(!order_by.is_empty())

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3886,17 +3886,16 @@ CREATE TABLE table_with_pk (
           (3, '2022-01-02 12:00:00'::timestamp, 'EUR', 200.0),
           (4, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0)
 
-# Over clauses in the form `OVER(ORDER BY <expr>)` gets treated as
-# `OVER(ORDER BY <expr> RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`
-# However, if we know that <expr> contains a unique column (such as PRIMARY KEY)
-# it can be treated as `OVER(ORDER BY <expr> ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`
-# where window frame units change from `RANGE` to `ROWS`.
-# At the same time this conversion means conversion from "non-causal" window frame to "causal" one.
-# (See window frame documentation what "causal" means in this context.)
-# Query below should have `ROWS` in its window frame.
+# An OVER clause of the form `OVER (ORDER BY <expr>)` gets treated as if it was
+# `OVER (ORDER BY <expr> RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`.
+# However, if we know that <expr> contains a unique column (e.g. a PRIMARY KEY),
+# it can be treated as `OVER (ORDER BY <expr> ROWS BETWEEN UNBOUNDED PRECEDING
+# AND CURRENT ROW)` where window frame units change from `RANGE` to `ROWS`. This
+# conversion makes the window frame manifestly causal by eliminating the possiblity
+# of ties explicitly (see window frame documentation for a discussion of causality
+# in this context). The Query below should have `ROWS` in its window frame.
 query TT
-EXPLAIN SELECT *, SUM(amount) OVER(ORDER BY sn) as sum1
-FROM table_with_pk;
+EXPLAIN SELECT *, SUM(amount) OVER (ORDER BY sn) as sum1 FROM table_with_pk;
 ----
 logical_plan
 Projection: table_with_pk.sn, table_with_pk.ts, table_with_pk.currency, table_with_pk.amount, SUM(table_with_pk.amount) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW AS sum1

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3886,6 +3886,14 @@ CREATE TABLE table_with_pk (
           (3, '2022-01-02 12:00:00'::timestamp, 'EUR', 200.0),
           (4, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0)
 
+# Over clauses in the form `OVER(ORDER BY <expr>)` gets treated as
+# `OVER(ORDER BY <expr> RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`
+# However, if we know that <expr> contains a unique column (such as PRIMARY KEY)
+# it can be treated as `OVER(ORDER BY <expr> ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`
+# where window frame units change from `RANGE` to `ROWS`.
+# At the same time this conversion means conversion from "non-causal" window frame to "causal" one.
+# (See window frame documentation what "causal" means in this context.)
+# Query below should have `ROWS` in its window frame.
 query TT
 EXPLAIN SELECT *, SUM(amount) OVER(ORDER BY sn) as sum1
 FROM table_with_pk;

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3871,3 +3871,31 @@ FROM (SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c1) as rn
     LIMIT 5)
 GROUP BY rn
 ORDER BY rn;
+
+# create a table for testing
+statement ok
+CREATE TABLE table_with_pk (
+          sn INT PRIMARY KEY,
+          ts TIMESTAMP,
+          currency VARCHAR(3),
+          amount FLOAT
+        ) as VALUES
+          (0, '2022-01-01 06:00:00'::timestamp, 'EUR', 30.0),
+          (1, '2022-01-01 08:00:00'::timestamp, 'EUR', 50.0),
+          (2, '2022-01-01 11:30:00'::timestamp, 'TRY', 75.0),
+          (3, '2022-01-02 12:00:00'::timestamp, 'EUR', 200.0),
+          (4, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0)
+
+query TT
+EXPLAIN SELECT *, SUM(amount) OVER(ORDER BY sn) as sum1
+FROM table_with_pk;
+----
+logical_plan
+Projection: table_with_pk.sn, table_with_pk.ts, table_with_pk.currency, table_with_pk.amount, SUM(table_with_pk.amount) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW AS sum1
+--WindowAggr: windowExpr=[[SUM(CAST(table_with_pk.amount AS Float64)) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+----TableScan: table_with_pk projection=[sn, ts, currency, amount]
+physical_plan
+ProjectionExec: expr=[sn@0 as sn, ts@1 as ts, currency@2 as currency, amount@3 as amount, SUM(table_with_pk.amount) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@4 as sum1]
+--BoundedWindowAggExec: wdw=[SUM(table_with_pk.amount) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "SUM(table_with_pk.amount) ORDER BY [table_with_pk.sn ASC NULLS LAST] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Rows, start_bound: Preceding(UInt64(NULL)), end_bound: CurrentRow }], mode=[Sorted]
+----SortExec: expr=[sn@0 ASC NULLS LAST]
+------MemoryExec: partitions=1, partition_sizes=[1]

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -973,11 +973,11 @@ pub async fn from_substrait_rex(
                 )
                 .await?,
                 order_by,
-                window_frame: datafusion::logical_expr::WindowFrame::try_new(
+                window_frame: datafusion::logical_expr::WindowFrame::new_frame(
                     units,
                     from_substrait_bound(&window.lower_bound, true)?,
                     from_substrait_bound(&window.upper_bound, false)?,
-                )?,
+                ),
             })))
         }
         Some(RexType::Subquery(subquery)) => match &subquery.as_ref().subquery_type {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -973,11 +973,11 @@ pub async fn from_substrait_rex(
                 )
                 .await?,
                 order_by,
-                window_frame: datafusion::logical_expr::WindowFrame {
+                window_frame: datafusion::logical_expr::WindowFrame::try_new(
                     units,
-                    start_bound: from_substrait_bound(&window.lower_bound, true)?,
-                    end_bound: from_substrait_bound(&window.upper_bound, false)?,
-                },
+                    from_substrait_bound(&window.lower_bound, true)?,
+                    from_substrait_bound(&window.upper_bound, false)?,
+                )?,
             })))
         }
         Some(RexType::Subquery(subquery)) => match &subquery.as_ref().subquery_type {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -973,7 +973,7 @@ pub async fn from_substrait_rex(
                 )
                 .await?,
                 order_by,
-                window_frame: datafusion::logical_expr::WindowFrame::new_frame(
+                window_frame: datafusion::logical_expr::WindowFrame::new_bounds(
                     units,
                     from_substrait_bound(&window.lower_bound, true)?,
                     from_substrait_bound(&window.upper_bound, false)?,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
In streaming execution, window functions generate result when frame end is smaller than batch size (This guarantees that future rows may not extend up the current window frame). However, for causal window frame (e.g window frame that doesn't include future rows than the current row). We can generate results even if frame end is same with batch size. 

With this support we can decrease latency for causal queries.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR adds support for causality analysis for window frame to decrease latency and memory during generating window function results.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
