### PR TITLE
RecordBatchReceiverStreamBuilder: don't stringify errors

### DIFF
--- a/datafusion/physical-plan/src/stream.rs
+++ b/datafusion/physical-plan/src/stream.rs
@@ -24,9 +24,9 @@ use std::task::Poll;
 
 use crate::displayable;
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use datafusion_common::internal_err;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result;
-use datafusion_common::{exec_err, internal_err};
 use datafusion_execution::TaskContext;
 use futures::stream::BoxStream;
 use futures::{Future, Stream, StreamExt};
@@ -116,9 +116,7 @@ impl<O: Send + 'static> ReceiverStreamBuilder<O> {
                             // nothing to report
                             Ok(_) => continue,
                             // This means a blocking task error
-                            Err(e) => {
-                                return Some(exec_err!("Spawned Task error: {e}"));
-                            }
+                            Err(error) => return Some(Err(error)),
                         }
                     }
                     // This means a tokio task error, likely a panic


### PR DESCRIPTION
The error is a DataFusionError already, so don't stringify it, just use it as-is.

## Are these changes tested?

`cargo test` passes; the behavior doesn't seem to be covered by tests.

## Are there any user-facing changes?

Technically yes but I doubt anybody was matching on the error value. And if they were, this change is even more desirable!