### PR TITLE
Fix partition columns when they they are not at the end of the schema (fix Removing Partition Columns from RecordBatch)

### DIFF
--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -53,19 +53,38 @@ select * from validate_partitioned_parquet_bar order by col1;
 2
 
 # Copy to directory as partitioned files
-query TTT
-COPY (values ('1', 'a', 'x'), ('2', 'b', 'y'), ('3', 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table2/' 
-(format parquet, compression 'zstd(10)', partition_by 'column1, column3');
+query ITT
+COPY (values (1, 'a', 'x'), (2, 'b', 'y'), (3, 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table2/' 
+(format parquet, compression 'zstd(10)', partition_by 'column2, column3');
 ----
 3
 
 # validate multiple partitioned parquet file output
 statement ok
 CREATE EXTERNAL TABLE validate_partitioned_parquet2 STORED AS PARQUET 
-LOCATION 'test_files/scratch/copy/partitioned_table2/' PARTITIONED BY (column1, column3);
+LOCATION 'test_files/scratch/copy/partitioned_table2/' PARTITIONED BY (column2, column3);
+
+query I??
+select * from validate_partitioned_parquet2 order by column1,column2,column3;
+----
+1 a x
+2 b y
+3 c z
+
+# Copy to directory as partitioned files
+query TTT
+COPY (values ('1', 'a', 'x'), ('2', 'b', 'y'), ('3', 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table3/' 
+(format parquet, compression 'zstd(10)', partition_by 'column1, column3');
+----
+3
+
+# validate multiple partitioned parquet file output
+statement ok
+CREATE EXTERNAL TABLE validate_partitioned_parquet3 STORED AS PARQUET 
+LOCATION 'test_files/scratch/copy/partitioned_table3/' PARTITIONED BY (column1, column3);
 
 query ?T?
-select column1, column2, column3 from validate_partitioned_parquet2 order by column1,column2,column3;
+select column1, column2, column3 from validate_partitioned_parquet3 order by column1,column2,column3;
 ----
 1 a x
 2 b y
@@ -73,7 +92,7 @@ select column1, column2, column3 from validate_partitioned_parquet2 order by col
 
 statement ok
 CREATE EXTERNAL TABLE validate_partitioned_parquet_a_x STORED AS PARQUET 
-LOCATION 'test_files/scratch/copy/partitioned_table2/column1=1/column3=x';
+LOCATION 'test_files/scratch/copy/partitioned_table3/column1=1/column3=x';
 
 query T
 select * from validate_partitioned_parquet_a_x order by column2;

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -53,19 +53,19 @@ select * from validate_partitioned_parquet_bar order by col1;
 2
 
 # Copy to directory as partitioned files
-query ITT
-COPY (values (1, 'a', 'x'), (2, 'b', 'y'), (3, 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table2/' 
-(format parquet, compression 'zstd(10)', partition_by 'column2, column3');
+query TTT
+COPY (values ('1', 'a', 'x'), ('2', 'b', 'y'), ('3', 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table2/' 
+(format parquet, compression 'zstd(10)', partition_by 'column1, column3');
 ----
 3
 
 # validate multiple partitioned parquet file output
 statement ok
 CREATE EXTERNAL TABLE validate_partitioned_parquet2 STORED AS PARQUET 
-LOCATION 'test_files/scratch/copy/partitioned_table2/' PARTITIONED BY (column2, column3);
+LOCATION 'test_files/scratch/copy/partitioned_table2/' PARTITIONED BY (column1, column3);
 
-query I??
-select * from validate_partitioned_parquet2 order by column1,column2,column3;
+query ?T?
+select column1, column2, column3 from validate_partitioned_parquet2 order by column1,column2,column3;
 ----
 1 a x
 2 b y
@@ -73,12 +73,12 @@ select * from validate_partitioned_parquet2 order by column1,column2,column3;
 
 statement ok
 CREATE EXTERNAL TABLE validate_partitioned_parquet_a_x STORED AS PARQUET 
-LOCATION 'test_files/scratch/copy/partitioned_table2/column2=a/column3=x';
+LOCATION 'test_files/scratch/copy/partitioned_table2/column1=1/column3=x';
 
-query I
-select * from validate_partitioned_parquet_a_x order by column1;
+query T
+select * from validate_partitioned_parquet_a_x order by column2;
 ----
-1
+a
 
 statement ok
 create table test ("'test'" varchar, "'test2'" varchar, "'test3'" varchar); 

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -71,6 +71,15 @@ select * from validate_partitioned_parquet2 order by column1,column2,column3;
 2 b y
 3 c z
 
+statement ok
+CREATE EXTERNAL TABLE validate_partitioned_parquet_a_x STORED AS PARQUET 
+LOCATION 'test_files/scratch/copy/partitioned_table2/column2=a/column3=x';
+
+query I
+select * from validate_partitioned_parquet_a_x order by column1;
+----
+1
+
 # Copy to directory as partitioned files
 query TTT
 COPY (values ('1', 'a', 'x'), ('2', 'b', 'y'), ('3', 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table3/' 

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -91,11 +91,11 @@ select column1, column2, column3 from validate_partitioned_parquet3 order by col
 3 c z
 
 statement ok
-CREATE EXTERNAL TABLE validate_partitioned_parquet_a_x STORED AS PARQUET 
+CREATE EXTERNAL TABLE validate_partitioned_parquet_1_x STORED AS PARQUET 
 LOCATION 'test_files/scratch/copy/partitioned_table3/column1=1/column3=x';
 
 query T
-select * from validate_partitioned_parquet_a_x order by column2;
+select * from validate_partitioned_parquet_1_x order by column2;
 ----
 a
 


### PR DESCRIPTION
## Which issue does this PR close?

closes #9290 

## Rationale for this change

The current logic for removing partition_by columns assumes that the columns are at the end of the record batch. This is not always true when using COPY with the partition_by option.

## What changes are included in this PR?

Removes columns from record batch based on name rather than position.

## Are these changes tested?

Yes, modified copy.slt to cover

## Are there any user-facing changes?

Yes, partitioned COPY statements will work correctly even if specifying columns that do not come at the end of the schema