### PR TITLE
fix: add `ArrayAndElementAndOptionalIndex` for proper casting in `array_position`

### DIFF
--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -965,7 +965,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ArrayNdims => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayDistinct => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayPosition => {
-                Signature::variadic_any(self.volatility())
+                Signature::array_and_element(self.volatility())
             }
             BuiltinScalarFunction::ArrayPositions => {
                 Signature::array_and_element(self.volatility())

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -965,7 +965,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ArrayNdims => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayDistinct => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayPosition => {
-                Signature::array_and_element(self.volatility())
+                Signature::array_and_element_and_optional_index(self.volatility())
             }
             BuiltinScalarFunction::ArrayPositions => {
                 Signature::array_and_element(self.volatility())

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -134,7 +134,7 @@ pub enum ArrayFunctionSignature {
     ElementAndArray,
     /// Specialized Signature for Array functions of the form (List/LargeList, Index)
     ArrayAndIndex,
-    /// Specialized Signature for Array functions of the form (List/LargeList, Element, [Index])
+    /// Specialized Signature for Array functions of the form (List/LargeList, Element, Optional Index)
     ArrayAndElementAndOptionalIndex,
 }
 

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -132,7 +132,9 @@ pub enum ArrayFunctionSignature {
     /// The first argument should be non-list or list, and the second argument should be List/LargeList.
     /// The first argument's list dimension should be one dimension less than the second argument's list dimension.
     ElementAndArray,
+    /// Specialized Signature for Array functions of the form (List/LargeList, Index)
     ArrayAndIndex,
+    /// Specialized Signature for Array functions of the form (List/LargeList, Element, [Index])
     ArrayAndElementAndOptionalIndex,
 }
 

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -133,6 +133,7 @@ pub enum ArrayFunctionSignature {
     /// The first argument's list dimension should be one dimension less than the second argument's list dimension.
     ElementAndArray,
     ArrayAndIndex,
+    ArrayAndElementAndOptionalIndex,
 }
 
 impl std::fmt::Display for ArrayFunctionSignature {
@@ -140,6 +141,9 @@ impl std::fmt::Display for ArrayFunctionSignature {
         match self {
             ArrayFunctionSignature::ArrayAndElement => {
                 write!(f, "array, element")
+            }
+            ArrayFunctionSignature::ArrayAndElementAndOptionalIndex => {
+                write!(f, "array, element, [index]")
             }
             ArrayFunctionSignature::ElementAndArray => {
                 write!(f, "element, array")
@@ -288,6 +292,15 @@ impl Signature {
         Signature {
             type_signature: TypeSignature::ArraySignature(
                 ArrayFunctionSignature::ArrayAndElement,
+            ),
+            volatility,
+        }
+    }
+    /// Specialized Signature for Array functions with an optional index
+    pub fn array_and_element_and_optional_index(volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::ArraySignature(
+                ArrayFunctionSignature::ArrayAndElementAndOptionalIndex,
             ),
             volatility,
         }

--- a/datafusion/expr/src/signature.rs
+++ b/datafusion/expr/src/signature.rs
@@ -91,7 +91,7 @@ pub enum TypeSignature {
     /// DataFusion attempts to coerce all argument types to match the first argument's type
     ///
     /// # Examples
-    /// Given types in signature should be coericible to the same final type.
+    /// Given types in signature should be coercible to the same final type.
     /// A function such as `make_array` is `VariadicEqual`.
     ///
     /// `make_array(i32, i64) -> make_array(i64, i64)`

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -133,13 +133,13 @@ fn get_valid_types(
     fn array_append_and_optional_index(
         current_types: &[DataType],
     ) -> Result<Vec<Vec<DataType>>> {
-        // make sure there's at least 2 arguments
+        // make sure there's 2 or 3 arguments
         if !(current_types.len() == 2 || current_types.len() == 3) {
             return Ok(vec![vec![]]);
         }
 
         let first_two_types = &current_types[0..2];
-        let valid_types = array_append_or_prepend_valid_types(first_two_types, true)?;
+        let mut valid_types = array_append_or_prepend_valid_types(first_two_types, true)?;
 
         let valid_types_with_index = valid_types
             .iter()
@@ -150,7 +150,6 @@ fn get_valid_types(
             })
             .collect::<Vec<_>>();
 
-        let mut valid_types = valid_types;
         valid_types.extend(valid_types_with_index);
 
         Ok(valid_types)

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -130,7 +130,7 @@ fn get_valid_types(
             _ => Ok(vec![vec![]]),
         }
     }
-    fn array_append_and_optional_index(
+    fn array_element_and_optional_index(
         current_types: &[DataType],
     ) -> Result<Vec<Vec<DataType>>> {
         // make sure there's 2 or 3 arguments
@@ -140,6 +140,11 @@ fn get_valid_types(
 
         let first_two_types = &current_types[0..2];
         let mut valid_types = array_append_or_prepend_valid_types(first_two_types, true)?;
+
+        // Early return if there are only 2 arguments
+        if current_types.len() == 2 {
+            return Ok(valid_types);
+        }
 
         let valid_types_with_index = valid_types
             .iter()
@@ -209,7 +214,7 @@ fn get_valid_types(
                 return array_append_or_prepend_valid_types(current_types, true)
             }
             ArrayFunctionSignature::ArrayAndElementAndOptionalIndex => {
-                return array_append_and_optional_index(current_types)
+                return array_element_and_optional_index(current_types)
             }
             ArrayFunctionSignature::ArrayAndIndex => {
                 return array_and_index(current_types)

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -130,6 +130,31 @@ fn get_valid_types(
             _ => Ok(vec![vec![]]),
         }
     }
+    fn array_append_and_optional_index(
+        current_types: &[DataType],
+    ) -> Result<Vec<Vec<DataType>>> {
+        // make sure there's at least 2 arguments
+        if !(current_types.len() == 2 || current_types.len() == 3) {
+            return Ok(vec![vec![]]);
+        }
+
+        let first_two_types = &current_types[0..2];
+        let valid_types = array_append_or_prepend_valid_types(first_two_types, true)?;
+
+        let valid_types_with_index = valid_types
+            .iter()
+            .map(|t| {
+                let mut t = t.clone();
+                t.push(DataType::Int64);
+                t
+            })
+            .collect::<Vec<_>>();
+
+        let mut valid_types = valid_types;
+        valid_types.extend(valid_types_with_index);
+
+        Ok(valid_types)
+    }
     fn array_and_index(current_types: &[DataType]) -> Result<Vec<Vec<DataType>>> {
         if current_types.len() != 2 {
             return Ok(vec![vec![]]);
@@ -183,6 +208,9 @@ fn get_valid_types(
         {
             ArrayFunctionSignature::ArrayAndElement => {
                 return array_append_or_prepend_valid_types(current_types, true)
+            }
+            ArrayFunctionSignature::ArrayAndElementAndOptionalIndex => {
+                return array_append_and_optional_index(current_types)
             }
             ArrayFunctionSignature::ArrayAndIndex => {
                 return array_and_index(current_types)

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2604,7 +2604,12 @@ select array_position(arrow_cast(make_array([1, 2, 3], [4, 5, 6], [5, 5, 5], [4,
 2 2
 
 query I
-SELECT array_position(arrow_cast([1, 2, 3, 4, 5], 'List(Int32)'), 5)
+SELECT array_position(arrow_cast([5, 2, 3, 4, 5], 'List(Int32)'), 5)
+----
+1
+
+query I
+SELECT array_position(arrow_cast([5, 2, 3, 4, 5], 'List(Int32)'), 5, 2)
 ----
 5
 

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2603,6 +2603,11 @@ select array_position(arrow_cast(make_array([1, 2, 3], [4, 5, 6], [5, 5, 5], [4,
 ----
 2 2
 
+query I
+SELECT array_position(arrow_cast([1, 2, 3, 4, 5], 'List(Int32)'), 5)
+----
+5
+
 # list_position scalar function #5 (function alias `array_position`)
 query III
 select list_position(['h', 'e', 'l', 'l', 'o'], 'l'), list_position([1, 2, 3, 4, 5], 5), list_position([1, 1, 1], 1);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2618,10 +2618,6 @@ SELECT array_position(arrow_cast([1, 1, 100, 1, 1], 'LargeList(Int32)'), 100)
 ----
 3
 
-statement error
-SELECT array_position(arrow_cast([5, 2, 3, 4, 5], 'List(Int32)'), 'foo')
-
-
 # list_position scalar function #5 (function alias `array_position`)
 query III
 select list_position(['h', 'e', 'l', 'l', 'o'], 'l'), list_position([1, 2, 3, 4, 5], 5), list_position([1, 1, 1], 1);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2613,6 +2613,15 @@ SELECT array_position(arrow_cast([5, 2, 3, 4, 5], 'List(Int32)'), 5, 2)
 ----
 5
 
+query I
+SELECT array_position(arrow_cast([1, 1, 100, 1, 1], 'LargeList(Int32)'), 100)
+----
+3
+
+statement error
+SELECT array_position(arrow_cast([5, 2, 3, 4, 5], 'List(Int32)'), 'foo')
+
+
 # list_position scalar function #5 (function alias `array_position`)
 query III
 select list_position(['h', 'e', 'l', 'l', 'o'], 'l'), list_position([1, 2, 3, 4, 5], 5), list_position([1, 1, 1], 1);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2618,6 +2618,16 @@ SELECT array_position(arrow_cast([1, 1, 100, 1, 1], 'LargeList(Int32)'), 100)
 ----
 3
 
+query I
+SELECT array_position([1, 2, 3], 'foo')
+----
+NULL
+
+query I
+SELECT array_position([1, 2, 3], 'foo', 2)
+----
+NULL
+
 # list_position scalar function #5 (function alias `array_position`)
 query III
 select list_position(['h', 'e', 'l', 'l', 'o'], 'l'), list_position([1, 2, 3, 4, 5], 5), list_position([1, 1, 1], 1);


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9093

## Rationale for this change

Currently throws an error when doing `SELECT array_position(arrow_cast([1, 2, 3, 4, 5], 'List(Int32)'), 5)`, and after this PR it won't.

## What changes are included in this PR?

Change recommended in https://github.com/apache/arrow-datafusion/issues/9093#issuecomment-1920673541

## Are these changes tested?

Added an additional sql logic test that failed w/o the change, and doesn't fail w/ the change.

## Are there any user-facing changes?

No