### PR TITLE
Update the comment and Add a check

### DIFF
--- a/datafusion/core/src/datasource/provider.rs
+++ b/datafusion/core/src/datasource/provider.rs
@@ -166,6 +166,7 @@ pub trait TableProvider: Sync + Send {
 
     /// Tests whether the table provider can make use of any or all filter expressions
     /// to optimise data retrieval.
+    /// the returned vector much have the same size as the filters argument.
     #[allow(deprecated)]
     fn supports_filters_pushdown(
         &self,

--- a/datafusion/core/src/datasource/provider.rs
+++ b/datafusion/core/src/datasource/provider.rs
@@ -166,7 +166,7 @@ pub trait TableProvider: Sync + Send {
 
     /// Tests whether the table provider can make use of any or all filter expressions
     /// to optimise data retrieval.
-    /// the returned vector much have the same size as the filters argument.
+    /// Note:  the returned vector much have the same size as the filters argument.
     #[allow(deprecated)]
     fn supports_filters_pushdown(
         &self,

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -26,8 +26,8 @@ use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::{
-    internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, DataFusionError,
-    JoinConstraint, Result,
+    internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, JoinConstraint,
+    Result,
 };
 use datafusion_expr::expr::Alias;
 use datafusion_expr::expr_rewriter::replace_col;

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -27,7 +27,7 @@ use datafusion_common::tree_node::{
 };
 use datafusion_common::{
     internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, JoinConstraint,
-    Result,
+    Result, DataFusionError
 };
 use datafusion_expr::expr::Alias;
 use datafusion_expr::expr_rewriter::replace_col;
@@ -859,6 +859,15 @@ impl OptimizerRule for PushDownFilter {
                 let results = scan
                     .source
                     .supports_filters_pushdown(filter_predicates.as_slice())?;
+                if filter_predicates.len() != results.len() {
+                    return Err(DataFusionError::Internal(format!(
+                        "Vec returned length: {} from supports_filters_pushdown is not the same size as the filters passed, which length is: {}",
+                        results.len(),
+                        filter_predicates.len(),
+
+                    )));
+                }
+
                 let zip = filter_predicates.iter().zip(results);
 
                 let new_scan_filters = zip

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -26,8 +26,8 @@ use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::{
-    internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, JoinConstraint,
-    Result, DataFusionError
+    internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, DataFusionError,
+    JoinConstraint, Result,
 };
 use datafusion_expr::expr::Alias;
 use datafusion_expr::expr_rewriter::replace_col;
@@ -860,12 +860,10 @@ impl OptimizerRule for PushDownFilter {
                     .source
                     .supports_filters_pushdown(filter_predicates.as_slice())?;
                 if filter_predicates.len() != results.len() {
-                    return Err(DataFusionError::Internal(format!(
+                    return internal_err!(
                         "Vec returned length: {} from supports_filters_pushdown is not the same size as the filters passed, which length is: {}",
                         results.len(),
-                        filter_predicates.len(),
-
-                    )));
+                        filter_predicates.len());
                 }
 
                 let zip = filter_predicates.iter().zip(results);


### PR DESCRIPTION
Update the comment on TableProvider::supports_filters_pushdown() to say that the returned vector much have the same size as the filters argument. Add a check at the callsite that the vec returned from supports_filters_pushdown is the same size as the filters passed:

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9405.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
following the suggestions:
> Update the comment on TableProvider::supports_filters_pushdown() to say that the returned vector much have the same size as the filters argument.
> Add a check at the callsite that the vec returned from supports_filters_pushdown is the same size as the filters passed:

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add a runtime error check for TableProvider::supports_filters_pushdown().
Update the comment on TableProvider::supports_filters_pushdown() .

## Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
make sure that the returned vector much have the same size as the filters argument.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
