### PR TITLE
Fix clippy failures: error: use of deprecated function `functions::make_scalar_function

### DIFF
--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -559,10 +559,10 @@ pub fn create_physical_fun(
         }),
         BuiltinScalarFunction::InStr => Arc::new(|args| match args[0].data_type() {
             DataType::Utf8 => {
-                make_scalar_function(string_expressions::instr::<i32>)(args)
+                make_scalar_function_inner(string_expressions::instr::<i32>)(args)
             }
             DataType::LargeUtf8 => {
-                make_scalar_function(string_expressions::instr::<i64>)(args)
+                make_scalar_function_inner(string_expressions::instr::<i64>)(args)
             }
             other => internal_err!("Unsupported data type {other:?} for function instr"),
         }),
@@ -790,10 +790,10 @@ pub fn create_physical_fun(
         }),
         BuiltinScalarFunction::EndsWith => Arc::new(|args| match args[0].data_type() {
             DataType::Utf8 => {
-                make_scalar_function(string_expressions::ends_with::<i32>)(args)
+                make_scalar_function_inner(string_expressions::ends_with::<i32>)(args)
             }
             DataType::LargeUtf8 => {
-                make_scalar_function(string_expressions::ends_with::<i64>)(args)
+                make_scalar_function_inner(string_expressions::ends_with::<i64>)(args)
             }
             other => {
                 internal_err!("Unsupported data type {other:?} for function ends_with")


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8973

## Rationale for this change
CI checks are failing on main: https://github.com/apache/arrow-datafusion/actions/runs/7628515989/job/20779877406
```
error: use of deprecated function `functions::make_scalar_function`: Implement your function directly in terms of ColumnarValue or use `ScalarUDF` instead
   --> datafusion/physical-expr/src/functions.rs:562:17
    |
562 |                 make_scalar_function(string_expressions::instr::<i32>)(args)
    |                 ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`

```

I believe this is a logical conflict between https://github.com/apache/arrow-datafusion/pull/8862 and https://github.com/apache/arrow-datafusion/pull/8878

## What changes are included in this PR?

Fix logical conflicts
## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
