### PR TITLE
Partitioning fixes

### DIFF
--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -139,8 +139,8 @@ mod tests {
     use datafusion_execution::object_store::{
         DefaultObjectStoreRegistry, ObjectStoreRegistry,
     };
-    use object_store::local::LocalFileSystem;
-    use std::sync::Arc;
+    use object_store::{local::LocalFileSystem, path::Path};
+    use std::{ops::Not, sync::Arc};
     use url::Url;
 
     #[test]
@@ -184,5 +184,40 @@ mod tests {
         let sut = DefaultObjectStoreRegistry::default();
         let url = ListingTableUrl::parse("../").unwrap();
         sut.get_store(url.as_ref()).unwrap();
+    }
+
+    #[test]
+    fn test_url_contains() {
+        let sut = DefaultObjectStoreRegistry::default();
+        let url = ListingTableUrl::parse("file:///var/data/mytable/").unwrap();
+
+        // as per documentation, when `ignore_subdirectory` is true, we should ignore files that aren't
+        // a direct child of the `url`
+        assert!(url
+            .contains(
+                &Path::parse("/var/data/mytable/mysubfolder/data.parquet").unwrap(),
+                true
+            )
+            .not());
+
+        // when we set `ignore_subdirectory` to false, we should not ignore the file
+        assert!(url.contains(
+            &Path::parse("/var/data/mytable/mysubfolder/data.parquet").unwrap(),
+            false
+        ));
+
+        // as above, `ignore_subdirectory` is false, so we include the file
+        assert!(url.contains(
+            &Path::parse("/var/data/mytable/year=2024/data.parquet").unwrap(),
+            false
+        ));
+
+        // in this case, we include the file even when `ignore_subdirectory` is true because the
+        // path segment is a hive partition which doesn't count as a subdirectory for the purposes
+        // of `Url::contains`
+        assert!(url.contains(
+            &Path::parse("/var/data/mytable/year=2024/data.parquet").unwrap(),
+            true
+        ));
     }
 }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -190,6 +190,18 @@ mod tests {
     fn test_url_contains() {
         let url = ListingTableUrl::parse("file:///var/data/mytable/").unwrap();
 
+        // standard case with default config
+        assert!(url.contains(
+            &Path::parse("/var/data/mytable/data.parquet").unwrap(),
+            true
+        ));
+
+        // standard case with `ignore_subdirectory` set to false
+        assert!(url.contains(
+            &Path::parse("/var/data/mytable/data.parquet").unwrap(),
+            false
+        ));
+
         // as per documentation, when `ignore_subdirectory` is true, we should ignore files that aren't
         // a direct child of the `url`
         assert!(url
@@ -218,5 +230,11 @@ mod tests {
             &Path::parse("/var/data/mytable/year=2024/data.parquet").unwrap(),
             true
         ));
+
+        // testing an empty path with default config
+        assert!(url.contains(&Path::parse("/var/data/mytable/").unwrap(), true));
+
+        // testing an empty path with `ignore_subdirectory` set to false
+        assert!(url.contains(&Path::parse("/var/data/mytable/").unwrap(), false));
     }
 }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -188,7 +188,6 @@ mod tests {
 
     #[test]
     fn test_url_contains() {
-        let sut = DefaultObjectStoreRegistry::default();
         let url = ListingTableUrl::parse("file:///var/data/mytable/").unwrap();
 
         // as per documentation, when `ignore_subdirectory` is true, we should ignore files that aren't

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -27,6 +27,7 @@ use glob::Pattern;
 use itertools::Itertools;
 use log::debug;
 use object_store::path::Path;
+use object_store::path::DELIMITER;
 use object_store::{ObjectMeta, ObjectStore};
 use std::sync::Arc;
 use url::Url;
@@ -194,7 +195,7 @@ impl ListingTableUrl {
         };
 
         // remove any segments that contain `=` as they are allowed even
-        // when ignore subdirectories is `true`
+        // when ignore subdirectories is `true`.
         let mut segments = all_segments.filter(|s| !s.contains('='));
 
         match &self.glob {
@@ -204,7 +205,7 @@ impl ListingTableUrl {
                         .next()
                         .map_or(false, |file_name| glob.matches(file_name))
                 } else {
-                    let stripped = segments.join("/");
+                    let stripped = segments.join(DELIMITER);
                     glob.matches(&stripped)
                 }
             }
@@ -221,7 +222,7 @@ impl ListingTableUrl {
 
     /// Returns `true` if `path` refers to a collection of objects
     pub fn is_collection(&self) -> bool {
-        self.url.as_str().ends_with('/')
+        self.url.as_str().ends_with(DELIMITER)
     }
 
     /// Strips the prefix of this [`ListingTableUrl`] from the provided path, returning
@@ -230,7 +231,6 @@ impl ListingTableUrl {
         &'a self,
         path: &'b Path,
     ) -> Option<impl Iterator<Item = &'b str> + 'a> {
-        use object_store::path::DELIMITER;
         let mut stripped = path.as_ref().strip_prefix(self.prefix.as_ref())?;
         if !stripped.is_empty() && !self.prefix.as_ref().is_empty() {
             stripped = stripped.strip_prefix(DELIMITER)?;

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -209,14 +209,12 @@ impl ListingTableUrl {
                     glob.matches(&stripped)
                 }
             }
-            None => {
-                if ignore_subdirectory {
-                    let has_subdirectory = segments.count() > 1;
-                    !has_subdirectory
-                } else {
-                    true
-                }
-            }
+            // where we are ignoring subdirectories, we require
+            // the path to be either empty, or contain just the
+            // final file name segment.
+            None if ignore_subdirectory => segments.count() <= 1,
+            // in this case, any valid path at or below the url is allowed
+            None => true,
         }
     }
 

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -189,28 +189,34 @@ impl ListingTableUrl {
 
     /// Returns `true` if `path` matches this [`ListingTableUrl`]
     pub fn contains(&self, path: &Path, ignore_subdirectory: bool) -> bool {
-        match self.strip_prefix(path) {
-            Some(mut segments) => match &self.glob {
-                Some(glob) => {
-                    if ignore_subdirectory {
-                        segments
-                            .next()
-                            .map_or(false, |file_name| glob.matches(file_name))
-                    } else {
-                        let stripped = segments.join("/");
-                        glob.matches(&stripped)
-                    }
+
+        let Some(all_segments) = self.strip_prefix(path) else {
+            return false
+        };
+
+        // remove any segments that contain `=` as they are allowed even
+        // when ignore subdirectories is `true`
+        let mut segments = all_segments.filter(|s| !s.contains('='));
+
+        match &self.glob {
+            Some(glob) => {
+                if ignore_subdirectory {
+                    segments
+                        .next()
+                        .map_or(false, |file_name| glob.matches(file_name))
+                } else {
+                    let stripped = segments.join("/");
+                    glob.matches(&stripped)
                 }
-                None => {
-                    if ignore_subdirectory {
-                        let has_subdirectory = segments.collect::<Vec<_>>().len() > 1;
-                        !has_subdirectory
-                    } else {
-                        true
-                    }
+            }
+            None => {
+                if ignore_subdirectory {
+                    let has_subdirectory = segments.collect::<Vec<_>>().len() > 1;
+                    !has_subdirectory
+                } else {
+                    true
                 }
-            },
-            None => false,
+            }
         }
     }
 
@@ -230,11 +236,11 @@ impl ListingTableUrl {
         if !stripped.is_empty() && !self.prefix.as_ref().is_empty() {
             stripped = stripped.strip_prefix(DELIMITER)?;
         }
-        Some(stripped.split_terminator(DELIMITER))
+        Some( stripped.split_terminator(DELIMITER))
     }
 
     /// List all files identified by this [`ListingTableUrl`] for the provided `file_extension`
-    pub(crate) async fn list_all_files<'a>(
+    pub async fn list_all_files<'a>(
         &'a self,
         ctx: &'a SessionState,
         store: &'a dyn ObjectStore,

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -210,7 +210,7 @@ impl ListingTableUrl {
             }
             None => {
                 if ignore_subdirectory {
-                    let has_subdirectory = segments.collect::<Vec<_>>().len() > 1;
+                    let has_subdirectory = segments.count() > 1;
                     !has_subdirectory
                 } else {
                     true

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -189,9 +189,8 @@ impl ListingTableUrl {
 
     /// Returns `true` if `path` matches this [`ListingTableUrl`]
     pub fn contains(&self, path: &Path, ignore_subdirectory: bool) -> bool {
-
         let Some(all_segments) = self.strip_prefix(path) else {
-            return false
+            return false;
         };
 
         // remove any segments that contain `=` as they are allowed even
@@ -236,7 +235,7 @@ impl ListingTableUrl {
         if !stripped.is_empty() && !self.prefix.as_ref().is_empty() {
             stripped = stripped.strip_prefix(DELIMITER)?;
         }
-        Some( stripped.split_terminator(DELIMITER))
+        Some(stripped.split_terminator(DELIMITER))
     }
 
     /// List all files identified by this [`ListingTableUrl`] for the provided `file_extension`


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9206.

## Rationale for this change

* Aligns the code behaviour with the documentation


## What changes are included in this PR?

* Altering the `ListingTableUrl::contains` method to skip hive partitions where they appear as a segment in the url
* Makes the `list_all_files` method public to allow users to more easily see what files are being included with the `ListingTableUrl`

## Are these changes tested?

Yes a new test is added to ensure that the changes continue to behave as expected

## Are there any user-facing changes?

* An additional public function on `ListingTableUrl`
* Extra files may be listed for a given `ListingTableUrl` which previously were not included. This could cause query results to change
