### PR TITLE
fix: sort_batch function unsupported mixed types with list

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -591,7 +591,8 @@ pub(crate) fn sort_batch(
         .collect::<Result<Vec<_>>>()?;
 
     let indices = if is_multi_column_with_lists(&sort_columns) {
-        // Ref: https://github.com/apache/arrow-rs/pull/2929
+        // lex_sort_to_indices doesn't support List with more than one colum
+        // https://github.com/apache/arrow-rs/issues/5454
         lexsort_to_indices_multi_columns(sort_columns, fetch)?
     } else {
         lexsort_to_indices(&sort_columns, fetch)?

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -784,3 +784,110 @@ SortPreservingMergeExec: [m@0 ASC NULLS LAST,t@1 ASC NULLS LAST]
 ----------------AggregateExec: mode=Partial, gby=[1 as Int64(1), t@0 as t], aggr=[], ordering_mode=PartiallySorted([0])
 ------------------ProjectionExec: expr=[column1@0 as t]
 --------------------ValuesExec
+
+#####
+# Multi column sorting with lists
+#####
+
+statement ok
+create table foo as values (2, [0]), (4, [1]), (2, [6]), (1, [2, 5]), (0, [3]), (3, [4]), (2, [2, 5]), (2, [7]);
+
+query I?
+select column1, column2 from foo ORDER BY column1, column2;
+----
+0 [3]
+1 [2, 5]
+2 [0]
+2 [2, 5]
+2 [6]
+2 [7]
+3 [4]
+4 [1]
+
+query I?
+select column1, column2 from foo ORDER BY column1 desc, column2;
+----
+4 [1]
+3 [4]
+2 [0]
+2 [2, 5]
+2 [6]
+2 [7]
+1 [2, 5]
+0 [3]
+
+query I?
+select column1, column2 from foo ORDER BY column1, column2 desc;
+----
+0 [3]
+1 [2, 5]
+2 [7]
+2 [6]
+2 [2, 5]
+2 [0]
+3 [4]
+4 [1]
+
+query I?
+select column1, column2 from foo ORDER BY column1 desc, column2 desc;
+----
+4 [1]
+3 [4]
+2 [7]
+2 [6]
+2 [2, 5]
+2 [0]
+1 [2, 5]
+0 [3]
+
+query ?I
+select column2, column1 from foo ORDER BY column2, column1;
+----
+[0] 2
+[1] 4
+[2, 5] 1
+[2, 5] 2
+[3] 0
+[4] 3
+[6] 2
+[7] 2
+
+query ?I
+select column2, column1 from foo ORDER BY column2 desc, column1;
+----
+[7] 2
+[6] 2
+[4] 3
+[3] 0
+[2, 5] 1
+[2, 5] 2
+[1] 4
+[0] 2
+
+query ?I
+select column2, column1 from foo ORDER BY column2, column1 desc;
+----
+[0] 2
+[1] 4
+[2, 5] 2
+[2, 5] 1
+[3] 0
+[4] 3
+[6] 2
+[7] 2
+
+query ?I
+select column2, column1 from foo ORDER BY column2 desc, column1 desc;
+----
+[7] 2
+[6] 2
+[4] 3
+[3] 0
+[2, 5] 2
+[2, 5] 1
+[1] 4
+[0] 2
+
+# Cleanup
+statement ok
+drop table foo;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/9418

## Rationale for this change

Support SQL:

```sql
SELECT * FROM table ORDER BY name, book_list
```

where  the`book_list` column is DataType::List .

BTW, I wanted to modify the `lexsort_to_indices` function in [arrow-rs](https://github.com/apache/arrow-rs/compare/master...JasonLi-cn:arrow-rs:fix/lexsort_to_indices_bug
), but after bench, I found that the `Rows` based implementation  was better.

Benchmark on `Apple M1 16G`: 

```shell
lexsort_to_indices([i32_opt, i32_list]): 4096
                        time:   [440.80 µs 442.16 µs 443.63 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

lexsort_rows([i32_opt, i32_list]): 4096
                        time:   [432.53 µs 434.24 µs 436.16 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

lexsort_to_indices([i32_opt, i32_list]): 32768
                        time:   [4.3801 ms 4.3925 ms 4.4059 ms]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

lexsort_rows([i32_opt, i32_list]): 32768
                        time:   [4.1159 ms 4.1266 ms 4.1409 ms]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

lexsort_to_indices([i32_opt, i32_list_opt]): 4096
                        time:   [433.11 µs 434.57 µs 436.12 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

lexsort_rows([i32_opt, i32_list_opt]): 4096
                        time:   [472.62 µs 473.97 µs 475.40 µs]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

lexsort_to_indices([i32_opt, i32_list_opt]): 32768
                        time:   [4.2414 ms 4.2460 ms 4.2508 ms]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

lexsort_rows([i32_opt, i32_list_opt]): 32768
                        time:   [4.3238 ms 4.3306 ms 4.3376 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

lexsort_to_indices([i32_list_opt, i32_opt]): 4096
                        time:   [533.95 µs 537.64 µs 543.46 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

lexsort_rows([i32_list_opt, i32_opt]): 4096
                        time:   [418.25 µs 421.96 µs 426.30 µs]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

lexsort_to_indices([i32_list_opt, i32_opt]): 32768
                        time:   [5.2264 ms 5.2651 ms 5.3096 ms]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

lexsort_rows([i32_list_opt, i32_opt]): 32768
                        time:   [3.7982 ms 3.8031 ms 3.8090 ms]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

lexsort_to_indices([i32, str_list(4)]): 4096
                        time:   [649.14 µs 650.99 µs 652.99 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

lexsort_rows([i32, str_list(4)]): 4096
                        time:   [464.10 µs 464.63 µs 465.23 µs]
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

lexsort_to_indices([i32, str_list(4)]): 32768
                        time:   [6.2407 ms 6.2484 ms 6.2582 ms]
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

lexsort_rows([i32, str_list(4)]): 32768
                        time:   [4.4957 ms 4.5017 ms 4.5091 ms]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

lexsort_to_indices([str_list(4), i32]): 4096
                        time:   [757.10 µs 758.69 µs 760.53 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

lexsort_rows([str_list(4), i32]): 4096
                        time:   [443.60 µs 444.90 µs 446.39 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

lexsort_to_indices([str_list(4), i32]): 32768
                        time:   [7.4594 ms 7.4905 ms 7.5280 ms]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

lexsort_rows([str_list(4), i32]): 32768
                        time:   [4.0570 ms 4.0609 ms 4.0652 ms]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

lexsort_to_indices([i32, str_list_opt(4)]): 4096
                        time:   [586.61 µs 587.43 µs 588.24 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

lexsort_rows([i32, str_list_opt(4)]): 4096
                        time:   [551.36 µs 552.57 µs 553.99 µs]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

lexsort_to_indices([i32, str_list_opt(4)]): 32768
                        time:   [5.5504 ms 5.5571 ms 5.5651 ms]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

lexsort_rows([i32, str_list_opt(4)]): 32768
                        time:   [5.0307 ms 5.0358 ms 5.0412 ms]
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe

lexsort_to_indices([str_list_opt(4), i32]): 4096
                        time:   [774.23 µs 775.50 µs 776.79 µs]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

lexsort_rows([str_list_opt(4), i32]): 4096
                        time:   [486.96 µs 488.71 µs 490.63 µs]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

lexsort_to_indices([str_list_opt(4), i32]): 32768
                        time:   [7.2347 ms 7.2419 ms 7.2502 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

lexsort_rows([str_list_opt(4), i32]): 32768
                        time:   [4.2789 ms 4.2883 ms 4.2988 ms]
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe

lexsort_to_indices([i32, i32_list, str(16)]): 4096
                        time:   [349.27 µs 351.48 µs 353.60 µs]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

lexsort_rows([i32, i32_list, str(16)]): 4096
                        time:   [411.21 µs 413.01 µs 414.80 µs]
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) low severe
  5 (5.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

lexsort_to_indices([i32, i32_list, str(16)]): 32768
                        time:   [3.5240 ms 3.5307 ms 3.5373 ms]

lexsort_rows([i32, i32_list, str(16)]): 32768
                        time:   [3.8712 ms 3.8813 ms 3.8926 ms]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

lexsort_to_indices([i32_opt, i32_list_opt, str_opt(50)]): 4096
                        time:   [458.24 µs 459.22 µs 460.20 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

lexsort_rows([i32_opt, i32_list_opt, str_opt(50)]): 4096
                        time:   [446.95 µs 447.50 µs 448.09 µs]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

lexsort_to_indices([i32_opt, i32_list_opt, str_opt(50)]): 32768
                        time:   [4.5581 ms 4.5668 ms 4.5766 ms]
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe

lexsort_rows([i32_opt, i32_list_opt, str_opt(50)]): 32768
                        time:   [4.1926 ms 4.1984 ms 4.2049 ms]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```


## What changes are included in this PR?

upgrade `sort_batch` function.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
