### PR TITLE
 Add a make_date function

### DIFF
--- a/datafusion-examples/README.md
+++ b/datafusion-examples/README.md
@@ -64,6 +64,7 @@ cargo run --example csv_sql
 - [`simple_udaf.rs`](examples/simple_udaf.rs): Define and invoke a User Defined Aggregate Function (UDAF)
 - [`advanced_udaf.rs`](examples/advanced_udaf.rs): Define and invoke a more complicated User Defined Aggregate Function (UDAF)
 - [`simple_udfw.rs`](examples/simple_udwf.rs): Define and invoke a User Defined Window Function (UDWF)
+- [`make_date.rs`](examples/make_date.rs): Examples of using the make_date function
 - [`to_timestamp.rs`](examples/to_timestamp.rs): Examples of using the to_timestamp functions
 - [`advanced_udwf.rs`](examples/advanced_udwf.rs): Define and invoke a more complicated User Defined Window Function (UDWF)
 

--- a/datafusion-examples/examples/make_date.rs
+++ b/datafusion-examples/examples/make_date.rs
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::Int32Array;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::Result;
+use datafusion::prelude::*;
+use datafusion_common::assert_contains;
+
+/// This example demonstrates how to use the make_date
+/// function in the DataFrame API as well as via sql.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // define a schema.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("y", DataType::Int32, false),
+        Field::new("m", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]));
+
+    // define data.
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![2020, 2021, 2022, 2023, 2024])),
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(Int32Array::from(vec![15, 16, 17, 18, 19])),
+        ],
+    )?;
+
+    // declare a new context. In spark API, this corresponds to a new spark SQLsession
+    let ctx = SessionContext::new();
+
+    // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
+    ctx.register_batch("t", batch)?;
+    let df = ctx.table("t").await?;
+
+    // use make_date function to convert col 'y', 'm' & 'd' to a date
+    let df = df.with_column("a", make_date(col("y"), col("m"), col("d")))?;
+    // use make_date function to convert col 'y' & 'm' with a static day to a date
+    let df = df.with_column("b", make_date(col("y"), col("m"), lit(22)))?;
+
+    let df = df.select_columns(&["a", "b"])?;
+
+    // print the results
+    df.show().await?;
+
+    // use sql to convert col 'y', 'm' & 'd' to a date
+    let df = ctx.sql("select make_date(y, m, d) from t").await?;
+
+    // print the results
+    df.show().await?;
+
+    // use sql to convert col 'y' & 'm' with a static string day to a date
+    let df = ctx.sql("select make_date(y, m, '22') from t").await?;
+
+    // print the results
+    df.show().await?;
+
+    // math expressions work
+    let df = ctx.sql("select make_date(y + 1, m, d) from t").await?;
+
+    // print the results
+    df.show().await?;
+
+    // you can cast to supported types (int, bigint, varchar) if required
+    let df = ctx
+        .sql("select make_date(2024::bigint, 01::bigint, 27::varchar(3))")
+        .await?;
+
+    // print the results
+    df.show().await?;
+
+    // arrow casts also work
+    let df = ctx
+        .sql("select make_date(arrow_cast(2024, 'Int64'), arrow_cast(1, 'Int64'), arrow_cast(27, 'Int64'))")
+        .await?;
+
+    // print the results
+    df.show().await?;
+
+    // invalid column values will result in an error
+    let result = ctx
+        .sql("select make_date(2024, null, 23)")
+        .await?
+        .collect()
+        .await;
+
+    let expected =
+        "DataFusion error: Execution error: Unable to parse date from null/empty value";
+    assert_contains!(result.unwrap_err().to_string(), expected);
+
+    // invalid date values will also result in an error
+    let result = ctx
+        .sql("select make_date(2024, 01, 32)")
+        .await?
+        .collect()
+        .await;
+
+    let expected = "Execution error: Unable to parse date from 2024, 1, 32";
+    assert_contains!(result.unwrap_err().to_string(), expected);
+
+    Ok(())
+}

--- a/datafusion-examples/examples/make_date.rs
+++ b/datafusion-examples/examples/make_date.rs
@@ -103,8 +103,7 @@ async fn main() -> Result<()> {
         .collect()
         .await;
 
-    let expected =
-        "DataFusion error: Execution error: Unable to parse date from null/empty value";
+    let expected = "Execution error: Unable to parse date from null/empty value";
     assert_contains!(result.unwrap_err().to_string(), expected);
 
     // invalid date values will also result in an error

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -295,6 +295,8 @@ pub enum BuiltinScalarFunction {
     CurrentDate,
     /// current_time
     CurrentTime,
+    /// make_date
+    MakeDate,
     /// translate
     Translate,
     /// trim
@@ -484,6 +486,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ToTimestampMicros => Volatility::Immutable,
             BuiltinScalarFunction::ToTimestampNanos => Volatility::Immutable,
             BuiltinScalarFunction::ToTimestampSeconds => Volatility::Immutable,
+            BuiltinScalarFunction::MakeDate => Volatility::Immutable,
             BuiltinScalarFunction::Translate => Volatility::Immutable,
             BuiltinScalarFunction::Trim => Volatility::Immutable,
             BuiltinScalarFunction::Upper => Volatility::Immutable,
@@ -834,6 +837,7 @@ impl BuiltinScalarFunction {
             }
             BuiltinScalarFunction::CurrentDate => Ok(Date32),
             BuiltinScalarFunction::CurrentTime => Ok(Time64(Nanosecond)),
+            BuiltinScalarFunction::MakeDate => Ok(Date32),
             BuiltinScalarFunction::Translate => {
                 utf8_to_str_type(&input_expr_types[0], "translate")
             }
@@ -1379,6 +1383,11 @@ impl BuiltinScalarFunction {
             | BuiltinScalarFunction::CurrentTime => {
                 Signature::uniform(0, vec![], self.volatility())
             }
+            BuiltinScalarFunction::MakeDate => Signature::uniform(
+                3,
+                vec![Int32, Int64, UInt32, UInt64, Utf8],
+                self.volatility(),
+            ),
             BuiltinScalarFunction::Isnan | BuiltinScalarFunction::Iszero => {
                 Signature::one_of(
                     vec![Exact(vec![Float32]), Exact(vec![Float64])],
@@ -1523,6 +1532,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Now => &["now"],
             BuiltinScalarFunction::CurrentDate => &["current_date", "today"],
             BuiltinScalarFunction::CurrentTime => &["current_time"],
+            BuiltinScalarFunction::MakeDate => &["make_date"],
             BuiltinScalarFunction::DateBin => &["date_bin"],
             BuiltinScalarFunction::DateTrunc => &["date_trunc", "datetrunc"],
             BuiltinScalarFunction::DatePart => &["date_part", "datepart"],

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -921,6 +921,7 @@ scalar_expr!(
 scalar_expr!(CurrentDate, current_date, ,"returns current UTC date as a [`DataType::Date32`] value");
 scalar_expr!(Now, now, ,"returns current timestamp in nanoseconds, using the same value for all instances of now() in same statement");
 scalar_expr!(CurrentTime, current_time, , "returns current UTC time as a [`DataType::Time64`] value");
+scalar_expr!(MakeDate, make_date, year month day, "make a date from year, month and day component parts");
 scalar_expr!(Nanvl, nanvl, x y, "returns x if x is not NaN otherwise returns y");
 scalar_expr!(
     Isnan,

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -502,7 +502,7 @@ pub fn make_current_time(
     move |_arg| Ok(ColumnarValue::Scalar(ScalarValue::Time64Nanosecond(nano)))
 }
 
-/// make_date(year, month, date) SQL function implementation
+/// make_date(year, month, day) SQL function implementation
 pub fn make_date(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     if args.len() != 3 {
         return exec_err!(

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -574,6 +574,7 @@ pub fn create_physical_fun(
                 execution_props.query_execution_start_time,
             ))
         }
+        BuiltinScalarFunction::MakeDate => Arc::new(datetime_expressions::make_date),
         BuiltinScalarFunction::ToTimestamp => {
             Arc::new(datetime_expressions::to_timestamp_invoke)
         }

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -671,6 +671,7 @@ enum ScalarFunction {
   ArrayResize = 130;
   EndsWith = 131;
   InStr = 132;
+  MakeDate = 133;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -22425,6 +22425,7 @@ impl serde::Serialize for ScalarFunction {
             Self::ArrayResize => "ArrayResize",
             Self::EndsWith => "EndsWith",
             Self::InStr => "InStr",
+            Self::MakeDate => "MakeDate",
         };
         serializer.serialize_str(variant)
     }
@@ -22569,6 +22570,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
             "ArrayResize",
             "EndsWith",
             "InStr",
+            "MakeDate",
         ];
 
         struct GeneratedVisitor;
@@ -22742,6 +22744,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
                     "ArrayResize" => Ok(ScalarFunction::ArrayResize),
                     "EndsWith" => Ok(ScalarFunction::EndsWith),
                     "InStr" => Ok(ScalarFunction::InStr),
+                    "MakeDate" => Ok(ScalarFunction::MakeDate),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2766,6 +2766,7 @@ pub enum ScalarFunction {
     ArrayResize = 130,
     EndsWith = 131,
     InStr = 132,
+    MakeDate = 133,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2907,6 +2908,7 @@ impl ScalarFunction {
             ScalarFunction::ArrayResize => "ArrayResize",
             ScalarFunction::EndsWith => "EndsWith",
             ScalarFunction::InStr => "InStr",
+            ScalarFunction::MakeDate => "MakeDate",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -3045,6 +3047,7 @@ impl ScalarFunction {
             "ArrayResize" => Some(Self::ArrayResize),
             "EndsWith" => Some(Self::EndsWith),
             "InStr" => Some(Self::InStr),
+            "MakeDate" => Some(Self::MakeDate),
             _ => None,
         }
     }

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -555,6 +555,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::Now => Self::Now,
             ScalarFunction::CurrentDate => Self::CurrentDate,
             ScalarFunction::CurrentTime => Self::CurrentTime,
+            ScalarFunction::MakeDate => Self::MakeDate,
             ScalarFunction::Uuid => Self::Uuid,
             ScalarFunction::Translate => Self::Translate,
             ScalarFunction::RegexpMatch => Self::RegexpMatch,
@@ -1699,6 +1700,16 @@ pub fn parse_expr(
                     parse_expr(&args[1], registry)?,
                 )),
                 ScalarFunction::ToHex => Ok(to_hex(parse_expr(&args[0], registry)?)),
+                ScalarFunction::MakeDate => {
+                    let args: Vec<_> = args
+                        .iter()
+                        .map(|expr| parse_expr(expr, registry))
+                        .collect::<std::result::Result<_, _>>()?;
+                    Ok(Expr::ScalarFunction(expr::ScalarFunction::new(
+                        BuiltinScalarFunction::MakeDate,
+                        args,
+                    )))
+                }
                 ScalarFunction::ToTimestamp => {
                     let args: Vec<_> = args
                         .iter()

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1550,6 +1550,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::Now => Self::Now,
             BuiltinScalarFunction::CurrentDate => Self::CurrentDate,
             BuiltinScalarFunction::CurrentTime => Self::CurrentTime,
+            BuiltinScalarFunction::MakeDate => Self::MakeDate,
             BuiltinScalarFunction::Translate => Self::Translate,
             BuiltinScalarFunction::RegexpMatch => Self::RegexpMatch,
             BuiltinScalarFunction::Coalesce => Self::Coalesce,

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2233,4 +2233,168 @@ SELECT val, ts1 - ts2 AS ts_diff FROM table_a ORDER BY ts2 - ts1
 1 0 days -1 hours 0 mins 0.000000000 secs
 2 0 days -1 hours 0 mins 0.000000000 secs
 
+##########
+## make date tests
+##########
 
+query D
+select make_date(2024, 1, 27);
+----
+2024-01-27
+
+query D
+select make_date(42, 1, 27);
+----
+0042-01-27
+
+query D
+select make_date(99, 1, 27);
+----
+0099-01-27
+
+query D
+select make_date(2024, 2, 29);
+----
+2024-02-29
+
+query D
+select make_date(10001, 1, 27);
+----
++10001-01-27
+
+query D
+select make_date('2024', '01', '27');
+----
+2024-01-27
+
+query D
+select make_date(12 + 2012, '01', '27');
+----
+2024-01-27
+
+query D
+select make_date(2024::bigint, 01::bigint, 27::bigint);
+----
+2024-01-27
+
+query D
+select make_date(arrow_cast(2024, 'Int64'), arrow_cast(1, 'Int64'), arrow_cast(27, 'Int64'));
+----
+2024-01-27
+
+query D
+select make_date(arrow_cast(2024, 'Int32'), arrow_cast(1, 'Int32'), arrow_cast(27, 'Int32'));
+----
+2024-01-27
+
+statement ok
+create table table_nums (year int, month int, day int) as values
+    (2024, 1, 23),
+    (2023, 11, 30);
+
+query D
+select make_date(t.year, t.month, t.day) from table_nums t;
+----
+2024-01-23
+2023-11-30
+
+query D
+select make_date(2021, t.month, t.day) from table_nums t;
+----
+2021-01-23
+2021-11-30
+
+query D
+select make_date(t.year, 3, t.day) from table_nums t;
+----
+2024-03-23
+2023-03-30
+
+query D
+select make_date(t.year, t.month, 4) from table_nums t;
+----
+2024-01-04
+2023-11-04
+
+query D
+select make_date('2021', t.month, t.day) from table_nums t;
+----
+2021-01-23
+2021-11-30
+
+query D
+select make_date(t.year, '3', t.day) from table_nums t;
+----
+2024-03-23
+2023-03-30
+
+query D
+select make_date(t.year, t.month, '4') from table_nums t;
+----
+2024-01-04
+2023-11-04
+
+statement ok
+insert into table_nums values (2024, null, 23);
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 0, 23
+select make_date(t.year, t.month, t.day) from table_nums t;
+
+statement ok
+drop table table_nums;
+
+statement ok
+create table table_strings (year varchar(4), month varchar(2), day varchar(2)) as values
+    ('2024', '1', '23'),
+    ('2023', '11', '30');
+
+query D
+select make_date(t.year, t.month, t.day) from table_strings t;
+----
+2024-01-23
+2023-11-30
+
+statement ok
+insert into table_strings values (2024, null, 23);
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 0, 23
+select make_date(t.year, t.month, t.day) from table_strings t;
+
+statement ok
+drop table table_strings;
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 13, 23
+select make_date(2024, 13, 23);
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 1, 32
+select make_date(2024, 01, 32);
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 0, 23
+select make_date(2024, 0, 23);
+
+query error DataFusion error: Execution error: Month value '\-1' is out of range
+select make_date(2024, -1, 23);
+
+query error DataFusion error: Execution error: Unable to parse date from 2024, 12, 0
+select make_date(2024, 12, 0);
+
+query error DataFusion error: Execution error: Day value '\-1' is out of range
+select make_date(2024, 13, -1);
+
+query error DataFusion error: Execution error: Unable to parse date from null/empty value
+select make_date(null, 1, 23);
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string '' to value of Int32 type
+select make_date('', 1, 23);
+
+query error DataFusion error: Execution error: Unable to parse date from null/empty value
+select make_date(2024, null, 23);
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string '' to value of Int32 type
+select make_date(2024, '', 27);
+
+query error DataFusion error: Execution error: Unable to parse date from null/empty value
+select make_date(2024, 1, null);
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string '' to value of Int32 type
+select make_date(2024, 1, '');

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1312,6 +1312,7 @@ regexp_replace(str, regexp, replacement, flags)
 - [datepart](#datepart)
 - [extract](#extract)
 - [today](#today)
+- [make_date](#make_date)
 - [to_timestamp](#to_timestamp)
 - [to_timestamp_millis](#to_timestamp_millis)
 - [to_timestamp_micros](#to_timestamp_micros)
@@ -1499,6 +1500,44 @@ extract(field FROM source)
 
 - **source**: Source time expression to operate on.
   Can be a constant, column, or function.
+
+### `make_date`
+
+Make a date from year/month/day component parts.
+
+```
+make_date(year, month, day)
+```
+
+#### Arguments
+
+- **year**: Year to use when making the date.
+  Can be a constant, column or function, and any combination of arithmetic operators.
+- **month**: Month to use when making the date.
+  Can be a constant, column or function, and any combination of arithmetic operators.
+- **day**: Day to use when making the date.
+  Can be a constant, column or function, and any combination of arithmetic operators.
+
+#### Example
+
+```
+❯ select make_date(2023, 1, 31);
++-------------------------------------------+
+| make_date(Int64(2023),Int64(1),Int64(31)) |
++-------------------------------------------+
+| 2023-01-31                                |
++-------------------------------------------+
+❯ select make_date('2023', '01', '31');
++-----------------------------------------------+
+| make_date(Utf8("2023"),Utf8("01"),Utf8("31")) |
++-----------------------------------------------+
+| 2023-01-31                                    |
++-----------------------------------------------+
+```
+
+Additional examples can be found [here]
+
+[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/make_date.rs
 
 ### `to_timestamp`
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9024

## Are these changes tested?

Yes, in code and sql logic tests.

## Are there any user-facing changes?

A new make_date function is available, documented in user guide with examples in the datafusion-examples module.
