### PR TITLE
bug: Datafusion doesn't respect case sensitive table references

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -298,7 +298,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.apply_expr_alias(plan, alias.columns)?;
 
         LogicalPlanBuilder::from(plan)
-            .alias(self.normalizer.normalize(alias.name))?
+            .alias(TableReference::bare(self.normalizer.normalize(alias.name)))?
             .build()
     }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3130,22 +3130,6 @@ fn cte_with_column_names() {
 }
 
 #[test]
-fn cte_with_uppercase_table_alias() {
-    let sql = "WITH \
-        \"NUMBERS\" AS ( \
-            SELECT 1 as a, 2 as b, 3 as c \
-        ) \
-        SELECT * FROM \"NUMBERS\";";
-
-    let expected = "Projection: NUMBERS.a, NUMBERS.b, NUMBERS.c\
-        \n  SubqueryAlias: NUMBERS\
-        \n    Projection: Int64(1) AS a, Int64(2) AS b, Int64(3) AS c\
-        \n      EmptyRelation";
-
-    quick_test(sql, expected)
-}
-
-#[test]
 fn cte_with_column_aliases_precedence() {
     // The end result should always be what CTE specification says
     let sql = "WITH \
@@ -4290,23 +4274,6 @@ fn test_table_alias() {
         \n        Projection: person.id\
         \n          TableScan: person\
         \n      SubqueryAlias: t2\
-        \n        Projection: person.age\
-        \n          TableScan: person";
-    quick_test(sql, expected);
-
-    let sql = "select * from (\
-          (select id from person) \"T1\" \
-            CROSS JOIN \
-          (select age from person) \"T2\" \
-        ) as \"F\"";
-
-    let expected = "Projection: F.id, F.age\
-        \n  SubqueryAlias: F\
-        \n    CrossJoin:\
-        \n      SubqueryAlias: T1\
-        \n        Projection: person.id\
-        \n          TableScan: person\
-        \n      SubqueryAlias: T2\
         \n        Projection: person.age\
         \n          TableScan: person";
     quick_test(sql, expected);

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3130,6 +3130,22 @@ fn cte_with_column_names() {
 }
 
 #[test]
+fn cte_with_uppercase_table_alias() {
+    let sql = "WITH \
+        \"NUMBERS\" AS ( \
+            SELECT 1 as a, 2 as b, 3 as c \
+        ) \
+        SELECT * FROM \"NUMBERS\";";
+
+    let expected = "Projection: NUMBERS.a, NUMBERS.b, NUMBERS.c\
+        \n  SubqueryAlias: NUMBERS\
+        \n    Projection: Int64(1) AS a, Int64(2) AS b, Int64(3) AS c\
+        \n      EmptyRelation";
+
+    quick_test(sql, expected)
+}
+
+#[test]
 fn cte_with_column_aliases_precedence() {
     // The end result should always be what CTE specification says
     let sql = "WITH \
@@ -4274,6 +4290,23 @@ fn test_table_alias() {
         \n        Projection: person.id\
         \n          TableScan: person\
         \n      SubqueryAlias: t2\
+        \n        Projection: person.age\
+        \n          TableScan: person";
+    quick_test(sql, expected);
+
+    let sql = "select * from (\
+          (select id from person) \"T1\" \
+            CROSS JOIN \
+          (select age from person) \"T2\" \
+        ) as \"F\"";
+
+    let expected = "Projection: F.id, F.age\
+        \n  SubqueryAlias: F\
+        \n    CrossJoin:\
+        \n      SubqueryAlias: T1\
+        \n        Projection: person.id\
+        \n          TableScan: person\
+        \n      SubqueryAlias: T2\
         \n        Projection: person.age\
         \n          TableScan: person";
     quick_test(sql, expected);

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -24,3 +24,15 @@ query I
 WITH "T" AS (SELECT 1 a) SELECT * FROM "T"
 ----
 1
+
+query TT
+EXPLAIN WITH "NUMBERS" AS (SELECT 1 as a, 2 as b, 3 as c) SELECT * FROM "NUMBERS"
+----
+logical_plan
+Projection: NUMBERS.a, NUMBERS.b, NUMBERS.c
+--SubqueryAlias: NUMBERS
+----Projection: Int64(1) AS a, Int64(2) AS b, Int64(3) AS c
+------EmptyRelation
+physical_plan
+ProjectionExec: expr=[1 as a, 2 as b, 3 as c]
+--PlaceholderRowExec

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -21,12 +21,12 @@ select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH 
 1 1
 
 query I
-WITH "T" AS (SELECT 1 a) SELECT * FROM "T"
+WITH "T" AS (SELECT 1 a) SELECT "T".* FROM "T"
 ----
 1
 
 query TT
-EXPLAIN WITH "NUMBERS" AS (SELECT 1 as a, 2 as b, 3 as c) SELECT * FROM "NUMBERS"
+EXPLAIN WITH "NUMBERS" AS (SELECT 1 as a, 2 as b, 3 as c) SELECT "NUMBERS".* FROM "NUMBERS"
 ----
 logical_plan
 Projection: NUMBERS.a, NUMBERS.b, NUMBERS.c

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -19,3 +19,8 @@ query II
 select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH source AS (select 1 as e) SELECT * FROM source) t2
 ----
 1 1
+
+query I
+WITH "T" AS (SELECT 1 a) SELECT * FROM "T"
+----
+1

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -20,11 +20,13 @@ select * from (WITH source AS (select 1 as e) SELECT * FROM source) t1,   (WITH 
 ----
 1 1
 
+# Ensure table aliases can be case sensitive
 query I
 WITH "T" AS (SELECT 1 a) SELECT "T".* FROM "T"
 ----
 1
 
+# Ensure table aliases can be case sensitive
 query TT
 EXPLAIN WITH "NUMBERS" AS (SELECT 1 as a, 2 as b, 3 as c) SELECT "NUMBERS".* FROM "NUMBERS"
 ----

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -234,9 +234,25 @@ false true false true true false false true false true true false true true fals
 
 # select uppercase alias table
 query I
-select "T".* from (select 1 a) as "T";
+SELECT "T".* from (SELECT 1 a) AS "T"
 ----
 1
+
+# explain select uppercase alias table
+query TT
+EXPLAIN SELECT * FROM ((SELECT column1 FROM foo) "T1" CROSS JOIN (SELECT column2 FROM foo) "T2") AS "F"
+----
+logical_plan
+SubqueryAlias: F
+--CrossJoin:
+----SubqueryAlias: T1
+------TableScan: foo projection=[column1]
+----SubqueryAlias: T2
+------TableScan: foo projection=[column2]
+physical_plan
+CrossJoinExec
+--MemoryExec: partitions=1, partition_sizes=[1]
+--MemoryExec: partitions=1, partition_sizes=[1]
 
 # select NaNs
 query BBBB

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -232,6 +232,12 @@ select
 ----
 false true false true true false false true false true true false true true false false true
 
+# select uppercase alias table
+query I
+select "T".* from (select 1 a) as "T";
+----
+1
+
 # select NaNs
 query BBBB
 select (isnan('NaN'::double) AND 'NaN'::double > 0) a, (isnan('-NaN'::double) AND '-NaN'::double < 0) b, (isnan('NaN'::float) AND 'NaN'::float > 0) c, (isnan('-NaN'::float) AND '-NaN'::float < 0) d


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Table alias will process uppercase alias into lowercase. This PR will fix it.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`TableReference::parse_str` method converts uppercase to lowercase. The alias here has already undergone `normalize`, so we can directly create a TableReference as a parameter.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
