### PR TITLE
fix: issue #8838 discard extra sort when sorted element is wrapped

### DIFF
--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -33,7 +33,7 @@ use crate::sort_properties::{ExprOrdering, SortProperties};
 use crate::{
     physical_exprs_contains, LexOrdering, LexOrderingRef, LexRequirement,
     LexRequirementRef, PhysicalExpr, PhysicalExprRef, PhysicalSortExpr,
-    PhysicalSortRequirement, ScalarFunctionExpr,
+    PhysicalSortRequirement,
 };
 
 use arrow_schema::SortOptions;

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -36,7 +36,7 @@ use crate::{
     PhysicalSortRequirement, ScalarFunctionExpr,
 };
 
-use arrow_schema::{SchemaRef, SortOptions};
+use arrow_schema::SortOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 
 /// A `EquivalenceProperties` object stores useful information related to a schema.
@@ -462,32 +462,6 @@ impl EquivalenceProperties {
                         } else {
                             sort_expr.clone()
                         }
-                    } else if let Some(scalar_func_expr) =
-                        r_expr.as_any().downcast_ref::<ScalarFunctionExpr>()
-                    {
-                        //println!("monotonicity is {:?}", scalar_func_expr.monotonicity());
-                        let mut result = sort_expr.clone();
-                        if let Some(v) = scalar_func_expr.monotonicity() {
-                            if v == &[Some(true)] {
-                                if let Some(arg) = scalar_func_expr.args().first() {
-                                    //println!("arg is {:?}", arg);
-                                    if arg.eq(&sort_expr.expr)
-                                        || arg.as_any().downcast_ref::<CastExpr>().map_or(
-                                            false,
-                                            |cast_expr| {
-                                                cast_expr.expr.eq(&sort_expr.expr)
-                                            },
-                                        )
-                                    {
-                                        result = PhysicalSortExpr {
-                                            expr: r_expr,
-                                            options: sort_expr.options,
-                                        };
-                                    }
-                                }
-                            }
-                        }
-                        result
                     } else {
                         sort_expr.clone()
                     }

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -444,7 +444,7 @@ impl EquivalenceProperties {
             .map(|sort_expr| {
                 let referring_exprs: Vec<_> = matching_exprs
                     .iter()
-                    .filter(|matched| expr_refers(&matched, &sort_expr.expr))
+                    .filter(|matched| expr_refers(matched, &sort_expr.expr))
                     .cloned()
                     .collect();
                 // does not referring to any matching component, we just skip it

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -449,7 +449,6 @@ impl EquivalenceProperties {
                     .filter(|matched| expr_refers(&matched, &sort_expr.expr))
                     .cloned()
                     .collect();
-                assert!(referring_exprs.len() <= 1);
                 // does not referring to any matching component, we just skip it
                 if referring_exprs.len() == 0 {
                     sort_expr.clone()

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -501,7 +501,7 @@ impl EquivalenceProperties {
     /// with A and B, we could surely use the ordering of the original ordering, However, if the A has been changed,
     /// for example, A-> Cast(A, Int64) or any other form, it is invalid if we continue using the original ordering
     /// Since it would cause bug in dependency constructions, we should substitute the input order in order to get correct
-    /// dependency map, happen in issue 8838: https://github.com/apache/arrow-datafusion/issues/8838
+    /// dependency map, happen in issue 8838: <https://github.com/apache/arrow-datafusion/issues/8838>
     pub fn substitute_oeq_class(
         &mut self,
         exprs: &[(Arc<dyn PhysicalExpr>, String)],

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -41,7 +41,7 @@ const DEFAULT_CAST_OPTIONS: CastOptions<'static> = CastOptions {
 #[derive(Debug, Clone)]
 pub struct CastExpr {
     /// The expression to cast
-    expr: Arc<dyn PhysicalExpr>,
+    pub expr: Arc<dyn PhysicalExpr>,
     /// The data type to cast to
     cast_type: DataType,
     /// Cast options

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -15,14 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::physical_expr::down_cast_any_ref;
+use crate::sort_properties::SortProperties;
+use crate::PhysicalExpr;
 use std::any::Any;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-
-use crate::physical_expr::down_cast_any_ref;
-use crate::sort_properties::SortProperties;
-use crate::PhysicalExpr;
+use DataType::*;
 
 use arrow::compute::{can_cast_types, kernels, CastOptions};
 use arrow::datatypes::{DataType, Schema};
@@ -75,6 +75,26 @@ impl CastExpr {
     /// The cast options
     pub fn cast_options(&self) -> &CastOptions<'static> {
         &self.cast_options
+    }
+    pub fn is_bigger_cast(&self, src: DataType) -> bool {
+        if src == self.cast_type {
+            return true;
+        }
+        matches!(
+            (src, &self.cast_type),
+            (Int8, Int16 | Int32 | Int64)
+                | (Int16, Int32 | Int64)
+                | (Int32, Int64)
+                | (UInt8, UInt16 | UInt32 | UInt64)
+                | (UInt16, UInt32 | UInt64)
+                | (UInt32, UInt64)
+                | (
+                    Int8 | Int16 | Int32 | UInt8 | UInt16 | UInt32,
+                    Float32 | Float64
+                )
+                | (Int64 | UInt64, Float64)
+                | (Utf8, LargeUtf8)
+        )
     }
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -205,8 +205,7 @@ impl ExecutionPlan for ProjectionExec {
     fn equivalence_properties(&self) -> EquivalenceProperties {
         let mut equi_properties = self.input.equivalence_properties();
         equi_properties.substitute_oeq_class(&self.expr, &self.projection_mapping);
-        let res = equi_properties.project(&self.projection_mapping, self.schema());
-        res
+        equi_properties.project(&self.projection_mapping, self.schema())
     }
 
     fn with_new_children(

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -70,7 +70,6 @@ impl ProjectionExec {
         input: Arc<dyn ExecutionPlan>,
     ) -> Result<Self> {
         let input_schema = input.schema();
-
         let fields: Result<Vec<Field>> = expr
             .iter()
             .map(|(e, name)| {
@@ -94,10 +93,11 @@ impl ProjectionExec {
 
         // construct a map from the input expressions to the output expression of the Projection
         let projection_mapping = ProjectionMapping::try_new(&expr, &input_schema)?;
-        //println!("projection_mapping is {:?}", projection_mapping);
+
         let mut input_eqs = input.equivalence_properties();
-        input_eqs.substitute_oeq_class(&expr, &projection_mapping);
-        //println!("input_eqs is {:?}", input_eqs);
+
+        input_eqs.substitute_oeq_class(&expr, &projection_mapping, input_schema.clone());
+
         let project_eqs = input_eqs.project(&projection_mapping, schema.clone());
         let output_ordering = project_eqs.oeq_class().output_ordering();
 
@@ -204,7 +204,11 @@ impl ExecutionPlan for ProjectionExec {
 
     fn equivalence_properties(&self) -> EquivalenceProperties {
         let mut equi_properties = self.input.equivalence_properties();
-        equi_properties.substitute_oeq_class(&self.expr, &self.projection_mapping);
+        equi_properties.substitute_oeq_class(
+            &self.expr,
+            &self.projection_mapping,
+            self.input.schema().clone(),
+        );
         equi_properties.project(&self.projection_mapping, self.schema())
     }
 

--- a/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
+++ b/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
@@ -64,11 +64,23 @@ physical_plan
 ProjectionExec: expr=[c_customer_sk@0 as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
 --CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
 
-# test for cast different type
-query error DataFusion error: This feature is not implemented: Unsupported SQL type Custom\(ObjectName\(\[Ident \{ value: "UTF8", quote_style: None \}\]\), \[\]\)
+
+# test for cast Utf8
+query TT
 EXPLAIN
 SELECT 
-    CAST(c_customer_sk AS UTF8) AS c_customer_sk_big,
+    CAST(c_customer_sk AS STRING) AS c_customer_sk_big,
     c_current_cdemo_sk
 FROM delta_encoding_required_column
 ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;
+----
+logical_plan
+Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_current_cdemo_sk DESC NULLS FIRST
+--Projection: CAST(delta_encoding_required_column.c_customer_sk AS Utf8) AS c_customer_sk_big, delta_encoding_required_column.c_current_cdemo_sk
+----TableScan: delta_encoding_required_column projection=[c_customer_sk, c_current_cdemo_sk]
+physical_plan
+SortPreservingMergeExec: [c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
+--SortExec: expr=[c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
+----ProjectionExec: expr=[CAST(c_customer_sk@0 AS Utf8) as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
+------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false

--- a/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
+++ b/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
@@ -47,25 +47,6 @@ SortPreservingMergeExec: [c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
 ----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
 ------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
 
-# test for substitute monotonic scalar function
-query TT
-EXPLAIN
-SELECT 
-    atan(c_customer_sk) AS c_customer_sk_big,
-    c_current_cdemo_sk
-FROM delta_encoding_required_column
-ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;
-----
-logical_plan
-Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_current_cdemo_sk DESC NULLS FIRST
---Projection: atan(CAST(delta_encoding_required_column.c_customer_sk AS Float64)) AS c_customer_sk_big, delta_encoding_required_column.c_current_cdemo_sk
-----TableScan: delta_encoding_required_column projection=[c_customer_sk, c_current_cdemo_sk]
-physical_plan
-SortPreservingMergeExec: [c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
---ProjectionExec: expr=[atan(CAST(c_customer_sk@0 AS Float64)) as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
-----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
-
 # test for commom rename
 query TT
 EXPLAIN
@@ -82,3 +63,12 @@ Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_curre
 physical_plan
 ProjectionExec: expr=[c_customer_sk@0 as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
 --CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
+
+# test for cast different type
+query error DataFusion error: This feature is not implemented: Unsupported SQL type Custom\(ObjectName\(\[Ident \{ value: "UTF8", quote_style: None \}\]\), \[\]\)
+EXPLAIN
+SELECT 
+    CAST(c_customer_sk AS UTF8) AS c_customer_sk_big,
+    c_current_cdemo_sk
+FROM delta_encoding_required_column
+ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;

--- a/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
+++ b/datafusion/sqllogictest/test_files/monotonic_projection_test.slt
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# prepare the table
+statement ok
+CREATE EXTERNAL TABLE delta_encoding_required_column (
+    c_customer_sk INT NOT NULL,
+    c_current_cdemo_sk INT NOT NULL
+)
+STORED AS CSV
+WITH ORDER (
+    c_customer_sk DESC,
+    c_current_cdemo_sk DESC
+)
+LOCATION '../../testing/data/csv/aggregate_test_100.csv';
+
+# test for substitute CAST senario
+query TT
+EXPLAIN
+SELECT 
+    CAST(c_customer_sk AS BIGINT) AS c_customer_sk_big,
+    c_current_cdemo_sk
+FROM delta_encoding_required_column
+ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;
+----
+logical_plan
+Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_current_cdemo_sk DESC NULLS FIRST
+--Projection: CAST(delta_encoding_required_column.c_customer_sk AS Int64) AS c_customer_sk_big, delta_encoding_required_column.c_current_cdemo_sk
+----TableScan: delta_encoding_required_column projection=[c_customer_sk, c_current_cdemo_sk]
+physical_plan
+SortPreservingMergeExec: [c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
+--ProjectionExec: expr=[CAST(c_customer_sk@0 AS Int64) as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
+----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
+
+# test for substitute monotonic scalar function
+query TT
+EXPLAIN
+SELECT 
+    atan(c_customer_sk) AS c_customer_sk_big,
+    c_current_cdemo_sk
+FROM delta_encoding_required_column
+ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;
+----
+logical_plan
+Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_current_cdemo_sk DESC NULLS FIRST
+--Projection: atan(CAST(delta_encoding_required_column.c_customer_sk AS Float64)) AS c_customer_sk_big, delta_encoding_required_column.c_current_cdemo_sk
+----TableScan: delta_encoding_required_column projection=[c_customer_sk, c_current_cdemo_sk]
+physical_plan
+SortPreservingMergeExec: [c_customer_sk_big@0 DESC,c_current_cdemo_sk@1 DESC]
+--ProjectionExec: expr=[atan(CAST(c_customer_sk@0 AS Float64)) as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
+----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false
+
+# test for commom rename
+query TT
+EXPLAIN
+SELECT 
+    c_customer_sk AS c_customer_sk_big,
+    c_current_cdemo_sk
+FROM delta_encoding_required_column
+ORDER BY c_customer_sk_big DESC, c_current_cdemo_sk DESC;
+----
+logical_plan
+Sort: c_customer_sk_big DESC NULLS FIRST, delta_encoding_required_column.c_current_cdemo_sk DESC NULLS FIRST
+--Projection: delta_encoding_required_column.c_customer_sk AS c_customer_sk_big, delta_encoding_required_column.c_current_cdemo_sk
+----TableScan: delta_encoding_required_column projection=[c_customer_sk, c_current_cdemo_sk]
+physical_plan
+ProjectionExec: expr=[c_customer_sk@0 as c_customer_sk_big, c_current_cdemo_sk@1 as c_current_cdemo_sk]
+--CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c_customer_sk, c_current_cdemo_sk], output_ordering=[c_customer_sk@0 DESC, c_current_cdemo_sk@1 DESC], has_header=false


### PR DESCRIPTION
fix: issue #8838 discard extra sort when sorted element is wrapped


## Which issue does this PR close?
improves the state in #8838
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
In the previous design, when we wanted to construct a dependency_map, we just used the order gotten from the previous node(In this issue, when we construct ProjectionExec, we just use the ordering gotten from CsvExec), however, previous design does not support a wrapper for the existing column, In this case, when we have orderings is [a DESC, b DESC] and the projection is CAST(a as BITINT), then we should change the ordering from a to CAST(a as BITINT) in order not to generate false dependency map(In this issue, when we construct the dependency map using the original expression, we would break prematurely and lose dependencies). In order to address this, we need to substitute original expression with those monotonic new expession
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
