### PR TITLE
fix issue where upper and lower functions only work correctly on ascii character 

### DIFF
--- a/datafusion/physical-expr/src/string_expressions.rs
+++ b/datafusion/physical-expr/src/string_expressions.rs
@@ -343,7 +343,7 @@ pub fn instr<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 /// Converts the string to all lower case.
 /// lower('TOM') = 'tom'
 pub fn lower(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    handle(args, |string| string.to_ascii_lowercase(), "lower")
+    handle(args, |string| string.to_lowercase(), "lower")
 }
 
 enum TrimType {
@@ -555,7 +555,7 @@ where
 /// Converts the string to all upper case.
 /// upper('tom') = 'TOM'
 pub fn upper(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    handle(args, |string| string.to_ascii_uppercase(), "upper")
+    handle(args, |string| string.to_uppercase(), "upper")
 }
 
 /// Prints random (v4) uuid values per row

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -623,9 +623,19 @@ SELECT upper('foo')
 FOO
 
 query T
-select upper(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
+SELECT upper(arrow_cast('foo', 'Dictionary(Int32, Utf8)'))
 ----
 FOO
+
+query T
+SELECT upper('árvore ação αβγ')
+----
+ÁRVORE AÇÃO ΑΒΓ
+
+query T
+SELECT upper(arrow_cast('árvore ação αβγ', 'Dictionary(Int32, Utf8)'))
+----
+ÁRVORE AÇÃO ΑΒΓ
 
 query T
 SELECT btrim('   foo  ')
@@ -671,6 +681,16 @@ query T
 SELECT lower(arrow_cast('FOObar', 'Dictionary(Int32, Utf8)'))
 ----
 foobar
+
+query T
+SELECT lower('ÁRVORE AÇÃO ΑΒΓ')
+----
+árvore ação αβγ
+
+query T
+SELECT lower(arrow_cast('ÁRVORE AÇÃO ΑΒΓ', 'Dictionary(Int32, Utf8)'))
+----
+árvore ação αβγ
 
 query T
 SELECT ltrim('   foo')


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9053

## Are these changes tested?

Yes, added sql tests with unicode characters

## Are there any user-facing changes?
No,
