### PR TITLE
Don't error in simplify_expressions rule

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -138,28 +138,6 @@ mod tests {
         ExprSchemable, JoinType,
     };
 
-    /// A macro to assert that one string is contained within another with
-    /// a nice error message if they are not.
-    ///
-    /// Usage: `assert_contains!(actual, expected)`
-    ///
-    /// Is a macro so test error
-    /// messages are on the same line as the failure;
-    ///
-    /// Both arguments must be convertable into Strings (Into<String>)
-    macro_rules! assert_contains {
-        ($ACTUAL: expr, $EXPECTED: expr) => {
-            let actual_value: String = $ACTUAL.into();
-            let expected_value: String = $EXPECTED.into();
-            assert!(
-                actual_value.contains(&expected_value),
-                "Can not find expected in actual.\n\nExpected:\n{}\n\nActual:\n{}",
-                expected_value,
-                actual_value
-            );
-        };
-    }
-
     fn test_table_scan() -> LogicalPlan {
         let schema = Schema::new(vec![
             Field::new("a", DataType::Boolean, false),
@@ -425,18 +403,6 @@ mod tests {
         assert_optimized_plan_eq(&plan, expected)
     }
 
-    // expect optimizing will result in an error, returning the error string
-    fn get_optimized_plan_err(plan: &LogicalPlan, date_time: &DateTime<Utc>) -> String {
-        let config = OptimizerContext::new().with_query_execution_start_time(*date_time);
-        let rule = SimplifyExpressions::new();
-
-        let err = rule
-            .try_optimize(plan, &config)
-            .expect_err("expected optimization to fail");
-
-        err.to_string()
-    }
-
     fn get_optimized_plan_formatted(
         plan: &LogicalPlan,
         date_time: &DateTime<Utc>,
@@ -469,21 +435,6 @@ mod tests {
     }
 
     #[test]
-    fn to_timestamp_expr_wrong_arg() -> Result<()> {
-        let table_scan = test_table_scan();
-        let proj = vec![to_timestamp_expr("I'M NOT A TIMESTAMP")];
-        let plan = LogicalPlanBuilder::from(table_scan)
-            .project(proj)?
-            .build()?;
-
-        let expected =
-            "Error parsing timestamp from 'I'M NOT A TIMESTAMP': error parsing date";
-        let actual = get_optimized_plan_err(&plan, &Utc::now());
-        assert_contains!(actual, expected);
-        Ok(())
-    }
-
-    #[test]
     fn cast_expr() -> Result<()> {
         let table_scan = test_table_scan();
         let proj = vec![Expr::Cast(Cast::new(Box::new(lit("0")), DataType::Int32))];
@@ -495,20 +446,6 @@ mod tests {
             \n  TableScan: test";
         let actual = get_optimized_plan_formatted(&plan, &Utc::now());
         assert_eq!(expected, actual);
-        Ok(())
-    }
-
-    #[test]
-    fn cast_expr_wrong_arg() -> Result<()> {
-        let table_scan = test_table_scan();
-        let proj = vec![Expr::Cast(Cast::new(Box::new(lit("")), DataType::Int32))];
-        let plan = LogicalPlanBuilder::from(table_scan)
-            .project(proj)?
-            .build()?;
-
-        let expected = "Cannot cast string '' to value of Int32 type";
-        let actual = get_optimized_plan_err(&plan, &Utc::now());
-        assert_contains!(actual, expected);
         Ok(())
     }
 

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -148,6 +148,11 @@ impl CaseExpr {
             // Make sure we only consider rows that have not been matched yet
             let when_match = and(&when_match, &remainder)?;
 
+            // When no rows available for when clause, skip then clause
+            if when_match.true_count() == 0 {
+                continue;
+            }
+
             let then_value = self.when_then_expr[i]
                 .1
                 .evaluate_selection(batch, &when_match)?;
@@ -213,6 +218,11 @@ impl CaseExpr {
             };
             // Make sure we only consider rows that have not been matched yet
             let when_value = and(&when_value, &remainder)?;
+
+            // When no rows available for when clause, skip then clause
+            if when_value.true_count() == 0 {
+                continue;
+            }
 
             let then_value = self.when_then_expr[i]
                 .1

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -405,7 +405,7 @@ select arrow_cast([1], 'FixedSizeList(1, Int64)');
 ----
 [1]
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed
+query error
 select arrow_cast(make_array(1, 2, 3), 'FixedSizeList(4, Int64)');
 
 query ?

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -405,7 +405,7 @@ select arrow_cast([1], 'FixedSizeList(1, Int64)');
 ----
 [1]
 
-query error
+query error DataFusion error: Arrow error: Cast error: Cannot cast to FixedSizeList\(4\): value at index 0 has length 3
 select arrow_cast(make_array(1, 2, 3), 'FixedSizeList(4, Int64)');
 
 query ?

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -121,7 +121,7 @@ statement error DataFusion error: Error during planning: No function matches the
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-statement error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nThis feature is not implemented: Unsupported data type Utf8 for function abs
+statement error
 SELECT abs('foo');
 
 
@@ -293,52 +293,52 @@ select c1*0, c2*0, c3*0, c4*0, c5*0, c6*0, c7*0, c8*0 from test_non_nullable_int
 ----
 0 0 0 0 0 0 0 0
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error 
 SELECT c1/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c2/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c3/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c4/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c5/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c6/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c7/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c8/0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c1%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c2%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c3%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c4%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c5%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c6%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c7%0 FROM test_non_nullable_integer
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c8%0 FROM test_non_nullable_integer
 
 statement ok
@@ -556,10 +556,10 @@ SELECT c1*0 FROM test_non_nullable_decimal
 ----
 0
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c1/0 FROM test_non_nullable_decimal 
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nError during planning: Divide by zero
+query error
 SELECT c1%0 FROM test_non_nullable_decimal 
 
 statement ok

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -121,7 +121,7 @@ statement error DataFusion error: Error during planning: No function matches the
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-statement error
+query error DataFusion error: This feature is not implemented: Unsupported data type Utf8 for function abs
 SELECT abs('foo');
 
 
@@ -293,52 +293,52 @@ select c1*0, c2*0, c3*0, c4*0, c5*0, c6*0, c7*0, c8*0 from test_non_nullable_int
 ----
 0 0 0 0 0 0 0 0
 
-query error 
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c1/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c2/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c3/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c4/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c5/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c6/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c7/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c8/0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c1%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c2%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c3%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c4%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c5%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c6%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c7%0 FROM test_non_nullable_integer
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c8%0 FROM test_non_nullable_integer
 
 statement ok
@@ -556,10 +556,10 @@ SELECT c1*0 FROM test_non_nullable_decimal
 ----
 0
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c1/0 FROM test_non_nullable_decimal 
 
-query error
+query error DataFusion error: Arrow error: Divide by zero error
 SELECT c1%0 FROM test_non_nullable_decimal 
 
 statement ok

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1529,10 +1529,6 @@ false true
 
 query error
 SELECT not(1), not(0)
-----
-DataFusion error: Internal error: NOT 'Literal { value: Int64(1) }' can't be evaluated because the expression's type is Int64, not boolean or NULL.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
-
 
 query ?B
 SELECT null, not(null)
@@ -1541,10 +1537,6 @@ NULL NULL
 
 query error
 SELECT NOT('hi')
-----
-DataFusion error: Internal error: NOT 'Literal { value: Utf8("hi") }' can't be evaluated because the expression's type is Utf8, not boolean or NULL.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
-
 
 # test_negative_expressions()
 

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1529,6 +1529,10 @@ false true
 
 query error
 SELECT not(1), not(0)
+----
+DataFusion error: Internal error: NOT 'Literal { value: Int64(1) }' can't be evaluated because the expression's type is Int64, not boolean or NULL.
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
 
 query ?B
 SELECT null, not(null)
@@ -1537,6 +1541,10 @@ NULL NULL
 
 query error
 SELECT NOT('hi')
+----
+DataFusion error: Internal error: NOT 'Literal { value: Utf8("hi") }' can't be evaluated because the expression's type is Utf8, not boolean or NULL.
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
 
 # test_negative_expressions()
 

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1527,7 +1527,7 @@ SELECT not(true), not(false)
 ----
 false true
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nInternal error: NOT 'Literal \{ value: Int64\(1\) \}' can't be evaluated because the expression's type is Int64, not boolean or NULL
+query error
 SELECT not(1), not(0)
 
 query ?B
@@ -1535,7 +1535,7 @@ SELECT null, not(null)
 ----
 NULL NULL
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed\ncaused by\nInternal error: NOT 'Literal \{ value: Utf8\("hi"\) \}' can't be evaluated because the expression's type is Utf8, not boolean or NULL
+query error
 SELECT NOT('hi')
 
 # test_negative_expressions()

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1175,3 +1175,14 @@ SELECT y = 0 or 1 / y < 1, x = 0 or y = 0 or 1 / y < 1 / x from t;
 
 statement ok
 DROP TABLE t;
+
+query I
+SELECT CASE 1 WHEN 2 THEN 4 / 0 END;
+----
+NULL
+
+query error DataFusion error: Arrow error: Parser error: Error parsing timestamp from 'I AM NOT A TIMESTAMP': error parsing date
+SELECT to_timestamp('I AM NOT A TIMESTAMP');
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string '' to value of Int32 type
+SELECT CAST('' AS int);


### PR DESCRIPTION
## Which issue does this PR close?


Closes #8909

## Rationale for this change

see #8910 and #8909 ,

## What changes are included in this PR?

before this pr, in simplify_espression we try to fold the expression, but this can result some error, for example 
```sql
select case 1 when 2 then 4/0 end;
```
`4/0` never reach in runtime.

so in this PR, if we encounter an error during fold expression, return the origin expression, and the error will occur in runtime if it is a real error(not the short-circuit problem).

Note: this pr doesn't solve #8910 , due to #8927



## Are these changes tested?

test by existing tests

## Are there any user-facing changes?


