### PR TITLE
chore: simplify the return type of `validate_data_types()`

### DIFF
--- a/datafusion/functions/src/datetime/common.rs
+++ b/datafusion/functions/src/datetime/common.rs
@@ -38,26 +38,27 @@ pub(crate) fn string_to_timestamp_nanos_shim(s: &str) -> Result<i64> {
     string_to_timestamp_nanos(s).map_err(|e| e.into())
 }
 
-pub(crate) fn validate_data_types(
-    args: &[ColumnarValue],
-    name: &str,
-) -> Option<Result<ColumnarValue>> {
+/// Checks that all the arguments from the second are of type [Utf8] or [LargeUtf8]
+///
+/// [Utf8]: DataType::Utf8
+/// [LargeUtf8]: DataType::LargeUtf8
+pub(crate) fn validate_data_types(args: &[ColumnarValue], name: &str) -> Result<()> {
     for (idx, a) in args.iter().skip(1).enumerate() {
         match a.data_type() {
             DataType::Utf8 | DataType::LargeUtf8 => {
                 // all good
             }
             _ => {
-                return Some(exec_err!(
+                return exec_err!(
                     "{name} function unsupported data type at index {}: {}",
                     idx + 1,
                     a.data_type()
-                ));
+                );
             }
         }
     }
 
-    None
+    Ok(())
 }
 
 /// Accepts a string and parses it using the [`chrono::format::strftime`] specifiers

--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -95,9 +95,7 @@ impl ScalarUDFImpl for ToDateFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_date") {
-                return value;
-            }
+            validate_data_types(args, "to_date")?;
         }
 
         match args[0].data_type() {

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -127,9 +127,7 @@ impl ScalarUDFImpl for ToTimestampFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_timestamp") {
-                return value;
-            }
+            validate_data_types(args, "to_timestamp")?;
         }
 
         match args[0].data_type() {
@@ -179,9 +177,7 @@ impl ScalarUDFImpl for ToTimestampSecondsFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_timestamp_seconds") {
-                return value;
-            }
+            validate_data_types(args, "to_timestamp")?;
         }
 
         match args[0].data_type() {
@@ -228,9 +224,7 @@ impl ScalarUDFImpl for ToTimestampMillisFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_timestamp_millis") {
-                return value;
-            }
+            validate_data_types(args, "to_timestamp")?;
         }
 
         match args[0].data_type() {
@@ -277,9 +271,7 @@ impl ScalarUDFImpl for ToTimestampMicrosFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_timestamp_micros") {
-                return value;
-            }
+            validate_data_types(args, "to_timestamp")?;
         }
 
         match args[0].data_type() {
@@ -326,9 +318,7 @@ impl ScalarUDFImpl for ToTimestampNanosFunc {
 
         // validate that any args after the first one are Utf8
         if args.len() > 1 {
-            if let Some(value) = validate_data_types(args, "to_timestamp_nanos") {
-                return value;
-            }
+            validate_data_types(args, "to_timestamp")?;
         }
 
         match args[0].data_type() {
@@ -390,8 +380,6 @@ mod tests {
 
     use datafusion_common::{assert_contains, DataFusionError, ScalarValue};
     use datafusion_expr::ScalarFunctionImplementation;
-
-    use crate::datetime::common::string_to_datetime_formatted;
 
     use super::*;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ref to https://github.com/apache/arrow-datafusion/pull/9077#discussion_r1515780055

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`validate_data_types()` has a logically unreachable type `ColumnarValue`. And this is sometimes misleading to the caller. Considering how it's implemented and would be used, I changed the return type to `Result<()>` to make it easier to invoke.

This function is from https://github.com/apache/arrow-datafusion/pull/9388

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change the return type of `validate_data_types()` and corresponding callers.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
