### PR TITLE
Minor: reduce unwraps in datetime_expressions.rs

### DIFF
--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -556,30 +556,25 @@ pub fn make_date(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let m = u32::try_from(value_fn(&months, i)?);
         let d = u32::try_from(value_fn(&days, i)?);
 
-        if m.is_err() {
+        let Ok(m) = m else {
             return exec_err!(
                 "Month value '{:?}' is out of range",
                 value_fn(&months, i).unwrap()
             );
-        }
-        if d.is_err() {
+        };
+
+        let Ok(d) = d else {
             return exec_err!(
                 "Day value '{:?}' is out of range",
                 value_fn(&days, i).unwrap()
             );
-        }
+        };
 
-        let date = NaiveDate::from_ymd_opt(y, m.unwrap(), d.unwrap());
+        let date = NaiveDate::from_ymd_opt(y, m, d);
 
         match date {
             Some(d) => builder.append_value(d.num_days_from_ce() - unix_days_from_ce),
-            None => {
-                return exec_err!(
-                    "Unable to parse date from {y}, {}, {}",
-                    m.unwrap(),
-                    d.unwrap()
-                )
-            }
+            None => return exec_err!("Unable to parse date from {y}, {m}, {d}"),
         };
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/9040

## Rationale for this change

Implement code suggestion I had while reviewing: https://github.com/apache/arrow-datafusion/pull/9040#discussion_r1470280245

There are several other uses of `unwrap` in datetime_expressions.rs that can probably be removed for cleaner code, but I don't think it is critical. 

## What changes are included in this PR?

Minor refactor to remove some `unwrap`


## Are these changes tested?
Covered by existing tests 

## Are there any user-facing changes?
No
