### PR TITLE
Run cargo-fmt on all of `datafusion-functions`

### DIFF
--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -53,7 +53,7 @@ impl EncodeFunc {
                     Exact(vec![LargeBinary, Utf8]),
                 ],
                 Volatility::Immutable,
-            )
+            ),
         }
     }
 }
@@ -107,7 +107,7 @@ impl DecodeFunc {
                     Exact(vec![LargeBinary, Utf8]),
                 ],
                 Volatility::Immutable,
-            )
+            ),
         }
     }
 }
@@ -272,8 +272,8 @@ impl Encoding {
     }
 
     fn encode_binary_array<T>(self, value: &dyn Array) -> Result<ColumnarValue>
-        where
-            T: OffsetSizeTrait,
+    where
+        T: OffsetSizeTrait,
     {
         let input_value = as_generic_binary_array::<T>(value)?;
         let array: ArrayRef = match self {
@@ -284,8 +284,8 @@ impl Encoding {
     }
 
     fn encode_utf8_array<T>(self, value: &dyn Array) -> Result<ColumnarValue>
-        where
-            T: OffsetSizeTrait,
+    where
+        T: OffsetSizeTrait,
     {
         let input_value = as_generic_string_array::<T>(value)?;
         let array: ArrayRef = match self {
@@ -352,8 +352,8 @@ impl Encoding {
     }
 
     fn decode_binary_array<T>(self, value: &dyn Array) -> Result<ColumnarValue>
-        where
-            T: OffsetSizeTrait,
+    where
+        T: OffsetSizeTrait,
     {
         let input_value = as_generic_binary_array::<T>(value)?;
         let array: ArrayRef = match self {
@@ -364,8 +364,8 @@ impl Encoding {
     }
 
     fn decode_utf8_array<T>(self, value: &dyn Array) -> Result<ColumnarValue>
-        where
-            T: OffsetSizeTrait,
+    where
+        T: OffsetSizeTrait,
     {
         let input_value = as_generic_string_array::<T>(value)?;
         let array: ArrayRef = match self {

--- a/datafusion/functions/src/encoding/mod.rs
+++ b/datafusion/functions/src/encoding/mod.rs
@@ -17,7 +17,6 @@
 
 mod inner;
 
-
 // create `encode` and `decode` UDFs
 make_udf_function!(inner::EncodeFunc, ENCODE, encode);
 make_udf_function!(inner::DecodeFunc, DECODE, decode);
@@ -27,4 +26,3 @@ export_functions!(
     (encode, input encoding, "encode the `input`, using the `encoding`. encoding can be base64 or hex"),
     (decode, input encoding, "decode the `input`, using the `encoding`. encoding can be base64 or hex")
 );
-

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -90,14 +90,25 @@ pub mod macros;
 pub mod core;
 make_stub_package!(core, "core_expressions");
 
-make_package!(
-    encoding,
-    "encoding_expressions",
-    "Hex and binary `encode` and `decode` functions."
-);
+/// Encoding expressions.
+/// Contains Hex and binary `encode` and `decode` functions.
+/// Enabled via feature flag `encoding_expressions`
+#[cfg(feature = "encoding_expressions")]
+pub mod encoding;
+make_stub_package!(encoding, "encoding_expressions");
 
-make_package!(math, "math_expressions", "Mathematical functions.");
-make_package!(regex, "regex_expressions", "Regex functions");
+/// Mathematical functions.
+/// Enabled via feature flag `math_expressions`
+#[cfg(feature = "math_expressions")]
+pub mod math;
+make_stub_package!(math, "math_expressions");
+
+/// Regular expression functions.
+/// Enabled via feature flag `regex_expressions`
+#[cfg(feature = "regex_expressions")]
+pub mod regex;
+make_stub_package!(regex, "regex_expressions");
+
 /// Fluent-style API for creating `Expr`s
 pub mod expr_fn {
     #[cfg(feature = "core_expressions")]

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -84,44 +84,6 @@ macro_rules! make_udf_function {
     };
 }
 
-/// Macro creates the named module if the feature is enabled
-/// otherwise creates a stub
-///
-/// Which returns:
-///
-/// 1. The list of actual function implementation when the relevant
-/// feature is activated,
-///
-/// 2. A list of stub function when the feature is not activated that produce
-/// a runtime error (and explain what feature flag is needed to activate them).
-///
-/// The rationale for providing stub functions is to help users to configure datafusion
-/// properly (so they get an error telling them why a function is not available)
-/// instead of getting a cryptic "no function found" message at runtime.
-
-macro_rules! make_package {
-    ($name:ident, $feature:literal, $DOC:expr) => {
-        #[cfg(feature = $feature)]
-        #[doc = $DOC ]
-        #[doc = concat!("Enabled via feature flag `", $feature, "`")]
-        pub mod $name;
-
-        #[cfg(not(feature = $feature))]
-        #[doc = concat!("Disabled. Enable via feature flag `", $feature, "`")]
-        pub mod $name {
-            use datafusion_expr::ScalarUDF;
-            use log::debug;
-            use std::sync::Arc;
-
-            /// Returns an empty list of functions when the feature is not enabled
-            pub fn functions() -> Vec<Arc<ScalarUDF>> {
-                debug!("{} functions disabled", stringify!($name));
-                vec![]
-            }
-        }
-    };
-}
-
 /// Macro creates a sub module if the feature is not enabled
 ///
 /// The rationale for providing stub functions is to help users to configure datafusion

--- a/datafusion/functions/src/math/abs.rs
+++ b/datafusion/functions/src/math/abs.rs
@@ -24,17 +24,17 @@ use arrow::array::Int32Array;
 use arrow::array::Int64Array;
 use arrow::array::Int8Array;
 use arrow::datatypes::DataType;
-use datafusion_common::{exec_err, not_impl_err};
 use datafusion_common::plan_datafusion_err;
-use datafusion_common::{Result, DataFusionError};
+use datafusion_common::{exec_err, not_impl_err};
+use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::utils;
 use datafusion_expr::ColumnarValue;
 
+use arrow::array::{ArrayRef, Float32Array, Float64Array};
+use arrow::error::ArrowError;
 use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 use std::sync::Arc;
-use arrow::array::{ArrayRef, Float32Array, Float64Array};
-use arrow::error::ArrowError;
 
 type MathArrayFunction = fn(&Vec<ArrayRef>) -> Result<ArrayRef>;
 
@@ -80,9 +80,7 @@ macro_rules! make_decimal_abs_function {
 
 /// Abs SQL function
 /// Return different implementations based on input datatype to reduce branches during execution
-fn create_abs_function(
-    input_data_type: &DataType,
-) -> Result<MathArrayFunction> {
+fn create_abs_function(input_data_type: &DataType) -> Result<MathArrayFunction> {
     match input_data_type {
         DataType::Float32 => Ok(make_abs_function!(Float32Array)),
         DataType::Float64 => Ok(make_abs_function!(Float64Array)),
@@ -115,7 +113,7 @@ pub(super) struct AbsFunc {
 impl AbsFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::any(1, Volatility::Immutable)
+            signature: Signature::any(1, Volatility::Immutable),
         }
     }
 }
@@ -155,9 +153,16 @@ impl ScalarUDFImpl for AbsFunc {
             DataType::UInt16 => Ok(DataType::UInt16),
             DataType::UInt32 => Ok(DataType::UInt32),
             DataType::UInt64 => Ok(DataType::UInt64),
-            DataType::Decimal128(precision, scale) => Ok(DataType::Decimal128(precision, scale)),
-            DataType::Decimal256(precision, scale) => Ok(DataType::Decimal256(precision, scale)),
-            _ => not_impl_err!("Unsupported data type {} for function abs", arg_types[0].to_string()),
+            DataType::Decimal128(precision, scale) => {
+                Ok(DataType::Decimal128(precision, scale))
+            }
+            DataType::Decimal256(precision, scale) => {
+                Ok(DataType::Decimal256(precision, scale))
+            }
+            _ => not_impl_err!(
+                "Unsupported data type {} for function abs",
+                arg_types[0].to_string()
+            ),
         }
     }
 
@@ -167,10 +172,10 @@ impl ScalarUDFImpl for AbsFunc {
         if args.len() != 1 {
             return exec_err!("abs function requires 1 argument, got {}", args.len());
         }
-    
+
         let input_data_type = args[0].data_type();
         let abs_fun = create_abs_function(input_data_type)?;
-    
+
         let arr = abs_fun(&args)?;
         Ok(ColumnarValue::Array(arr))
     }

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -20,16 +20,16 @@ use arrow::array::{Array, ArrayRef, OffsetSizeTrait};
 use arrow::compute::kernels::regexp;
 use arrow::datatypes::DataType;
 use arrow::datatypes::Field;
-use datafusion_common::ScalarValue;
-use datafusion_expr::TypeSignature::*;
-use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
-use std::any::Any;
 use datafusion_common::exec_err;
+use datafusion_common::ScalarValue;
 use datafusion_common::{arrow_datafusion_err, plan_err};
 use datafusion_common::{
     cast::as_generic_string_array, internal_err, DataFusionError, Result,
 };
 use datafusion_expr::ColumnarValue;
+use datafusion_expr::TypeSignature::*;
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+use std::any::Any;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -107,12 +107,8 @@ impl ScalarUDFImpl for RegexpMatchFunc {
 }
 fn regexp_match_func(args: &[ArrayRef]) -> Result<ArrayRef> {
     match args[0].data_type() {
-        DataType::Utf8 => {
-            regexp_match::<i32>(args)
-        }
-        DataType::LargeUtf8 => {
-            regexp_match::<i64>(args)
-        }
+        DataType::Utf8 => regexp_match::<i32>(args),
+        DataType::LargeUtf8 => regexp_match::<i64>(args),
         other => {
             internal_err!("Unsupported data type {other:?} for function regexp_match")
         }


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9281


## Rationale for this change

The way we were defining modules in `datafusion-functions` meant that rustfmt was not running on them 

## What changes are included in this PR?

This applies the fix in https://github.com/apache/arrow-datafusion/pull/9367 to all the packages in the `datafusion-functions` crate

## Are these changes tested?
covered by CI


## Are there any user-facing changes?
No
