### PR TITLE
feat: support for defining ARRAY columns in `CREATE TABLE`

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -238,7 +238,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let mut fields = Vec::with_capacity(columns.len());
 
         for column in columns {
-            let data_type = self.convert_simple_data_type(&column.data_type)?;
+            let data_type = self.convert_data_type(&column.data_type)?;
             let not_nullable = column
                 .options
                 .iter()
@@ -358,7 +358,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         match sql_type {
             SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type))
             | SQLDataType::Array(ArrayElemTypeDef::SquareBracket(inner_sql_type)) => {
-                let data_type = self.convert_simple_data_type(inner_sql_type)?;
+                // Arrays may be multi-dimensional.
+                let data_type = self.convert_data_type(inner_sql_type)?;
 
                 Ok(DataType::List(Arc::new(Field::new(
                     "field", data_type, true,

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -6165,6 +6165,39 @@ NULL NULL
 [60, 59, 58, 57, 56, 55, 54, , 52, 51] [51, 52, , 54, 55, 56, 57, 58, 59, 60]
 [70, 69, 68, 67, 66, 65, 64, 63, 62, 61] [61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
 
+
+# Test defining a table with array columns
+statement ok
+create table test_create_array_table(
+  a int[],
+  b text[],
+  -- two-dimensional array
+  c int[][],
+  d int
+);
+
+query ???I
+insert into test_create_array_table values
+  ([1, 2, 3], ['a', 'b', 'c'], [[4,6], [6,7,8]], 1);
+----
+1
+
+query ???I
+select * from test_create_array_table;
+----
+[1, 2, 3] [a, b, c] [[4, 6], [6, 7, 8]] 1
+
+query T
+select arrow_typeof(a) from test_create_array_table;
+----
+List(Field { name: "field", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+
+query T
+select arrow_typeof(c) from test_create_array_table;
+----
+List(Field { name: "field", data_type: List(Field { name: "field", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+
+
 ### Delete tables
 
 statement ok
@@ -6334,3 +6367,6 @@ drop table large_arrays_values_without_nulls;
 
 statement ok
 drop table fixed_size_arrays_values_without_nulls;
+
+statement ok
+drop table test_create_array_table;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9380.

## Rationale for this change

Support the syntax `create table t(a int[])`.

## What changes are included in this PR?
Support for defining ARRAY columns in `CREATE TABLE`.


## Are these changes tested?
Yes
## Are there any user-facing changes?
No
