### PR TITLE
refactor: fix typo in PruningPredicate::always_true()

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -132,7 +132,7 @@ impl ParquetExec {
                     }
                 }
             })
-            .filter(|p| !p.allways_true());
+            .filter(|p| !p.always_true());
 
         let page_pruning_predicate = predicate.as_ref().and_then(|predicate_expr| {
             match PagePruningPredicate::try_new(predicate_expr, file_schema.clone()) {

--- a/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs
@@ -116,7 +116,7 @@ impl PagePruningPredicate {
             .filter_map(|predicate| {
                 match PruningPredicate::try_new(predicate.clone(), schema.clone()) {
                     Ok(p)
-                        if (!p.allways_true())
+                        if (!p.always_true())
                             && (p.required_columns().n_columns() < 2) =>
                     {
                         Some(Ok(p))

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -517,7 +517,7 @@ impl PruningPredicate {
     ///
     /// This happens if the predicate is a literal `true`  and
     /// literal_guarantees is empty.
-    pub fn allways_true(&self) -> bool {
+    pub fn always_true(&self) -> bool {
         is_always_true(&self.predicate_expr) && self.literal_guarantees.is_empty()
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

no

## Rationale for this change


## What changes are included in this PR?

Fix a typo:

```
allways => always
```

## Are these changes tested?



## Are there any user-facing changes?

Yes, this renames a public API and is a breaking change.
