### PR TITLE
Minor: fix warning of 'Unnecessary braces in use statement'

### DIFF
--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -17,18 +17,16 @@
 
 //! Encoding expressions
 
-use arrow::{
-    datatypes::DataType,
-};
+use arrow::datatypes::DataType;
 use datafusion_common::{internal_err, Result, DataFusionError};
-use datafusion_expr::{ColumnarValue};
+use datafusion_expr::ColumnarValue;
 
 use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 use arrow::array::Array;
 use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::nullif::nullif;
-use datafusion_common::{ ScalarValue};
+use datafusion_common::ScalarValue;
 
 #[derive(Debug)]
 pub(super) struct NullIfFunc {

--- a/datafusion/functions/src/math/nans.rs
+++ b/datafusion/functions/src/math/nans.rs
@@ -17,9 +17,7 @@
 
 //! Encoding expressions
 
-use arrow::{
-    datatypes::DataType,
-};
+use arrow::datatypes::DataType;
 use datafusion_common::{internal_err, Result, DataFusionError};
 use datafusion_expr::ColumnarValue;
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
Reported by rust-analyzer diagnostics.

![c632bef6-c8cc-4f32-a731-2cf38b4b0288_capture](https://github.com/apache/arrow-datafusion/assets/26053282/4bd147f3-02cd-4f37-a866-3c33ea2f8eab)


## What changes are included in this PR?


## Are these changes tested?
Yes

## Are there any user-facing changes?
No
