### PR TITLE
Disable Parallel Parquet Writer by Default, Improve Writing Test Coverage

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -385,7 +385,7 @@ config_namespace! {
         /// parquet files by serializing them in parallel. Each column
         /// in each row group in each output file are serialized in parallel
         /// leveraging a maximum possible core count of n_files*n_row_groups*n_columns.
-        pub allow_single_file_parallelism: bool, default = true
+        pub allow_single_file_parallelism: bool, default = false
 
         /// By default parallel parquet writer is tuned for minimum
         /// memory usage in a streaming execution plan. You may see

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -19,6 +19,9 @@
 statement ok
 create table source_table(col1 integer, col2 varchar) as values (1, 'Foo'), (2, 'Bar');
 
+statement ok
+create table source_table_nested as values (struct ('foo', 1)), (struct('bar', 2));
+
 # Copy to directory as multiple files
 query IT
 COPY source_table TO 'test_files/scratch/copy/table' (format parquet, single_file_output false, compression 'zstd(10)');
@@ -63,6 +66,22 @@ select * from validate_parquet;
 2 Bar
 1 Foo
 2 Bar
+
+query ?
+COPY (select * from source_table_nested) to 'test_files/scratch/copy/table_nested' (format parquet, single_file_output false);
+----
+2
+
+# validate multiple parquet file output
+statement ok
+CREATE EXTERNAL TABLE validate_parquet_nested STORED AS PARQUET LOCATION 'test_files/scratch/copy/table_nested/';
+
+query ?
+select * from validate_parquet_nested;
+----
+{c0: foo, c1: 1}
+{c0: bar, c1: 2}
+
 
 # Copy parquet with all supported statment overrides
 query IT


### PR DESCRIPTION
## Which issue does this PR close?

Related to #8853 and #8851

## Rationale for this change

A number of issues were recently brought up related to the parallel parquet writer. Most appear to be related to how nested types are being handled. It is not immediately obvious where the flaw is related to handling nested types.

## What changes are included in this PR?

Disables parallel writing by default. Adds tests to `copy.slt` that cover the failure cases.

## Are these changes tested?

Yes

## Are there any user-facing changes?

Potentially fewer cores will be used by default when writing parquet files.
