### PR TITLE
Fix Dockerfile min rust version to 1.72

### DIFF
--- a/datafusion-cli/Dockerfile
+++ b/datafusion-cli/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.70 as builder
+FROM rust:1.72 as builder
 
 COPY . /usr/src/arrow-datafusion
 COPY ./datafusion /usr/src/arrow-datafusion/datafusion


### PR DESCRIPTION
## Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/8743

## Rationale for this change

I didn't completely update rust versions in https://github.com/apache/arrow-datafusion/pull/8997, as pointed out by  @Omega359  https://github.com/apache/arrow-datafusion/pull/8997#issuecomment-1927094492

## What changes are included in this PR?

Update Dockerfile to use rust 1.72

## Are these changes tested?

No (it might be good to add some sort of short CI check that the rust versions are consistent)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
