### PR TITLE
support unprefixed config format options

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -855,6 +855,26 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let file_type = try_infer_file_type(&mut options, &statement.target)?;
         let partition_by = take_partition_by(&mut options);
 
+        match &file_type {
+            // Renames un-prefixed keys to support legacy format specific options
+            FileType::CSV | FileType::JSON | FileType::PARQUET => {
+                let prefix = format!("{}", file_type);
+                let keys_to_rename: Vec<_> = options
+                    .keys()
+                    .filter(|key| !key.starts_with(&prefix))
+                    .cloned()
+                    .collect();
+
+                for key in keys_to_rename {
+                    if let Some(value) = options.remove(&key) {
+                        let new_key = format!("{}.{}", prefix, key);
+                        options.insert(new_key, value);
+                    }
+                }
+            }
+            _ => {}
+        }
+
         Ok(LogicalPlan::Copy(CopyTo {
             input: Arc::new(input),
             output_url: statement.target,

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -484,3 +484,35 @@ COPY (select col2, sum(col1) from source_table
 # Copy from table with non literal
 query error DataFusion error: SQL error: ParserError\("Expected ',' or '\)' after option definition, found: \+"\)
 COPY source_table  to '/tmp/table.parquet' (row_group_size 55 + 102);
+
+
+# Legacy Format Options Support
+
+# Copy with legacy format options for Parquet
+query IT
+COPY source_table TO 'test_files/scratch/copy/format_table/' (
+    format parquet,
+    compression snappy,
+    'compression::col1' 'zstd(5)'
+);
+----
+2
+
+# Copy with legacy format options for JSON
+query IT
+COPY source_table  to 'test_files/scratch/copy/format_table' (format json, compression gzip);
+----
+2
+
+# Copy with legacy format options for CSV
+query IT
+COPY source_table to 'test_files/scratch/copy/format_table' (
+    format csv,
+    has_header false,
+    compression xz,
+    datetime_format '%FT%H:%M:%S.%9f',
+    delimiter ';',
+    null_value 'NULLVAL'
+);
+----
+2


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9575

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#9382 standardised write configuration but broke backwards compatibility for the format specific options of the `COPY` command.

Earlier users could have a query like this without prefixing all options:
```
COPY source_table TO 'test_files/scratch/copy/format_table/' (
    format parquet,
    compression snappy,
    'compression::col1' 'zstd(5)'
);
```

But after #9382, they'd need to prefix every format-specific options in this verbose way:

```
COPY source_table TO 'test_files/scratch/copy/format_table/' (
    format parquet,
    'parquet.compression' snappy,
    'parquet.compression::col1' 'zstd(5)'
);
```

This PR adds back the support for format-specific options that worked without providing the format prefix.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR renames keys without the file_type/format prefix for file types supported by the `COPY` command for backwards compatibility.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- Existing tests in `copy.slt` confirm that the prefixed format options (eg. `(format json, 'json.compression' gzip)`) added in #9382 work & aren't broken.
- Tests have been added for the legacy format (eg. `(format json, compression gzip)`).

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes. But the current documentation (https://arrow.apache.org/datafusion/user-guide/sql/write_options.html#available-options) lists the legacy format so this PR doesn't require a doc update. 


> If there are any breaking changes to public APIs, please add the `api change` label.

This PR restores breaking changes so I'm not adding the `api change` label. Please let me know if you think we should add the label nonetheless.
