### PR TITLE
docs: fix extraneous char in array functions table of contents

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1951,7 +1951,7 @@ from_unixtime(expression)
 - [array_dims](#array_dims)
 - [array_has](#array_has)
 - [array_has_all](#array_has_all)
-- [array_has_any](#array_has_any)]
+- [array_has_any](#array_has_any)
 - [array_element](#array_element)
 - [array_except](#array_except)
 - [array_extract](#array_extract)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Minor doc change to remove this extra char in the array function TOC.

<img width="203" alt="image" src="https://github.com/apache/arrow-datafusion/assets/421839/69ec7867-7c0a-4c7b-8185-f899679be1b5">


## What changes are included in this PR?

Deletes a character.

## Are these changes tested?

Checked docs post build.

## Are there any user-facing changes?

Slight doc update