### PR TITLE
docs: update parquet_sql_multiple_files.rs with a relative path ex

### DIFF
--- a/datafusion-examples/examples/parquet_sql_multiple_files.rs
+++ b/datafusion-examples/examples/parquet_sql_multiple_files.rs
@@ -36,7 +36,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Configure listing options
     let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
     let listing_options = ListingOptions::new(Arc::new(file_format))
-        // This is a hack for this example since `test_data` contains many different parquet different files,
+        // This is a workaround for this example since `test_data` contains
+        // many different parquet different files,
         // in practice use FileType::PARQUET.get_ext().
         .with_file_extension("alltypes_plain.parquet");
 
@@ -68,7 +69,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cur_dir = std::env::current_dir()?;
 
     let test_data_path = Path::new(&test_data);
-    let test_data_path_parent = test_data_path.parent().ok_or("No parent")?;
+    let test_data_path_parent = test_data_path
+        .parent()
+        .ok_or("test_data path needs a parent")?;
 
     std::env::set_current_dir(test_data_path_parent)?;
 

--- a/datafusion-examples/examples/parquet_sql_multiple_files.rs
+++ b/datafusion-examples/examples/parquet_sql_multiple_files.rs
@@ -18,9 +18,9 @@
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
 use datafusion::prelude::*;
-use std::sync::Arc;
-use std::path::Path;
 use object_store::local::LocalFileSystem;
+use std::path::Path;
+use std::sync::Arc;
 
 /// This example demonstrates executing a simple query against an Arrow data source (a directory
 /// with multiple Parquet files) and fetching results. The query is run twice, once showing
@@ -85,7 +85,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         listing_options.clone(),
         None,
         None,
-    ).await?;
+    )
+    .await?;
 
     // execute the query
     let df = ctx

--- a/datafusion-examples/examples/parquet_sql_multiple_files.rs
+++ b/datafusion-examples/examples/parquet_sql_multiple_files.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Configure listing options
     let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
     let listing_options = ListingOptions::new(Arc::new(file_format))
-        // This is a hack for this example since `testdata` contains many different parquet different files,
+        // This is a hack for this example since `test_data` contains many different parquet different files,
         // in practice use FileType::PARQUET.get_ext().
         .with_file_extension("alltypes_plain.parquet");
 

--- a/datafusion-examples/examples/parquet_sql_multiple_files.rs
+++ b/datafusion-examples/examples/parquet_sql_multiple_files.rs
@@ -17,31 +17,34 @@
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
-use datafusion::error::Result;
 use datafusion::prelude::*;
-use datafusion_common::{FileType, GetExt};
 use std::sync::Arc;
+use std::path::Path;
+use object_store::local::LocalFileSystem;
 
 /// This example demonstrates executing a simple query against an Arrow data source (a directory
-/// with multiple Parquet files) and fetching results
+/// with multiple Parquet files) and fetching results. The query is run twice, once showing
+/// how to used `register_listing_table` with an absolute path, and once registering an
+/// ObjectStore to use a relative path.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create local execution context
     let ctx = SessionContext::new();
 
-    let testdata = datafusion::test_util::parquet_test_data();
+    let test_data = datafusion::test_util::parquet_test_data();
 
     // Configure listing options
     let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
     let listing_options = ListingOptions::new(Arc::new(file_format))
-        .with_file_extension(FileType::PARQUET.get_ext());
+        // This is a hack for this example since `testdata` contains many different parquet different files,
+        // in practice use FileType::PARQUET.get_ext().
+        .with_file_extension("alltypes_plain.parquet");
 
-    // Register a listing table - this will use all files in the directory as data sources
-    // for the query
+    // First example were we use an absolute path, which requires no additional setup.
     ctx.register_listing_table(
         "my_table",
-        &format!("file://{testdata}/alltypes_plain.parquet"),
-        listing_options,
+        &format!("file://{test_data}/"),
+        listing_options.clone(),
         None,
         None,
     )
@@ -59,6 +62,45 @@ async fn main() -> Result<()> {
 
     // print the results
     df.show().await?;
+
+    // Second example were we temporarily move into the test data's parent directory and
+    // simulate a relative path, this requires registering an ObjectStore.
+    let cur_dir = std::env::current_dir()?;
+
+    let test_data_path = Path::new(&test_data);
+    let test_data_path_parent = test_data_path.parent().ok_or("No parent")?;
+
+    std::env::set_current_dir(test_data_path_parent)?;
+
+    let local_fs = Arc::new(LocalFileSystem::default());
+
+    let u = url::Url::parse("file://./")?;
+    ctx.runtime_env().register_object_store(&u, local_fs);
+
+    // Register a listing table - this will use all files in the directory as data sources
+    // for the query
+    ctx.register_listing_table(
+        "relative_table",
+        "./data",
+        listing_options.clone(),
+        None,
+        None,
+    ).await?;
+
+    // execute the query
+    let df = ctx
+        .sql(
+            "SELECT * \
+        FROM relative_table \
+        LIMIT 1",
+        )
+        .await?;
+
+    // print the results
+    df.show().await?;
+
+    // Reset the current directory
+    std::env::set_current_dir(cur_dir)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

Related to #9280, but not sure if it'd technically close it.

## Rationale for this change

It's easy to get tripped up when querying the local file system if you aren't using absolute paths because by default there's a local file system registered at `file://`, so nothing needs to be done for absolute paths. But if you want to query with relative paths, you first need to register an ObjectStore, so this example shows that.

An alternative might be to also register `file://./` by default, but I'm not sure all the consequences of that. Or perhaps something easy like `ctx.register_cwd()`?

## What changes are included in this PR?

Updates the example.

## Are these changes tested?

Yes, running:

```console
arrow-datafusion update-p… ➜ cargo run --example parquet_sql_multiple_files                                    
    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
     Running `target/debug/examples/parquet_sql_multiple_files`
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
| id | bool_col | tinyint_col | smallint_col | int_col | bigint_col | float_col | double_col | date_string_col  | string_col | timestamp_col       |
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
| 4  | true     | 0           | 0            | 0       | 0          | 0.0       | 0.0        | 30332f30312f3039 | 30         | 2009-03-01T00:00:00 |
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
| id | bool_col | tinyint_col | smallint_col | int_col | bigint_col | float_col | double_col | date_string_col  | string_col | timestamp_col       |
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
| 4  | true     | 0           | 0            | 0       | 0          | 0.0       | 0.0        | 30332f30312f3039 | 30         | 2009-03-01T00:00:00 |
+----+----------+-------------+--------------+---------+------------+-----------+------------+------------------+------------+---------------------+
```

## Are there any user-facing changes?

Insofar as it's a doc-related update.