### PR TITLE
Remove custom doubling strategy + add examples to `VecAllocEx`

### DIFF
--- a/datafusion/execution/src/memory_pool/proxy.rs
+++ b/datafusion/execution/src/memory_pool/proxy.rs
@@ -47,6 +47,16 @@ pub trait VecAllocExt {
     /// assert_eq!(allocated, 64); // underlying vec has space for 10 u32s
     /// assert_eq!(vec.allocated_size(), 64);
     /// ```
+    /// # Example with other allocations:
+    /// ```
+    /// # use datafusion_execution::memory_pool::proxy::VecAllocExt;
+    /// // You can use the same allocated size to track memory allocated by
+    /// // another source. For example
+    /// let mut allocated = 27;
+    /// let mut vec = Vec::new();
+    /// vec.push_accounted(1, &mut allocated); // allocates 16 bytes for vec
+    /// assert_eq!(allocated, 43); // 16 bytes for vec, 27 bytes for other
+    /// ```
     fn push_accounted(&mut self, x: Self::T, accounting: &mut usize);
 
     /// Return the amount of memory allocated by this Vec to store elements
@@ -84,6 +94,10 @@ impl<T> VecAllocExt for Vec<T> {
         if new_capacity > prev_capacty {
             // capacity changed, so we allocated more
             let bump_size = (new_capacity - prev_capacty) * std::mem::size_of::<T>();
+            // Note multiplication should never overflow because `push` would
+            // have panic'd first, but the checked_add could potentially
+            // overflow since accounting could be tracking additional values, and
+            // could be greater than what is stored in the Vec
             *accounting = (*accounting).checked_add(bump_size).expect("overflow");
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/9057

## Rationale for this change
While writing documentation as suggested by @crepererum  on https://github.com/apache/arrow-datafusion/pull/9025#discussion_r1469361209 I found that the accounting with `push_accounted` and  `allocated_size` were different and inconsistent


## What changes are included in this PR?
1. Add examples + tests
2. Remove custom doubling strategy (use the default rust Vec implementation)


## Are these changes tested?
Yes, with doc tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Allocation accounting is now different
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
