### PR TITLE
Add example for `ScalarStructBuilder::new_null`, fix display for `null` `ScalarValue::Struct`

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -83,7 +83,7 @@ pub use struct_builder::ScalarStructBuilder;
 ///
 /// In general, performance will be better using arrow [`Array`]s rather than
 /// [`ScalarValue`], as it is far more efficient to process multiple values at
-/// once (vecctorized processing).
+/// once (vectorized processing).
 ///
 /// # Example
 /// ```

--- a/datafusion/common/src/scalar/struct_builder.rs
+++ b/datafusion/common/src/scalar/struct_builder.rs
@@ -53,8 +53,8 @@ impl ScalarStructBuilder {
     ///    Field::new("a", DataType::Int32, false),
     /// ];
     /// let sv = ScalarStructBuilder::new_null(fields);
-    /// // Note this not is `null`, but a struct with a single field that is `null`
-    /// assert_eq!(format!("{sv}"), "{a:NULL}");
+    /// // Note this is `null`, not `{a:NULL}`
+    /// assert_eq!(format!("{sv}"), "NULL");
     ///```
     pub fn new_null(fields: impl IntoFields) -> ScalarValue {
         DataType::Struct(fields.into()).try_into().unwrap()

--- a/datafusion/common/src/scalar/struct_builder.rs
+++ b/datafusion/common/src/scalar/struct_builder.rs
@@ -39,10 +39,10 @@ impl ScalarStructBuilder {
         Self::default()
     }
 
-    /// Return a new [`ScalarValue::Struct`] with a single struct where all the
-    /// specified fields are null.
+    /// Return a new [`ScalarValue::Struct`] with a single null value.
     ///
-    /// Note, this is different from a single null value in the struct
+    /// Note this is different from a struct where each of the specified fields
+    /// are null (e.g. `{a: NULL}`
     ///
     /// # Example
     ///
@@ -53,9 +53,26 @@ impl ScalarStructBuilder {
     ///    Field::new("a", DataType::Int32, false),
     /// ];
     /// let sv = ScalarStructBuilder::new_null(fields);
-    /// // Note this is `null`, not `{a:NULL}`
+    /// // Note this is `NULL`, not `{a: NULL}`
     /// assert_eq!(format!("{sv}"), "NULL");
     ///```
+    ///
+    /// To create a struct where the *fields* are null, use `Self::new()` and
+    /// pass null values for each field:
+    ///
+    /// ```rust
+    /// # use arrow::datatypes::{DataType, Field};
+    /// # use datafusion_common::scalar::{ScalarStructBuilder, ScalarValue};
+    /// // make a nullable field
+    /// let field = Field::new("a", DataType::Int32, true);
+    /// // add a null value for the "a" field
+    /// let sv = ScalarStructBuilder::new()
+    ///   .with_scalar(field, ScalarValue::Int32(None))
+    ///   .build()
+    ///   .unwrap();
+    /// // value is not null, but field is
+    /// assert_eq!(format!("{sv}"), "{a:}");
+    /// ```
     pub fn new_null(fields: impl IntoFields) -> ScalarValue {
         DataType::Struct(fields.into()).try_into().unwrap()
     }

--- a/datafusion/common/src/scalar/struct_builder.rs
+++ b/datafusion/common/src/scalar/struct_builder.rs
@@ -39,10 +39,10 @@ impl ScalarStructBuilder {
         Self::default()
     }
 
-    /// Return a new [`ScalarValue::Struct`] with a single null value.
+    /// Return a new [`ScalarValue::Struct`] with a single `null` value.
     ///
     /// Note this is different from a struct where each of the specified fields
-    /// are null (e.g. `{a: NULL}`
+    /// are null (e.g. `{a: NULL}`)
     ///
     /// # Example
     ///

--- a/datafusion/common/src/scalar/struct_builder.rs
+++ b/datafusion/common/src/scalar/struct_builder.rs
@@ -39,8 +39,23 @@ impl ScalarStructBuilder {
         Self::default()
     }
 
-    /// Return a new [`ScalarValue::Struct`] with the specified fields and a
-    /// single null value
+    /// Return a new [`ScalarValue::Struct`] with a single struct where all the
+    /// specified fields are null.
+    ///
+    /// Note, this is different from a single null value in the struct
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use arrow::datatypes::{DataType, Field};
+    /// # use datafusion_common::scalar::ScalarStructBuilder;
+    /// let fields = vec![
+    ///    Field::new("a", DataType::Int32, false),
+    /// ];
+    /// let sv = ScalarStructBuilder::new_null(fields);
+    /// // Note this not is `null`, but a struct with a single field that is `null`
+    /// assert_eq!(format!("{sv}"), "{a:NULL}");
+    ///```
     pub fn new_null(fields: impl IntoFields) -> ScalarValue {
         DataType::Struct(fields.into()).try_into().unwrap()
     }


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/9229
related to  https://github.com/apache/arrow-datafusion/issues/9227

## Rationale for this change

@NGA-TRAN  asked internally about exactly what `ScalarStructBuilder::new_null` internally so I wanted to document it in an example here.

When I did the PR the display didn't match what I thought `new_null` did, so I fixed a bug in null display as well

## What changes are included in this PR?

1. Add a doc example for `ScalarStructBuilder::new_null`
2. Fix bug in `ScalarValue::Struct` null display 
3. Add test for ScalarValue::Struct display
4. Fix a typo

## Are these changes tested?
Yes, new test and by CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
