### PR TITLE
Export datafusion-functions UDFs publically

### DIFF
--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -66,9 +66,8 @@ macro_rules! export_functions {
 macro_rules! make_udf_function {
     ($UDF:ty, $GNAME:ident, $NAME:ident) => {
         /// Singleton instance of the function
-        pub static $GNAME: std::sync::OnceLock<
-            std::sync::Arc<datafusion_expr::ScalarUDF>,
-        > = std::sync::OnceLock::new();
+        static $GNAME: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
+            std::sync::OnceLock::new();
 
         /// Return a [`ScalarUDF`] for [`$UDF`]
         ///

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -66,13 +66,14 @@ macro_rules! export_functions {
 macro_rules! make_udf_function {
     ($UDF:ty, $GNAME:ident, $NAME:ident) => {
         /// Singleton instance of the function
-        static $GNAME: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-            std::sync::OnceLock::new();
+        pub static $GNAME: std::sync::OnceLock<
+            std::sync::Arc<datafusion_expr::ScalarUDF>,
+        > = std::sync::OnceLock::new();
 
         /// Return a [`ScalarUDF`] for [`$UDF`]
         ///
         /// [`ScalarUDF`]: datafusion_expr::ScalarUDF
-        fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
+        pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
             $GNAME
                 .get_or_init(|| {
                     std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(


### PR DESCRIPTION
## Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/9584

## Rationale for this change
See https://github.com/apache/arrow-datafusion/issues/9584 (basically I want to find the UDF without having to search by name at runtime)

## What changes are included in this PR?
Export udf's publically 

(note I checked that datafusion-functions-array already exports these functions

## Are these changes tested?
no -- not sure what to test...

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
