### PR TITLE
Minor: Remove datafusion-functions-array dependency from datafusion-optimizer

### DIFF
--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -33,9 +33,8 @@ name = "datafusion_optimizer"
 path = "src/lib.rs"
 
 [features]
-array_expressions = ["datafusion-functions-array"]
 crypto_expressions = ["datafusion-physical-expr/crypto_expressions"]
-default = ["unicode_expressions", "crypto_expressions", "regex_expressions", "array_expressions"]
+default = ["unicode_expressions", "crypto_expressions", "regex_expressions"]
 regex_expressions = ["datafusion-physical-expr/regex_expressions"]
 unicode_expressions = ["datafusion-physical-expr/unicode_expressions"]
 
@@ -45,7 +44,6 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
-datafusion-functions-array = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true }
 hashbrown = { version = "0.14", features = ["raw"] }
 itertools = { workspace = true }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -6025,11 +6025,24 @@ select make_array(arrow_cast(f0, 'List(Int64)')) from fixed_size_list_array
 [[1, 2]]
 [[3, 4]]
 
+query T
+select arrow_typeof(make_array(arrow_cast(f0, 'List(Int64)'))) from fixed_size_list_array
+----
+List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+
 query ?
 select make_array(f0) from fixed_size_list_array
 ----
 [[1, 2]]
 [[3, 4]]
+
+query T
+select arrow_typeof(make_array(f0)) from fixed_size_list_array
+----
+List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+
 
 query ?
 select array_concat(column1, [7]) from arrays_values_v2;


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/9285

## Rationale for this change

We are trying to decouple the functions from the rest of the system so the core functionality doesn't directly depend on the specific function packages. 

## What changes are included in this PR?
1. Remove the explicit dependency on datafusion-functions-array from datafusion-optimizer
2. Port a test to sqllogictests

## Are these changes tested?
Yes

## Are there any user-facing changes?

No (maybe slightly faster compile speeds)

