### PR TITLE
Minor: add a sql_planner benchmarks to reflecte select many field on a huge table

### DIFF
--- a/datafusion/core/benches/sql_planner.rs
+++ b/datafusion/core/benches/sql_planner.rs
@@ -166,6 +166,8 @@ fn create_context() -> SessionContext {
         .unwrap();
     ctx.register_table("t700", create_table_provider("c", 700))
         .unwrap();
+    ctx.register_table("t1000", create_table_provider("d", 1000))
+        .unwrap();
 
     let tpch_schemas = create_tpch_schemas();
     tpch_schemas.iter().for_each(|(name, schema)| {
@@ -192,6 +194,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     // https://github.com/apache/arrow-datafusion/issues/5157
     c.bench_function("physical_select_one_from_700", |b| {
         b.iter(|| physical_plan(&ctx, "SELECT c1 FROM t700"))
+    });
+
+    // Test simplest
+    c.bench_function("logical_select_all_from_1000", |b| {
+        b.iter(|| logical_plan(&ctx, "SELECT * FROM t1000"))
+    });
+
+    // Test simplest
+    c.bench_function("physical_select_all_from_1000", |b| {
+        b.iter(|| physical_plan(&ctx, "SELECT * FROM t1000"))
     });
 
     c.bench_function("logical_trivial_join_low_numbered_columns", |b| {


### PR DESCRIPTION
## Which issue does this PR close?


Closes #.

## Rationale for this change

I find current sql_planner doesn't have benchmarks that reflect the query type that selects many fields on a huge table(more than 1000). maybe this also can reflect the query type describe in #7698.

## What changes are included in this PR?



## Are these changes tested?



## Are there any user-facing changes?


