### PR TITLE
fix: issue #9130 substitute redundant columns when doing cross join

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -219,7 +219,6 @@ async fn exec_and_print(
 
     let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
     for statement in statements {
-        // println!("cur statement is {:?}", statement);
         let plan = create_plan(ctx, statement).await?;
 
         // For plans like `Explain` ignore `MaxRows` option and always display all rows
@@ -229,7 +228,6 @@ async fn exec_and_print(
                 | LogicalPlan::DescribeTable(_)
                 | LogicalPlan::Analyze(_)
         );
-        // println!("the final logical plan is {:?}", plan);
         let df = ctx.execute_logical_plan(plan).await?;
         let physical_plan = df.create_physical_plan().await?;
 

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -219,6 +219,7 @@ async fn exec_and_print(
 
     let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
     for statement in statements {
+        // println!("cur statement is {:?}", statement);
         let plan = create_plan(ctx, statement).await?;
 
         // For plans like `Explain` ignore `MaxRows` option and always display all rows
@@ -228,7 +229,7 @@ async fn exec_and_print(
                 | LogicalPlan::DescribeTable(_)
                 | LogicalPlan::Analyze(_)
         );
-
+        // println!("the final logical plan is {:?}", plan);
         let df = ctx.execute_logical_plan(plan).await?;
         let physical_plan = df.create_physical_plan().await?;
 

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -70,10 +70,6 @@ impl MemTable {
     pub fn try_new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
         for batches in partitions.iter().flatten() {
             let batches_schema = batches.schema();
-            println!(
-                "the new schema is {:?}, schema set is {:?}",
-                batches_schema, schema
-            );
             if !schema.contains(&batches_schema) {
                 debug!(
                     "mem table schema does not contain batches schema. \

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -70,6 +70,10 @@ impl MemTable {
     pub fn try_new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
         for batches in partitions.iter().flatten() {
             let batches_schema = batches.schema();
+            println!(
+                "the new schema is {:?}, schema set is {:?}",
+                batches_schema, schema
+            );
             if !schema.contains(&batches_schema) {
                 debug!(
                     "mem table schema does not contain batches schema. \

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2102,10 +2102,11 @@ mod tests {
     fn test_change_redundant_column() -> Result<()> {
         let t1_field_1 = DFField::new_unqualified("a", DataType::Int32, false);
         let t2_field_1 = DFField::new_unqualified("a", DataType::Int32, false);
+        let t2_field_3 = DFField::new_unqualified("a", DataType::Int32, false);
         let t1_field_2 = DFField::new_unqualified("b", DataType::Int32, false);
         let t2_field_2 = DFField::new_unqualified("b", DataType::Int32, false);
 
-        let field_vec = vec![t1_field_1, t2_field_1, t1_field_2, t2_field_2];
+        let field_vec = vec![t1_field_1, t2_field_1, t1_field_2, t2_field_2, t2_field_3];
         let remove_redundant = change_redundant_column(field_vec);
 
         assert_eq!(
@@ -2114,7 +2115,8 @@ mod tests {
                 DFField::new_unqualified("a", DataType::Int32, false),
                 DFField::new_unqualified("a:1", DataType::Int32, false),
                 DFField::new_unqualified("b", DataType::Int32, false),
-                DFField::new_unqualified("b:1", DataType::Int32, false)
+                DFField::new_unqualified("b:1", DataType::Int32, false),
+                DFField::new_unqualified("a:2", DataType::Int32, false),
             ]
         );
         Ok(())

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1204,7 +1204,6 @@ pub fn build_join_schema(
             right_fields.clone()
         }
     };
-    //println!("total fields is {:?}", fields);
     let func_dependencies = left.functional_dependencies().join(
         right.functional_dependencies(),
         join_type,
@@ -1212,7 +1211,6 @@ pub fn build_join_schema(
     );
     let mut metadata = left.metadata().clone();
     metadata.extend(right.metadata().clone());
-    // let schema = DFSchema::new_with_metadata(change_redundant_column(fields), metadata)?;
     let schema = DFSchema::new_with_metadata(fields, metadata)?;
     schema.with_functional_dependencies(func_dependencies)
 }
@@ -1268,7 +1266,6 @@ pub(crate) fn validate_unique_names<'a>(
                 Ok(())
             },
             Some((existing_position, existing_expr)) => {
-                //println!("node_name is {}, existing expr is {:?}", node_name, existing_expr);
                 plan_err!("{node_name} require unique expression names \
                              but the expression \"{existing_expr}\" at position {existing_position} and \"{expr}\" \
                              at position {position} have the same name. Consider aliasing (\"AS\") one of them."

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -47,7 +47,7 @@ use crate::{
     TableProviderFilterPushDown, TableSource, WriteOp,
 };
 
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Schema, SchemaRef};
 use datafusion_common::display::ToStringifiedPlan;
 use datafusion_common::{
     get_target_functional_dependencies, plan_datafusion_err, plan_err, Column, DFField,
@@ -1254,9 +1254,6 @@ fn add_group_by_exprs_from_dependencies(
     }
     Ok(group_expr)
 }
-pub(crate) fn validate_unique_names_with_table<'a>() {
-    unimplemented!()
-}
 /// Errors if one or more expressions have equal names.
 pub(crate) fn validate_unique_names<'a>(
     node_name: &str,
@@ -1599,7 +1596,6 @@ mod tests {
     use crate::{col, expr, expr_fn::exists, in_subquery, lit, scalar_subquery, sum};
 
     use arrow::datatypes::{DataType, Field};
-    use arrow::ipc::Int;
     use datafusion_common::{OwnedTableReference, SchemaError, TableReference};
 
     #[test]

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1132,7 +1132,7 @@ pub fn change_redundant_column(fields: Vec<DFField>) -> Vec<DFField> {
             let counter = name_map.entry(field.name().to_string()).or_insert(0);
             *counter += 1;
             if *counter > 1 {
-                let new_name = format!("{}:{}", field.name(), counter);
+                let new_name = format!("{}:{}", field.name(), *counter - 1);
                 DFField::new(
                     field.qualifier().cloned(),
                     &new_name,
@@ -2115,9 +2115,9 @@ mod tests {
             remove_redundant,
             vec![
                 DFField::new_unqualified("a", DataType::Int32, false),
-                DFField::new_unqualified("a:0", DataType::Int32, false),
+                DFField::new_unqualified("a:1", DataType::Int32, false),
                 DFField::new_unqualified("b", DataType::Int32, false),
-                DFField::new_unqualified("b:0", DataType::Int32, false)
+                DFField::new_unqualified("b:1", DataType::Int32, false)
             ]
         );
         Ok(())

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2186,10 +2186,7 @@ impl TableScan {
                 df_schema.with_functional_dependencies(func_dependencies)
             })?;
         let projected_schema = Arc::new(projected_schema);
-        // println!(
-        //     "projected_schema is {:?} \n and projection is {:?}",
-        //     projected_schema, projection,
-        // );
+
         Ok(Self {
             table_name,
             source: table_source,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1894,9 +1894,7 @@ impl SubqueryAlias {
         let alias = alias.into();
         let fields = change_redundant_column(plan.schema().fields().clone());
         let meta_data = plan.schema().as_ref().metadata().clone();
-        let schema: Schema = DFSchema::new_with_metadata(fields, meta_data)
-            .unwrap()
-            .into();
+        let schema: Schema = DFSchema::new_with_metadata(fields, meta_data)?.into();
         // Since schema is the same, other than qualifier, we can use existing
         // functional dependencies:
         let func_dependencies = plan.schema().functional_dependencies().clone();

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -66,7 +66,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if !select.sort_by.is_empty() {
             return not_impl_err!("SORT BY");
         }
-
+        // println!("select from is {:?}", select.from);
+        // println!("current planner_context is {:?}", planner_context);
         // process `from` clause
         let plan = self.plan_from_tables(select.from, planner_context)?;
         let empty_from = matches!(plan, LogicalPlan::EmptyRelation(_));
@@ -77,7 +78,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // handle named windows before processing the projection expression
         check_conflicting_windows(&select.named_window)?;
         match_window_definitions(&mut select.projection, &select.named_window)?;
-
         // process the SELECT expressions, with wildcards expanded.
         let select_exprs = self.prepare_select_exprs(
             &base_plan,
@@ -85,7 +85,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             empty_from,
             planner_context,
         )?;
-
+        // println!(
+        //     "base plan is {:?} \n select expression is {:?} \n planner_context is {:?}",
+        //     base_plan, select_exprs, planner_context
+        // );
         // having and group by clause may reference aliases defined in select projection
         let projected_plan = self.project(base_plan.clone(), select_exprs.clone())?;
         // Place the fields of the base plan at the front so that when there are references

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -66,8 +66,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if !select.sort_by.is_empty() {
             return not_impl_err!("SORT BY");
         }
-        // println!("select from is {:?}", select.from);
-        // println!("current planner_context is {:?}", planner_context);
+
         // process `from` clause
         let plan = self.plan_from_tables(select.from, planner_context)?;
         let empty_from = matches!(plan, LogicalPlan::EmptyRelation(_));
@@ -85,10 +84,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             empty_from,
             planner_context,
         )?;
-        // println!(
-        //     "base plan is {:?} \n select expression is {:?} \n planner_context is {:?}",
-        //     base_plan, select_exprs, planner_context
-        // );
+
         // having and group by clause may reference aliases defined in select projection
         let projected_plan = self.project(base_plan.clone(), select_exprs.clone())?;
         // Place the fields of the base plan at the front so that when there are references

--- a/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
+++ b/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
@@ -40,7 +40,8 @@ query IIIIII
 select * from (t1 cross join t2) as t cross join t3;
 -------
 ----
-5 6 1 2 3 4
+1 2 3 4 5 6
+
 
 
 query IIIIIIII
@@ -54,10 +55,10 @@ query IIIIIIIIIIII
 select * from (t1 cross join t2) as t cross join (t2 cross join t3) cross join (t1 cross join t3) as tt
 --------
 ----
-1 2 5 6 1 2 3 4 3 4 5 6
+1 2 3 4 3 4 5 6 1 2 5 6
 
 query IIIIIIIIIIIIIIII
 select * from (t1 cross join t2) as t cross join (t2 cross join t3) cross join (t1 cross join t3) as tt cross join (t2 cross join t3) as ttt;
 --------
 ----
-1 2 5 6 1 2 3 4 3 4 5 6 3 4 5 6
+1 2 3 4 3 4 5 6 1 2 5 6 3 4 5 6

--- a/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
+++ b/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# prepare the tables
+
+statement ok
+create table t1 (a int, b int);
+
+statement ok
+create table t2 (a int, b int);
+
+statement ok
+create table t3 (a int, b int);
+
+statement ok
+insert into t1 values (1, 2);
+
+statement ok
+insert into t2 values (3, 4);
+
+statement ok
+insert into t3 values (5, 6);
+
+query IIIIII
+select * from (t1 cross join t2) as t cross join t3;
+-------
+----
+5 6 1 2 3 4
+
+query IIIIIIII
+select * from (t1 cross join t2) as t cross join (t2 cross join t3)
+-------
+----
+1 2 3 4 3 4 5 6
+
+query IIIIIIIIIIII
+select * from (t1 cross join t2) as t cross join (t2 cross join t3) cross join (t1 cross join t3) as tt
+--------
+----
+1 2 5 6 1 2 3 4 3 4 5 6
+
+query IIIIIIIIIIIIIIII
+select * from (t1 cross join t2) as t cross join (t2 cross join t3) cross join (t1 cross join t3) as tt cross join (t2 cross join t3) as ttt;
+--------
+----
+1 2 5 6 1 2 3 4 3 4 5 6 3 4 5 6

--- a/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
+++ b/datafusion/sqllogictest/test_files/same_column_name_cross_join.slt
@@ -42,11 +42,13 @@ select * from (t1 cross join t2) as t cross join t3;
 ----
 5 6 1 2 3 4
 
+
 query IIIIIIII
 select * from (t1 cross join t2) as t cross join (t2 cross join t3)
 -------
 ----
 1 2 3 4 3 4 5 6
+
 
 query IIIIIIIIIIII
 select * from (t1 cross join t2) as t cross join (t2 cross join t3) cross join (t1 cross join t3) as tt


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9130 

## Rationale for this change
In cross-join, Since we have to validate the uniqueness of the name, we would throw an error when failed to do it. as what sqlite did, they just substituted the name of the redundant column(supposed to be a) into a:1, and we followed the strategy. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
