### PR TITLE
Handle invalid types for negation

### DIFF
--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -164,9 +164,7 @@ pub fn negative(
         && !is_interval(&data_type)
         && !is_timestamp(&data_type)
     {
-        Err(DataFusionError::Plan(
-            "Negation only supports numeric, interval and timestamp types".to_string(),
-        ))
+        plan_err!("Negation only supports numeric, interval and timestamp types")
     } else {
         Ok(Arc::new(NegativeExpr::new(arg)))
     }

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -30,7 +30,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::{
     type_coercion::{is_interval, is_null, is_signed_numeric, is_timestamp},
@@ -164,9 +164,9 @@ pub fn negative(
         && !is_interval(&data_type)
         && !is_timestamp(&data_type)
     {
-        internal_err!(
-            "Can't create negative physical expr for (- '{arg:?}'), the type of child expr is {data_type}, not signed numeric"
-        )
+        Err(DataFusionError::Plan(
+            "Negation only supports numeric, interval and timestamp types".to_string(),
+        ))
     } else {
         Ok(Arc::new(NegativeExpr::new(arg)))
     }
@@ -250,6 +250,28 @@ mod tests {
             )?,
             after_propagation
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_negation_valid_types() -> Result<()> {
+        let negatable_types = [
+            DataType::Int8,
+            DataType::Timestamp(TimeUnit::Second, None),
+            DataType::Interval(IntervalUnit::YearMonth),
+        ];
+        for negatable_type in negatable_types {
+            let schema = Schema::new(vec![Field::new("a", negatable_type, true)]);
+            let _expr = negative(col("a", &schema)?, &schema)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_negation_invalid_types() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
+        let expr = negative(col("a", &schema)?, &schema).unwrap_err();
+        matches!(expr, DataFusionError::Plan(_));
         Ok(())
     }
 }

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -30,7 +30,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{plan_err, DataFusionError, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::{
     type_coercion::{is_interval, is_null, is_signed_numeric, is_timestamp},

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1546,6 +1546,9 @@ SELECT null, -null
 ----
 NULL NULL
 
+query error DataFusion error: Error during planning: Negation only supports numeric, interval and timestamp types
+SELECT -'100'
+
 statement ok
 drop table test_boolean
 


### PR DESCRIPTION
## Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/9060

## Rationale for this change
For non-numeric/non-interval/non-timestamp types, we should gracefully handle and return a meaningful error message.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Handle error instead of panicking.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
added unit test + sqllogictest + manually

```
❯ select -'100';
Error during planning: Negation only supports numeric, interval and timestamp types
```

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
