### PR TITLE
Add "Extended" clickbench queries

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -74,6 +74,7 @@ parquet:                Benchmark of parquet reader's filtering speed
 sort:                   Benchmark of sorting speed
 clickbench_1:           ClickBench queries against a single parquet file
 clickbench_partitioned: ClickBench queries against a partitioned (100 files) parquet
+clickbench_extended:    ClickBench "inspired" queries against a single parquet (DataFusion specific)
 
 **********
 * Supported Configuration (Environment Variables)
@@ -155,6 +156,9 @@ main() {
                 clickbench_partitioned)
                     data_clickbench_partitioned
                     ;;
+                clickbench_extended)
+                    data_clickbench_1
+                    ;;
                 *)
                     echo "Error: unknown benchmark '$BENCHMARK' for data generation"
                     usage
@@ -193,6 +197,7 @@ main() {
                     run_sort
                     run_clickbench_1
                     run_clickbench_partitioned
+                    run_clickbench_extended
                     ;;
                 tpch)
                     run_tpch "1"
@@ -217,6 +222,9 @@ main() {
                     ;;
                 clickbench_partitioned)
                     run_clickbench_partitioned
+                    ;;
+                clickbench_extended)
+                    run_clickbench_extended
                     ;;
                 *)
                     echo "Error: unknown benchmark '$BENCHMARK' for run"
@@ -400,6 +408,15 @@ run_clickbench_partitioned() {
     echo "Running clickbench (partitioned, 100 files) benchmark..."
     $CARGO_COMMAND --bin dfbench -- clickbench  --iterations 5 --path "${DATA_DIR}/hits_partitioned" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o ${RESULTS_FILE}
 }
+
+# Runs the clickbench "extended" benchmark with a single large parquet file
+run_clickbench_extended() {
+    RESULTS_FILE="${RESULTS_DIR}/clickbench_extended.json"
+    echo "RESULTS_FILE: ${RESULTS_FILE}"
+    echo "Running clickbench (1 file) extended benchmark..."
+    $CARGO_COMMAND --bin dfbench -- clickbench  --iterations 5 --path "${DATA_DIR}/hits.parquet" --queries-path "${SCRIPT_DIR}/queries/clickbench/extended.sql" -o ${RESULTS_FILE}
+}
+
 
 compare_benchmarks() {
     BASE_RESULTS_DIR="${SCRIPT_DIR}/results"

--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -1,0 +1,33 @@
+# ClickBench queries
+
+This directory contains queries for the ClickBench benchmark https://benchmark.clickhouse.com/
+
+ClickBench is focused on aggregation and filtering performance (though it has no Joins)
+
+## Files:
+* `queries.sql` - Actual ClickBench queries, downloaded from the [ClickBench repository]
+* `extended.sql` - "Extended" DataFusion specific queries. 
+
+[ClickBench repository]: https://github.com/ClickHouse/ClickBench/blob/main/datafusion/queries.sql
+
+## "Extended" Queries 
+The "extended" queries are not part of the official ClickBench benchmark. 
+Instead they are used to test other DataFusion features that are not 
+covered by the standard benchmark
+
+Each description below is for the corresponding line in `extended.sql` (line 1
+is `Q0`, line 2 is `Q1`, etc.)  
+
+### Q0
+Models initial Data exploration, to understand some statistics of data. 
+Import Query Properties: multiple `COUNT DISTINCT` on strings
+
+```sql
+SELECT 
+    COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") 
+FROM hits;
+```
+
+
+
+

--- a/benchmarks/queries/clickbench/README.txt
+++ b/benchmarks/queries/clickbench/README.txt
@@ -1,1 +1,0 @@
-Downloaded from https://github.com/ClickHouse/ClickBench/blob/main/datafusion/queries.sql

--- a/benchmarks/queries/clickbench/extended.sql
+++ b/benchmarks/queries/clickbench/extended.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8860

## Rationale for this change

I would like to have benchmarks that allow us to show improvements such as https://github.com/apache/arrow-datafusion/pull/8827 and https://github.com/apache/arrow-datafusion/pull/8849 are significant 

## What changes are included in this PR?
Add new "Extended" datafusion specific clickbench queries:

to run:
```shell
./benchmarks/bench.sh run clickbench_extended
```

Example:
```
***************************
DataFusion Benchmark Script
COMMAND: run
BENCHMARK: clickbench_extended
DATAFUSION_DIR: /Users/andrewlamb/Software/arrow-datafusion/benchmarks/..
BRACH_NAME: alamb_clickbench_extended
DATA_DIR: /Users/andrewlamb/Software/arrow-datafusion/benchmarks/data
RESULTS_DIR: /Users/andrewlamb/Software/arrow-datafusion/benchmarks/results/alamb_clickbench_extended
CARGO_COMMAND: cargo run --profile release-nonlto
***************************
RESULTS_FILE: /Users/andrewlamb/Software/arrow-datafusion/benchmarks/results/alamb_clickbench_extended/clickbench_extended.json
Running clickbench (1 file) extended benchmark...
   Compiling datafusion-benchmarks v34.0.0 (/Users/andrewlamb/Software/arrow-datafusion/benchmarks)
     Running `/Users/andrewlamb/Software/arrow-datafusion/target/release-nonlto/dfbench clickbench --iterations 5 --path /Users/andrewlamb/Software/ar
row-datafusion/benchmarks/data/hits.parquet --queries-path /Users/andrewlamb/Software/arrow-datafusion/benchmarks/queries/clickbench/extended.sql -o /Users/andrewlamb/Software/arrow-datafusion/benchmarks/results/alamb_clickbench_extended/clickbench_extended.json`
Running benchmarks with the following options: RunOpt { query: None, common: CommonOpt { iterations: 5, partitions: None, batch_size: 8192, debug: false }, path: "/Users/andrewlamb/Software/arrow-datafusion/benchmarks/data/hits.parquet", queries_path: "/Users/andrewlamb/Software/arrow-datafusion/benchmarks/queries/clickbench/extended.sql", output_path: Some("/Users/andrewlamb/Software/arrow-datafusion/benchmarks/results/alamb_clickbench_extended/clickbench_extended.json") }
Q0: SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;
Query 0 iteration 0 took 5614.0 ms and returned 1 rows
Query 0 iteration 1 took 5652.6 ms and returned 1 rows
Query 0 iteration 2 took 5554.3 ms and returned 1 rows
Query 0 iteration 3 took 5511.4 ms and returned 1 rows
Query 0 iteration 4 took 5554.3 ms and returned 1 rows
Done
```

## Are these changes tested?
I tested this (and clickbench_1) manually 

## Are there any user-facing changes?
this is a development tool only 