### PR TITLE
aggregate_statistics should only optimize MIN/MAX when relation is not empty

### DIFF
--- a/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
@@ -197,17 +197,28 @@ fn take_optimizable_min(
     agg_expr: &dyn AggregateExpr,
     stats: &Statistics,
 ) -> Option<(ScalarValue, String)> {
-    let col_stats = &stats.column_statistics;
-    if let Some(casted_expr) = agg_expr.as_any().downcast_ref::<expressions::Min>() {
-        if casted_expr.expressions().len() == 1 {
-            // TODO optimize with exprs other than Column
-            if let Some(col_expr) = casted_expr.expressions()[0]
-                .as_any()
-                .downcast_ref::<expressions::Column>()
+    if let Precision::Exact(num_rows) = &stats.num_rows {
+        if *num_rows > 0 {
+            let col_stats = &stats.column_statistics;
+            if let Some(casted_expr) =
+                agg_expr.as_any().downcast_ref::<expressions::Min>()
             {
-                if let Precision::Exact(val) = &col_stats[col_expr.index()].min_value {
-                    if !val.is_null() {
-                        return Some((val.clone(), casted_expr.name().to_string()));
+                if casted_expr.expressions().len() == 1 {
+                    // TODO optimize with exprs other than Column
+                    if let Some(col_expr) = casted_expr.expressions()[0]
+                        .as_any()
+                        .downcast_ref::<expressions::Column>()
+                    {
+                        if let Precision::Exact(val) =
+                            &col_stats[col_expr.index()].min_value
+                        {
+                            if !val.is_null() {
+                                return Some((
+                                    val.clone(),
+                                    casted_expr.name().to_string(),
+                                ));
+                            }
+                        }
                     }
                 }
             }
@@ -221,17 +232,28 @@ fn take_optimizable_max(
     agg_expr: &dyn AggregateExpr,
     stats: &Statistics,
 ) -> Option<(ScalarValue, String)> {
-    let col_stats = &stats.column_statistics;
-    if let Some(casted_expr) = agg_expr.as_any().downcast_ref::<expressions::Max>() {
-        if casted_expr.expressions().len() == 1 {
-            // TODO optimize with exprs other than Column
-            if let Some(col_expr) = casted_expr.expressions()[0]
-                .as_any()
-                .downcast_ref::<expressions::Column>()
+    if let Precision::Exact(num_rows) = &stats.num_rows {
+        if *num_rows > 0 {
+            let col_stats = &stats.column_statistics;
+            if let Some(casted_expr) =
+                agg_expr.as_any().downcast_ref::<expressions::Max>()
             {
-                if let Precision::Exact(val) = &col_stats[col_expr.index()].max_value {
-                    if !val.is_null() {
-                        return Some((val.clone(), casted_expr.name().to_string()));
+                if casted_expr.expressions().len() == 1 {
+                    // TODO optimize with exprs other than Column
+                    if let Some(col_expr) = casted_expr.expressions()[0]
+                        .as_any()
+                        .downcast_ref::<expressions::Column>()
+                    {
+                        if let Precision::Exact(val) =
+                            &col_stats[col_expr.index()].max_value
+                        {
+                            if !val.is_null() {
+                                return Some((
+                                    val.clone(),
+                                    casted_expr.name().to_string(),
+                                ));
+                            }
+                        }
                     }
                 }
             }

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3260,3 +3260,19 @@ query I
 select count(*) from (select count(*) a, count(*) b from (select 1));
 ----
 1
+
+statement ok
+CREATE TABLE empty(col0 INTEGER);
+
+query I
+SELECT MIN(col0) FROM empty WHERE col0=1;
+----
+NULL
+
+query I
+SELECT MAX(col0) FROM empty WHERE col0=1;
+----
+NULL
+
+statement ok
+DROP TABLE empty;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3261,6 +3261,8 @@ select count(*) from (select count(*) a, count(*) b from (select 1));
 ----
 1
 
+# rule `aggregate_statistics` should not optimize MIN/MAX to wrong values on empty relation
+
 statement ok
 CREATE TABLE empty(col0 INTEGER);
 
@@ -3276,3 +3278,19 @@ NULL
 
 statement ok
 DROP TABLE empty;
+
+statement ok
+CREATE TABLE t(col0 INTEGER) as VALUES(2);
+
+query I
+SELECT MIN(col0) FROM t WHERE col0=1;
+----
+NULL
+
+query I
+SELECT MAX(col0) FROM t WHERE col0=1;
+----
+NULL
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8911.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
