### PR TITLE
GROUP-BY prioritizes input columns in case of ambiguity

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3192,7 +3192,7 @@ SELECT 0 as "t.a" FROM t GROUP BY t.a;
 0
 0
 
-# The column name referenced by HAVING is ambiguous
+# The column name referenced by HAVING is ambiguous, prefer the column in the base plan
 query I
 SELECT 0 AS "t.a" FROM t HAVING MAX(t.a) = 0;
 ----

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3184,7 +3184,7 @@ DROP TABLE t;
 statement ok
 CREATE TABLE t(a BIGINT) AS VALUES(1), (2), (3);
 
-# The column name referenced by GROUP-BY is ambiguous
+# The column name referenced by GROUP-BY is ambiguous, prefer the column in base plan
 query I
 SELECT 0 as "t.a" FROM t GROUP BY t.a;
 ----

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3179,3 +3179,23 @@ NULL
 statement ok
 DROP TABLE t;
 
+
+# Test for the case when the column name is ambiguous
+statement ok
+CREATE TABLE t(a BIGINT) AS VALUES(1), (2), (3);
+
+# The column name referenced by GROUP-BY is ambiguous
+query I
+SELECT 0 as "t.a" FROM t GROUP BY t.a;
+----
+0
+0
+0
+
+# The column name referenced by HAVING is ambiguous
+query I
+SELECT 0 AS "t.a" FROM t HAVING MAX(t.a) = 0;
+----
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
## Which issue does this PR close?
Closes #9162.

## Rationale for this change


When a column referenced by group-by exists both in the select list and the input, the one from the input should be given priority. In issue 9162, there are two references with the same name: one is an unqualified "t.a," and the other is a qualified t.a.

This is the practice of many databases, including PostgreSQL, Oracle, MySQL, Duckdb, etc. 
In the PostgreSQL documentation, there is an [explanation](https://www.postgresql.org/docs/current/sql-select.html#SQL-GROUPBY) about it.
> An expression used inside a grouping_element can be an input column name, or the name or ordinal number of an output column (SELECT list item), or an arbitrary expression formed from input-column values. In case of ambiguity, a GROUP BY name will be interpreted as an **input-column** name rather than an output column name.

## What changes are included in this PR?
Prioritize searching the schema of the base plan when generating GROUP BY expressions.


## Are these changes tested?
Yes

## Are there any user-facing changes?
No