### PR TITLE
Minor: Improve `DataFrame` docs, add examples

### DIFF
--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -26,7 +26,27 @@ use super::{
 };
 
 impl DataFrame {
-    /// Write a `DataFrame` to a Parquet file.
+    /// Execute the `DataFrame` and write the results to Parquet file(s).
+    ///
+    /// # Example
+    /// ```
+    /// # use datafusion::prelude::*;
+    /// # use datafusion::error::Result;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// use datafusion::dataframe::DataFrameWriteOptions;
+    /// let ctx = SessionContext::new();
+    /// // Sort the data by column "b" and write it to a new location
+    /// ctx.read_csv("tests/data/example.csv", CsvReadOptions::new()).await?
+    ///   .sort(vec![col("b").sort(true, true)])? // sort by b asc, nulls first
+    ///   .write_parquet(
+    ///     "output.parquet",
+    ///     DataFrameWriteOptions::new(),
+    ///     None, // can also specify parquet writing options here
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn write_parquet(
         self,
         path: &str,

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -164,7 +164,7 @@ where
 ///
 /// [`SessionContext`] provides the following functionality:
 ///
-/// * Create a DataFrame from a CSV or Parquet data source.
+/// * Create a [`DataFrame`] from a CSV or Parquet data source.
 /// * Register a CSV or Parquet data source as a table that can be referenced from a SQL query.
 /// * Register a custom data source that can be referenced from a SQL query.
 /// * Execution a SQL query
@@ -172,7 +172,7 @@ where
 /// # Example: DataFrame API
 ///
 /// The following example demonstrates how to use the context to execute a query against a CSV
-/// data source using the DataFrame API:
+/// data source using the [`DataFrame`] API:
 ///
 /// ```
 /// use datafusion::prelude::*;

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -511,7 +511,9 @@ pub async fn collect(
     common::collect(stream).await
 }
 
-/// Execute the [ExecutionPlan] and return a single stream of results.
+/// Execute the [ExecutionPlan] and return a single stream of `RecordBatch`es.
+///
+/// See [collect] to buffer the `RecordBatch`es in memory.
 ///
 /// # Aborting Execution
 ///


### PR DESCRIPTION
## Which issue does this PR close?

Part of #7013 

## Rationale for this change
I was watching @carols10cents try to find how to write a parquet file via a `DataFrame` in the API docs and they left something to be desired

## What changes are included in this PR?
1. Add examples to `DataFrame::` `write_json`, `write_csv`, `write_parquet`
2. Improve more of the DataFrame documentations

## Are these changes tested?
Covered by CI doc tests 

## Are there any user-facing changes?
Better docs
