### PR TITLE
fix: casting to ARRAY types failed

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -362,7 +362,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let data_type = self.convert_data_type(inner_sql_type)?;
 
                 Ok(DataType::List(Arc::new(Field::new(
-                    "field", data_type, true,
+                    "item", data_type, true,
                 ))))
             }
             SQLDataType::Array(ArrayElemTypeDef::None) => {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -359,11 +359,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type))
             | SQLDataType::Array(ArrayElemTypeDef::SquareBracket(inner_sql_type)) => {
                 // Arrays may be multi-dimensional.
-                let data_type = self.convert_data_type(inner_sql_type)?;
-
-                Ok(DataType::List(Arc::new(Field::new(
-                    "item", data_type, true,
-                ))))
+                let inner_data_type = self.convert_data_type(inner_sql_type)?;
+                Ok(DataType::new_list(inner_data_type, true))
             }
             SQLDataType::Array(ArrayElemTypeDef::None) => {
                 not_impl_err!("Arrays with unspecified type is not supported")

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -6213,12 +6213,19 @@ select * from test_create_array_table;
 query T
 select arrow_typeof(a) from test_create_array_table;
 ----
-List(Field { name: "field", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+List(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 
 query T
 select arrow_typeof(c) from test_create_array_table;
 ----
-List(Field { name: "field", data_type: List(Field { name: "field", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+
+# Test casting to array types
+# issue: https://github.com/apache/arrow-datafusion/issues/9440
+query ??T
+select [1,2,3]::int[], [['1']]::int[][], arrow_typeof([]::text[]);
+----
+[1, 2, 3] [[1]] List(Field { name: "item", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 
 
 ### Delete tables


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9440.

## Rationale for this change

`int[]`  has been converted to `DataType::List`. However, the inner field should be renamed to 'item' instead of 'field' to ensure better integration with the existing ARRAY implementation. For instance, the `arrow_cast` function uses 'item'.
https://github.com/apache/arrow-datafusion/blob/c43d9b347ab17f458150ffbc1339b4e63d9e8b43/datafusion/sql/src/expr/arrow_cast.rs#L166-L167



## What changes are included in this PR?
Change the name of the inner field for `List` type within the SQL planner.

## Are these changes tested?
Yes

## Are there any user-facing changes?

No
