### PR TITLE
fix: panic in isnan() when no args are given

### DIFF
--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1874,6 +1874,16 @@ SELECT arrow_typeof(1, 1);
 statement error Error during planning: No function matches the given name and argument types 'power\(Int64, Int64, Int64\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tpower\(Int64, Int64\)\n\tpower\(Float64, Float64\)
 SELECT power(1, 2, 3);
 
+# The following functions need 1 argument
+statement error Error during planning: No function matches the given name and argument types 'abs\(\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tabs\(Any\)
+SELECT abs();
+
+statement error Error during planning: No function matches the given name and argument types 'acos\(\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tacos\(Float64/Float32\)
+SELECT acos();
+
+statement error Error during planning: No function matches the given name and argument types 'isnan\(\)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tisnan\(Float32\)\n\tisnan\(Float64\)
+SELECT isnan();
+
 # turn off enable_ident_normalization
 statement ok
 set datafusion.sql_parser.enable_ident_normalization = false;


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

This PR fixes the panic that happens if no arguments are given to `isnan()`:

before:

```sh
❯ select isnan();
thread 'main' panicked at arrow-datafusion/datafusion/functions/src/math/nans.rs:67:39:
index out of bounds: the len is 0 but the index is 0
```

after:

```sh
❯ select isnan();
Error during planning: No function matches the given name and argument types 'isnan()'. You might need to add explicit type casts.
        Candidate functions:
        isnan(Float32)
        isnan(Float64)
```
## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
