### PR TITLE
Update list_to_string alias to point to array_to_string

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3029,7 +3029,7 @@ _Alias of [array_slice](#array_slice)._
 
 ### `list_to_string`
 
-_Alias of [list_to_string](#list_to_string)._
+_Alias of [array_to_string](#array_to_string)._
 
 ### `make_array`
 


### PR DESCRIPTION
## Which issue does this PR close?
Closed #9350.

## Rationale for this change
This is a correction to the docs.

## What changes are included in this PR?
In the docs, the alias of [list_to_string](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#list-to-string) will point to [array_to_string](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#array-to-string) instead of itself.

## Are these changes tested?
No, this is only a docs change.

## Are there any user-facing changes?
Yes, this is a change to the docs.

