### PR TITLE
docs: update contributor guide (format toml/inte test)

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -202,7 +202,7 @@ There are several tests of the public interface of the DataFusion library in the
 You can run these tests individually using `cargo` as normal command such as
 
 ```shell
-cargo test -p datafusion --test dataframe
+cargo test -p datafusion --test parquet_exec
 ```
 
 ## Benchmarks
@@ -337,4 +337,29 @@ After you've confirmed your prettier version, you can format all the `.md` files
 
 ```bash
 prettier -w {datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md
+```
+
+## How to format `.toml` files
+
+We use `taplo` to format `.toml` files.
+
+For Rust developers, you can install it via:
+
+```sh
+cargo install taplo-cli --locked
+```
+
+> Refer to the [Installation section][doc] on other ways to install it.
+>
+> [doc]: https://taplo.tamasfe.dev/cli/installation/binary.html
+
+```bash
+$ taplo --version
+taplo 0.9.0
+```
+
+After you've confirmed your `taplo` version, you can format all the `.toml` files:
+
+```bash
+taplo fmt
 ```


### PR DESCRIPTION
## Which issue does this PR close?

no

## Rationale for this change



## What changes are included in this PR?

1. Update the docs on integration test, `dataframe` is no longer a test target:

    ```sh
    $ cargo t -p datafusion --test dataframe
    error: no test target named `dataframe`.
    Available test targets:
        config_from_env
        core_integration
        custom_sources
        fifo
        fuzz
        memory_limit
        parquet_exec
        path_partition
        simplification
        tpcds_planning
        user_defined_integration
    ```

2. Add docs on how to format `.toml` files, ref: #9263 #9262

## Are these changes tested?


## Are there any user-facing changes?

no
