### PR TITLE
Change remove from swap to shift in index map

### DIFF
--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -730,7 +730,7 @@ impl EquivalenceProperties {
             for (PhysicalSortExpr { expr, .. }, idx) in &ordered_exprs {
                 eq_properties =
                     eq_properties.add_constants(std::iter::once(expr.clone()));
-                search_indices.swap_remove(idx);
+                search_indices.shift_remove(idx);
             }
             // Add new ordered section to the state.
             result.extend(ordered_exprs);
@@ -1779,6 +1779,7 @@ mod tests {
         let col_c = &col("c", &test_schema)?;
         let col_d = &col("d", &test_schema)?;
         let col_e = &col("e", &test_schema)?;
+        let col_f = &col("f", &test_schema)?;
         let col_h = &col("h", &test_schema)?;
         // a + d
         let a_plus_d = Arc::new(BinaryExpr::new(
@@ -1795,7 +1796,7 @@ mod tests {
             descending: true,
             nulls_first: true,
         };
-        // [d ASC, h ASC] also satisfies schema.
+        // [d ASC, h DESC] also satisfies schema.
         eq_properties.add_new_orderings([vec![
             PhysicalSortExpr {
                 expr: col_d.clone(),
@@ -1835,6 +1836,17 @@ mod tests {
             (
                 vec![col_c, col_e],
                 vec![(col_c, option_asc), (col_e, option_desc)],
+            ),
+            // TEST CASE 7
+            (
+                vec![col_d, col_h, col_e, col_f, col_b],
+                vec![
+                    (col_d, option_asc),
+                    (col_e, option_desc),
+                    (col_h, option_desc),
+                    (col_f, option_asc),
+                    (col_b, option_asc),
+                ],
             ),
         ];
         for (exprs, expected) in test_cases {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
In the [#PR9034](https://github.com/apache/arrow-datafusion/pull/9034), @viirya resolved CI error, by replacing `.remove` method of `IndexMap` with `.swap_remove` (they are equal). 
However, while reviewing I thought maybe it is better to use `.shift_remove`(where relative order is preserved after removal).

As an example, assume we have the alternative valid orderings: `[d ASC, b ASC]`, `[e ASC, f ASC]`, `[d ASC, h ASC]`,
and `find_longest_permutation` is called with expressions: `d, h, e, f, b`. Conceptually any result in the following form:
`[permutation(d ASC, e DESC) + permutation(b ASC, f ASC, h DESC)]` is valid. Meaning,
following orderings:
`[d ASC, e ASC, b ASC, f ASC, h ASC]`,
`[e ASC, d ASC, b ASC, f ASC, h ASC]`,
`[d ASC, e ASC, f ASC, b ASC, h ASC]`,
...
are all valid. 

However, to not depend on any internal implementation. It is better to prefer argument ordering between permutations. e.g we want to return ordering: `[d ASC, e ASC, b ASC, f ASC, h ASC]`, for the arguments `d, h, e, f, b`.

Similarly, we want to return ordering: `[e ASC, d ASC, b ASC, f ASC, h ASC]`, for the arguments `e, d, h, f, b` to be consistent, and to be least surprising. 
Replacing `.swap_remove` with `.shift_remove` ensures this property.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
