### PR TITLE
Improve documentation for ExecutionPlanProperties, use consistent field name

### DIFF
--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -464,6 +464,24 @@ impl ExecutionPlanProperties for Arc<dyn ExecutionPlan> {
     }
 }
 
+impl ExecutionPlanProperties for &dyn ExecutionPlan {
+    fn output_partitioning(&self) -> &Partitioning {
+        self.properties().output_partitioning()
+    }
+
+    fn execution_mode(&self) -> ExecutionMode {
+        self.properties().execution_mode()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.properties().output_ordering()
+    }
+
+    fn equivalence_properties(&self) -> &EquivalenceProperties {
+        self.properties().equivalence_properties()
+    }
+}
+
 /// Describes the execution mode of an operator's resulting stream with respect
 /// to its size and behavior. There are three possible execution modes: `Bounded`,
 /// `Unbounded` and `PipelineBreaking`.


### PR DESCRIPTION
Draft until https://github.com/apache/arrow-datafusion/pull/9346 is merged

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/pull/9346

## Rationale for this change

After https://github.com/apache/arrow-datafusion/pull/9346, some of the functions that were previously on ExecutionPlan were moved to an extension trait


But the docs don't show up in rustdoc
![Screenshot 2024-02-28 at 1 25 54 PM](https://github.com/apache/arrow-datafusion/assets/490673/870aa9db-5ef8-4bf8-be42-61f9b18788e4)



## What changes are included in this PR?

1. Move docs to the trait so they show up in rustdoc
2. Add a reference to the new trait to rust docs


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
