### PR TITLE
fix: flight examples

### DIFF
--- a/ci/scripts/rust_example.sh
+++ b/ci/scripts/rust_example.sh
@@ -20,6 +20,7 @@
 set -ex
 cd datafusion-examples/examples/
 cargo fmt --all -- --check
+cargo check --examples
 
 files=$(ls .)
 for filename in $files

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -54,6 +54,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
-tonic = "0.11"
+tonic = "0.10"
 url = { workspace = true }
 uuid = "1.2"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -29,6 +29,30 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 
+[[example]]
+name = "flight_sql_server"
+path = "examples/flight/flight_sql_server.rs"
+
+[[example]]
+name = "flight_server"
+path = "examples/flight/flight_server.rs"
+
+[[example]]
+name = "flight_client"
+path = "examples/flight/flight_client.rs"
+
+[[example]]
+name = "catalog"
+path = "examples/external_dependency/catalog.rs"
+
+[[example]]
+name = "dataframe_to_s3"
+path = "examples/external_dependency/dataframe-to-s3.rs"
+
+[[example]]
+name = "query_aws_s3"
+path = "examples/external_dependency/query-aws-s3.rs"
+
 [dev-dependencies]
 arrow = { workspace = true }
 arrow-flight = { workspace = true }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -78,6 +78,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
+# 0.10 and 0.11 are incompatible. Need to upgrade tonic to 0.11 when upgrading to arrow 51
 tonic = "0.10"
 url = { workspace = true }
 uuid = "1.2"

--- a/datafusion-examples/examples/external_dependency/catalog.rs
+++ b/datafusion-examples/examples/external_dependency/catalog.rs
@@ -24,7 +24,7 @@ use datafusion::{
     arrow::util::pretty,
     catalog::{
         schema::SchemaProvider,
-        {CatalogProviderList, CatalogProvider},
+        {CatalogProvider, CatalogProviderList},
     },
     datasource::{
         file_format::{csv::CsvFormat, parquet::ParquetFormat, FileFormat},
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     .unwrap();
     let mut ctx = SessionContext::new();
     let state = ctx.state();
-    let catlist = Arc::new(CustomCatalogProvderList::new());
+    let catlist = Arc::new(CustomCatalogProviderList::new());
     // use our custom catalog list for context. each context has a single catalog list.
     // context will by default have [`MemoryCatalogProviderList`]
     ctx.register_catalog_list(catlist.clone());

--- a/datafusion-examples/examples/flight/flight_sql_server.rs
+++ b/datafusion-examples/examples/flight/flight_sql_server.rs
@@ -231,7 +231,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         info!("getting results for {handle}");
         let result = self.get_result(&handle)?;
         // if we get an empty result, create an empty schema
-        let (schema, batches) = match result.get(0) {
+        let (schema, batches) = match result.first() {
             None => (Arc::new(Schema::empty()), vec![]),
             Some(batch) => (batch.schema(), result.clone()),
         };
@@ -287,7 +287,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
             .map_err(|e| status!("Error executing query", e))?;
 
         // if we get an empty result, create an empty schema
-        let schema = match result.get(0) {
+        let schema = match result.first() {
             None => Schema::empty(),
             Some(batch) => (*batch.schema()).clone(),
         };


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9334.

## Rationale for this change

It allows the arrow flight examples to compile and makes all nested examples runnable.

## What changes are included in this PR?

This PR downgrades the `tonic` dependency to `0.10` to match `arrow-flight` and adds explicit `[[example]]` blocks so nested examples can be run with `cargo run --example`.

## Are these changes tested?

I verified locally that the arrow flight examples compile with this change, and I was able to run queries with JDBC against the `arrow_flight_sql` example.

## Are there any user-facing changes?

No, just example fixes.
