### PR TITLE
Minor: improve the display name of `unnest` expressions

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1770,7 +1770,7 @@ fn create_name(e: &Expr) -> Result<String> {
                 }
             }
         }
-        Expr::Unnest(Unnest { exprs }) => Ok(format!("UNNEST({exprs:?})")),
+        Expr::Unnest(Unnest { exprs }) => create_function_name("unnest", false, exprs),
         Expr::ScalarFunction(fun) => create_function_name(fun.name(), false, &fun.args),
         Expr::WindowFunction(WindowFunction {
             fun,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Make the display name of `unnest` shorter and more consistent with other functions.

Currently on main branch:
```sh
select unnest(a), array_length(a) from (values([1,2])) as t(a);
+-----------------------------------------------------------------------------+-------------------+
| UNNEST([Column(Column { relation: Some(Bare { table: "t" }), name: "a" })]) | array_length(t.a) |
+-----------------------------------------------------------------------------+-------------------+
| 1                                                                           | 2                 |
| 2                                                                           | 2                 |
+-----------------------------------------------------------------------------+-------------------+
```

After PR:
```sh
❯ select unnest(a), array_length(a) from (values([1,2])) as t(a);
+-------------+-------------------+
| unnest(t.a) | array_length(t.a) |
+-------------+-------------------+
| 1           | 2                 |
| 2           | 2                 |
+-------------+-------------------+
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Tested on CLI.

## Are there any user-facing changes?

No
