### PR TITLE
feat: support block gzip for streams

### DIFF
--- a/datafusion/core/src/datasource/file_format/file_compression_type.rs
+++ b/datafusion/core/src/datasource/file_format/file_compression_type.rs
@@ -265,8 +265,11 @@ mod tests {
         FileCompressionType, FileTypeExt,
     };
     use crate::error::DataFusionError;
+    use bytes::Bytes;
     use datafusion_common::file_options::file_type::FileType;
+    use futures::StreamExt;
     use std::str::FromStr;
+    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn get_ext_with_compression() {
@@ -344,5 +347,46 @@ mod tests {
             FileCompressionType::from_str("Unknown"),
             Err(DataFusionError::NotImplemented(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_bgzip_stream_decoding() -> Result<(), DataFusionError> {
+        // As described in https://samtools.github.io/hts-specs/SAMv1.pdf ("The BGZF compression format")
+
+        // Ignore rust formatting so the byte array is easier to read
+        #[rustfmt::skip]
+        let data = [
+            // Block header
+            0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+            0x02, 0x00,
+            // Block 0, literal: 42
+            0x1e, 0x00, 0x33, 0x31, 0xe2, 0x02, 0x00, 0x31, 0x29, 0x86, 0xd1, 0x03, 0x00, 0x00, 0x00,
+            // Block header
+            0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+            0x02, 0x00,
+            // Block 1, literal: 42
+            0x1e, 0x00, 0x33, 0x31, 0xe2, 0x02, 0x00, 0x31, 0x29, 0x86, 0xd1, 0x03, 0x00, 0x00, 0x00,
+            // EOF
+            0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+            0x02, 0x00, 0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        // Create a byte stream
+        let stream = futures::stream::iter(vec![Ok::<Bytes, DataFusionError>(
+            Bytes::from(data.to_vec()),
+        )]);
+        let converted_stream =
+            FileCompressionType::GZIP.convert_stream(stream.boxed())?;
+
+        let vec = converted_stream
+            .map(|r| r.unwrap())
+            .collect::<Vec<Bytes>>()
+            .await;
+
+        let string_value = String::from_utf8_lossy(&vec[0]);
+
+        assert_eq!(string_value, "42\n42\n");
+
+        Ok(())
     }
 }

--- a/datafusion/core/src/datasource/file_format/file_compression_type.rs
+++ b/datafusion/core/src/datasource/file_format/file_compression_type.rs
@@ -269,7 +269,6 @@ mod tests {
     use datafusion_common::file_options::file_type::FileType;
     use futures::StreamExt;
     use std::str::FromStr;
-    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn get_ext_with_compression() {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9156

## Rationale for this change

Updates the stream gzip decoding to check for multiple members within a file.

## What changes are included in this PR?

Doesn't update the `Read` decoder because it already supports multiple members in a file.

## Are these changes tested?

The gzip decoding still seems to work, and I checked a manually bgzipped file, but I'm not sure if this code path is tested already.

## Are there any user-facing changes?

No
