### PR TITLE
Add `/benchmark` github command to comparison benchmark between base and pr commit

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,12 +1,13 @@
 name: Benchmarks
 
 on:
-  pull_request:
+  issue_comment:
 
 jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/benchmark')
     steps:
       - name: Dump GitHub context
         env:
@@ -15,6 +16,8 @@ jobs:
 
       - name: Checkout PR changes
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Setup data and generate unique result names
         run: |
@@ -24,14 +27,11 @@ jobs:
           # Setup the TPC-H data set with a scale factor of 10
           ./bench.sh data tpch
           
-          # Generate a unique-ish identifier for the results using 
-          # branch name and commit sha
-          short_ref=$(echo "${{ github.head_ref }}" | cut -c1-20)
-          short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "HEAD_REF_SHA=$short_ref-$short_sha" >> "$GITHUB_ENV" 
+          # Generate a unique-ish identifiers for the results
+          echo "HEAD_REF_SHA=pr-${{ github.event.issue.number }}" >> "$GITHUB_ENV" 
           
-          short_sha=$(echo "${{ github.event.pull_request.base.sha }}" | cut -c1-7)
-          echo "BASE_REF_SHA=${{ github.base_ref }}-$short_sha" >> "$GITHUB_ENV"
+          short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "BASE_REF_SHA=main-$short_sha" >> "$GITHUB_ENV"
 
       - name: Benchmark PR changes
         env:
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout base commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
           clean: false
 
       - name: Benchmark baseline and generate comparison message
@@ -58,14 +58,14 @@ jobs:
           # Temporary workaround, until `RESULTS_NAME` var lands into main
           mv -f results/HEAD results/${{ env.BASE_REF_SHA }}
           
-          echo ${{ github.event.pull_request.number }} > pr
+          echo ${{ github.event.issue.number }} > pr
           
           pip3 install rich
           cat > message.md <<EOF
           # Benchmark results
           
           <details>
-          <summary>Benchmarks comparing ${{ github.event.pull_request.base.sha }} and ${{ github.sha }}</summary>
+          <summary>Benchmarks comparing ${{ github.sha }} and PR ${{ github.event.issue.number }}</summary>
 
           \`\`\`
           $(./bench.sh compare ${{ env.BASE_REF_SHA }} ${{ env.HEAD_REF_SHA }})
@@ -87,37 +87,3 @@ jobs:
         with:
           name: pr
           path: benchmarks/pr
-
-  comment:
-    name: Post benchmarks comment
-    runs-on: ubuntu-latest
-    needs: [ benchmark ]
-    steps:
-      - name: Download comment message
-        uses: actions/download-artifact@v4
-        with:
-          name: message
-
-      - name: Download pr number
-        uses: actions/download-artifact@v4
-        with:
-          name: pr
-
-      - name: Print message and pr number
-        run: |
-          cat pr
-          echo "PR_NUMBER=$(cat pr)" >> "$GITHUB_ENV"
-          cat message.md
-
-      - name: Post a comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const content = fs.readFileSync('message.md', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: process.env.PR_NUMBER,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: content,
-            })

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,3 +1,5 @@
+# Runs the benchmark command on the PR and
+# on the branch, posting the results as a comment back the PR
 name: Benchmarks
 
 on:

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,8 +1,7 @@
-name: Run and Cache Benchmarks
+name: Benchmarks
 
 on:
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
 
 jobs:
   benchmark:
@@ -48,7 +47,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           clean: false
 
-      - name: Benchmark baseline and compare
+      - name: Benchmark baseline and generate comparison message
         env:
           RESULTS_NAME: ${{ env.BASE_REF_SHA }}
         run: |
@@ -59,5 +58,66 @@ jobs:
           # Temporary workaround, until `RESULTS_NAME` var lands into main
           mv -f results/HEAD results/${{ env.BASE_REF_SHA }}
           
+          echo ${{ github.event.pull_request.number }} > pr
+          
           pip3 install rich
-          ./bench.sh compare ${{ env.BASE_REF_SHA }} ${{ env.HEAD_REF_SHA }}
+          cat > message.md <<EOF
+          # Benchmark results
+          
+          <details>
+          <summary>Benchmarks comparing ${{ github.event.pull_request.base.sha }} and ${{ github.sha }}</summary>
+
+          \`\`\`
+          $(./bench.sh compare ${{ env.BASE_REF_SHA }} ${{ env.HEAD_REF_SHA }})
+          \`\`\`
+
+          </details>
+          EOF
+          
+          cat message.md
+
+      - name: Upload benchmark comparison message
+        uses: actions/upload-artifact@v4
+        with:
+          name: message
+          path: benchmarks/message.md
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: benchmarks/pr
+
+  comment:
+    name: Post benchmarks comment
+    runs-on: ubuntu-latest
+    needs: [ benchmark ]
+    steps:
+      - name: Download comment message
+        uses: actions/download-artifact@v4
+        with:
+          name: message
+
+      - name: Download pr number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr
+
+      - name: Print message and pr number
+        run: |
+          cat pr
+          echo "PR_NUMBER=$(cat pr)" >> "$GITHUB_ENV"
+          cat message.md
+
+      - name: Post a comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const content = fs.readFileSync('message.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: content,
+            })

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -28,14 +28,13 @@ jobs:
           ./bench.sh data tpch
           
           # Generate a unique-ish identifiers for the results
-          echo "HEAD_REF_SHA=pr-${{ github.event.issue.number }}" >> "$GITHUB_ENV" 
-          
-          short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "BASE_REF_SHA=main-$short_sha" >> "$GITHUB_ENV"
+          echo "HEAD_LONG_SHA=$(git log -1 --format='%H')" >> "$GITHUB_ENV" 
+          echo "HEAD_SHORT_SHA=$(git log -1 --format='%h' --abbrev=7)" >> "$GITHUB_ENV" 
+          echo "BASE_SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)" >> "$GITHUB_ENV"
 
       - name: Benchmark PR changes
         env:
-          RESULTS_NAME: ${{ env.HEAD_REF_SHA }}
+          RESULTS_NAME: ${{ env.HEAD_SHORT_SHA }}
         run: |
           cd benchmarks
 
@@ -49,14 +48,11 @@ jobs:
 
       - name: Benchmark baseline and generate comparison message
         env:
-          RESULTS_NAME: ${{ env.BASE_REF_SHA }}
+          RESULTS_NAME: ${{ env.BASE_SHORT_SHA }}
         run: |
           cd benchmarks
 
           ./bench.sh run tpch
-          
-          # Temporary workaround, until `RESULTS_NAME` var lands into main
-          mv -f results/HEAD results/${{ env.BASE_REF_SHA }}
           
           echo ${{ github.event.issue.number }} > pr
           
@@ -65,10 +61,10 @@ jobs:
           # Benchmark results
           
           <details>
-          <summary>Benchmarks comparing ${{ github.sha }} and PR ${{ github.event.issue.number }}</summary>
+          <summary>Benchmarks comparing ${{ github.sha }} (main) and ${{ env.HEAD_LONG_SHA }} (PR)</summary>
 
           \`\`\`
-          $(./bench.sh compare ${{ env.BASE_REF_SHA }} ${{ env.HEAD_REF_SHA }})
+          $(./bench.sh compare ${{ env.BASE_SHORT_SHA }} ${{ env.HEAD_SHORT_SHA }})
           \`\`\`
 
           </details>

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,0 +1,63 @@
+name: Run and Cache Benchmarks
+
+on:
+  pull_request:
+    types: [labeled, opened, reopened, synchronize]
+
+jobs:
+  benchmark:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Checkout PR changes
+        uses: actions/checkout@v4
+
+      - name: Setup data and generate unique result names
+        run: |
+          cd benchmarks
+          mkdir data
+          
+          # Setup the TPC-H data set with a scale factor of 10
+          ./bench.sh data tpch
+          
+          # Generate a unique-ish identifier for the results using 
+          # branch name and commit sha
+          short_ref=$(echo "${{ github.head_ref }}" | cut -c1-20)
+          short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "HEAD_REF_SHA=$short_ref-$short_sha" >> "$GITHUB_ENV" 
+          
+          short_sha=$(echo "${{ github.event.pull_request.base.sha }}" | cut -c1-7)
+          echo "BASE_REF_SHA=${{ github.base_ref }}-$short_sha" >> "$GITHUB_ENV"
+
+      - name: Benchmark PR changes
+        env:
+          RESULTS_NAME: ${{ env.HEAD_REF_SHA }}
+        run: |
+          cd benchmarks
+
+          ./bench.sh run tpch
+
+      - name: Checkout base commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          clean: false
+
+      - name: Benchmark baseline and compare
+        env:
+          RESULTS_NAME: ${{ env.BASE_REF_SHA }}
+        run: |
+          cd benchmarks
+
+          ./bench.sh run tpch
+          
+          # Temporary workaround, until `RESULTS_NAME` var lands into main
+          mv -f results/HEAD results/${{ env.BASE_REF_SHA }}
+          
+          pip3 install rich
+          ./bench.sh compare ${{ env.BASE_REF_SHA }} ${{ env.HEAD_REF_SHA }}

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,53 @@
+name: PR Comment
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: PR Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Download comment message
+        uses: actions/download-artifact@v4
+        with:
+          name: message
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download pr number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print message and pr number
+        run: |
+          cat pr
+          echo "PR_NUMBER=$(cat pr)" >> "$GITHUB_ENV"
+          cat message.md
+
+      - name: Post the comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const content = fs.readFileSync('message.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: content,
+            })

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -10,9 +10,7 @@ jobs:
   comment:
     name: PR Comment
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,3 +1,5 @@
+# Downloads any `message` artifacts created by other jobs
+# and posts them as comments to the PR
 name: PR Comment
 
 on:

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -82,6 +82,7 @@ clickbench_extended:    ClickBench "inspired" queries against a single parquet (
 DATA_DIR        directory to store datasets
 CARGO_COMMAND   command that runs the benchmark binary
 DATAFUSION_DIR  directory to use (default $DATAFUSION_DIR)
+RESULTS_NAME    folder where the benchmark files are stored
 "
     exit 1
 }
@@ -166,18 +167,19 @@ main() {
             esac
             ;;
         run)
-            # Parse positional paraleters
+            # Parse positional parameters
             BENCHMARK=${ARG2:-"${BENCHMARK}"}
             BRANCH_NAME=$(cd ${DATAFUSION_DIR} && git rev-parse --abbrev-ref HEAD)
             BRANCH_NAME=${BRANCH_NAME//\//_} # mind blowing syntax to replace / with _
-            RESULTS_DIR=${RESULTS_DIR:-"$SCRIPT_DIR/results/$BRANCH_NAME"}
+            RESULTS_NAME=${RESULTS_NAME:-"${BRANCH_NAME}"}
+            RESULTS_DIR=${RESULTS_DIR:-"$SCRIPT_DIR/results/$RESULTS_NAME"}
 
             echo "***************************"
             echo "DataFusion Benchmark Script"
             echo "COMMAND: ${COMMAND}"
             echo "BENCHMARK: ${BENCHMARK}"
             echo "DATAFUSION_DIR: ${DATAFUSION_DIR}"
-            echo "BRACH_NAME: ${BRANCH_NAME}"
+            echo "BRANCH_NAME: ${BRANCH_NAME}"
             echo "DATA_DIR: ${DATA_DIR}"
             echo "RESULTS_DIR: ${RESULTS_DIR}"
             echo "CARGO_COMMAND: ${CARGO_COMMAND}"
@@ -278,7 +280,7 @@ data_tpch() {
         echo " tbl files exist ($FILE exists)."
     else
         echo " creating tbl files with tpch_dbgen..."
-        docker run -v "${TPCH_DIR}":/data -it --rm ghcr.io/scalytics/tpch-docker:main -vf -s ${SCALE_FACTOR}
+        docker run -v "${TPCH_DIR}":/data --rm ghcr.io/scalytics/tpch-docker:main -vf -s ${SCALE_FACTOR}
     fi
 
     # Copy expected answers into the ./data/answers directory if it does not already exist
@@ -288,7 +290,7 @@ data_tpch() {
     else
         echo " Copying answers to ${TPCH_DIR}/answers"
         mkdir -p "${TPCH_DIR}/answers"
-        docker run -v "${TPCH_DIR}":/data -it --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
+        docker run -v "${TPCH_DIR}":/data --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
     fi
 
     # Create 'parquet' files from tbl

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -980,6 +980,9 @@ impl ExecutionPlan for SortExec {
                         let batch = batch?;
                         sorter.insert_batch(batch).await?;
                     }
+                    // Test whether benchmarks catch this
+                    // TODO: remove before merge!
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     sorter.sort()
                 })
                 .try_flatten(),

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -980,9 +980,6 @@ impl ExecutionPlan for SortExec {
                         let batch = batch?;
                         sorter.insert_batch(batch).await?;
                     }
-                    // Test whether benchmarks catch this
-                    // TODO: remove before merge!
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     sorter.sort()
                 })
                 .try_flatten(),


### PR DESCRIPTION
## Which issue does this PR close?

Partially progresses #5504.

## Rationale for this change

Enable automated comparative PR benchmarking, and thus make performance regression less likely to be introduced into the code.

## What changes are included in this PR?

Add two new workflows:

1. `Benchmarks`, that is triggered by a PR comment `/benchmark`, and which runs the standard repo benchmarks against the base and head commits.
2. A generic `PR Comment` workflow, that in this case should post a message along the lines of

> # Benchmark results
> 
> <details>
> <summary>Benchmarks comparing e5404a13fa3fe82a1f108430342ed7b7b0358ff1 and 3bf178a432460ac069ab9d94fc80486710d6341f</summary>
> 
> ```
> Comparing main-e5404a1 and ci-benches-3bf178a
> --------------------
> Benchmark tpch.json
> --------------------
> ┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
> ┃ Query        ┃ main-e5404a1 ┃ ci-benches-3bf178a ┃        Change ┃
> ┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
> │ QQuery 1     │     445.21ms │          1446.96ms │  3.25x slower │
> │ QQuery 2     │      60.82ms │          1062.72ms │ 17.47x slower │
> │ QQuery 3     │     147.76ms │          1153.42ms │  7.81x slower │
> │ QQuery 4     │      89.77ms │          1094.23ms │ 12.19x slower │
> │ QQuery 5     │     208.05ms │          1215.64ms │  5.84x slower │
> │ QQuery 6     │     109.18ms │           109.30ms │     no change │
> │ QQuery 7     │     295.69ms │          1312.57ms │  4.44x slower │
> │ QQuery 8     │     200.32ms │          1207.25ms │  6.03x slower │
> │ QQuery 9     │     304.16ms │          1316.10ms │  4.33x slower │
> │ QQuery 10    │     244.40ms │          1254.85ms │  5.13x slower │
> │ QQuery 11    │      66.08ms │          1068.05ms │ 16.16x slower │
> │ QQuery 12    │     127.32ms │          1132.51ms │  8.89x slower │
> │ QQuery 13    │     179.09ms │          1191.68ms │  6.65x slower │
> │ QQuery 14    │     129.67ms │           132.54ms │     no change │
> │ QQuery 15    │     198.01ms │          1201.44ms │  6.07x slower │
> │ QQuery 16    │      53.18ms │          1059.45ms │ 19.92x slower │
> │ QQuery 17    │     323.30ms │           340.44ms │  1.05x slower │
> │ QQuery 18    │     465.16ms │          1464.97ms │  3.15x slower │
> │ QQuery 19    │     235.39ms │           235.56ms │     no change │
> │ QQuery 20    │     193.32ms │          1214.60ms │  6.28x slower │
> │ QQuery 21    │     458.16ms │          1349.42ms │  2.95x slower │
> │ QQuery 22    │      54.80ms │          1059.73ms │ 19.34x slower │
> └──────────────┴──────────────┴────────────────────┴───────────────┘
> ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
> ┃ Benchmark Summary                 ┃            ┃
> ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
> │ Total Time (main-e5404a1)         │  4588.85ms │
> │ Total Time (ci-benches-3bf178a)   │ 22623.43ms │
> │ Average Time (main-e5404a1)       │   208.58ms │
> │ Average Time (ci-benches-3bf178a) │  1028.34ms │
> │ Queries Faster                    │          0 │
> │ Queries Slower                    │         19 │
> │ Queries with No Change            │          3 │
> └───────────────────────────────────┴────────────┘
> ```
> 
> </details>


## Are these changes tested?

Sort of.

There is a big catch-22 here at play:
- The HEAD~1 commit relies on a `pull_request` event to run the benchmarks, as is [officially recommended](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). The [workflow fails](https://github.com/apache/arrow-datafusion/actions/runs/8185910722/job/22383649908?pr=9461) just prior to posting a comment because in the case of `pull_request` events there are insufficient permission to write on the PR (trying to override the permissions of a job itself doesn't work).
- Workaround 1 is to execute a `workflow_call` workflow, but the problem there is that this type of workflow inherits permissions from the caller workflow so again this isn't sufficient.
- Workaround 2 is to use the `pull_request_target` which does have sufficient permissions and call a `workflow_call` workflow, but suffers from another problem, namely it must be present on the default branch to be run, so in this case it won't be executed until the PR is merged..
- Workaround 3 is to rely on the `workflow_run` event that gets triggered by the benchmark workflow, but the same problem appears here (can't run until merged).

In the end I decided to go with a `issue_comment`-based (covers pull requests too) benchmarking workflow (which also needs to be on the main branch to be run, and then make that trigger the PR commenting workflow via a `workflow_run` event. I figured since there has to be a two-step motion to test this out anyway we might as well try not to spam and add noise between steps (plus I envision the PR benchmarking to be triggered by a comment anyway).

## Are there any user-facing changes?

None (there will be dev-facing changes with the follow-up).

