### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -244,7 +244,7 @@ At this point, you can use the `smooth_it` function in your query:
 
 For example, if we have a [`cars.csv`](https://github.com/apache/arrow-datafusion/blob/main/datafusion/core/tests/data/cars.csv) whose contents like
 
-```csv
+```
 car,speed,time
 red,20.0,1996-04-12T12:05:03.000000000
 red,20.3,1996-04-12T12:05:04.000000000
@@ -279,7 +279,7 @@ df.show().await?;
 
 the output will be like:
 
-```csv
+```
 +-------+-------+--------------------+---------------------+
 | car   | speed | smooth_speed       | time                |
 +-------+-------+--------------------+---------------------+

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -583,7 +583,7 @@ For example, to set `datafusion.execution.batch_size` to `1024` you
 would set the `DATAFUSION_EXECUTION_BATCH_SIZE` environment variable
 appropriately:
 
-```SQL
+```shell
 $ DATAFUSION_EXECUTION_BATCH_SIZE=1024 datafusion-cli
 DataFusion CLI v12.0.0
 ❯ show all;
@@ -603,10 +603,9 @@ DataFusion CLI v12.0.0
 
 You can change the configuration options using `SET` statement as well
 
-```SQL
+```shell
 $ datafusion-cli
 DataFusion CLI v13.0.0
-
 ❯ show datafusion.execution.batch_size;
 +---------------------------------+---------+
 | name                            | value   |

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -198,7 +198,7 @@ You can also query directly from the remote location via HTTP(S) without
 registering the location as a table
 
 ```sql
-❯ select count(*) from 'https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_1.parquet'
+select count(*) from 'https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_1.parquet'
 +----------+
 | COUNT(*) |
 +----------+
@@ -285,7 +285,7 @@ LOCATION 'https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hit
 ```
 
 ```sql
-❯ select count(*) from hits;
+select count(*) from hits;
 +----------+
 | COUNT(*) |
 +----------+

--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -228,7 +228,7 @@ codegen-units = 1
 
 Then, in `main.rs.` update the memory allocator with the below after your imports:
 
-```rust,ignore
+```rust ,ignore
 use datafusion::prelude::*;
 
 #[global_allocator]

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -152,7 +152,7 @@ but these operators always return a `bool` which makes them not work with the ex
 Unlike to some databases the math functions in Datafusion works the same way as Rust math functions, avoiding failing on corner cases e.g
 
 ```sql
-❯ select log(-1), log(0), sqrt(-1);
+select log(-1), log(0), sqrt(-1);
 +----------------+---------------+-----------------+
 | log(Int64(-1)) | log(Int64(0)) | sqrt(Int64(-1)) |
 +----------------+---------------+-----------------+

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -29,7 +29,7 @@ You can see the corresponding Arrow type for any SQL expression using
 the `arrow_typeof` function. For example:
 
 ```sql
-❯ select arrow_typeof(interval '1 month');
+select arrow_typeof(interval '1 month');
 +-------------------------------------+
 | arrowtypeof(IntervalYearMonth("1")) |
 +-------------------------------------+
@@ -41,7 +41,7 @@ You can cast a SQL expression to a specific Arrow type using the `arrow_cast` fu
 For example, to cast the output of `now()` to a `Timestamp` with second precision:
 
 ```sql
-❯ select arrow_cast(now(), 'Timestamp(Second, None)');
+select arrow_cast(now(), 'Timestamp(Second, None)');
 +---------------------+
 | now()               |
 +---------------------+

--- a/docs/source/user-guide/sql/ddl.md
+++ b/docs/source/user-guide/sql/ddl.md
@@ -188,7 +188,7 @@ LOCATION '/path/to/aggregate_test_100.csv';
 
 Where `WITH ORDER` clause specifies the sort order:
 
-```sql
+```
 WITH ORDER (sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
          [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...])
 ```

--- a/docs/source/user-guide/sql/explain.md
+++ b/docs/source/user-guide/sql/explain.md
@@ -30,7 +30,7 @@ EXPLAIN [ANALYZE] [VERBOSE] statement
 Shows the execution plan of a statement.
 If you need more detailed output, use `EXPLAIN VERBOSE`.
 
-```sql
+```
 EXPLAIN SELECT SUM(x) FROM table GROUP BY b;
 +---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                           |
@@ -54,7 +54,7 @@ EXPLAIN SELECT SUM(x) FROM table GROUP BY b;
 Shows the execution plan and metrics of a statement.
 If you need more information output, use `EXPLAIN ANALYZE VERBOSE`.
 
-```sql
+```
 EXPLAIN ANALYZE SELECT SUM(x) FROM table GROUP BY b;
 +-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type         | plan                                                                                                                                                      |

--- a/docs/source/user-guide/sql/information_schema.md
+++ b/docs/source/user-guide/sql/information_schema.md
@@ -55,7 +55,7 @@ or
 To show the current session configuration options, use the `SHOW ALL` command or the `information_schema.df_settings` view:
 
 ```sql
-❯ select * from information_schema.df_settings;
+select * from information_schema.df_settings;
 
 +-------------------------------------------------+---------+
 | name                                            | setting |

--- a/docs/source/user-guide/sql/operators.md
+++ b/docs/source/user-guide/sql/operators.md
@@ -21,11 +21,13 @@
 
 ## Numerical Operators
 
-- [+ (plus)](#id1)
-- [- (minus)](#id2)
-- [\* (multiply)](#id3)
-- [/ (divide)](#id4)
-- [% (modulo)](#id5)
+- [+ (plus)](#op_plus)
+- [- (minus)](#op_minus)
+- [\* (multiply)](#op_multiply)
+- [/ (divide)](#op_divide)
+- [% (modulo)](#op_modulo)
+
+(op_plus)=
 
 ### `+`
 
@@ -40,6 +42,8 @@ Addition
 +---------------------+
 ```
 
+(op_minus)=
+
 ### `-`
 
 Subtraction
@@ -52,6 +56,8 @@ Subtraction
 | 1                   |
 +---------------------+
 ```
+
+(op_multiply)=
 
 ### `*`
 
@@ -66,6 +72,8 @@ Multiplication
 +---------------------+
 ```
 
+(op_divide)=
+
 ### `/`
 
 Division (integer division truncates toward zero)
@@ -78,6 +86,8 @@ Division (integer division truncates toward zero)
 | 2                   |
 +---------------------+
 ```
+
+(op_modulo)=
 
 ### `%`
 
@@ -94,18 +104,20 @@ Modulo (remainder)
 
 ## Comparison Operators
 
-- [= (equal)](#id6)
-- [!= (not equal)](#id7)
-- [< (less than)](#id8)
-- [<= (less than or equal to)](#id9)
-- [> (greater than)](#id10)
-- [>= (greater than or equal to)](#id11)
+- [= (equal)](#op_eq)
+- [!= (not equal)](#op_neq)
+- [< (less than)](#op_lt)
+- [<= (less than or equal to)](#op_le)
+- [> (greater than)](#op_gt)
+- [>= (greater than or equal to)](#op_ge)
 - [IS DISTINCT FROM](#is-distinct-from)
 - [IS NOT DISTINCT FROM](#is-not-distinct-from)
-- [~ (regex match)](#id12)
-- [~\* (regex case-insensitive match)](#id13)
-- [!~ (not regex match)](#id14)
-- [!~\* (not regex case-insensitive match)](#id15)
+- [~ (regex match)](#op_re_match)
+- [~\* (regex case-insensitive match)](#op_re_match_i)
+- [!~ (not regex match)](#op_re_not_match)
+- [!~\* (not regex case-insensitive match)](#op_re_not_match_i)
+
+(op_eq)=
 
 ### `=`
 
@@ -120,6 +132,8 @@ Equal
 +---------------------+
 ```
 
+(op_neq)=
+
 ### `!=`
 
 Not Equal
@@ -132,6 +146,8 @@ Not Equal
 | true                 |
 +----------------------+
 ```
+
+(op_lt)=
 
 ### `<`
 
@@ -146,6 +162,8 @@ Less Than
 +---------------------+
 ```
 
+(op_le)=
+
 ### `<=`
 
 Less Than or Equal To
@@ -159,6 +177,8 @@ Less Than or Equal To
 +----------------------+
 ```
 
+(op_gt)=
+
 ### `>`
 
 Greater Than
@@ -171,6 +191,8 @@ Greater Than
 | true                |
 +---------------------+
 ```
+
+(op_ge)=
 
 ### `>=`
 
@@ -211,6 +233,8 @@ The negation of `IS DISTINCT FROM`
 +--------------------------------+
 ```
 
+(op_re_match)=
+
 ### `~`
 
 Regex Match
@@ -223,6 +247,8 @@ Regex Match
 | true                                            |
 +-------------------------------------------------+
 ```
+
+(op_re_match_i)=
 
 ### `~*`
 
@@ -237,6 +263,8 @@ Regex Case-Insensitive Match
 +--------------------------------------------------+
 ```
 
+(op_re_not_match)=
+
 ### `!~`
 
 Not Regex Match
@@ -249,6 +277,8 @@ Not Regex Match
 | true                                             |
 +--------------------------------------------------+
 ```
+
+(op_re_not_match_i)=
 
 ### `!~*`
 
@@ -348,11 +378,13 @@ Logical Or
 
 ## Bitwise Operators
 
-- [& (bitwise and)](#id16)
-- [| (bitwise or)](#id17)
-- [# (bitwise xor)](#id18)
-- [>> (bitwise shift right)](#id19)
-- [<< (bitwise shift left)](#id20)
+- [& (bitwise and)](#op_bit_and)
+- [| (bitwise or)](#op_bit_or)
+- [# (bitwise xor)](#op_bit_xor)
+- [>> (bitwise shift right)](#op_shift_r)
+- [<< (bitwise shift left)](#op_shift_l)
+
+(op_bit_and)=
 
 ### `&`
 
@@ -367,6 +399,8 @@ Bitwise And
 +---------------------+
 ```
 
+(op_bit_or)=
+
 ### `|`
 
 Bitwise Or
@@ -379,6 +413,8 @@ Bitwise Or
 | 7                   |
 +---------------------+
 ```
+
+(op_bit_xor)=
 
 ### `#`
 
@@ -393,6 +429,8 @@ Bitwise Xor (interchangeable with `^`)
 +---------------------+
 ```
 
+(op_shift_r)=
+
 ### `>>`
 
 Bitwise Shift Right
@@ -405,6 +443,8 @@ Bitwise Shift Right
 | 0                    |
 +----------------------+
 ```
+
+(op_shift_l)=
 
 ### `<<`
 
@@ -421,9 +461,11 @@ Bitwise Shift Left
 
 ## Other Operators
 
-- [|| (string concatenation)](#id21)
-- [@> (array contains)](#id22)
-- [<@ (array is contained by)](#id23)
+- [|| (string concatenation)](#op_str_cat)
+- [@> (array contains)](#op_arr_contains)
+- [<@ (array is contained by)](#op_arr_contained_by)
+
+(op_str_cat)=
 
 ### `||`
 
@@ -438,6 +480,8 @@ String Concatenation
 +----------------------------------------+
 ```
 
+(op_arr_contains)=
+
 ### `@>`
 
 Array Contains
@@ -450,6 +494,8 @@ Array Contains
 | true                                                                    |
 +-------------------------------------------------------------------------+
 ```
+
+(op_arr_contained_by)=
 
 ### `<@`
 

--- a/docs/source/user-guide/sql/operators.md
+++ b/docs/source/user-guide/sql/operators.md
@@ -298,7 +298,7 @@ Not Regex Case-Insensitive Match
 Like Match
 
 ```sql
-❯ SELECT 'datafusion' ~~ 'dat_f%n';
+SELECT 'datafusion' ~~ 'dat_f%n';
 +---------------------------------------+
 | Utf8("datafusion") ~~ Utf8("dat_f%n") |
 +---------------------------------------+
@@ -311,7 +311,7 @@ Like Match
 Case-Insensitive Like Match
 
 ```sql
-❯ SELECT 'datafusion' ~~* 'Dat_F%n';
+SELECT 'datafusion' ~~* 'Dat_F%n';
 +----------------------------------------+
 | Utf8("datafusion") ~~* Utf8("Dat_F%n") |
 +----------------------------------------+
@@ -324,7 +324,7 @@ Case-Insensitive Like Match
 Not Like Match
 
 ```sql
-❯ SELECT 'datafusion' !~~ 'Dat_F%n';
+SELECT 'datafusion' !~~ 'Dat_F%n';
 +----------------------------------------+
 | Utf8("datafusion") !~~ Utf8("Dat_F%n") |
 +----------------------------------------+
@@ -337,7 +337,7 @@ Not Like Match
 Not Case-Insensitive Like Match
 
 ```sql
-❯ SELECT 'datafusion' !~~* 'Dat%F_n';
+SELECT 'datafusion' !~~* 'Dat%F_n';
 +-----------------------------------------+
 | Utf8("datafusion") !~~* Utf8("Dat%F_n") |
 +-----------------------------------------+

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1298,13 +1298,13 @@ regexp_like(str, regexp[, flags])
 #### Example
 
 ```sql
-❯ select regexp_like('Köln', '[a-zA-Z]ö[a-zA-Z]{2}');
+select regexp_like('Köln', '[a-zA-Z]ö[a-zA-Z]{2}');
 +--------------------------------------------------------+
 | regexp_like(Utf8("Köln"),Utf8("[a-zA-Z]ö[a-zA-Z]{2}")) |
 +--------------------------------------------------------+
 | true                                                   |
 +--------------------------------------------------------+
-❯ SELECT regexp_like('aBc', '(b|d)', 'i');
+SELECT regexp_like('aBc', '(b|d)', 'i');
 +--------------------------------------------------+
 | regexp_like(Utf8("aBc"),Utf8("(b|d)"),Utf8("i")) |
 +--------------------------------------------------+
@@ -1339,13 +1339,13 @@ regexp_match(str, regexp[, flags])
 #### Example
 
 ```sql
-❯ select regexp_match('Köln', '[a-zA-Z]ö[a-zA-Z]{2}');
+select regexp_match('Köln', '[a-zA-Z]ö[a-zA-Z]{2}');
 +---------------------------------------------------------+
 | regexp_match(Utf8("Köln"),Utf8("[a-zA-Z]ö[a-zA-Z]{2}")) |
 +---------------------------------------------------------+
 | [Köln]                                                  |
 +---------------------------------------------------------+
-❯ SELECT regexp_match('aBc', '(b|d)', 'i');
+SELECT regexp_match('aBc', '(b|d)', 'i');
 +---------------------------------------------------+
 | regexp_match(Utf8("aBc"),Utf8("(b|d)"),Utf8("i")) |
 +---------------------------------------------------+
@@ -1383,13 +1383,13 @@ regexp_replace(str, regexp, replacement[, flags])
 #### Example
 
 ```sql
-❯ SELECT regexp_replace('foobarbaz', 'b(..)', 'X\\1Y', 'g');
+SELECT regexp_replace('foobarbaz', 'b(..)', 'X\\1Y', 'g');
 +------------------------------------------------------------------------+
 | regexp_replace(Utf8("foobarbaz"),Utf8("b(..)"),Utf8("X\1Y"),Utf8("g")) |
 +------------------------------------------------------------------------+
 | fooXarYXazY                                                            |
 +------------------------------------------------------------------------+
-❯ SELECT regexp_replace('aBc', '(b|d)', 'Ab\\1a', 'i');
+SELECT regexp_replace('aBc', '(b|d)', 'Ab\\1a', 'i');
 +-------------------------------------------------------------------+
 | regexp_replace(Utf8("aBc"),Utf8("(b|d)"),Utf8("Ab\1a"),Utf8("i")) |
 +-------------------------------------------------------------------+
@@ -3070,8 +3070,8 @@ struct(expression1[, ..., expression_n])
 For example, this query converts two columns `a` and `b` to a single column with
 a struct type of fields `c0` and `c1`:
 
-```sql
-❯ select * from t;
+```
+select * from t;
 +---+---+
 | a | b |
 +---+---+
@@ -3079,7 +3079,7 @@ a struct type of fields `c0` and `c1`:
 | 3 | 4 |
 +---+---+
 
-❯ select struct(a, b) from t;
+select struct(a, b) from t;
 +-----------------+
 | struct(t.a,t.b) |
 +-----------------+

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2031,6 +2031,10 @@ array_concat(array[, ..., array_n])
 - list_cat
 - list_concat
 
+### `array_contains`
+
+_Alias of [array_has](#array_has)._
+
 ### `array_has`
 
 Returns true if the array contains the element

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -722,7 +722,7 @@ concat(str[, ..., str_n])
 - **str_n**: Subsequent string column or literal string to concatenate.
 
 **Related functions**:
-[contcat_ws](#contcat_ws)
+[concat_ws](#concat_ws)
 
 ### `concat_ws`
 

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1312,15 +1312,11 @@ regexp_like(str, regexp[, flags])
 +--------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs)
 
 ### `regexp_match`
 
-Returns a list of [regular expression] matches in a string.
-
-[regular expression]: https://docs.rs/regex/latest/regex/#syntax
+Returns a list of [regular expression](https://docs.rs/regex/latest/regex/#syntax) matches in a string.
 
 ```
 regexp_match(str, regexp[, flags])
@@ -1357,15 +1353,11 @@ regexp_match(str, regexp[, flags])
 +---------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs)
 
 ### `regexp_replace`
 
-Replaces substrings in a string that match a [regular expression].
-
-[regular expression]: https://docs.rs/regex/latest/regex/#syntax
+Replaces substrings in a string that match a [regular expression](https://docs.rs/regex/latest/regex/#syntax).
 
 ```
 regexp_replace(str, regexp, replacement[, flags])
@@ -1405,9 +1397,7 @@ regexp_replace(str, regexp, replacement[, flags])
 +-------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/regexp.rs)
 
 ### `position`
 
@@ -1657,9 +1647,7 @@ make_date(year, month, day)
 +-----------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/make_date.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/make_date.rs)
 
 ### `to_timestamp`
 
@@ -1704,9 +1692,7 @@ to_timestamp(expression[, ..., format_n])
 +--------------------------------------------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs)
 
 ### `to_timestamp_millis`
 
@@ -1745,9 +1731,7 @@ to_timestamp_millis(expression[, ..., format_n])
 +---------------------------------------------------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs)
 
 ### `to_timestamp_micros`
 
@@ -1786,9 +1770,7 @@ to_timestamp_micros(expression[, ..., format_n])
 +---------------------------------------------------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs)
 
 ### `to_timestamp_nanos`
 
@@ -1827,9 +1809,7 @@ to_timestamp_nanos(expression[, ..., format_n])
 +---------------------------------------------------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs)
 
 ### `to_timestamp_seconds`
 
@@ -1868,9 +1848,7 @@ to_timestamp_seconds(expression[, ..., format_n])
 +----------------------------------------------------------------------------------------------------------------+
 ```
 
-Additional examples can be found [here]
-
-[here]: https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs
+Additional examples can be found [here](https://github.com/apache/arrow-datafusion/blob/main/datafusion-examples/examples/to_timestamp.rs)
 
 ### `from_unixtime`
 

--- a/docs/source/user-guide/sql/select.md
+++ b/docs/source/user-guide/sql/select.md
@@ -102,7 +102,7 @@ select * from x;
 The keywords `JOIN` or `INNER JOIN` define a join that only shows rows where there is a match in both tables.
 
 ```sql
-❯ select * from x inner join x y ON x.column_1 = y.column_1;
+select * from x inner join x y ON x.column_1 = y.column_1;
 +----------+----------+----------+----------+
 | column_1 | column_2 | column_1 | column_2 |
 +----------+----------+----------+----------+
@@ -116,7 +116,7 @@ The keywords `LEFT JOIN` or `LEFT OUTER JOIN` define a join that includes all ro
 is not a match in the right table. When there is no match, null values are produced for the right side of the join.
 
 ```sql
-❯ select * from x left join x y ON x.column_1 = y.column_2;
+select * from x left join x y ON x.column_1 = y.column_2;
 +----------+----------+----------+----------+
 | column_1 | column_2 | column_1 | column_2 |
 +----------+----------+----------+----------+
@@ -130,7 +130,7 @@ The keywords `RIGHT JOIN` or `RIGHT OUTER JOIN` define a join that includes all 
 is not a match in the left table. When there is no match, null values are produced for the left side of the join.
 
 ```sql
-❯ select * from x right join x y ON x.column_1 = y.column_2;
+select * from x right join x y ON x.column_1 = y.column_2;
 +----------+----------+----------+----------+
 | column_1 | column_2 | column_1 | column_2 |
 +----------+----------+----------+----------+
@@ -145,7 +145,7 @@ The keywords `FULL JOIN` or `FULL OUTER JOIN` define a join that is effectively 
 either side of the join where there is not a match.
 
 ```sql
-❯ select * from x full outer join x y ON x.column_1 = y.column_2;
+select * from x full outer join x y ON x.column_1 = y.column_2;
 +----------+----------+----------+----------+
 | column_1 | column_2 | column_1 | column_2 |
 +----------+----------+----------+----------+
@@ -160,7 +160,7 @@ A natural join defines an inner join based on common column names found between 
 column names are found, it behaves like a cross join.
 
 ```sql
-❯ select * from x natural join x y;
+select * from x natural join x y;
 +----------+----------+
 | column_1 | column_2 |
 +----------+----------+
@@ -174,7 +174,7 @@ A cross join produces a cartesian product that matches every row in the left sid
 right side of the join.
 
 ```sql
-❯ select * from x cross join x y;
+select * from x cross join x y;
 +----------+----------+----------+----------+
 | column_1 | column_2 | column_1 | column_2 |
 +----------+----------+----------+----------+

--- a/docs/source/user-guide/sql/subqueries.md
+++ b/docs/source/user-guide/sql/subqueries.md
@@ -24,7 +24,7 @@ DataFusion supports `EXISTS`, `NOT EXISTS`, `IN`, `NOT IN` and Scalar Subqueries
 The examples below are based on the following table.
 
 ```sql
-❯ select * from x;
+select * from x;
 +----------+----------+
 | column_1 | column_2 |
 +----------+----------+
@@ -38,7 +38,7 @@ The `EXISTS` syntax can be used to find all rows in a relation where a correlate
 for that row. Only correlated subqueries are supported.
 
 ```sql
-❯ select * from x y where exists (select * from x where x.column_1 = y.column_1);
+select * from x y where exists (select * from x where x.column_1 = y.column_1);
 +----------+----------+
 | column_1 | column_2 |
 +----------+----------+
@@ -53,7 +53,7 @@ The `NOT EXISTS` syntax can be used to find all rows in a relation where a corre
 for that row. Only correlated subqueries are supported.
 
 ```sql
-❯ select * from x y where not exists (select * from x where x.column_1 = y.column_1);
+select * from x y where not exists (select * from x where x.column_1 = y.column_1);
 0 rows in set.
 ```
 
@@ -63,7 +63,7 @@ The `IN` syntax can be used to find all rows in a relation where a given express
 results of a correlated subquery.
 
 ```sql
-❯ select * from x where column_1 in (select column_1 from x);
+select * from x where column_1 in (select column_1 from x);
 +----------+----------+
 | column_1 | column_2 |
 +----------+----------+
@@ -78,7 +78,7 @@ The `NOT IN` syntax can be used to find all rows in a relation where a given exp
 results of a correlated subquery.
 
 ```sql
-❯ select * from x where column_1 not in (select column_1 from x);
+select * from x where column_1 not in (select column_1 from x);
 0 rows in set.
 ```
 
@@ -88,7 +88,7 @@ A scalar subquery can be used to produce a single value that can be used in many
 is an example of a filter using a scalar subquery. Only correlated subqueries are supported.
 
 ```sql
-❯ select * from x y where column_1 < (select sum(column_2) from x where x.column_1 = y.column_1);
+select * from x y where column_1 < (select sum(column_2) from x where x.column_1 = y.column_1);
 +----------+----------+
 | column_1 | column_2 |
 +----------+----------+

--- a/docs/source/user-guide/sql/window_functions.md
+++ b/docs/source/user-guide/sql/window_functions.md
@@ -104,7 +104,7 @@ WINDOW w AS (PARTITION BY depname ORDER BY salary DESC);
 
 The syntax for the OVER-clause is
 
-```sql
+```
 function([expr])
   OVER(
     [PARTITION BY expr[, …]]
@@ -115,7 +115,7 @@ function([expr])
 
 where **frame_clause** is one of:
 
-```sql
+```
   { RANGE | ROWS | GROUPS } frame_start
   { RANGE | ROWS | GROUPS } BETWEEN frame_start AND frame_end
 ```

--- a/docs/source/user-guide/sql/write_options.md
+++ b/docs/source/user-guide/sql/write_options.md
@@ -29,7 +29,7 @@ Write related options can be specified in the following ways:
 - `CREATE EXTERNAL TABLE` options
 - `COPY` option tuples
 
-For a list of supported session level config defaults see [Configuration Settings](configs). These defaults apply to all write operations but have the lowest level of precedence.
+For a list of supported session level config defaults see [Configuration Settings](../configs). These defaults apply to all write operations but have the lowest level of precedence.
 
 If inserting to an external table, table specific write options can be specified when the table is created using the `OPTIONS` clause:
 


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

The document building process produces multiple warnings. Some of these warnings are not really a big deal, but some may contains valuable information, and it's really difficult to notice that when a huge warning message is emitted.

## What changes are included in this PR?

- Remove/modify some syntax tag of code blocks, since syntax coloring not working but only produces warnings.
- Remove leading ❯ in sql code blocks.
- Fix reference links.
- Fix typos.

## Are these changes tested?

No code changed in this PR.

## Are there any user-facing changes?

Yes.