### PR TITLE
feat: use effective memory size for memory management purpose

### DIFF
--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -679,6 +679,25 @@ pub fn find_indices<T: PartialEq, S: Borrow<T>>(
         .ok_or_else(|| DataFusionError::Execution("Target not found".to_string()))
 }
 
+pub trait EffectiveSize {
+    fn get_effective_memory_size(&self) -> usize;
+}
+
+impl EffectiveSize for ArrayRef {
+    fn get_effective_memory_size(&self) -> usize {
+        self.to_data().get_slice_memory_size().unwrap_or(0)
+    }
+}
+
+impl EffectiveSize for RecordBatch {
+    fn get_effective_memory_size(&self) -> usize {
+        self.columns()
+            .iter()
+            .map(|x| x.get_effective_memory_size())
+            .sum()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ScalarValue;

--- a/datafusion/core/tests/memory_limit.rs
+++ b/datafusion/core/tests/memory_limit.rs
@@ -61,7 +61,7 @@ async fn oom_sort() {
         .with_expected_errors(vec![
             "Resources exhausted: Memory Exhausted while Sorting (DiskManager is disabled)",
         ])
-        .with_memory_limit(200_000)
+        .with_memory_limit(100_000)
         .run()
         .await
 }
@@ -656,7 +656,10 @@ fn make_dict_batches() -> Vec<RecordBatch> {
     let batches: Vec<_> = gen.take(num_batches).collect();
 
     batches.iter().enumerate().for_each(|(i, batch)| {
-        println!("Dict batch[{i}] size is: {}", batch.get_effective_memory_size());
+        println!(
+            "Dict batch[{i}] size is: {}",
+            batch.get_effective_memory_size()
+        );
     });
 
     batches

--- a/datafusion/core/tests/memory_limit.rs
+++ b/datafusion/core/tests/memory_limit.rs
@@ -43,6 +43,7 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use datafusion_common::{assert_contains, Result};
 
 use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_common::utils::EffectiveSize;
 use datafusion_execution::TaskContext;
 use test_utils::AccessLogGenerator;
 
@@ -655,7 +656,7 @@ fn make_dict_batches() -> Vec<RecordBatch> {
     let batches: Vec<_> = gen.take(num_batches).collect();
 
     batches.iter().enumerate().for_each(|(i, batch)| {
-        println!("Dict batch[{i}] size is: {}", batch.get_array_memory_size());
+        println!("Dict batch[{i}] size is: {}", batch.get_effective_memory_size());
     });
 
     batches
@@ -663,7 +664,7 @@ fn make_dict_batches() -> Vec<RecordBatch> {
 
 // How many bytes does the memory from dict_batches consume?
 fn batches_byte_size(batches: &[RecordBatch]) -> usize {
-    batches.iter().map(|b| b.get_array_memory_size()).sum()
+    batches.iter().map(|b| b.get_effective_memory_size()).sum()
 }
 
 struct DummyStreamPartition {

--- a/datafusion/physical-plan/src/joins/cross_join.rs
+++ b/datafusion/physical-plan/src/joins/cross_join.rs
@@ -43,8 +43,8 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 
 use async_trait::async_trait;
-use futures::{ready, Stream, StreamExt, TryStreamExt};
 use datafusion_common::utils::EffectiveSize;
+use futures::{ready, Stream, StreamExt, TryStreamExt};
 
 /// Data of the left side
 type JoinLeftData = (RecordBatch, MemoryReservation);

--- a/datafusion/physical-plan/src/joins/cross_join.rs
+++ b/datafusion/physical-plan/src/joins/cross_join.rs
@@ -44,6 +44,7 @@ use datafusion_physical_expr::equivalence::join_equivalence_properties;
 
 use async_trait::async_trait;
 use futures::{ready, Stream, StreamExt, TryStreamExt};
+use datafusion_common::utils::EffectiveSize;
 
 /// Data of the left side
 type JoinLeftData = (RecordBatch, MemoryReservation);
@@ -158,7 +159,7 @@ async fn load_left_input(
         .try_fold(
             (Vec::new(), 0usize, metrics, reservation),
             |mut acc, batch| async {
-                let batch_size = batch.get_array_memory_size();
+                let batch_size = batch.get_effective_memory_size();
                 // Reserve memory for incoming batch
                 acc.3.try_grow(batch_size)?;
                 // Update metrics

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -68,6 +68,7 @@ use datafusion_physical_expr::PhysicalExprRef;
 
 use ahash::RandomState;
 use futures::{ready, Stream, StreamExt, TryStreamExt};
+use datafusion_common::utils::EffectiveSize;
 
 /// HashTable and input data for the left (build side) of a join
 struct JoinLeftData {
@@ -703,7 +704,7 @@ async fn collect_left_input(
     let initial = (Vec::new(), 0, metrics, reservation);
     let (batches, num_rows, metrics, mut reservation) = stream
         .try_fold(initial, |mut acc, batch| async {
-            let batch_size = batch.get_array_memory_size();
+            let batch_size = batch.get_effective_memory_size();
             // Reserve memory for incoming batch
             acc.3.try_grow(batch_size)?;
             // Update metrics

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -67,8 +67,8 @@ use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr::PhysicalExprRef;
 
 use ahash::RandomState;
-use futures::{ready, Stream, StreamExt, TryStreamExt};
 use datafusion_common::utils::EffectiveSize;
+use futures::{ready, Stream, StreamExt, TryStreamExt};
 
 /// HashTable and input data for the left (build side) of a join
 struct JoinLeftData {

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -51,8 +51,8 @@ use datafusion_execution::TaskContext;
 use datafusion_expr::JoinType;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 
-use futures::{ready, Stream, StreamExt, TryStreamExt};
 use datafusion_common::utils::EffectiveSize;
+use futures::{ready, Stream, StreamExt, TryStreamExt};
 
 /// Data of the inner table side
 type JoinLeftData = (RecordBatch, MemoryReservation);

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -52,6 +52,7 @@ use datafusion_expr::JoinType;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 
 use futures::{ready, Stream, StreamExt, TryStreamExt};
+use datafusion_common::utils::EffectiveSize;
 
 /// Data of the inner table side
 type JoinLeftData = (RecordBatch, MemoryReservation);
@@ -347,7 +348,7 @@ async fn load_specified_partition_of_input(
         .try_fold(
             (Vec::new(), 0usize, join_metrics, reservation),
             |mut acc, batch| async {
-                let batch_size = batch.get_array_memory_size();
+                let batch_size = batch.get_effective_memory_size();
                 // Reserve memory for incoming batch
                 acc.3.try_grow(batch_size)?;
                 // Update metrics

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -56,6 +56,7 @@ use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr::{PhysicalExprRef, PhysicalSortRequirement};
 
 use futures::{Stream, StreamExt};
+use datafusion_common::utils::EffectiveSize;
 
 /// join execution plan executes partitions in parallel and combines them into a set of
 /// partitions.
@@ -571,10 +572,10 @@ impl BufferedBatch {
         // + worst case null_joined (as vector capacity * element size)
         // + Range size
         // + size of this estimation
-        let size_estimation = batch.get_array_memory_size()
+        let size_estimation = batch.get_effective_memory_size()
             + join_arrays
                 .iter()
-                .map(|arr| arr.get_array_memory_size())
+                .map(|arr| arr.get_effective_memory_size())
                 .sum::<usize>()
             + batch.num_rows().next_power_of_two() * mem::size_of::<usize>()
             + mem::size_of::<Range<usize>>()

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -55,8 +55,8 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr::{PhysicalExprRef, PhysicalSortRequirement};
 
-use futures::{Stream, StreamExt};
 use datafusion_common::utils::EffectiveSize;
+use futures::{Stream, StreamExt};
 
 /// join execution plan executes partitions in parallel and combines them into a set of
 /// partitions.

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -62,7 +62,7 @@ use arrow::compute::concat_batches;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::hash_utils::create_hashes;
-use datafusion_common::utils::bisect;
+use datafusion_common::utils::{bisect, EffectiveSize};
 use datafusion_common::{internal_err, plan_err, JoinSide, JoinType, Result};
 use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_execution::TaskContext;
@@ -974,7 +974,7 @@ impl OneSideHashJoiner {
         let mut size = 0;
         size += std::mem::size_of_val(self);
         size += std::mem::size_of_val(&self.build_side);
-        size += self.input_buffer.get_array_memory_size();
+        size += self.input_buffer.get_effective_memory_size();
         size += std::mem::size_of_val(&self.on);
         size += self.hashmap.size();
         size += self.hashes_buffer.capacity() * std::mem::size_of::<u64>();

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -46,12 +46,12 @@ use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr, PhysicalSortExpr};
 
+use datafusion_common::utils::EffectiveSize;
 use futures::stream::Stream;
 use futures::{FutureExt, StreamExt};
 use hashbrown::HashMap;
 use log::trace;
 use parking_lot::Mutex;
-use datafusion_common::utils::EffectiveSize;
 
 mod distributor_channels;
 

--- a/datafusion/physical-plan/src/sorts/builder.rs
+++ b/datafusion/physical-plan/src/sorts/builder.rs
@@ -19,6 +19,7 @@ use arrow::compute::interleave;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::Result;
+use datafusion_common::utils::EffectiveSize;
 use datafusion_execution::memory_pool::MemoryReservation;
 
 #[derive(Debug, Copy, Clone, Default)]
@@ -68,7 +69,7 @@ impl BatchBuilder {
 
     /// Append a new batch in `stream_idx`
     pub fn push_batch(&mut self, stream_idx: usize, batch: RecordBatch) -> Result<()> {
-        self.reservation.try_grow(batch.get_array_memory_size())?;
+        self.reservation.try_grow(batch.get_effective_memory_size())?;
         let batch_idx = self.batches.len();
         self.batches.push((stream_idx, batch));
         self.cursors[stream_idx] = BatchCursor {
@@ -140,7 +141,7 @@ impl BatchBuilder {
                 stream_cursor.batch_idx = retained;
                 retained += 1;
             } else {
-                self.reservation.shrink(batch.get_array_memory_size());
+                self.reservation.shrink(batch.get_effective_memory_size());
             }
             retain
         });

--- a/datafusion/physical-plan/src/sorts/builder.rs
+++ b/datafusion/physical-plan/src/sorts/builder.rs
@@ -18,8 +18,8 @@
 use arrow::compute::interleave;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::Result;
 use datafusion_common::utils::EffectiveSize;
+use datafusion_common::Result;
 use datafusion_execution::memory_pool::MemoryReservation;
 
 #[derive(Debug, Copy, Clone, Default)]
@@ -69,7 +69,8 @@ impl BatchBuilder {
 
     /// Append a new batch in `stream_idx`
     pub fn push_batch(&mut self, stream_idx: usize, batch: RecordBatch) -> Result<()> {
-        self.reservation.try_grow(batch.get_effective_memory_size())?;
+        self.reservation
+            .try_grow(batch.get_effective_memory_size())?;
         let batch_idx = self.batches.len();
         self.batches.push((stream_idx, batch));
         self.cursors[stream_idx] = BatchCursor {

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -32,6 +32,7 @@ use datafusion_execution::{
 };
 use datafusion_physical_expr::PhysicalSortExpr;
 use hashbrown::HashMap;
+use datafusion_common::utils::EffectiveSize;
 
 use crate::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
 
@@ -573,7 +574,7 @@ impl RecordBatchStore {
     pub fn insert(&mut self, entry: RecordBatchEntry) {
         // uses of 0 means that none of the rows in the batch were stored in the topk
         if entry.uses > 0 {
-            self.batches_size += entry.batch.get_array_memory_size();
+            self.batches_size += entry.batch.get_effective_memory_size();
             self.batches.insert(entry.id, entry);
         }
     }
@@ -628,7 +629,7 @@ impl RecordBatchStore {
             let old_entry = self.batches.remove(&id).unwrap();
             self.batches_size = self
                 .batches_size
-                .checked_sub(old_entry.batch.get_array_memory_size())
+                .checked_sub(old_entry.batch.get_effective_memory_size())
                 .unwrap();
         }
     }

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -25,6 +25,7 @@ use std::{cmp::Ordering, collections::BinaryHeap, sync::Arc};
 
 use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
+use datafusion_common::utils::EffectiveSize;
 use datafusion_common::Result;
 use datafusion_execution::{
     memory_pool::{MemoryConsumer, MemoryReservation},
@@ -32,7 +33,6 @@ use datafusion_execution::{
 };
 use datafusion_physical_expr::PhysicalSortExpr;
 use hashbrown::HashMap;
-use datafusion_common::utils::EffectiveSize;
 
 use crate::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9417.

## Rationale for this change

`ArrayData::get_slice_memory_size` serves our requirements for memory management better.

## What changes are included in this PR?

Introduce an `EffectiveSize` trait in `common::utils`, and substitute `batch.get_array_memory_size()` usages with `batch.get_effective_memory_size()` for codes related to memory management.

## Are these changes tested?

Existing tests and also the case noted in the issue.

## Are there any user-facing changes?

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
