### PR TITLE
Minor: Remove unecessary map_err

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -27,7 +27,6 @@ use std::iter::repeat;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::arrow_datafusion_err;
 use crate::cast::{
     as_decimal128_array, as_decimal256_array, as_dictionary_array,
     as_fixed_size_binary_array, as_fixed_size_list_array,
@@ -1732,18 +1731,16 @@ impl ScalarValue {
         scale: i8,
         size: usize,
     ) -> Result<Decimal128Array> {
-        match value {
+        Ok(match value {
             Some(val) => Decimal128Array::from(vec![val; size])
-                .with_precision_and_scale(precision, scale)
-                .map_err(|e| arrow_datafusion_err!(e)),
+                .with_precision_and_scale(precision, scale)?,
             None => {
                 let mut builder = Decimal128Array::builder(size)
-                    .with_precision_and_scale(precision, scale)
-                    .map_err(|e| arrow_datafusion_err!(e))?;
+                    .with_precision_and_scale(precision, scale)?;
                 builder.append_nulls(size);
-                Ok(builder.finish())
+                builder.finish()
             }
-        }
+        })
     }
 
     fn build_decimal256_array(
@@ -1752,11 +1749,10 @@ impl ScalarValue {
         scale: i8,
         size: usize,
     ) -> Result<Decimal256Array> {
-        std::iter::repeat(value)
+        Ok(std::iter::repeat(value)
             .take(size)
             .collect::<Decimal256Array>()
-            .with_precision_and_scale(precision, scale)
-            .map_err(|e| arrow_datafusion_err!(e))
+            .with_precision_and_scale(precision, scale)?)
     }
 
     /// Converts `Vec<ScalarValue>` where each element has type corresponding to
@@ -2146,7 +2142,7 @@ impl ScalarValue {
 
     fn list_to_array_of_size(arr: &dyn Array, size: usize) -> Result<ArrayRef> {
         let arrays = std::iter::repeat(arr).take(size).collect::<Vec<_>>();
-        arrow::compute::concat(arrays.as_slice()).map_err(|e| arrow_datafusion_err!(e))
+        Ok(arrow::compute::concat(arrays.as_slice())?)
     }
 
     /// Retrieve ScalarValue for each row in `array`


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I noticed on https://github.com/apache/arrow-datafusion/pull/9174# there were map_err that are not needed so I figured I would propose a PR to clean them up

## What changes are included in this PR?
Make code more concise

## Are these changes tested?
existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
