### PR TITLE
Update InfluxDB links in Known Users section of documentation

### DIFF
--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -104,7 +104,7 @@ Here are some active projects using DataFusion:
 - [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) Open Source & Cloud Native Distributed Time Series Database
 - [GlareDB](https://github.com/GlareDB/glaredb) Fast SQL database for querying and analyzing distributed data.
 - [HoraeDB](https://github.com/apache/incubator-horaedb) Distributed Time-Series Database
-- [InfluxDB IOx](https://github.com/influxdata/influxdb_iox) Time Series Database
+- [InfluxDB](https://github.com/influxdata/influxdb) Time Series Database
 - [Kamu](https://github.com/kamu-data/kamu-cli/) Planet-scale streaming data pipeline
 - [LakeSoul](https://github.com/lakesoul-io/LakeSoul) Open source LakeHouse framework with native IO in Rust.
 - [Lance](https://github.com/lancedb/lance) Modern columnar data format for ML


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
The previous repository / project name of InfluxDB IOx have changed to InfluxDB 3.0, so let's update the documentation to reflect that

## What changes are included in this PR?
Update https://arrow.apache.org/datafusion/user-guide/introduction.html#known-users with correct link

## Are these changes tested?


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
