### PR TITLE
fix: `substr_index` not handling negative occurrence correctly

### DIFF
--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -1031,6 +1031,16 @@ SELECT substring_index('arrow.apache.org', 'ac', 0)
 ----
 (empty)
 
+# Test substring_index with large occurrences
+query TT
+SELECT
+  -- i64::MIN
+  substring_index('arrow.apache.org', '.', -9223372036854775808) as c1,
+  -- i64::MAX
+  substring_index('arrow.apache.org', '.', 9223372036854775807) as c2;
+----
+arrow.apache.org arrow.apache.org
+
 # Test substring_index issue https://github.com/apache/arrow-datafusion/issues/9472
 query TTT
 SELECT

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -933,80 +933,113 @@ SELECT levenshtein(NULL, NULL)
 ----
 NULL
 
-query T
-SELECT substr_index('www.apache.org', '.', 1)
+# Test substring_index using '.' as delimiter
+# This query is compatible with MySQL(8.0.19 or later), convenient for comparing results
+query TIT
+SELECT str, n, substring_index(str, '.', n) AS c FROM
+	(VALUES
+		ROW('arrow.apache.org'),
+		ROW('.'),
+		ROW('...')
+	) AS strings(str),
+  (VALUES
+		ROW(1),
+		ROW(2),
+		ROW(3),
+		ROW(100),
+	  ROW(-1),
+    ROW(-2),
+		ROW(-3),
+    ROW(-100)
+	) AS occurrences(n)
+ORDER BY str DESC, n;
 ----
-www
+arrow.apache.org -100 arrow.apache.org
+arrow.apache.org -3 arrow.apache.org
+arrow.apache.org -2 apache.org
+arrow.apache.org -1 org
+arrow.apache.org 1 arrow
+arrow.apache.org 2 arrow.apache
+arrow.apache.org 3 arrow.apache.org
+arrow.apache.org 100 arrow.apache.org
+... -100 ...
+... -3 ..
+... -2 .
+... -1 (empty)
+... 1 (empty)
+... 2 .
+... 3 ..
+... 100 ...
+. -100 .
+. -3 .
+. -2 .
+. -1 (empty)
+. 1 (empty)
+. 2 .
+. 3 .
+. 100 .
 
-query T
-SELECT substr_index('www.apache.org', '.', 2)
+# Test substring_index using 'ac' as delimiter
+query TIT
+SELECT str, n, substring_index(str, 'ac', n) AS c FROM
+	(VALUES
+		ROW('arrow.apache.org')
+	) AS strings(str),
+  (VALUES
+		ROW(1),
+		ROW(2),
+	  ROW(-1),
+    ROW(-2)
+	) AS occurrences(n)
+ORDER BY str DESC, n;
 ----
-www.apache
+arrow.apache.org -2 arrow.apache.org
+arrow.apache.org -1 he.org
+arrow.apache.org 1 arrow.ap
+arrow.apache.org 2 arrow.apache.org
 
-query T
-SELECT substr_index('www.apache.org', '.', -1)
+# Test substring_index with NULL values
+query ?TT?
+SELECT
+  substring_index(NULL, '.', 1),
+  substring_index('arrow.apache.org', NULL, 1),
+  substring_index('arrow.apache.org', '.', NULL),
+  substring_index(NULL, NULL, NULL)
 ----
-org
+NULL NULL NULL NULL
 
-query T
-SELECT substr_index('www.apache.org', '.', -2)
+# Test substring_index with empty strings
+query TT
+SELECT
+  -- input string is empty
+  substring_index('', '.', 1),
+  -- delimiter is empty
+  substring_index('arrow.apache.org', '', 1)
 ----
-apache.org
+(empty) (empty)
 
+# Test substring_index with 0 occurrence
 query T
-SELECT substr_index('www.apache.org', 'ac', 1)
-----
-www.ap
-
-query T
-SELECT substr_index('www.apache.org', 'ac', -1)
-----
-he.org
-
-query T
-SELECT substr_index('www.apache.org', 'ac', 2)
-----
-www.apache.org
-
-query T
-SELECT substr_index('www.apache.org', 'ac', -2)
-----
-www.apache.org
-
-query ?
-SELECT substr_index(NULL, 'ac', 1)
-----
-NULL
-
-query T
-SELECT substr_index('www.apache.org', NULL, 1)
-----
-NULL
-
-query T
-SELECT substr_index('www.apache.org', 'ac', NULL)
-----
-NULL
-
-query T
-SELECT substr_index('', 'ac', 1)
+SELECT substring_index('arrow.apache.org', 'ac', 0)
 ----
 (empty)
 
-query T
-SELECT substr_index('www.apache.org', '', 1)
+# Test substring_index issue https://github.com/apache/arrow-datafusion/issues/9472
+query TTT
+SELECT
+  url,
+  substring_index(url, '.', 1) AS subdomain,
+  substring_index(url, '.', -1) AS tld
+FROM
+  (values ROW('docs.apache.com'),
+          ROW('community.influxdata.com'),
+          ROW('arrow.apache.org')
+  ) data(url)
 ----
-(empty)
+docs.apache.com docs com
+community.influxdata.com community com
+arrow.apache.org arrow org
 
-query T
-SELECT substr_index('www.apache.org', 'ac', 0)
-----
-(empty)
-
-query ?
-SELECT substr_index(NULL, NULL, NULL)
-----
-NULL
 
 query I
 SELECT find_in_set('b', 'a,b,c,d')

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -937,21 +937,21 @@ NULL
 # This query is compatible with MySQL(8.0.19 or later), convenient for comparing results
 query TIT
 SELECT str, n, substring_index(str, '.', n) AS c FROM
-	(VALUES
-		ROW('arrow.apache.org'),
-		ROW('.'),
-		ROW('...')
-	) AS strings(str),
   (VALUES
-		ROW(1),
-		ROW(2),
-		ROW(3),
-		ROW(100),
-	  ROW(-1),
+    ROW('arrow.apache.org'),
+    ROW('.'),
+    ROW('...')
+  ) AS strings(str),
+  (VALUES
+    ROW(1),
+    ROW(2),
+    ROW(3),
+    ROW(100),
+    ROW(-1),
     ROW(-2),
-		ROW(-3),
+    ROW(-3),
     ROW(-100)
-	) AS occurrences(n)
+  ) AS occurrences(n)
 ORDER BY str DESC, n;
 ----
 arrow.apache.org -100 arrow.apache.org
@@ -982,15 +982,15 @@ arrow.apache.org 100 arrow.apache.org
 # Test substring_index using 'ac' as delimiter
 query TIT
 SELECT str, n, substring_index(str, 'ac', n) AS c FROM
-	(VALUES
-		ROW('arrow.apache.org')
-	) AS strings(str),
   (VALUES
-		ROW(1),
-		ROW(2),
-	  ROW(-1),
+    ROW('arrow.apache.org')
+  ) AS strings(str),
+  (VALUES
+    ROW(1),
+    ROW(2),
+    ROW(-1),
     ROW(-2)
-	) AS occurrences(n)
+  ) AS occurrences(n)
 ORDER BY str DESC, n;
 ----
 arrow.apache.org -2 arrow.apache.org
@@ -1031,7 +1031,7 @@ SELECT
   substring_index(url, '.', 1) AS subdomain,
   substring_index(url, '.', -1) AS tld
 FROM
-  (values ROW('docs.apache.com'),
+  (VALUES ROW('docs.apache.com'),
           ROW('community.influxdata.com'),
           ROW('arrow.apache.org')
   ) data(url)

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -983,6 +983,9 @@ arrow.apache.org 100 arrow.apache.org
 query TIT
 SELECT str, n, substring_index(str, 'ac', n) AS c FROM
   (VALUES
+    -- input string does not contain the delimiter
+    ROW('arrow'),
+    -- input string contains the delimiter
     ROW('arrow.apache.org')
   ) AS strings(str),
   (VALUES
@@ -997,6 +1000,10 @@ arrow.apache.org -2 arrow.apache.org
 arrow.apache.org -1 he.org
 arrow.apache.org 1 arrow.ap
 arrow.apache.org 2 arrow.apache.org
+arrow -2 arrow
+arrow -1 arrow
+arrow 1 arrow
+arrow 2 arrow
 
 # Test substring_index with NULL values
 query ?TT?


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9472.

## Rationale for this change
Example query: `select substr_index('arrow.apache.org', '.', -1)`.
Expected result is `org`, but the current result of main branch is `e.org`.
```sh
DataFusion CLI v36.0.0
❯ select substr_index('arrow.apache.org', '.', -1);
+------------------------------------------------------------+
| substr_index(Utf8("arrow.apache.org"),Utf8("."),Int64(-1)) |
+------------------------------------------------------------+
| e.org                                                      |
+------------------------------------------------------------+
1 row in set. Query took 0.006 seconds.
```


The previous test input was "www.apache.org", where "www" and "org" have the same length, which coincidentally led to the tests on negative occurrences being passed.

Background: Since this function originates from [MySQL](https://github.com/apache/arrow-datafusion/pull/8272), its behavior should remain consistent with MySQL.

## What changes are included in this PR?
Refactor the implementation of `substr_index` and fix bug.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No