### PR TITLE
minor: Add more doc to clarify permutation satisfying input order in `InputOrderMode`

### DIFF
--- a/datafusion/physical-plan/src/ordering.rs
+++ b/datafusion/physical-plan/src/ordering.rs
@@ -28,11 +28,14 @@
 /// - A `PARTITION BY a, b` or a `PARTITION BY b, a` can use `Sorted` mode.
 ///
 /// ## Aggregations
-/// - A `GROUP BY b` clause can use `Linear` mode.
-/// - A `GROUP BY a, c` or a `GROUP BY BY c, a` can use
-///   `PartiallySorted([0])` or `PartiallySorted([1])` modes, respectively.
+/// - A `GROUP BY b` clause can use `Linear` mode, as the only one permutation `[b]`
+///   cannot satisfy the existing ordering.
+/// - A `GROUP BY a, c` or a `GROUP BY c, a` can use
+///   `PartiallySorted([0])` or `PartiallySorted([1])` modes, respectively, as
+///   the permutation `[a]` satisfies the existing ordering.
 ///   (The vector stores the index of `a` in the respective PARTITION BY expression.)
-/// - A `GROUP BY a, b` or a `GROUP BY b, a` can use `Sorted` mode.
+/// - A `GROUP BY a, b` or a `GROUP BY b, a` can use `Sorted` mode, as the
+///   full permutation `[a, b]` satisfies the existing ordering.
 ///
 /// Note these are the same examples as above, but with `GROUP BY` instead of
 /// `PARTITION BY` to make the examples easier to read.

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -329,11 +329,11 @@ pub(crate) fn calc_requirements<
     (!sort_reqs.is_empty()).then_some(sort_reqs)
 }
 
-/// This function calculates the indices such that when partition by expressions reordered with this indices
+/// This function calculates the indices such that when partition by expressions reordered with the indices
 /// resulting expressions define a preset for existing ordering.
-// For instance, if input is ordered by a, b, c and PARTITION BY b, a is used
-// This vector will be [1, 0]. It means that when we iterate b,a columns with the order [1, 0]
-// resulting vector (a, b) is a preset of the existing ordering (a, b, c).
+/// For instance, if input is ordered by a, b, c and PARTITION BY b, a is used,
+/// this vector will be [1, 0]. It means that when we iterate b, a columns with the order [1, 0]
+/// resulting vector (a, b) is a preset of the existing ordering (a, b, c).
 pub(crate) fn get_ordered_partition_by_indices(
     partition_by_exprs: &[Arc<dyn PhysicalExpr>],
     input: &Arc<dyn ExecutionPlan>,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When investigating an issue about Comet, I'm reading through `InputOrderMode`.  It takes some time to trace other related code to understand what it means. This patch adds a few more doc to `InputOrderMode` to make it more clear.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
