### PR TITLE
fix: support two argument TRIM

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -468,11 +468,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 trim_where,
                 trim_what,
+                trim_characters,
                 ..
             } => self.sql_trim_to_expr(
                 *expr,
                 trim_where,
                 trim_what,
+                trim_characters,
                 schema,
                 planner_context,
             ),
@@ -699,6 +701,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         expr: SQLExpr,
         trim_where: Option<TrimWhereField>,
         trim_what: Option<Box<SQLExpr>>,
+        trim_characters: Option<Vec<SQLExpr>>,
         schema: &DFSchema,
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
@@ -708,15 +711,31 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             Some(TrimWhereField::Both) => BuiltinScalarFunction::Btrim,
             None => BuiltinScalarFunction::Trim,
         };
+
         let arg = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
-        let args = match trim_what {
-            Some(to_trim) => {
+        let args = match (trim_what, trim_characters) {
+            (Some(to_trim), None) => {
                 let to_trim =
                     self.sql_expr_to_logical_expr(*to_trim, schema, planner_context)?;
-                vec![arg, to_trim]
+                Ok(vec![arg, to_trim])
             }
-            None => vec![arg],
-        };
+            (None, Some(trim_characters)) => {
+                if let Some(first) = trim_characters.first() {
+                    let to_trim = self.sql_expr_to_logical_expr(
+                        first.clone(),
+                        schema,
+                        planner_context,
+                    )?;
+                    Ok(vec![arg, to_trim])
+                } else {
+                    plan_err!("TRIM CHARACTERS cannot be empty")
+                }
+            }
+            (Some(_), Some(_)) => {
+                plan_err!("Both TRIM and TRIM CHARACTERS cannot be specified")
+            }
+            (None, None) => Ok(vec![arg]),
+        }?;
         Ok(Expr::ScalarFunction(ScalarFunction::new(fun, args)))
     }
 

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -666,9 +666,9 @@ SELECT trim(TRAILING ' ' FROM ' tom ')
  tom
 
 query T
-SELECT trim('tommy', 'my')
+SELECT trim('test.com', '.com')
 ----
-tom
+test
 
 statement error
 SELECT trim(BOTH 'tom' FROM 'tommy', 'my')

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -483,7 +483,7 @@ NULL
 query T
 SELECT ltrim(' zzzytest ')
 ----
-zzzytest
+zzzytest 
 
 query T
 SELECT ltrim('zzzytest', 'xyz')
@@ -643,7 +643,7 @@ tom
 query T
 SELECT trim(LEADING ' tom ')
 ----
-tom
+tom 
 
 query T
 SELECT trim(TRAILING ' tom ')
@@ -658,12 +658,20 @@ tom
 query T
 SELECT trim(LEADING ' ' FROM ' tom ')
 ----
-tom
+tom 
 
 query T
 SELECT trim(TRAILING ' ' FROM ' tom ')
 ----
  tom
+
+query T
+SELECT trim('tommy', 'my')
+----
+tom
+
+statement error
+SELECT trim(BOTH 'tom' FROM 'tommy', 'my')
 
 query T
 SELECT trim(BOTH ' ' FROM ' tom ')
@@ -732,14 +740,6 @@ SELECT trim('tom ')
 tom
 
 query T
-SELECT trim('tommy', 'my')
-----
-tom
-
-query T
-SELECT trim(BOTH 'tom' FROM 'tommy', 'my')
-
-query T
 SELECT upper('')
 ----
 (empty)
@@ -764,7 +764,7 @@ NULL
 
 # test_random_expression
 query BB
-SELECT
+SELECT 
     random() BETWEEN 0.0 AND 1.0,
     random() = random()
 ----
@@ -1366,7 +1366,7 @@ SELECT encode('','base64');
 query ?
 SELECT decode('','base64');
 ----
-
+    
 
 query T
 SELECT encode('','hex');
@@ -1376,7 +1376,7 @@ SELECT encode('','hex');
 query ?
 SELECT decode('','hex');
 ----
-
+    
 
 query T
 SELECT md5('tom');

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -483,7 +483,7 @@ NULL
 query T
 SELECT ltrim(' zzzytest ')
 ----
-zzzytest 
+zzzytest
 
 query T
 SELECT ltrim('zzzytest', 'xyz')
@@ -643,7 +643,7 @@ tom
 query T
 SELECT trim(LEADING ' tom ')
 ----
-tom 
+tom
 
 query T
 SELECT trim(TRAILING ' tom ')
@@ -658,7 +658,7 @@ tom
 query T
 SELECT trim(LEADING ' ' FROM ' tom ')
 ----
-tom 
+tom
 
 query T
 SELECT trim(TRAILING ' ' FROM ' tom ')
@@ -732,6 +732,14 @@ SELECT trim('tom ')
 tom
 
 query T
+SELECT trim('tommy', 'my')
+----
+tom
+
+query T
+SELECT trim(BOTH 'tom' FROM 'tommy', 'my')
+
+query T
 SELECT upper('')
 ----
 (empty)
@@ -756,7 +764,7 @@ NULL
 
 # test_random_expression
 query BB
-SELECT 
+SELECT
     random() BETWEEN 0.0 AND 1.0,
     random() = random()
 ----
@@ -1358,7 +1366,7 @@ SELECT encode('','base64');
 query ?
 SELECT decode('','base64');
 ----
-    
+
 
 query T
 SELECT encode('','hex');
@@ -1368,7 +1376,7 @@ SELECT encode('','hex');
 query ?
 SELECT decode('','hex');
 ----
-    
+
 
 query T
 SELECT md5('tom');


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9487

## Rationale for this change

Currently `SELECT TRIM('test.com', '.com')` doesn't work as expected because `.com` isn't removed.

## What changes are included in this PR?

This PR updates the translation step between the sql expression and the trim execution so that for both ways `TRIM` can be called, the proper trim characters are passes as an argument.

## Are these changes tested?

Yes, but minimal to start out with.

## Are there any user-facing changes?

Not really