### PR TITLE
Minor: clarify performance in docs for `ScalarUDF`, `ScalarUDAF` and `ScalarUDWF`

### DIFF
--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -44,9 +44,10 @@ use std::sync::Arc;
 ///
 /// For more information, please see [the examples]:
 ///
-/// 1. For simple (less performant) use cases, use [`create_udaf`] and [`simple_udaf.rs`].
+/// 1. For simple use cases, use [`create_udaf`] (examples in [`simple_udaf.rs`]).
 ///
-/// 2. For advanced use cases, use [`AggregateUDFImpl`] and [`advanced_udaf.rs`].
+/// 2. For advanced use cases, use [`AggregateUDFImpl`] which provides full API
+/// access (examples in [`advanced_udaf.rs`]).
 ///
 /// # API Note
 /// This is a separate struct from `AggregateUDFImpl` to maintain backwards

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -37,9 +37,10 @@ use std::sync::Arc;
 /// functions you supply such name, type signature, return type, and actual
 /// implementation.
 ///
-/// 1. For simple (less performant) use cases, use [`create_udf`] and [`simple_udf.rs`].
+/// 1. For simple use cases, use [`create_udf`] (examples in [`simple_udf.rs`]).
 ///
-/// 2. For advanced use cases, use  [`ScalarUDFImpl`] and [`advanced_udf.rs`].
+/// 2. For advanced use cases, use [`ScalarUDFImpl`] which provides full API
+/// access (examples in  [`advanced_udf.rs`]).
 ///
 /// # API Note
 ///

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -32,11 +32,13 @@ use std::{
 /// Logical representation of a user-defined window function (UDWF)
 /// A UDWF is different from a UDF in that it is stateful across batches.
 ///
-/// See the documetnation on [`PartitionEvaluator`] for more details
+/// See the documentation on [`PartitionEvaluator`] for more details
 ///
-/// 1. For simple (less performant) use cases, use [`create_udwf`] and [`simple_udwf.rs`].
+/// 1. For simple use cases, use [`create_udwf`] (examples in
+/// [`simple_udwf.rs`]).
 ///
-/// 2. For advanced use cases, use [`WindowUDFImpl`] and [`advanced_udwf.rs`].
+/// 2. For advanced use cases, use [`WindowUDFImpl`] which provides full API
+/// access (examples in [`advanced_udwf.rs`]).
 ///
 /// # API Note
 /// This is a separate struct from `WindowUDFImpl` to maintain backwards


### PR DESCRIPTION


## Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/pull/8578

## Rationale for this change

@SteveLauC  asked about why the "simple" APIs were less performant https://github.com/apache/arrow-datafusion/pull/8578/files#r1505483541

In researching the answer I concluded that they are not really less performant, and thus the documentation shouldn't imply they are. 

## What changes are included in this PR?
Update the docs to explain the difference better


## Are these changes tested?
CI docs test
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
