### PR TITLE
[CI] Fix RUSTFLAGS

### DIFF
--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -36,6 +36,5 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV  
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
-        echo "RUST_MIN_STACK=3000000" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
      

--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -36,5 +36,6 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV  
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
+        echo "RUST_MIN_STACK=3000000" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
      

--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -37,5 +37,5 @@ runs:
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
         echo "RUST_MIN_STACK=3000000" >> $GITHUB_ENV
-        echo "RUST_FLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV                                   
+        echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
      

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -285,8 +285,6 @@ jobs:
           cargo test --lib --tests --bins --features avro,json,backtrace
           cd datafusion-cli
           cargo test --lib --tests --bins --all-features
-        env:
-          RUSTFLAGS: "-C debuginfo=line-tables-only"
 
   macos:
     name: cargo test (macos)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -285,6 +285,8 @@ jobs:
           cargo test --lib --tests --bins --features avro,json,backtrace
           cd datafusion-cli
           cargo test --lib --tests --bins --all-features
+        env:
+          RUSTFLAGS: "-C debuginfo=line-tables-only"
 
   macos:
     name: cargo test (macos)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

https://github.com/apache/arrow-datafusion/commit/428973732b14055971604204bf3dcd605120b3dd sped win ci up, running at 33min:

- https://github.com/apache/arrow-datafusion/actions/runs/7433532490

Following commit https://github.com/apache/arrow-datafusion/commit/dd4263f843e093c807d63edf73a571b1ba2669b5 had runtime of 39min:

- https://github.com/apache/arrow-datafusion/actions/runs/7433765725

Subsequent runs fall around 39-42min range

Until this commit https://github.com/apache/arrow-datafusion/commit/d9a1d4261f78dfd3ead235d6b850c64e0ae9bec6 which causes runtime of 47min:

- https://github.com/apache/arrow-datafusion/actions/runs/7494637547

Subsequent runs (up to latest main) fall around 44-48min range

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix accidental regression by https://github.com/apache/arrow-datafusion/commit/d9a1d4261f78dfd3ead235d6b850c64e0ae9bec6 which named the env var incorrectly.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
