### PR TITLE
feat: expand `unnest`  to accept arbitrary single array expression

### DIFF
--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -101,8 +101,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 DataType::Struct(_) => {
                     return not_impl_err!("unnest() does not support struct yet");
                 }
+                DataType::Null => {
+                    return not_impl_err!("unnest() does not support null yet");
+                }
                 _ => {
-                    return plan_err!("unnest() can only be applied to array and struct");
+                    return plan_err!(
+                        "unnest() can only be applied to array, struct and null"
+                    );
                 }
             }
 

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -16,16 +16,17 @@
 // under the License.
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use arrow_schema::DataType;
 use datafusion_common::{
-    exec_err, not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError,
-    Dependency, Result,
+    not_impl_err, plan_datafusion_err, plan_err, DFSchema, DataFusionError, Dependency,
+    Result,
 };
 use datafusion_expr::expr::{ScalarFunction, Unnest};
 use datafusion_expr::function::suggest_valid_function;
 use datafusion_expr::window_frame::{check_window_frame, regularize_window_order_by};
 use datafusion_expr::{
-    expr, AggregateFunction, BuiltinScalarFunction, Expr, ScalarFunctionDefinition,
-    WindowFrame, WindowFunctionDefinition,
+    expr, AggregateFunction, BuiltinScalarFunction, Expr, ExprSchemable, WindowFrame,
+    WindowFunctionDefinition,
 };
 use sqlparser::ast::{
     Expr as SQLExpr, Function as SQLFunction, FunctionArg, FunctionArgExpr, WindowType,
@@ -80,39 +81,29 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if name.eq("unnest") {
             let exprs =
                 self.function_args_to_expr(args.clone(), schema, planner_context)?;
-
-            match exprs.len() {
+            // Currently only one argument is supported
+            let arg = match exprs.len() {
                 0 => {
-                    return exec_err!("unnest() requires at least one argument");
+                    return plan_err!("unnest() requires at least one argument");
                 }
-                1 => {
-                    if let Expr::ScalarFunction(ScalarFunction {
-                        func_def:
-                            ScalarFunctionDefinition::BuiltIn(
-                                BuiltinScalarFunction::MakeArray,
-                            ),
-                        ..
-                    }) = exprs[0]
-                    {
-                        // valid
-                    } else if let Expr::Column(_) = exprs[0] {
-                        // valid
-                    } else if let Expr::ScalarFunction(ScalarFunction {
-                        func_def:
-                            ScalarFunctionDefinition::BuiltIn(BuiltinScalarFunction::Struct),
-                        ..
-                    }) = exprs[0]
-                    {
-                        return not_impl_err!("unnest() does not support struct yet");
-                    } else {
-                        return plan_err!(
-                            "unnest() can only be applied to array and structs and null"
-                        );
-                    }
-                }
+                1 => &exprs[0],
                 _ => {
                     return not_impl_err!(
                         "unnest() does not support multiple arguments yet"
+                    );
+                }
+            };
+            // Check argument type, array types are supported
+            match arg.get_type(schema)? {
+                DataType::List(_)
+                | DataType::LargeList(_)
+                | DataType::FixedSizeList(_, _) => {}
+                DataType::Struct(_) => {
+                    return not_impl_err!("unnest() does not support struct yet");
+                }
+                _ => {
+                    return plan_err!(
+                        "unnest() can only be applied to array and structs and null"
                     );
                 }
             }

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -102,9 +102,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return not_impl_err!("unnest() does not support struct yet");
                 }
                 _ => {
-                    return plan_err!(
-                        "unnest() can only be applied to array and structs and null"
-                    );
+                    return plan_err!("unnest() can only be applied to array and struct");
                 }
             }
 

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -36,7 +36,7 @@ select unnest([1,2,3]);
 2
 3
 
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
+query error DataFusion error: This feature is not implemented: unnest\(\) does not support null yet
 select unnest(null);
 
 ## Unnest empty array
@@ -71,7 +71,7 @@ NULL
 NULL
 
 ## Unnest column with scalars
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array, struct and null
 select unnest(column3) from unnest_table;
 
 ## Unnest multiple columns
@@ -79,7 +79,7 @@ query error DataFusion error: This feature is not implemented: Only support sing
 select unnest(column1), unnest(column2) from unnest_table;
 
 ## Unnest scalar
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array, struct and null
 select unnest(1);
 
 

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -71,14 +71,8 @@ NULL
 NULL
 
 ## Unnest column with scalars
-# TODO: This should be an error, but unnest is able to process scalar values now.
-query I
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and structs and null
 select unnest(column3) from unnest_table;
-----
-1
-2
-3
-NULL
 
 ## Unnest multiple columns
 query error DataFusion error: This feature is not implemented: Only support single unnest expression for now
@@ -90,8 +84,42 @@ select unnest(1);
 
 
 ## Unnest empty expression
-query error DataFusion error: Execution error: unnest\(\) requires at least one argument
+query error DataFusion error: Error during planning: unnest\(\) requires at least one argument
 select unnest();
+
+## Unnest struct expression
+query error DataFusion error: This feature is not implemented: unnest\(\) does not support struct yet
+select unnest(struct(null));
+
+
+## Unnest array expression
+query I
+select unnest(range(1, 3));
+----
+1
+2
+
+query I
+select unnest(arrow_cast(range(1, 3), 'LargeList(Int64)'));
+----
+1
+2
+
+query I
+select unnest(arrow_cast(range(1, 3), 'FixedSizeList(2, Int64)'));
+----
+1
+2
+
+query I
+select unnest(array_remove(column1, 12)) from unnest_table;
+----
+1
+2
+3
+4
+5
+6
 
 statement ok
 drop table unnest_table;

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -36,7 +36,7 @@ select unnest([1,2,3]);
 2
 3
 
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and structs and null
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
 select unnest(null);
 
 ## Unnest empty array
@@ -71,7 +71,7 @@ NULL
 NULL
 
 ## Unnest column with scalars
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and structs and null
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
 select unnest(column3) from unnest_table;
 
 ## Unnest multiple columns
@@ -79,7 +79,7 @@ query error DataFusion error: This feature is not implemented: Only support sing
 select unnest(column1), unnest(column2) from unnest_table;
 
 ## Unnest scalar
-query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and structs and null
+query error DataFusion error: Error during planning: unnest\(\) can only be applied to array and struct
 select unnest(1);
 
 


### PR DESCRIPTION
## Which issue does this PR close?
Found in https://github.com/apache/arrow-datafusion/discussions/9315#discussioncomment-8562638

`unnest(make_array(1,2))` is supported, but `unnest(range(1,3))` is not supported.

```sh
DataFusion CLI v36.0.0
❯ select unnest(make_array(1,2));
+-------------------------------+
| make_array(Int64(1),Int64(2)) |
+-------------------------------+
| 1                             |
| 2                             |
+-------------------------------+
2 rows in set. Query took 0.008 seconds.

❯ select unnest(range(1,3));
Error during planning: unnest() can only be applied to array and structs and null
```
These are all supported in DuckDB.
## Rationale for this change
If I understand correctly, `unnest` should support any expression with a return type of Array, not just the `make_array` function and column expressions.

## What changes are included in this PR?
The `unnest` function can accept any array expression, which is ensured by checking the return type of the argument.
Previously, it only supported the `make_array` function and column expressions.

## Are these changes tested?

Yes.  New tests and existing tests.

## Are there any user-facing changes?
No
