### PR TITLE
Document parallelism and thread scheduling in the architecture guide

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -350,12 +350,12 @@
 //! as a [`SendableRecordBatchStream`], which implements a pull based execution
 //! API. Calling `.next().await` will incrementally compute and return the next
 //! [`RecordBatch`]. Balanced parallelism is achieved using [Volcano style]
-//! "Exchange" operations implemented by  [`RepartitionExec`].
+//! "Exchange" operations implemented by [`RepartitionExec`].
 //!
 //! While some recent research such as [Morsel-Driven Parallelism] describes challenges
 //! with the pull style Volcano execution model on NUMA architectures, in practice DataFusion achieves
 //! similar scalability as systems that use morsel driven approach such as DuckDB.
-//! See the [DataFusion paper submitted SIGMOD] for more details.
+//! See the [DataFusion paper submitted to SIGMOD] for more details.
 //!
 //! [`execute`]: physical_plan::ExecutionPlan::execute
 //! [`SendableRecordBatchStream`]: crate::physical_plan::SendableRecordBatchStream
@@ -381,7 +381,7 @@
 //! for asynchronous network I/O, its combination of an efficient, work-stealing
 //! scheduler, first class compiler support for automatic continuation generation,
 //! and exceptional performance makes it a compelling choice for CPU intensive
-//! applications as well, as explained in more detail in [Using Rustlang’s Async Tokio
+//! applications as well. This is explained in more detail in [Using Rustlang’s Async Tokio
 //! Runtime for CPU-Bound Tasks].
 //!
 //! [Tokio]:  https://tokio.rs


### PR DESCRIPTION
## Which issue does this PR close?

Part of #7013 

## Rationale for this change

The topic of thread scheduling and why not use Rayon or morsel driven parallelism has come up several times, most recently in the Discord channel: https://discord.com/channels/885562378132000778/1166447479609376850/1198721509842235402

I would like to document what is going on so that we can refer people to the documentation when these questions inevitably arise in the future

## What changes are included in this PR?
1. Add a note on pull execution and why Datafusion doesn't implement morsel driven paralleism directly
2. Add a note about using tokio as the thread pool

## Are these changes tested?
Existing CI checks
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
More docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
