### PR TITLE
refactor: rename FileStream.file_reader to file_opener & update doc

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -83,11 +83,9 @@ pub struct FileStream<F: FileOpener> {
     projected_schema: SchemaRef,
     /// The remaining number of records to parse, None if no limit
     remain: Option<usize>,
-    /// A closure that takes a reader and an optional remaining number of lines
-    /// (before reaching the limit) and returns a batch iterator. If the file reader
-    /// is not capable of limiting the number of records in the last batch, the file
-    /// stream will take care of truncating it.
-    file_reader: F,
+    /// A generic [`FileOpener`]. Calling `open()` returns a [`FileOpenFuture`],
+    /// which can be resolved to a stream of `RecordBatch`.
+    file_opener: F,
     /// The partition column projector
     pc_projector: PartitionColumnProjector,
     /// The stream state
@@ -250,7 +248,7 @@ impl<F: FileOpener> FileStream<F> {
     pub fn new(
         config: &FileScanConfig,
         partition: usize,
-        file_reader: F,
+        file_opener: F,
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
         let (projected_schema, ..) = config.project();
@@ -269,7 +267,7 @@ impl<F: FileOpener> FileStream<F> {
             file_iter: files.into(),
             projected_schema,
             remain: config.limit,
-            file_reader,
+            file_opener,
             pc_projector,
             state: FileStreamState::Idle,
             file_stream_metrics: FileStreamMetrics::new(metrics, partition),
@@ -301,7 +299,7 @@ impl<F: FileOpener> FileStream<F> {
         };
 
         Some(
-            self.file_reader
+            self.file_opener
                 .open(file_meta)
                 .map(|future| (future, part_file.partition_values)),
         )


### PR DESCRIPTION
## Which issue does this PR close?

Can be seen as a fix to #2990.

## Rationale for this change

The `FileStream.file_reader` field is a generic type that implements the `FileOpener` trait, so it is kinda confusing to call it `file_reader` rather than `file_opener`.

#2291 tried to do some naming refactoring to this file, but it seems that @tustvold forgot to update this field name I guess?

And that doc comment was added in #1138, which is quite old and outdated.

## What changes are included in this PR?

1. rename `FileStream.file_reader` to `FileStream.file_opener`.
2. Update the doc for this field.

## Are these changes tested?

No

## Are there any user-facing changes?

This field is private so I guess no.