### PR TITLE
Return an error when a column does not exist in window function

### DIFF
--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -195,8 +195,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             let window_frame = if let Some(window_frame) = window_frame {
                 regularize_window_order_by(&window_frame, &mut order_by)?;
                 window_frame
-            } else if let Some(_) = is_ordering_strict {
-                WindowFrame::new(Some(true))
+            } else if let Some(is_ordering_strict) = is_ordering_strict {
+                match is_ordering_strict {
+                    true => WindowFrame::new(Some(true)),
+                    false => WindowFrame::new(Some(false)),
+                }
             } else {
                 WindowFrame::new((!order_by.is_empty()).then_some(false))
             };

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -16,7 +16,10 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{exec_err, not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Dependency, Result, schema_err, SchemaError};
+use datafusion_common::{
+    exec_err, not_impl_err, plan_datafusion_err, plan_err, schema_err, DFSchema,
+    DataFusionError, Dependency, Result, SchemaError,
+};
 use datafusion_expr::expr::{ScalarFunction, Unnest};
 use datafusion_expr::function::suggest_valid_function;
 use datafusion_expr::window_frame::{check_window_frame, regularize_window_order_by};
@@ -153,24 +156,27 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         let idx_result = schema.index_of_column(col);
 
                         // Propagate the error to the caller and return it immediately
-                        let idx = idx_result.map_err(|_| -> Result<usize, DataFusionError> {
-                             schema_err!(SchemaError::FieldNotFound {
-                                field: Box::new(col.clone()),
-                                valid_fields: schema
-                                    .fields()
-                                    .iter()
-                                    .map(|f| f.qualified_column())
-                                    .collect(),
+                        let idx = idx_result
+                            .map_err(|_| -> Result<usize, DataFusionError> {
+                                schema_err!(SchemaError::FieldNotFound {
+                                    field: Box::new(col.clone()),
+                                    valid_fields: schema
+                                        .fields()
+                                        .iter()
+                                        .map(|f| f.qualified_column())
+                                        .collect(),
+                                })
                             })
-                        }).ok()?;
+                            .ok()?;
 
                         return if func_deps.iter().any(|dep| {
-                            dep.source_indices == vec![idx] && dep.mode == Dependency::Single
+                            dep.source_indices == vec![idx]
+                                && dep.mode == Dependency::Single
                         }) {
                             Some(true)
                         } else {
                             Some(false)
-                        }
+                        };
                     }
                 }
                 Some(false)

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -157,7 +157,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                     && dep.mode == Dependency::Single
                             }),
                             Err(_) => {
-                                schema_err!("Column '{col}' not found in schema")
+                                schema_err!(format!("Column '{}' does not exist in schema", col))
                             }
                         };
                     }

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{exec_err, not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Dependency, Result, schema_err};
+use datafusion_common::{exec_err, not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Dependency, Result, schema_err, SchemaError};
 use datafusion_expr::expr::{ScalarFunction, Unnest};
 use datafusion_expr::function::suggest_valid_function;
 use datafusion_expr::window_frame::{check_window_frame, regularize_window_order_by};
@@ -146,23 +146,34 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             )?;
 
             let func_deps = schema.functional_dependencies();
-            // Find whether ties are possible in the given ordering:
-            let is_ordering_strict = order_by.iter().any(|orderby_expr| {
+            // Find whether ties are possible in the given ordering
+            let is_ordering_strict = order_by.iter().find_map(|orderby_expr| {
                 if let Expr::Sort(sort_expr) = orderby_expr {
                     if let Expr::Column(col) = sort_expr.expr.as_ref() {
                         let idx_result = schema.index_of_column(col);
-                        return match idx_result {
-                            Ok(index) => func_deps.iter().any(|dep| {
-                                dep.source_indices == vec![index]
-                                    && dep.mode == Dependency::Single
-                            }),
-                            Err(_) => {
-                                schema_err!(format!("Column '{}' does not exist in schema", col))
-                            }
-                        };
+
+                        // Propagate the error to the caller and return it immediately
+                        let idx = idx_result.map_err(|_| -> Result<usize, DataFusionError> {
+                             schema_err!(SchemaError::FieldNotFound {
+                                field: Box::new(col.clone()),
+                                valid_fields: schema
+                                    .fields()
+                                    .iter()
+                                    .map(|f| f.qualified_column())
+                                    .collect(),
+                            })
+                        }).ok()?;
+
+                        return if func_deps.iter().any(|dep| {
+                            dep.source_indices == vec![idx] && dep.mode == Dependency::Single
+                        }) {
+                            Some(true)
+                        } else {
+                            Some(false)
+                        }
                     }
                 }
-                false
+                Some(false)
             });
 
             let window_frame = window
@@ -178,7 +189,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             let window_frame = if let Some(window_frame) = window_frame {
                 regularize_window_order_by(&window_frame, &mut order_by)?;
                 window_frame
-            } else if is_ordering_strict {
+            } else if let Some(_) = is_ordering_strict {
                 WindowFrame::new(Some(true))
             } else {
                 WindowFrame::new((!order_by.is_empty()).then_some(false))

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -17,8 +17,8 @@
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{
-    exec_err, not_impl_err, plan_datafusion_err, plan_err, schema_err, DFSchema,
-    DataFusionError, Dependency, Result, SchemaError,
+    exec_err, not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError,
+    Dependency, Result,
 };
 use datafusion_expr::expr::{ScalarFunction, Unnest};
 use datafusion_expr::function::suggest_valid_function;
@@ -153,22 +153,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             let is_ordering_strict = order_by.iter().find_map(|orderby_expr| {
                 if let Expr::Sort(sort_expr) = orderby_expr {
                     if let Expr::Column(col) = sort_expr.expr.as_ref() {
-                        let idx_result = schema.index_of_column(col);
-
-                        // Propagate the error to the caller and return it immediately
-                        let idx = idx_result
-                            .map_err(|_| -> Result<usize, DataFusionError> {
-                                schema_err!(SchemaError::FieldNotFound {
-                                    field: Box::new(col.clone()),
-                                    valid_fields: schema
-                                        .fields()
-                                        .iter()
-                                        .map(|f| f.qualified_column())
-                                        .collect(),
-                                })
-                            })
-                            .ok()?;
-
+                        let idx = schema.index_of_column(col).ok()?;
                         return if func_deps.iter().any(|dep| {
                             dep.source_indices == vec![idx]
                                 && dep.mode == Dependency::Single

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -196,10 +196,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 regularize_window_order_by(&window_frame, &mut order_by)?;
                 window_frame
             } else if let Some(is_ordering_strict) = is_ordering_strict {
-                match is_ordering_strict {
-                    true => WindowFrame::new(Some(true)),
-                    false => WindowFrame::new(Some(false)),
-                }
+                WindowFrame::new(Some(is_ordering_strict))
             } else {
                 WindowFrame::new((!order_by.is_empty()).then_some(false))
             };

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4343,6 +4343,13 @@ fn test_multi_grouping_sets() {
     quick_test(sql, expected);
 }
 
+#[test]
+fn test_field_not_found_window_function() {
+    let sql = "SELECT count() OVER (order by a);";
+    let err = logical_plan(sql).expect_err("query should have failed");
+    assert_eq!("Schema error: No field named a.", err.strip_backtrace());
+}
+
 fn assert_field_not_found(err: DataFusionError, name: &str) {
     match err {
         DataFusionError::SchemaError { .. } => {


### PR DESCRIPTION
## Which issue does this PR close?
Closes #9166.

## Rationale for this change
To return an error instead of panicking when columns don't exist in window function.

## What changes are included in this PR?
Code, tests

## Are these changes tested?
Yes

## Are there any user-facing changes?
