### PR TITLE
feat: Disable client console highlight by default

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -128,6 +128,7 @@ pub async fn exec_from_repl(
     let mut rl = Editor::new()?;
     rl.set_helper(Some(CliHelper::new(
         &ctx.task_ctx().session_config().options().sql_parser.dialect,
+        print_options.color,
     )));
     rl.load_history(".history").ok();
 

--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -38,20 +38,25 @@ use rustyline::Context;
 use rustyline::Helper;
 use rustyline::Result;
 
-use crate::highlighter::SyntaxHighlighter;
+use crate::highlighter::{NoSyntaxSyntaxHighlighter, SyntaxHighlighter};
 
 pub struct CliHelper {
     completer: FilenameCompleter,
     dialect: String,
-    highlighter: SyntaxHighlighter,
+    highlighter: Box<dyn Highlighter>,
 }
 
 impl CliHelper {
-    pub fn new(dialect: &str) -> Self {
+    pub fn new(dialect: &str, color: bool) -> Self {
+        let highlighter: Box<dyn Highlighter> = if !color {
+            Box::new(NoSyntaxSyntaxHighlighter {})
+        } else {
+            Box::new(SyntaxHighlighter::new(dialect))
+        };
         Self {
             completer: FilenameCompleter::new(),
             dialect: dialect.into(),
-            highlighter: SyntaxHighlighter::new(dialect),
+            highlighter,
         }
     }
 
@@ -102,7 +107,7 @@ impl CliHelper {
 
 impl Default for CliHelper {
     fn default() -> Self {
-        Self::new("generic")
+        Self::new("generic", false)
     }
 }
 

--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -38,7 +38,7 @@ use rustyline::Context;
 use rustyline::Helper;
 use rustyline::Result;
 
-use crate::highlighter::{NoSyntaxSyntaxHighlighter, SyntaxHighlighter};
+use crate::highlighter::{NoSyntaxHighlighter, SyntaxHighlighter};
 
 pub struct CliHelper {
     completer: FilenameCompleter,
@@ -49,7 +49,7 @@ pub struct CliHelper {
 impl CliHelper {
     pub fn new(dialect: &str, color: bool) -> Self {
         let highlighter: Box<dyn Highlighter> = if !color {
-            Box::new(NoSyntaxSyntaxHighlighter {})
+            Box::new(NoSyntaxHighlighter {})
         } else {
             Box::new(SyntaxHighlighter::new(dialect))
         };

--- a/datafusion-cli/src/highlighter.rs
+++ b/datafusion-cli/src/highlighter.rs
@@ -42,9 +42,9 @@ impl SyntaxHighlighter {
     }
 }
 
-pub struct NoSyntaxSyntaxHighlighter {}
+pub struct NoSyntaxHighlighter {}
 
-impl Highlighter for NoSyntaxSyntaxHighlighter {}
+impl Highlighter for NoSyntaxHighlighter {}
 
 impl Highlighter for SyntaxHighlighter {
     fn highlight<'l>(&self, line: &'l str, _: usize) -> Cow<'l, str> {

--- a/datafusion-cli/src/highlighter.rs
+++ b/datafusion-cli/src/highlighter.rs
@@ -30,19 +30,21 @@ use datafusion::sql::sqlparser::{
 use rustyline::highlight::Highlighter;
 
 /// The syntax highlighter.
+#[derive(Debug)]
 pub struct SyntaxHighlighter {
     dialect: Box<dyn Dialect>,
 }
 
 impl SyntaxHighlighter {
     pub fn new(dialect: &str) -> Self {
-        let dialect = match dialect_from_str(dialect) {
-            Some(dialect) => dialect,
-            None => Box::new(GenericDialect {}),
-        };
+        let dialect = dialect_from_str(dialect).unwrap_or(Box::new(GenericDialect {}));
         Self { dialect }
     }
 }
+
+pub struct NoSyntaxSyntaxHighlighter {}
+
+impl Highlighter for NoSyntaxSyntaxHighlighter {}
 
 impl Highlighter for SyntaxHighlighter {
     fn highlight<'l>(&self, line: &'l str, _: usize) -> Cow<'l, str> {

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -23,8 +23,7 @@ pub mod command;
 pub mod exec;
 pub mod functions;
 pub mod helper;
+pub mod highlighter;
 pub mod object_storage;
 pub mod print_format;
 pub mod print_options;
-
-mod highlighter;

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -136,6 +136,9 @@ struct Args {
         default_value = "40"
     )]
     maxrows: MaxRows,
+
+    #[clap(long, help = "Enables console syntax highlighting")]
+    color: bool,
 }
 
 #[tokio::main]
@@ -169,28 +172,28 @@ async fn main_inner() -> Result<()> {
         session_config = session_config.with_batch_size(batch_size);
     };
 
-    let rn_config = RuntimeConfig::new();
-    let rn_config =
+    let rt_config = RuntimeConfig::new();
+    let rt_config =
         // set memory pool size
         if let Some(memory_limit) = args.memory_limit {
             let memory_limit = extract_memory_pool_size(&memory_limit).unwrap();
             // set memory pool type
             if let Some(mem_pool_type) = args.mem_pool_type {
                 match mem_pool_type {
-                    PoolType::Greedy => rn_config
+                    PoolType::Greedy => rt_config
                         .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit))),
-                    PoolType::Fair => rn_config
+                    PoolType::Fair => rt_config
                         .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit))),
                 }
             } else {
-                rn_config
+                rt_config
                 .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
             }
         } else {
-            rn_config
+            rt_config
         };
 
-    let runtime_env = create_runtime_env(rn_config.clone())?;
+    let runtime_env = create_runtime_env(rt_config.clone())?;
 
     let mut ctx =
         SessionContext::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
@@ -207,6 +210,7 @@ async fn main_inner() -> Result<()> {
         format: args.format,
         quiet: args.quiet,
         maxrows: args.maxrows,
+        color: args.color,
     };
 
     let commands = args.command;

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -18,9 +18,11 @@
 use std::fmt::{Display, Formatter};
 use std::io::Write;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::str::FromStr;
 use std::time::Instant;
 
+use crate::highlighter::SyntaxHighlighter;
 use crate::print_format::PrintFormat;
 
 use arrow::record_batch::RecordBatch;
@@ -70,6 +72,7 @@ pub struct PrintOptions {
     pub format: PrintFormat,
     pub quiet: bool,
     pub maxrows: MaxRows,
+    pub color: bool,
 }
 
 fn get_timing_info_str(

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -18,11 +18,9 @@
 use std::fmt::{Display, Formatter};
 use std::io::Write;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::str::FromStr;
 use std::time::Instant;
 
-use crate::highlighter::SyntaxHighlighter;
 use crate::print_format::PrintFormat;
 
 use arrow::record_batch::RecordBatch;

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -112,7 +112,7 @@ OPTIONS:
             Execute the given command string(s), then exit
 
         --color
-            Enables console syntax highlighting            
+            Enables console syntax highlighting
 
     -f, --file <FILE>...
             Execute commands from file(s), then exit

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -111,6 +111,9 @@ OPTIONS:
     -c, --command <COMMAND>...
             Execute the given command string(s), then exit
 
+        --color
+            Enables console syntax highlighting            
+
     -f, --file <FILE>...
             Execute commands from file(s), then exit
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
The syntax highlight has been introduced in https://github.com/apache/arrow-datafusion/pull/8918. Thanks again @trungda 

Some users is not comfortable with new syntax highlight, so the PR makes it optional. The user can enable coloring providing color flag ```datafusion-cli --color```

For now the syntax highlight put as disabled by default, my humble vision its a little bit experimental and we may want to improve the color schema to be more smooth.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

introduced NoColor strategy and the color provider gets enabled by the ```--color``` flag

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes,  manually
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
