### PR TITLE
Minor: Document third argument of `date_bin` as optional and default value

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1350,7 +1350,6 @@ date_bin(interval, expression, origin-timestamp)
 - **origin-timestamp**: Optional. Starting point used to determine bin boundaries. If not specified
   defaults `1970-01-01T00:00:00Z` (the UNIX epoch in UTC).
 
-
 The following intervals are supported:
 
 - nanoseconds

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1347,7 +1347,9 @@ date_bin(interval, expression, origin-timestamp)
 - **interval**: Bin interval.
 - **expression**: Time expression to operate on.
   Can be a constant, column, or function.
-- **timestamp**: Starting point used to determine bin boundaries.
+- **origin-timestamp**: Optional. Starting point used to determine bin boundaries. If not specified
+  defaults `1970-01-01T00:00:00Z` (the UNIX epoch in UTC).
+
 
 The following intervals are supported:
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A
## Rationale for this change
@mhilton  noticed this as part of an internal discussion where we were confused about the output values of `date_bin` for timestamps with timezones (as the default argument is for the unix EPOCH in UTC)

The default is defined here: https://github.com/apache/arrow-datafusion/blob/3a9e23d138c935ffea68408899016c9323aa0f36/datafusion/physical-expr/src/datetime_expressions.rs#L534C1-L538

## What changes are included in this PR?

Document the third parameter to `date_bin` better

## Are these changes tested?
existing tests


## Are there any user-facing changes?
Better [documentation](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#date-bin)