### PR TITLE
Doc: Workaround for Running cargo test locally without signficant memory

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -157,6 +157,8 @@ DataFusion is written in Rust and it uses a standard rust toolkit:
 - `cargo test` to test
 - etc.
 
+Note that running `cargo test` requires signficant memory resources, due to cargo running many tests in parallel by default. If you run into issues with slow tests or system lock ups, you can signficantly reduce the memory required by instead running `cargo test -- --test-threads=1`. For more information see [this issue](https://github.com/apache/arrow-datafusion/issues/5347).
+
 Testing setup:
 
 - `rustup update stable` DataFusion uses the latest stable release of rust

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -157,7 +157,7 @@ DataFusion is written in Rust and it uses a standard rust toolkit:
 - `cargo test` to test
 - etc.
 
-Note that running `cargo test` requires signficant memory resources, due to cargo running many tests in parallel by default. If you run into issues with slow tests or system lock ups, you can signficantly reduce the memory required by instead running `cargo test -- --test-threads=1`. For more information see [this issue](https://github.com/apache/arrow-datafusion/issues/5347).
+Note that running `cargo test` requires significant memory resources, due to cargo running many tests in parallel by default. If you run into issues with slow tests or system lock ups, you can significantly reduce the memory required by instead running `cargo test -- --test-threads=1`. For more information see [this issue](https://github.com/apache/arrow-datafusion/issues/5347).
 
 Testing setup:
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9398
Closes #5347 

## Rationale for this change

New contributors (myself included!) often run `cargo test` locally when setting up DataFusion for development and are surprised to see their system lock up or fail to complete the tests. This is due to very high memory requirements to complete the tests with default parallelism.  See linked issues for more discussion on the cause of high memory usage.

## What changes are included in this PR?

Documents this phenomenon in the contributors documentation page and suggests a workaround to run

```bash
cargo test -- --test-threads 1
```
if you run into memory limitations.

## Are these changes tested?

No - just a doc update.

## Are there any user-facing changes?

New contributor docs
