### PR TITLE
CI: releasing CLI to PyPI

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,125 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: PyPI Release CLI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          working-directory: ./datafusion-cli
+          args: --release --out dist
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: datafusion-cli/dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: ./datafusion-cli
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: datafusion-cli/dist
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: ./datafusion-cli
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: datafusion-cli/dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          working-directory: ./datafusion-cli
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: datafusion-cli/dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')" # only release tagged commits
+    needs: [linux, windows, macos, sdist]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing *
+

--- a/datafusion-cli/pyproject.toml
+++ b/datafusion-cli/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["maturin>=0.14,<2.0"] 
+build-backend = "maturin" 
+
+[project]
+name = "datafusion-cli" 
+description = "Command Line Client for DataFusion query engine."
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]
+
+[tool.maturin]
+bindings = "bin" 

--- a/datafusion-cli/pyproject.toml
+++ b/datafusion-cli/pyproject.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [build-system]
 requires = ["maturin>=0.14,<2.0"] 
 build-backend = "maturin" 

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -57,21 +57,12 @@ Install it as any other pre-built software like this:
 ```bash
 pip3 install datafusion-cli
 # Defaulting to user installation because normal site-packages is not writeable
-# Collecting datafusion
-#   Downloading datafusion-33.0.0-cp38-abi3-macosx_11_0_arm64.whl.metadata (9.6 kB)
-# Collecting pyarrow>=11.0.0 (from datafusion)
-#   Downloading pyarrow-14.0.1-cp39-cp39-macosx_11_0_arm64.whl.metadata (3.0 kB)
-# Requirement already satisfied: numpy>=1.16.6 in /Users/Library/Python/3.9/lib/python/site-packages (from pyarrow>=11.0.0->datafusion) (1.23.4)
-# Downloading datafusion-33.0.0-cp38-abi3-macosx_11_0_arm64.whl (13.5 MB)
-#    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.5/13.5 MB 3.6 MB/s eta 0:00:00
-# Downloading pyarrow-14.0.1-cp39-cp39-macosx_11_0_arm64.whl (24.0 MB)
-#    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 24.0/24.0 MB 36.4 MB/s eta 0:00:00
-# Installing collected packages: pyarrow, datafusion
-#   Attempting uninstall: pyarrow
-#     Found existing installation: pyarrow 10.0.1
-#     Uninstalling pyarrow-10.0.1:
-#       Successfully uninstalled pyarrow-10.0.1
-# Successfully installed datafusion-33.0.0 pyarrow-14.0.1
+# Collecting datafusion-cli
+#   Downloading datafusion_cli-36.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.7 kB)
+# Downloading datafusion_cli-36.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (24.8 MB)
+#    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 24.8/24.8 MB 3.5 MB/s eta 0:00:00
+# Installing collected packages: datafusion-cli
+# Successfully installed datafusion-cli-36.0.0
 
 datafusion-cli
 ```

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -55,7 +55,7 @@ DataFusion CLI can also be installed via PyPI. You can check how to install PyPI
 Install it as any other pre-built software like this:
 
 ```bash
-pip3 install datafusion
+pip3 install datafusion-cli
 # Defaulting to user installation because normal site-packages is not writeable
 # Collecting datafusion
 #   Downloading datafusion-33.0.0-cp38-abi3-macosx_11_0_arm64.whl.metadata (9.6 kB)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9294.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Documentation states that datafusion-cli can be installed through pip; however, that is not the case. This adds a workflow to deploy datafusion-cli (and only the CLI, not the python module) to PyPI , allowing installation using pip.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This is meant to be a minimal CI, to be reviewed and edited as necessary (handle licensing, tag names, maybe maintainers prefer manual releases, etc)

CC @andygrove as he's involved in arrow-datafusion-python workflows and can have some comments.

A final note: builds for 32-bit systems fail because of  `src/main.rs:304` which expects `1 << 40` to be usize. This causes cargo to panic and abort builds.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

-->

You can try testing the deployment yourself using `pip install datafusion-cli`. I thought I changed the name and the repo to reference my fork, but apparently not.

I'll remove it from PyPI once the PR is ready to merge, to be redeployed by the maintainers.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Should be able to use pip to install datafusion-cli
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
