### PR TITLE
docs: fix array_position docs

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2176,7 +2176,7 @@ array_pop_back(array)
 
 ### `array_position`
 
-Returns a string with an input string repeated a specified number.
+Returns the position of the first occurrence of the specified element in the array.
 
 ```
 array_position(array, element)


### PR DESCRIPTION
## Rationale for this change

Minor doc update where it looks like the summary of `array_position` is a duplicate of `repeat`.

## What changes are included in this PR?

Small update to the markdown.

## Are these changes tested?

<img width="800" alt="image" src="https://github.com/apache/arrow-datafusion/assets/421839/ba7fe87f-95b0-4476-a84e-d72bf9170d77">

## Are there any user-facing changes?

Slight doc change.
