### PR TITLE
Fix update_expr for projection pushdown

### DIFF
--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -1380,16 +1380,16 @@ mod tests {
     fn test_update_projected_exprs() -> Result<()> {
         let exprs: Vec<Arc<dyn PhysicalExpr>> = vec![
             Arc::new(BinaryExpr::new(
-                Arc::new(Column::new("a", 3)),
+                Arc::new(Column::new("a", 0)),
                 Operator::Divide,
-                Arc::new(Column::new("e", 5)),
+                Arc::new(Column::new("e", 4)),
             )),
             Arc::new(CastExpr::new(
-                Arc::new(Column::new("a", 3)),
+                Arc::new(Column::new("a", 0)),
                 DataType::Float32,
                 None,
             )),
-            Arc::new(NegativeExpr::new(Arc::new(Column::new("f", 4)))),
+            Arc::new(NegativeExpr::new(Arc::new(Column::new("f", 5)))),
             Arc::new(ScalarFunctionExpr::new(
                 "scalar_expr",
                 Arc::new(|_: &[ColumnarValue]| unimplemented!("not implemented")),
@@ -1397,10 +1397,10 @@ mod tests {
                     Arc::new(BinaryExpr::new(
                         Arc::new(Column::new("b", 1)),
                         Operator::Divide,
-                        Arc::new(Column::new("c", 0)),
+                        Arc::new(Column::new("c", 2)),
                     )),
                     Arc::new(BinaryExpr::new(
-                        Arc::new(Column::new("c", 0)),
+                        Arc::new(Column::new("c", 2)),
                         Operator::Divide,
                         Arc::new(Column::new("b", 1)),
                     )),
@@ -1409,29 +1409,29 @@ mod tests {
                 None,
             )),
             Arc::new(CaseExpr::try_new(
-                Some(Arc::new(Column::new("d", 2))),
+                Some(Arc::new(Column::new("d", 3))),
                 vec![
                     (
-                        Arc::new(Column::new("a", 3)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>,
                         Arc::new(BinaryExpr::new(
-                            Arc::new(Column::new("d", 2)),
+                            Arc::new(Column::new("d", 3)),
                             Operator::Plus,
-                            Arc::new(Column::new("e", 5)),
+                            Arc::new(Column::new("e", 4)),
                         )) as Arc<dyn PhysicalExpr>,
                     ),
                     (
-                        Arc::new(Column::new("a", 3)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>,
                         Arc::new(BinaryExpr::new(
-                            Arc::new(Column::new("e", 5)),
+                            Arc::new(Column::new("e", 4)),
                             Operator::Plus,
-                            Arc::new(Column::new("d", 2)),
+                            Arc::new(Column::new("d", 3)),
                         )) as Arc<dyn PhysicalExpr>,
                     ),
                 ],
                 Some(Arc::new(BinaryExpr::new(
-                    Arc::new(Column::new("a", 3)),
+                    Arc::new(Column::new("a", 0)),
                     Operator::Modulo,
-                    Arc::new(Column::new("e", 5)),
+                    Arc::new(Column::new("e", 4)),
                 ))),
             )?),
         ];

--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -477,7 +477,7 @@ fn try_swapping_with_sort_preserving_merge(
     projection: &ProjectionExec,
     spm: &SortPreservingMergeExec,
 ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-    // If the projection does not narrow the the schema, we should not try to push it down.
+    // If the projection does not narrow the schema, we should not try to push it down.
     if projection.expr().len() >= projection.input().schema().fields().len() {
         return Ok(None);
     }
@@ -916,7 +916,9 @@ fn update_expr(
                     .find_map(|(index, (projected_expr, alias))| {
                         projected_expr.as_any().downcast_ref::<Column>().and_then(
                             |projected_column| {
-                                column.name().eq(projected_column.name()).then(|| {
+                                (column.name().eq(projected_column.name())
+                                    && column.index() == projected_column.index())
+                                .then(|| {
                                     state = RewriteState::RewrittenValid;
                                     Arc::new(Column::new(alias, index)) as _
                                 })

--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -1503,7 +1503,6 @@ mod tests {
         ];
 
         for (expr, expected_expr) in exprs.into_iter().zip(expected_exprs.into_iter()) {
-            println!("expr: {:?}", expr);
             assert!(update_expr(&expr, &projected_exprs, false)?
                 .unwrap()
                 .eq(&expected_expr));

--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -1380,16 +1380,16 @@ mod tests {
     fn test_update_projected_exprs() -> Result<()> {
         let exprs: Vec<Arc<dyn PhysicalExpr>> = vec![
             Arc::new(BinaryExpr::new(
-                Arc::new(Column::new("a", 0)),
+                Arc::new(Column::new("a", 3)),
                 Operator::Divide,
-                Arc::new(Column::new("e", 4)),
+                Arc::new(Column::new("e", 5)),
             )),
             Arc::new(CastExpr::new(
-                Arc::new(Column::new("a", 0)),
+                Arc::new(Column::new("a", 3)),
                 DataType::Float32,
                 None,
             )),
-            Arc::new(NegativeExpr::new(Arc::new(Column::new("f", 5)))),
+            Arc::new(NegativeExpr::new(Arc::new(Column::new("f", 4)))),
             Arc::new(ScalarFunctionExpr::new(
                 "scalar_expr",
                 Arc::new(|_: &[ColumnarValue]| unimplemented!("not implemented")),
@@ -1397,10 +1397,10 @@ mod tests {
                     Arc::new(BinaryExpr::new(
                         Arc::new(Column::new("b", 1)),
                         Operator::Divide,
-                        Arc::new(Column::new("c", 2)),
+                        Arc::new(Column::new("c", 0)),
                     )),
                     Arc::new(BinaryExpr::new(
-                        Arc::new(Column::new("c", 2)),
+                        Arc::new(Column::new("c", 0)),
                         Operator::Divide,
                         Arc::new(Column::new("b", 1)),
                     )),
@@ -1409,39 +1409,39 @@ mod tests {
                 None,
             )),
             Arc::new(CaseExpr::try_new(
-                Some(Arc::new(Column::new("d", 3))),
+                Some(Arc::new(Column::new("d", 2))),
                 vec![
                     (
-                        Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new("a", 3)) as Arc<dyn PhysicalExpr>,
                         Arc::new(BinaryExpr::new(
-                            Arc::new(Column::new("d", 3)),
+                            Arc::new(Column::new("d", 2)),
                             Operator::Plus,
-                            Arc::new(Column::new("e", 4)),
+                            Arc::new(Column::new("e", 5)),
                         )) as Arc<dyn PhysicalExpr>,
                     ),
                     (
-                        Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new("a", 3)) as Arc<dyn PhysicalExpr>,
                         Arc::new(BinaryExpr::new(
-                            Arc::new(Column::new("e", 4)),
+                            Arc::new(Column::new("e", 5)),
                             Operator::Plus,
-                            Arc::new(Column::new("d", 3)),
+                            Arc::new(Column::new("d", 2)),
                         )) as Arc<dyn PhysicalExpr>,
                     ),
                 ],
                 Some(Arc::new(BinaryExpr::new(
-                    Arc::new(Column::new("a", 0)),
+                    Arc::new(Column::new("a", 3)),
                     Operator::Modulo,
-                    Arc::new(Column::new("e", 4)),
+                    Arc::new(Column::new("e", 5)),
                 ))),
             )?),
         ];
         let projected_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![
-            (Arc::new(Column::new("a", 0)), "a".to_owned()),
+            (Arc::new(Column::new("a", 3)), "a".to_owned()),
             (Arc::new(Column::new("b", 1)), "b_new".to_owned()),
-            (Arc::new(Column::new("c", 2)), "c".to_owned()),
-            (Arc::new(Column::new("d", 3)), "d_new".to_owned()),
-            (Arc::new(Column::new("e", 4)), "e".to_owned()),
-            (Arc::new(Column::new("f", 5)), "f_new".to_owned()),
+            (Arc::new(Column::new("c", 0)), "c".to_owned()),
+            (Arc::new(Column::new("d", 2)), "d_new".to_owned()),
+            (Arc::new(Column::new("e", 5)), "e".to_owned()),
+            (Arc::new(Column::new("f", 4)), "f_new".to_owned()),
         ];
 
         let expected_exprs: Vec<Arc<dyn PhysicalExpr>> = vec![
@@ -1503,6 +1503,7 @@ mod tests {
         ];
 
         for (expr, expected_expr) in exprs.into_iter().zip(expected_exprs.into_iter()) {
+            println!("expr: {:?}", expr);
             assert!(update_expr(&expr, &projected_exprs, false)?
                 .unwrap()
                 .eq(&expected_expr));

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -679,3 +679,9 @@ Trevor R Jeyork
 John B Shalk
 Alice B ShuttlP
 Samanta J ShuttlP
+
+statement ok
+DROP TABLE companies
+
+statement ok
+DROP TABLE leads

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -602,14 +602,15 @@ CREATE TABLE t1(a text, b int) AS VALUES ('Alice', 50), ('Alice', 100);
 statement ok
 CREATE TABLE t2(a text, b int) AS VALUES ('Alice', 2), ('Alice', 1);
 
-# the current query results are incorrect, becuase the query was incorrectly rewritten as:
-# SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t1.b;
-# the difference is ORDER BY clause rewrite from t2.b to t1.b, it is incorrect.
-# after https://github.com/apache/arrow-datafusion/issues/8374 fixed, the correct result should be:
-# Alice 50
-# Alice 100
-# Alice 50
-# Alice 100
+# test 'ORDER BY' joined result with same column name
+query TI
+SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t1.b;
+----
+Alice 50
+Alice 50
+Alice 100
+Alice 100
+
 query TI
 SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t2.b;
 ----

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -614,8 +614,8 @@ query TI
 SELECT t1.a, t1.b FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t2.b;
 ----
 Alice 50
-Alice 50
 Alice 100
+Alice 50
 Alice 100
 
 query TITI
@@ -663,3 +663,19 @@ DROP TABLE t1;
 
 statement ok
 DROP TABLE t2;
+
+# sort by company name and then by lead name
+statement ok
+CREATE TABLE companies(name VARCHAR, employees INT) AS VALUES ('Jeyork', 150),('Shalk', 350),('ShuttlP', 75)
+
+statement ok
+CREATE TABLE leads(name VARCHAR, company VARCHAR) AS VALUES ('Alex F', 'Jeyork'),('John B', 'Shalk'),('Samanta J', 'ShuttlP'),('Trevor R', 'Jeyork'),('Alice B', 'ShuttlP')
+
+query TT
+SELECT l.* FROM leads l LEFT JOIN companies c ON c."name" = l."company" ORDER BY c."name", l."name"
+----
+Alex F Jeyork
+Trevor R Jeyork
+John B Shalk
+Alice B ShuttlP
+Samanta J ShuttlP


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9091.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`projection_pushdown` rule uses function `update_expr` to check if a plan's expressions could be updated with projection expressions. The function only checks column name so if there are columns with same name, the check will return incorrect `RewrittenValid` state. Column index should be checked too in the function `update_expr`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
