### PR TITLE
feat: bgzip support

### DIFF
--- a/datafusion/common/src/parsers.rs
+++ b/datafusion/common/src/parsers.rs
@@ -34,6 +34,8 @@ pub enum CompressionTypeVariant {
     ZSTD,
     /// Uncompressed file
     UNCOMPRESSED,
+    /// A Block Gzip-ed file
+    BGZIP,
 }
 
 impl FromStr for CompressionTypeVariant {
@@ -43,6 +45,7 @@ impl FromStr for CompressionTypeVariant {
         let s = s.to_uppercase();
         match s.as_str() {
             "GZIP" | "GZ" => Ok(Self::GZIP),
+            "BGZIP" | "BGZ" => Ok(Self::BGZIP),
             "BZIP2" | "BZ2" => Ok(Self::BZIP2),
             "XZ" => Ok(Self::XZ),
             "ZST" | "ZSTD" => Ok(Self::ZSTD),
@@ -61,6 +64,7 @@ impl ToString for CompressionTypeVariant {
             Self::BZIP2 => "BZIP2",
             Self::XZ => "XZ",
             Self::ZSTD => "ZSTD",
+            Self::BGZIP => "BGZIP",
             Self::UNCOMPRESSED => "",
         }
         .to_string()

--- a/datafusion/core/src/datasource/file_format/file_compression_type.rs
+++ b/datafusion/core/src/datasource/file_format/file_compression_type.rs
@@ -123,7 +123,11 @@ impl FileCompressionType {
                 .map_err(DataFusionError::from)
                 .boxed(),
             #[cfg(feature = "compression")]
-            BGZIP => return Err(DataFusionError::NotImplemented("BGZIP is not supported".to_owned())),
+            BGZIP => {
+                return Err(DataFusionError::NotImplemented(
+                    "BGZIP is not supported".to_owned(),
+                ))
+            }
             #[cfg(feature = "compression")]
             BZIP2 => ReaderStream::new(AsyncBzEncoder::new(StreamReader::new(s)))
                 .map_err(DataFusionError::from)
@@ -156,7 +160,11 @@ impl FileCompressionType {
             #[cfg(feature = "compression")]
             GZIP => Box::new(GzipEncoder::new(w)),
             #[cfg(feature = "compression")]
-            BGZIP => return Err(DataFusionError::NotImplemented("BGZIP is not supported".to_owned())),
+            BGZIP => {
+                return Err(DataFusionError::NotImplemented(
+                    "BGZIP is not supported".to_owned(),
+                ))
+            }
             #[cfg(feature = "compression")]
             BZIP2 => Box::new(BzEncoder::new(w)),
             #[cfg(feature = "compression")]
@@ -164,7 +172,7 @@ impl FileCompressionType {
             #[cfg(feature = "compression")]
             ZSTD => Box::new(ZstdEncoder::new(w)),
             #[cfg(not(feature = "compression"))]
-            GZIP | BZIP2 | XZ | ZSTD => {
+            GZIP | BZIP2 | XZ | ZSTD | BGZIP => {
                 return Err(DataFusionError::NotImplemented(
                     "Compression feature is not enabled".to_owned(),
                 ))
@@ -188,7 +196,9 @@ impl FileCompressionType {
                 let mut decoder = AsyncGzDecoder::new(StreamReader::new(s));
                 decoder.multiple_members(true);
 
-                ReaderStream::new(decoder).map_err(DataFusionError::from).boxed()
+                ReaderStream::new(decoder)
+                    .map_err(DataFusionError::from)
+                    .boxed()
             }
             #[cfg(feature = "compression")]
             BZIP2 => ReaderStream::new(AsyncBzDecoder::new(StreamReader::new(s)))
@@ -203,7 +213,7 @@ impl FileCompressionType {
                 .map_err(DataFusionError::from)
                 .boxed(),
             #[cfg(not(feature = "compression"))]
-            GZIP | BZIP2 | XZ | ZSTD => {
+            GZIP | BZIP2 | XZ | ZSTD | BGZIP => {
                 return Err(DataFusionError::NotImplemented(
                     "Compression feature is not enabled".to_owned(),
                 ))

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -133,6 +133,12 @@ pub fn partitioned_file_groups(
                 Box::new(GzEncoder::new(file, GzCompression::default()))
             }
             #[cfg(feature = "compression")]
+            FileCompressionType::BGZIP => {
+                return Err(DataFusionError::NotImplemented(
+                    "BGZIP is not supported".to_string(),
+                ))
+            }
+            #[cfg(feature = "compression")]
             FileCompressionType::XZ => Box::new(XzEncoder::new(file, 9)),
             #[cfg(feature = "compression")]
             FileCompressionType::ZSTD => {
@@ -147,6 +153,7 @@ pub fn partitioned_file_groups(
             }
             #[cfg(not(feature = "compression"))]
             FileCompressionType::GZIP
+            | FileCompressionType::BGZIP
             | FileCompressionType::BZIP2
             | FileCompressionType::XZ
             | FileCompressionType::ZSTD => {

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -1202,6 +1202,7 @@ enum CompressionTypeVariant {
   XZ = 2;
   ZSTD = 3;
   UNCOMPRESSED = 4;
+  BGZIP = 5;
 }
 
 message PartitionColumn {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -3509,6 +3509,7 @@ impl serde::Serialize for CompressionTypeVariant {
             Self::Xz => "XZ",
             Self::Zstd => "ZSTD",
             Self::Uncompressed => "UNCOMPRESSED",
+            Self::Bgzip => "BGZIP",
         };
         serializer.serialize_str(variant)
     }
@@ -3525,6 +3526,7 @@ impl<'de> serde::Deserialize<'de> for CompressionTypeVariant {
             "XZ",
             "ZSTD",
             "UNCOMPRESSED",
+            "BGZIP",
         ];
 
         struct GeneratedVisitor;
@@ -3570,6 +3572,7 @@ impl<'de> serde::Deserialize<'de> for CompressionTypeVariant {
                     "XZ" => Ok(CompressionTypeVariant::Xz),
                     "ZSTD" => Ok(CompressionTypeVariant::Zstd),
                     "UNCOMPRESSED" => Ok(CompressionTypeVariant::Uncompressed),
+                    "BGZIP" => Ok(CompressionTypeVariant::Bgzip),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -3416,6 +3416,7 @@ pub enum CompressionTypeVariant {
     Xz = 2,
     Zstd = 3,
     Uncompressed = 4,
+    Bgzip = 5,
 }
 impl CompressionTypeVariant {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -3429,6 +3430,7 @@ impl CompressionTypeVariant {
             CompressionTypeVariant::Xz => "XZ",
             CompressionTypeVariant::Zstd => "ZSTD",
             CompressionTypeVariant::Uncompressed => "UNCOMPRESSED",
+            CompressionTypeVariant::Bgzip => "BGZIP",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -3439,6 +3441,7 @@ impl CompressionTypeVariant {
             "XZ" => Some(Self::Xz),
             "ZSTD" => Some(Self::Zstd),
             "UNCOMPRESSED" => Some(Self::Uncompressed),
+            "BGZIP" => Some(Self::Bgzip),
             _ => None,
         }
     }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -820,6 +820,7 @@ impl From<protobuf::CompressionTypeVariant> for CompressionTypeVariant {
     fn from(value: protobuf::CompressionTypeVariant) -> Self {
         match value {
             protobuf::CompressionTypeVariant::Gzip => Self::GZIP,
+            protobuf::CompressionTypeVariant::Bgzip => Self::BGZIP,
             protobuf::CompressionTypeVariant::Bzip2 => Self::BZIP2,
             protobuf::CompressionTypeVariant::Xz => Self::XZ,
             protobuf::CompressionTypeVariant::Zstd => Self::ZSTD,
@@ -835,6 +836,7 @@ impl From<CompressionTypeVariant> for protobuf::CompressionTypeVariant {
             CompressionTypeVariant::BZIP2 => Self::Bzip2,
             CompressionTypeVariant::XZ => Self::Xz,
             CompressionTypeVariant::ZSTD => Self::Zstd,
+            CompressionTypeVariant::BGZIP => Self::Bgzip,
             CompressionTypeVariant::UNCOMPRESSED => Self::Uncompressed,
         }
     }

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -899,6 +899,7 @@ impl From<&CompressionTypeVariant> for protobuf::CompressionTypeVariant {
     fn from(value: &CompressionTypeVariant) -> Self {
         match value {
             CompressionTypeVariant::GZIP => Self::Gzip,
+            CompressionTypeVariant::BGZIP => Self::Bgzip,
             CompressionTypeVariant::BZIP2 => Self::Bzip2,
             CompressionTypeVariant::XZ => Self::Xz,
             CompressionTypeVariant::ZSTD => Self::Zstd,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9156 

## Rationale for this change

block gzip is a variant of gzip where blocks are concatenated together in a single file. This PR aims to support that compression type only for decoding and otherwise raises an error for writes.

## What changes are included in this PR?

Adding a new `CompressionTypeVariant` and propagating updates.

## Are these changes tested?

Not significantly, but I will update this PR with appropriate tests if this approach is reasonable.

## Are there any user-facing changes?

A user would be able to create external tables from files that are block-gzip encoded.