### PR TITLE
Add test to verify issue #9161

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3199,7 +3199,7 @@ SELECT 0 AS "t.a" FROM t HAVING MAX(t.a) = 0;
 
 # Test issue: https://github.com/apache/arrow-datafusion/issues/9161
 query I rowsort
-select cast(a as int) from t group by t.a;
+SELECT CAST(a AS INT) FROM t GROUP BY t.a;
 ----
 1
 2

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3197,5 +3197,13 @@ query I
 SELECT 0 AS "t.a" FROM t HAVING MAX(t.a) = 0;
 ----
 
+# Test issue: https://github.com/apache/arrow-datafusion/issues/9161
+query I rowsort
+select cast(a as int) from t group by t.a;
+----
+1
+2
+3
+
 statement ok
 DROP TABLE t;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9161.

## Rationale for this change
In issue #9161, the expression `cast(a as int)` in the select list [generated](https://github.com/apache/arrow-datafusion/blob/497cb9d46c6f68de6762998c241d0860072c7909/datafusion/expr/src/expr.rs#L1687) a unqualified column named 't.a', which was then incorrectly referenced by the group by clause, leading to a schema error.

After merging PR #9228, the group by clause will now preferentially reference the column of the same name from the **input**, rather than the one in the **select list**, thereby resolving the issue.

I suspect there will still be similar issues, but we may need to find a new case to verify whether they truly exist.

## What changes are included in this PR?
Add a test.

## Are these changes tested?

Yes

## Are there any user-facing changes?
No