### PR TITLE
Remove constant expressions from SortExprs in the SortExec

### DIFF
--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -28,7 +28,8 @@ use super::output_requirements::OutputRequirementExec;
 use crate::config::ConfigOptions;
 use crate::error::Result;
 use crate::physical_optimizer::utils::{
-    add_sort_above, is_coalesce_partitions, is_repartition, is_sort_preserving_merge,
+    add_sort_above_with_check, is_coalesce_partitions, is_repartition,
+    is_sort_preserving_merge,
 };
 use crate::physical_optimizer::PhysicalOptimizerRule;
 use crate::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
@@ -1159,8 +1160,11 @@ fn ensure_distribution(
                     // make sure ordering requirements are still satisfied after.
                     if ordering_satisfied {
                         // Make sure to satisfy ordering requirement:
-                        child =
-                            add_sort_above(child, required_input_ordering.to_vec(), None);
+                        child = add_sort_above_with_check(
+                            child,
+                            required_input_ordering.to_vec(),
+                            None,
+                        );
                     }
                 }
                 // Stop tracking distribution changing operators

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -28,7 +28,7 @@ use super::output_requirements::OutputRequirementExec;
 use crate::config::ConfigOptions;
 use crate::error::Result;
 use crate::physical_optimizer::utils::{
-    is_coalesce_partitions, is_repartition, is_sort_preserving_merge,
+    add_sort_above, is_coalesce_partitions, is_repartition, is_sort_preserving_merge,
 };
 use crate::physical_optimizer::PhysicalOptimizerRule;
 use crate::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
@@ -50,10 +50,8 @@ use datafusion_expr::logical_plan::JoinType;
 use datafusion_physical_expr::expressions::{Column, NoOp};
 use datafusion_physical_expr::utils::map_columns_before_projection;
 use datafusion_physical_expr::{
-    physical_exprs_equal, EquivalenceProperties, LexRequirementRef, PhysicalExpr,
-    PhysicalExprRef, PhysicalSortRequirement,
+    physical_exprs_equal, EquivalenceProperties, PhysicalExpr, PhysicalExprRef,
 };
-use datafusion_physical_plan::sorts::sort::SortExec;
 use datafusion_physical_plan::windows::{get_best_fitting_window, BoundedWindowAggExec};
 use datafusion_physical_plan::ExecutionPlanProperties;
 
@@ -1030,30 +1028,6 @@ fn replace_order_preserving_variants(
     context.update_plan_from_children()
 }
 
-/// This utility function adds a [`SortExec`] above an operator according to the
-/// given ordering requirements while preserving the original partitioning.
-fn add_sort_preserving_partitions(
-    node: DistributionContext,
-    sort_requirement: LexRequirementRef,
-    fetch: Option<usize>,
-) -> DistributionContext {
-    // If the ordering requirement is already satisfied, do not add a sort.
-    if !node
-        .plan
-        .equivalence_properties()
-        .ordering_satisfy_requirement(sort_requirement)
-    {
-        let sort_expr = PhysicalSortRequirement::to_sort_exprs(sort_requirement.to_vec());
-        let mut new_sort = SortExec::new(sort_expr, node.plan.clone()).with_fetch(fetch);
-        if node.plan.output_partitioning().partition_count() > 1 {
-            new_sort = new_sort.with_preserve_partitioning(true);
-        }
-        DistributionContext::new(Arc::new(new_sort), false, vec![node])
-    } else {
-        node
-    }
-}
-
 /// This function checks whether we need to add additional data exchange
 /// operators to satisfy distribution requirements. Since this function
 /// takes care of such requirements, we should avoid manually adding data
@@ -1185,11 +1159,8 @@ fn ensure_distribution(
                     // make sure ordering requirements are still satisfied after.
                     if ordering_satisfied {
                         // Make sure to satisfy ordering requirement:
-                        child = add_sort_preserving_partitions(
-                            child,
-                            required_input_ordering,
-                            None,
-                        );
+                        child =
+                            add_sort_above(child, required_input_ordering.to_vec(), None);
                     }
                 }
                 // Stop tracking distribution changing operators

--- a/datafusion/core/src/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_sorting.rs
@@ -36,7 +36,7 @@
 
 use std::sync::Arc;
 
-use super::utils::add_sort_above;
+use super::utils::{add_sort_above, add_sort_above_with_check};
 use crate::config::ConfigOptions;
 use crate::error::Result;
 use crate::physical_optimizer::replace_with_order_preserving_variants::{
@@ -285,13 +285,7 @@ fn parallelize_sorts(
         // deals with the children and their children and so on.
         requirements = requirements.children.swap_remove(0);
 
-        if !requirements
-            .plan
-            .equivalence_properties()
-            .ordering_satisfy_requirement(&sort_reqs)
-        {
-            requirements = add_sort_above(requirements, sort_reqs, fetch);
-        }
+        requirements = add_sort_above_with_check(requirements, sort_reqs, fetch);
 
         let spm = SortPreservingMergeExec::new(sort_exprs, requirements.plan.clone());
         Ok(Transformed::yes(

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -52,6 +52,25 @@ pub fn add_sort_above<T: Clone + Default>(
     PlanContext::new(Arc::new(new_sort), T::default(), vec![node])
 }
 
+/// This utility function adds a `SortExec` above an operator according to the
+/// given ordering requirements while preserving the original partitioning. If
+/// requirement is already satisfied no `SortExec` is added.
+pub fn add_sort_above_with_check<T: Clone + Default>(
+    node: PlanContext<T>,
+    sort_requirements: LexRequirement,
+    fetch: Option<usize>,
+) -> PlanContext<T> {
+    if !node
+        .plan
+        .equivalence_properties()
+        .ordering_satisfy_requirement(&sort_requirements)
+    {
+        add_sort_above(node, sort_requirements, fetch)
+    } else {
+        node
+    }
+}
+
 /// Checks whether the given operator is a limit;
 /// i.e. either a [`LocalLimitExec`] or a [`GlobalLimitExec`].
 pub fn is_limit(plan: &Arc<dyn ExecutionPlan>) -> bool {

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -38,7 +38,13 @@ pub fn add_sort_above<T: Clone + Default>(
     sort_requirements: LexRequirement,
     fetch: Option<usize>,
 ) -> PlanContext<T> {
-    let sort_expr = PhysicalSortRequirement::to_sort_exprs(sort_requirements);
+    let mut sort_expr = PhysicalSortRequirement::to_sort_exprs(sort_requirements);
+    sort_expr.retain(|sort_expr| {
+        !node
+            .plan
+            .equivalence_properties()
+            .is_expr_constant(&sort_expr.expr)
+    });
     let mut new_sort = SortExec::new(sort_expr, node.plan.clone()).with_fetch(fetch);
     if node.plan.output_partitioning().partition_count() > 1 {
         new_sort = new_sort.with_preserve_partitioning(true);

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -820,7 +820,7 @@ impl EquivalenceProperties {
     ///
     /// Returns `true` if the expression is constant according to equivalence
     /// group, `false` otherwise.
-    fn is_expr_constant(&self, expr: &Arc<dyn PhysicalExpr>) -> bool {
+    pub fn is_expr_constant(&self, expr: &Arc<dyn PhysicalExpr>) -> bool {
         // As an example, assume that we know columns `a` and `b` are constant.
         // Then, `a`, `b` and `a + b` will all return `true` whereas `c` will
         // return `false`.

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3407,6 +3407,27 @@ WITH ORDER (a ASC, b ASC)
 WITH ORDER (c ASC)
 LOCATION '../core/tests/data/window_2.csv';
 
+# Since column b is constant after filter b=0,
+# There should be no SortExec(b ASC) in the plan
+# window requirement b ASC is already satisfied by existing ordering.
+query TT
+EXPLAIN SELECT *, SUM(a) OVER(ORDER BY b ASC)
+FROM multiple_ordered_table
+where b=0
+----
+logical_plan
+WindowAggr: windowExpr=[[SUM(CAST(multiple_ordered_table.a AS Int64)) ORDER BY [multiple_ordered_table.b ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+--Filter: multiple_ordered_table.b = Int32(0)
+----TableScan: multiple_ordered_table projection=[a0, a, b, c, d], partial_filters=[multiple_ordered_table.b = Int32(0)]
+physical_plan
+BoundedWindowAggExec: wdw=[SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int32(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
+--CoalesceBatchesExec: target_batch_size=4096
+----FilterExec: b@2 = 0
+------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_orderings=[[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST], [c@3 ASC NULLS LAST]], has_header=true
+
+# Since column b is constant after filter b=0,
+# window requirement b ASC, d ASC can be satisfied
+# by the SortExec(d ASC). We do not need to sort by [b ASC, d ASC]
 query TT
 EXPLAIN SELECT *, SUM(a) OVER(ORDER BY b ASC, d ASC)
 FROM multiple_ordered_table

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -3407,6 +3407,23 @@ WITH ORDER (a ASC, b ASC)
 WITH ORDER (c ASC)
 LOCATION '../core/tests/data/window_2.csv';
 
+query TT
+EXPLAIN SELECT *, SUM(a) OVER(ORDER BY b ASC, d ASC)
+FROM multiple_ordered_table
+where b=0
+----
+logical_plan
+WindowAggr: windowExpr=[[SUM(CAST(multiple_ordered_table.a AS Int64)) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+--Filter: multiple_ordered_table.b = Int32(0)
+----TableScan: multiple_ordered_table projection=[a0, a, b, c, d], partial_filters=[multiple_ordered_table.b = Int32(0)]
+physical_plan
+BoundedWindowAggExec: wdw=[SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int32(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
+--SortExec: expr=[d@4 ASC NULLS LAST]
+----CoalesceBatchesExec: target_batch_size=4096
+------FilterExec: b@2 = 0
+--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_orderings=[[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST], [c@3 ASC NULLS LAST]], has_header=true
+
+
 # Create an unbounded source where there is multiple orderings.
 statement ok
 CREATE UNBOUNDED EXTERNAL TABLE multiple_ordered_table_inf (


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to [#9612](https://github.com/apache/arrow-datafusion/issues/9612) (not solves this problem)

## Rationale for this change
Datafusion can analyze `expressions` during planning. Then can mark them as constant (such as after `FilterExec`). This information can help with optimizing away some `SortExec`s from the plan. However, some `SortEXec`s stil have unnecessary constant fields in their sort expressions. This is suboptimal. This PR filters out constant fields from sort expressions at the `SortExec`. Since this behaviour is not triggerred by existing tests. I added a test for this behaviour also.

The query
```
EXPLAIN SELECT *, SUM(a) OVER(ORDER BY b ASC, d ASC)
FROM multiple_ordered_table
where b=0
```
generates following physical plan in the main
```
physical_plan
BoundedWindowAggExec: wdw=[SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int32(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
--SortExec: expr=[b@2 ASC NULLS LAST,d@4 ASC NULLS LAST] 
----CoalesceBatchesExec: target_batch_size=4096
------FilterExec: b@2 = 0
--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_orderings=[[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST], [c@3 ASC NULLS LAST]], has_header=true
```
whereas in this branch generates
```
BoundedWindowAggExec: wdw=[SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "SUM(multiple_ordered_table.a) ORDER BY [multiple_ordered_table.b ASC NULLS LAST, multiple_ordered_table.d ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(Int32(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
--SortExec: expr=[d@4 ASC NULLS LAST] 
----CoalesceBatchesExec: target_batch_size=4096
------FilterExec: b@2 = 0
--------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_orderings=[[a@1 ASC NULLS LAST, b@2 ASC NULLS LAST], [c@3 ASC NULLS LAST]], has_header=true
```
where `SortExec` is converted from `SortExec: expr=[b@2 ASC NULLS LAST,d@4 ASC NULLS LAST] ` to `SortExec: expr=[d@4 ASC NULLS LAST] ` since it is known that `b` is constant.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
