### PR TITLE
Add string aggregagte grouping fuzz test

### DIFF
--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -29,9 +29,10 @@ use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion_common::{
-    not_impl_err, plan_err, Constraints, DataFusionError, SchemaExt,
+    not_impl_err, plan_err, Constraints, DFSchema, DataFusionError, SchemaExt,
 };
 use datafusion_execution::TaskContext;
+use parking_lot::Mutex;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 
@@ -44,6 +45,7 @@ use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::{common, SendableRecordBatchStream};
 use crate::physical_plan::{repartition::RepartitionExec, Partitioning};
 use crate::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
+use crate::physical_planner::create_physical_sort_expr;
 
 /// Type alias for partition data
 pub type PartitionData = Arc<RwLock<Vec<RecordBatch>>>;
@@ -58,6 +60,9 @@ pub struct MemTable {
     pub(crate) batches: Vec<PartitionData>,
     constraints: Constraints,
     column_defaults: HashMap<String, Expr>,
+    /// Optional pre-known sort order(s). Must be `SortExpr`s.
+    /// inserting data into this table removes the order
+    pub sort_order: Arc<Mutex<Vec<Vec<Expr>>>>,
 }
 
 impl MemTable {
@@ -82,6 +87,7 @@ impl MemTable {
                 .collect::<Vec<_>>(),
             constraints: Constraints::empty(),
             column_defaults: HashMap::new(),
+            sort_order: Arc::new(Mutex::new(vec![])),
         })
     }
 
@@ -97,6 +103,21 @@ impl MemTable {
         column_defaults: HashMap<String, Expr>,
     ) -> Self {
         self.column_defaults = column_defaults;
+        self
+    }
+
+    /// Specify an optional pre-known sort order(s). Must be `SortExpr`s.
+    ///
+    /// If the data is not sorted by this order, DataFusion may produce
+    /// incorrect results.
+    ///
+    /// DataFusion may take advantage of this ordering to omit sorts
+    /// or use more efficient algorithms.
+    ///
+    /// Note that multiple sort orders are supported, if some are known to be
+    /// equivalent,
+    pub fn with_sort_order(self, mut sort_order: Vec<Vec<Expr>>) -> Self {
+        std::mem::swap(self.sort_order.lock().as_mut(), &mut sort_order);
         self
     }
 
@@ -184,7 +205,7 @@ impl TableProvider for MemTable {
 
     async fn scan(
         &self,
-        _state: &SessionState,
+        state: &SessionState,
         projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
@@ -194,11 +215,33 @@ impl TableProvider for MemTable {
             let inner_vec = arc_inner_vec.read().await;
             partitions.push(inner_vec.clone())
         }
-        Ok(Arc::new(MemoryExec::try_new(
-            &partitions,
-            self.schema(),
-            projection.cloned(),
-        )?))
+        let mut exec =
+            MemoryExec::try_new(&partitions, self.schema(), projection.cloned())?;
+
+        // add sort information if present
+        let sort_order = self.sort_order.lock();
+        if !sort_order.is_empty() {
+            let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+
+            let file_sort_order = sort_order
+                .iter()
+                .map(|sort_exprs| {
+                    sort_exprs
+                        .iter()
+                        .map(|expr| {
+                            create_physical_sort_expr(
+                                expr,
+                                &df_schema,
+                                state.execution_props(),
+                            )
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })
+                .collect::<Result<Vec<_>>>()?;
+            exec = exec.with_sort_information(file_sort_order);
+        }
+
+        Ok(Arc::new(exec))
     }
 
     /// Returns an ExecutionPlan that inserts the execution results of a given [`ExecutionPlan`] into this [`MemTable`].
@@ -219,6 +262,9 @@ impl TableProvider for MemTable {
         input: Arc<dyn ExecutionPlan>,
         overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // If we are inserting into the table, any sort order may be messed up so reset it here
+        *self.sort_order.lock() = vec![];
+
         // Create a physical plan from the logical plan.
         // Check that the schema of the plan matches the schema of this table.
         if !self

--- a/datafusion/core/tests/fuzz_cases/distinct_count_string_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/distinct_count_string_fuzz.rs
@@ -19,43 +19,22 @@
 
 use std::sync::Arc;
 
-use arrow::array::ArrayRef;
 use arrow::record_batch::RecordBatch;
-use arrow_array::{Array, GenericStringArray, OffsetSizeTrait, UInt32Array};
+use arrow_array::{Array, OffsetSizeTrait};
 
 use arrow_array::cast::AsArray;
 use datafusion::datasource::MemTable;
-use rand::rngs::StdRng;
-use rand::{thread_rng, Rng, SeedableRng};
 use std::collections::HashSet;
 use tokio::task::JoinSet;
 
 use datafusion::prelude::{SessionConfig, SessionContext};
-use test_utils::stagger_batch;
+use test_utils::StringBatchGenerator;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn distinct_count_string_test() {
-    // max length of generated strings
     let mut join_set = JoinSet::new();
-    let mut rng = thread_rng();
-    for null_pct in [0.0, 0.01, 0.1, 0.5] {
-        for _ in 0..100 {
-            let max_len = rng.gen_range(1..50);
-            let num_strings = rng.gen_range(1..100);
-            let num_distinct_strings = if num_strings > 1 {
-                rng.gen_range(1..num_strings)
-            } else {
-                num_strings
-            };
-            let generator = BatchGenerator {
-                max_len,
-                num_strings,
-                num_distinct_strings,
-                null_pct,
-                rng: StdRng::from_seed(rng.gen()),
-            };
-            join_set.spawn(async move { run_distinct_count_test(generator).await });
-        }
+    for generator in StringBatchGenerator::interesting_cases() {
+        join_set.spawn(async move { run_distinct_count_test(generator).await });
     }
     while let Some(join_handle) = join_set.join_next().await {
         // propagate errors
@@ -65,7 +44,7 @@ async fn distinct_count_string_test() {
 
 /// Run COUNT DISTINCT using SQL and compare the result to computing the
 /// distinct count using HashSet<String>
-async fn run_distinct_count_test(mut generator: BatchGenerator) {
+async fn run_distinct_count_test(mut generator: StringBatchGenerator) {
     let input = generator.make_input_batches();
 
     let schema = input[0].schema();
@@ -135,77 +114,4 @@ fn extract_i64(results: &[RecordBatch], col_idx: usize) -> usize {
     assert_eq!(array.len(), 1);
     assert!(!array.is_null(0));
     array.value(0).try_into().unwrap()
-}
-
-struct BatchGenerator {
-    //// The maximum length of the strings
-    max_len: usize,
-    /// the total number of strings in the output
-    num_strings: usize,
-    /// The number of distinct strings in the columns
-    num_distinct_strings: usize,
-    /// The percentage of nulls in the columns
-    null_pct: f64,
-    /// Random number generator
-    rng: StdRng,
-}
-
-impl BatchGenerator {
-    /// Make batches of random strings with a random length columns "a" and "b":
-    ///
-    /// * "a" is a StringArray
-    /// * "b" is a LargeStringArray
-    fn make_input_batches(&mut self) -> Vec<RecordBatch> {
-        // use a random number generator to pick a random sized output
-
-        let batch = RecordBatch::try_from_iter(vec![
-            ("a", self.gen_data::<i32>()),
-            ("b", self.gen_data::<i64>()),
-        ])
-        .unwrap();
-
-        stagger_batch(batch)
-    }
-
-    /// Creates a StringArray or LargeStringArray with random strings according
-    /// to the parameters of the BatchGenerator
-    fn gen_data<O: OffsetSizeTrait>(&mut self) -> ArrayRef {
-        // table of strings from which to draw
-        let distinct_strings: GenericStringArray<O> = (0..self.num_distinct_strings)
-            .map(|_| Some(random_string(&mut self.rng, self.max_len)))
-            .collect();
-
-        // pick num_strings randomly from the distinct string table
-        let indicies: UInt32Array = (0..self.num_strings)
-            .map(|_| {
-                if self.rng.gen::<f64>() < self.null_pct {
-                    None
-                } else if self.num_distinct_strings > 1 {
-                    let range = 1..(self.num_distinct_strings as u32);
-                    Some(self.rng.gen_range(range))
-                } else {
-                    Some(0)
-                }
-            })
-            .collect();
-
-        let options = None;
-        arrow::compute::take(&distinct_strings, &indicies, options).unwrap()
-    }
-}
-
-/// Return a string of random characters of length 1..=max_len
-fn random_string(rng: &mut StdRng, max_len: usize) -> String {
-    // pick characters at random (not just ascii)
-    match max_len {
-        0 => "".to_string(),
-        1 => String::from(rng.gen::<char>()),
-        _ => {
-            let len = rng.gen_range(1..=max_len);
-            rng.sample_iter::<char, _>(rand::distributions::Standard)
-                .take(len)
-                .map(char::from)
-                .collect::<String>()
-        }
-    }
 }

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -507,6 +507,9 @@ impl AggregateExec {
         }
         true
     }
+    pub fn input_order_mode(&self) -> &InputOrderMode {
+        &self.input_order_mode
+    }
 }
 
 impl DisplayAs for AggregateExec {

--- a/test-utils/src/data_gen.rs
+++ b/test-utils/src/data_gen.rs
@@ -46,6 +46,7 @@ impl Default for GeneratorOptions {
     }
 }
 
+/// Creates access log like entries
 #[derive(Default)]
 struct BatchBuilder {
     service: StringDictionaryBuilder<Int32Type>,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -22,8 +22,10 @@ use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 
 mod data_gen;
+mod string_gen;
 
 pub use data_gen::AccessLogGenerator;
+pub use string_gen::StringBatchGenerator;
 
 pub use env_logger;
 

--- a/test-utils/src/string_gen.rs
+++ b/test-utils/src/string_gen.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// use arrow::array::{ArrayRef, GenericStringArray, OffsetSizeTrait, RecordBatch, UInt32Array};
+use crate::stagger_batch;
+use arrow::array::{ArrayRef, GenericStringArray, OffsetSizeTrait, UInt32Array};
+use arrow::record_batch::RecordBatch;
+use rand::rngs::StdRng;
+use rand::{thread_rng, Rng, SeedableRng};
+
+/// Randomly generate strings
+pub struct StringBatchGenerator {
+    //// The maximum length of the strings
+    pub max_len: usize,
+    /// the total number of strings in the output
+    pub num_strings: usize,
+    /// The number of distinct strings in the columns
+    pub num_distinct_strings: usize,
+    /// The percentage of nulls in the columns
+    pub null_pct: f64,
+    /// Random number generator
+    pub rng: StdRng,
+}
+
+impl StringBatchGenerator {
+    /// Make batches of random strings with a random length columns "a" and "b".
+    ///
+    /// * "a" is a StringArray
+    /// * "b" is a LargeStringArray
+    pub fn make_input_batches(&mut self) -> Vec<RecordBatch> {
+        // use a random number generator to pick a random sized output
+        let batch = RecordBatch::try_from_iter(vec![
+            ("a", self.gen_data::<i32>()),
+            ("b", self.gen_data::<i64>()),
+        ])
+        .unwrap();
+        stagger_batch(batch)
+    }
+
+    /// Return a column sorted array of random strings, sorted by a
+    ///
+    /// if large is false, the array is a StringArray
+    /// if large is true, the array is a LargeStringArray
+    pub fn make_sorted_input_batches(&mut self, large: bool) -> Vec<RecordBatch> {
+        let array = if large {
+            self.gen_data::<i32>()
+        } else {
+            self.gen_data::<i64>()
+        };
+
+        let array = arrow::compute::sort(&array, None).unwrap();
+
+        let batch = RecordBatch::try_from_iter(vec![("a", array)]).unwrap();
+        stagger_batch(batch)
+    }
+
+    /// Creates a StringArray or LargeStringArray with random strings according
+    /// to the parameters of the BatchGenerator
+    fn gen_data<O: OffsetSizeTrait>(&mut self) -> ArrayRef {
+        // table of strings from which to draw
+        let distinct_strings: GenericStringArray<O> = (0..self.num_distinct_strings)
+            .map(|_| Some(random_string(&mut self.rng, self.max_len)))
+            .collect();
+
+        // pick num_strings randomly from the distinct string table
+        let indicies: UInt32Array = (0..self.num_strings)
+            .map(|_| {
+                if self.rng.gen::<f64>() < self.null_pct {
+                    None
+                } else if self.num_distinct_strings > 1 {
+                    let range = 1..(self.num_distinct_strings as u32);
+                    Some(self.rng.gen_range(range))
+                } else {
+                    Some(0)
+                }
+            })
+            .collect();
+
+        let options = None;
+        arrow::compute::take(&distinct_strings, &indicies, options).unwrap()
+    }
+
+    /// Return an set of `BatchGenerator`s that cover a range of interesting
+    /// cases
+    pub fn interesting_cases() -> Vec<Self> {
+        let mut cases = vec![];
+        let mut rng = thread_rng();
+        for null_pct in [0.0, 0.01, 0.1, 0.5] {
+            for _ in 0..100 {
+                // max length of generated strings
+                let max_len = rng.gen_range(1..50);
+                let num_strings = rng.gen_range(1..100);
+                let num_distinct_strings = if num_strings > 1 {
+                    rng.gen_range(1..num_strings)
+                } else {
+                    num_strings
+                };
+                cases.push(StringBatchGenerator {
+                    max_len,
+                    num_strings,
+                    num_distinct_strings,
+                    null_pct,
+                    rng: StdRng::from_seed(rng.gen()),
+                })
+            }
+        }
+        cases
+    }
+}
+
+/// Return a string of random characters of length 1..=max_len
+fn random_string(rng: &mut StdRng, max_len: usize) -> String {
+    // pick characters at random (not just ascii)
+    match max_len {
+        0 => "".to_string(),
+        1 => String::from(rng.gen::<char>()),
+        _ => {
+            let len = rng.gen_range(1..=max_len);
+            rng.sample_iter::<char, _>(rand::distributions::Standard)
+                .take(len)
+                .map(char::from)
+                .collect::<String>()
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/7064

## Rationale for this change

I want fuzz test coverage for the grouping by single string columns so no regressions are introduced

## What changes are included in this PR?
1. Add fuzz test coverage for  both sorted (streaming) and non streaming
2. Add `MemTable::with_sort_exprs` which is needed to write this test

## Are these changes tested?
Yes

## Are there any user-facing changes?
1. New API `MemTable::with_sort_exprs`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
