### PR TITLE
Update Docs with Copy partition_by support

### DIFF
--- a/docs/source/user-guide/sql/dml.md
+++ b/docs/source/user-guide/sql/dml.md
@@ -57,6 +57,18 @@ files in the `dir_name` directory:
 +-------+
 ```
 
+Copy the contents of `source_table` to multiple directories
+of hive-style partitioned parquet files:
+
+```sql
+> COPY source_table TO 'dir_name' (FORMAT parquet, partition_by 'column1, column2');
++-------+
+| count |
++-------+
+| 2     |
++-------+
+```
+
 Run the query `SELECT * from source ORDER BY time` and write the
 results (maintaining the order) to a parquet file named
 `output.parquet` with a maximum parquet row group size of 10MB:

--- a/docs/source/user-guide/sql/write_options.md
+++ b/docs/source/user-guide/sql/write_options.md
@@ -56,6 +56,7 @@ TO 'test/table_with_options'
 (format parquet,
 compression snappy,
 'compression::col1' 'zstd(5)',
+partition_by 'column3, column4'
 )
 ```
 
@@ -70,6 +71,8 @@ The following special options are specific to the `COPY` command.
 | Option | Description                                                                                                                                                                         | Default Value |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | FORMAT | Specifies the file format COPY query will write out. If there're more than one output file or the format cannot be inferred from the file extension, then FORMAT must be specified. | N/A           |
+| PARTITION_BY | Specifies the columns that the output files should be partitioned by into separate hive-style directories. Value should be a comma separated string literal, e.g. 'col1,col2' | N/A           |
+
 
 ### JSON Format Specific Options
 

--- a/docs/source/user-guide/sql/write_options.md
+++ b/docs/source/user-guide/sql/write_options.md
@@ -68,11 +68,10 @@ In this example, we write the entirety of `source_table` out to a folder of parq
 
 The following special options are specific to the `COPY` command.
 
-| Option | Description                                                                                                                                                                         | Default Value |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| FORMAT | Specifies the file format COPY query will write out. If there're more than one output file or the format cannot be inferred from the file extension, then FORMAT must be specified. | N/A           |
-| PARTITION_BY | Specifies the columns that the output files should be partitioned by into separate hive-style directories. Value should be a comma separated string literal, e.g. 'col1,col2' | N/A           |
-
+| Option       | Description                                                                                                                                                                         | Default Value |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| FORMAT       | Specifies the file format COPY query will write out. If there're more than one output file or the format cannot be inferred from the file extension, then FORMAT must be specified. | N/A           |
+| PARTITION_BY | Specifies the columns that the output files should be partitioned by into separate hive-style directories. Value should be a comma separated string literal, e.g. 'col1,col2'       | N/A           |
 
 ### JSON Format Specific Options
 


### PR DESCRIPTION
## Which issue does this PR close?

NA

## Rationale for this change

Support for writing partitioned files via partition_by was recently added.

## What changes are included in this PR?

Give examples of partition_by option for copy statements in the docs.

## Are these changes tested?

NA

## Are there any user-facing changes?

Doc updates
