### PR TITLE
Improve Robustness of Unparser Testing and Implementation

### DIFF
--- a/datafusion/sql/src/unparser/mod.rs
+++ b/datafusion/sql/src/unparser/mod.rs
@@ -18,6 +18,7 @@
 mod ast;
 mod expr;
 mod plan;
+mod utils;
 
 pub use expr::expr_to_sql;
 pub use plan::plan_to_sql;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -15,16 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_common::{
-    internal_err, not_impl_err, plan_err,
-    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
-    DataFusionError, Result,
-};
-use datafusion_expr::{
-    expr::Alias, utils::find_column_exprs, Expr, ExprSchemable, JoinConstraint, JoinType,
-    LogicalPlan,
-};
-use sqlparser::ast::{self, Ident, SelectItem};
+use datafusion_common::{internal_err, not_impl_err, plan_err, DataFusionError, Result};
+use datafusion_expr::{expr::Alias, Expr, JoinConstraint, JoinType, LogicalPlan};
+use sqlparser::ast::{self};
 
 use crate::unparser::utils::unproject_agg_exprs;
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -183,8 +183,6 @@ impl Unparser<'_> {
                 }
             }
             LogicalPlan::Filter(filter) => {
-                println!("filter {plan:?}");
-
                 if let Some(agg) =
                     find_agg_node_within_select(plan, select.already_projected())
                 {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -17,13 +17,14 @@
 
 use datafusion_common::{internal_err, not_impl_err, plan_err, DataFusionError, Result};
 use datafusion_expr::{expr::Alias, Expr, JoinConstraint, JoinType, LogicalPlan};
-use sqlparser::ast::{self, Ident, SelectItem};
+use sqlparser::ast;
 
 use super::{
     ast::{
         BuilderError, DerivedRelationBuilder, QueryBuilder, RelationBuilder,
         SelectBuilder, TableRelationBuilder, TableWithJoinsBuilder,
-    },  Unparser
+    },
+    Unparser,
 };
 
 /// Convert a DataFusion [`LogicalPlan`] to `sqlparser::ast::Statement`
@@ -130,7 +131,6 @@ impl Unparser<'_> {
             LogicalPlan::Projection(p) => {
                 // A second projection implies a derived tablefactor
                 if !select.already_projected() {
-
                     let items = p
                         .expr
                         .iter()
@@ -143,7 +143,6 @@ impl Unparser<'_> {
                         select,
                         relation,
                     )
-
                 } else {
                     let mut derived_builder = DerivedRelationBuilder::default();
                     derived_builder.lateral(false).alias(None).subquery({
@@ -163,11 +162,11 @@ impl Unparser<'_> {
             LogicalPlan::Filter(filter) => {
                 let filter_expr = self.expr_to_sql(&filter.predicate)?;
 
-                if let LogicalPlan::Aggregate(_) = filter.input.as_ref(){
+                if let LogicalPlan::Aggregate(_) = filter.input.as_ref() {
                     select.having(Some(filter_expr));
                 } else {
                     select.selection(Some(filter_expr));
-                }               
+                }
 
                 self.select_to_sql_recursively(
                     filter.input.as_ref(),
@@ -203,11 +202,11 @@ impl Unparser<'_> {
             }
             LogicalPlan::Aggregate(agg) => {
                 select.group_by(ast::GroupByExpr::Expressions(
-                            agg.group_expr
-                                .iter()
-                                .map(|expr| self.expr_to_sql(expr))
-                                .collect::<Result<Vec<_>>>()?,
-                        ));
+                    agg.group_expr
+                        .iter()
+                        .map(|expr| self.expr_to_sql(expr))
+                        .collect::<Result<Vec<_>>>()?,
+                ));
                 self.select_to_sql_recursively(
                     agg.input.as_ref(),
                     query,

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -3,7 +3,7 @@ use datafusion_common::{
     tree_node::{Transformed, TreeNode},
     Result,
 };
-use datafusion_expr::{Aggregate, Expr, LogicalPlan, Projection};
+use datafusion_expr::{Aggregate, Expr, LogicalPlan};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if one exists
 /// prior to encountering a Join, TableScan, or subquery node. If an Aggregate node is not found

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -23,8 +23,8 @@ use datafusion_common::{
 use datafusion_expr::{Aggregate, Expr, LogicalPlan};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if one exists
-/// prior to encountering a Join, TableScan, or a nested subquery (derived table factor). 
-/// If an Aggregate node is not found prior to this or at all before reaching the end 
+/// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
+/// If an Aggregate node is not found prior to this or at all before reaching the end
 /// of the tree, None is returned.
 pub(crate) fn find_agg_node_within_select(
     plan: &LogicalPlan,

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use datafusion_common::{
     internal_err,
     tree_node::{Transformed, TreeNode},

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -23,12 +23,15 @@ use datafusion_common::{
 use datafusion_expr::{Aggregate, Expr, LogicalPlan};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if one exists
-/// prior to encountering a Join, TableScan, or subquery node. If an Aggregate node is not found
-/// prior to this or at all before reaching the end of the tree, None is returned.
+/// prior to encountering a Join, TableScan, or a nested subquery (derived table factor). 
+/// If an Aggregate node is not found prior to this or at all before reaching the end 
+/// of the tree, None is returned.
 pub(crate) fn find_agg_node_within_select(
     plan: &LogicalPlan,
     already_projected: bool,
 ) -> Option<&Aggregate> {
+    // Note that none of the nodes that have a corresponding agg node can have more
+    // than 1 input node. E.g. Projection / Filter always have 1 input node.
     let input = plan.inputs();
     let input = if input.len() > 1 {
         return None;

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -1,0 +1,64 @@
+use datafusion_common::{
+    internal_err,
+    tree_node::{Transformed, TreeNode},
+    Result,
+};
+use datafusion_expr::{Aggregate, Expr, LogicalPlan, Projection};
+
+/// Recursively searches children of [LogicalPlan] to find an Aggregate node if one exists
+/// prior to encountering a Join, TableScan, or subquery node. If an Aggregate node is not found
+/// prior to this or at all before reaching the end of the tree, None is returned.
+pub(crate) fn find_agg_node_within_select(
+    plan: &LogicalPlan,
+    already_projected: bool,
+) -> Option<&Aggregate> {
+    let input = plan.inputs();
+    let input = if input.len() > 1 {
+        return None;
+    } else {
+        input.first()?
+    };
+    if let LogicalPlan::Aggregate(agg) = input {
+        Some(agg)
+    } else if let LogicalPlan::TableScan(_) = input {
+        None
+    } else if let LogicalPlan::Projection(_) = input {
+        if already_projected {
+            None
+        } else {
+            find_agg_node_within_select(input, true)
+        }
+    } else {
+        find_agg_node_within_select(input, already_projected)
+    }
+}
+
+/// Recursively identify all Column expressions and transform them into the appropriate
+/// aggregate expression contained in agg.
+///
+/// For example, if expr contains the column expr "COUNT(*)" it will be transformed
+/// into an actual aggregate expression COUNT(*) as identified in the aggregate node.
+pub(crate) fn unproject_agg_exprs(expr: &Expr, agg: &Aggregate) -> Result<Expr> {
+    expr.clone()
+        .transform(&|sub_expr| {
+            if let Expr::Column(c) = sub_expr {
+                // find the column in the agg schmea
+                if let Ok(n) = agg.schema.index_of_column(&c) {
+                    let unprojected_expr = agg
+                        .group_expr
+                        .iter()
+                        .chain(agg.aggr_expr.iter())
+                        .nth(n)
+                        .unwrap();
+                    Ok(Transformed::yes(unprojected_expr.clone()))
+                } else {
+                    internal_err!(
+                        "Tried to unproject agg expr not found in provided Aggregate!"
+                    )
+                }
+            } else {
+                Ok(Transformed::no(sub_expr))
+            }
+        })
+        .map(|e| e.data)
+}

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -2824,6 +2824,20 @@ impl ContextProvider for MockContextProvider {
                 ),
                 Field::new("😀", DataType::Int32, false),
             ])),
+            "person_quoted_cols" => Ok(Schema::new(vec![
+                Field::new("id", DataType::UInt32, false),
+                Field::new("First Name", DataType::Utf8, false),
+                Field::new("Last Name", DataType::Utf8, false),
+                Field::new("Age", DataType::Int32, false),
+                Field::new("State", DataType::Utf8, false),
+                Field::new("Salary", DataType::Float64, false),
+                Field::new(
+                    "Birth Date",
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    false,
+                ),
+                Field::new("😀", DataType::Int32, false),
+            ])),
             "orders" => Ok(Schema::new(vec![
                 Field::new("order_id", DataType::UInt32, false),
                 Field::new("customer_id", DataType::UInt32, false),
@@ -4493,17 +4507,25 @@ impl TableSource for EmptyTable {
 #[test]
 fn roundtrip_expr() {
     let tests: Vec<(TableReference, &str, &str)> = vec![
-        (TableReference::bare("person"), "age > 35", "(age > 35)"),
-        (TableReference::bare("person"), "id = '10'", "(id = '10')"),
+        (
+            TableReference::bare("person"),
+            "age > 35",
+            r#"("age" > 35)"#,
+        ),
+        (
+            TableReference::bare("person"),
+            "id = '10'",
+            r#"("id" = '10')"#,
+        ),
         (
             TableReference::bare("person"),
             "CAST(id AS VARCHAR)",
-            "CAST(id AS VARCHAR)",
+            r#"CAST("id" AS VARCHAR)"#,
         ),
         (
             TableReference::bare("person"),
             "SUM((age * 2))",
-            "SUM((age * 2))",
+            r#"SUM(("age" * 2))"#,
         ),
     ];
 
@@ -4530,91 +4552,61 @@ fn roundtrip_expr() {
 }
 
 #[test]
-fn roundtrip_statement() {
-    let tests: Vec<(&str, &str)> = vec![
-        (
+fn roundtrip_statement() -> Result<()> {
+    let tests: Vec<&str> = vec![
             "select ta.j1_id from j1 ta;",
-            r#"SELECT ta.j1_id FROM j1 AS ta"#,
-        ),
-        (
             "select ta.j1_id from j1 ta order by ta.j1_id;",
-            r#"SELECT ta.j1_id FROM j1 AS ta ORDER BY ta.j1_id ASC NULLS LAST"#,
-        ),
-        (
             "select * from j1 ta order by ta.j1_id, ta.j1_string desc;",
-            r#"SELECT ta.j1_id, ta.j1_string FROM j1 AS ta ORDER BY ta.j1_id ASC NULLS LAST, ta.j1_string DESC NULLS FIRST"#,
-        ),
-        (
             "select * from j1 limit 10;",
-            r#"SELECT j1.j1_id, j1.j1_string FROM j1 LIMIT 10"#,
-        ),
-        (
             "select ta.j1_id from j1 ta where ta.j1_id > 1;",
-            r#"SELECT ta.j1_id FROM j1 AS ta WHERE (ta.j1_id > 1)"#,
-        ),
-        (
             "select ta.j1_id, tb.j2_string from j1 ta join j2 tb on (ta.j1_id = tb.j2_id);",
-            r#"SELECT ta.j1_id, tb.j2_string FROM j1 AS ta JOIN j2 AS tb ON (ta.j1_id = tb.j2_id)"#,
-        ),
-        (
             "select ta.j1_id, tb.j2_string, tc.j3_string from j1 ta join j2 tb on (ta.j1_id = tb.j2_id) join j3 tc on (ta.j1_id = tc.j3_id);",
-            r#"SELECT ta.j1_id, tb.j2_string, tc.j3_string FROM j1 AS ta JOIN j2 AS tb ON (ta.j1_id = tb.j2_id) JOIN j3 AS tc ON (ta.j1_id = tc.j3_id)"#,
-        ),
-        (
             "select * from (select id, first_name from person)",
-            "SELECT person.id, person.first_name FROM (SELECT person.id, person.first_name FROM person)"
-        ),
-        (
             "select * from (select id, first_name from (select * from person))",
-            "SELECT person.id, person.first_name FROM (SELECT person.id, person.first_name FROM (SELECT person.id, person.first_name, person.last_name, person.age, person.state, person.salary, person.birth_date, person.😀 FROM person))"
-        ),
-        (
             "select id, count(*) as cnt from (select id from person) group by id",
-            "SELECT person.id, COUNT(*) AS cnt FROM (SELECT person.id FROM person) GROUP BY person.id"
-        ),
-        (
+            "select (id-1)/2, count(*) / (sum(id/10)-1) as agg_expr from (select (id-1) as id from person) group by id",
+            r#"select "First Name" from person_quoted_cols"#,
+            r#"select id, count("First Name") as cnt from (select id, "First Name" from person_quoted_cols) group by id"#,
             "select id, count(*) as cnt from (select p1.id as id from person p1 inner join person p2 on p1.id=p2.id) group by id",
-            "SELECT p1.id, COUNT(*) AS cnt FROM (SELECT p1.id FROM person AS p1 JOIN person AS p2 ON (p1.id = p2.id)) GROUP BY p1.id"
-        ),
-        (
             "select id, count(*), first_name from person group by first_name, id",
-            "SELECT person.id, COUNT(*), person.first_name FROM person GROUP BY person.first_name, person.id"
-        ),
-        (
             "select id, sum(age), first_name from person group by first_name, id",
-            "SELECT person.id, SUM(person.age), person.first_name FROM person GROUP BY person.first_name, person.id"
-        ),
-        ("select id, count(*), first_name 
-        from person 
-        where id!=3 and first_name=='test'
-        group by first_name, id 
-        having count(*)>5 and count(*)<10
-        order by count(*)",
-        " person.id, COUNT(*), person.first_name FROM person WHERE ((person.id <> 3) AND (person.first_name = 'test')) GROUP BY person.first_name, person.id HAVING ((COUNT(*) > 5) AND (COUNT(*) < 10)) ORDER BY COUNT(*) ASC NULLS LAST"
-    )
-    ];
+            "select id, count(*), first_name 
+            from person 
+            where id!=3 and first_name=='test'
+            group by first_name, id 
+            having count(*)>5 and count(*)<10
+            order by count(*)",
+            r#"select id, count("First Name") as count_first_name, "Last Name" 
+            from person_quoted_cols
+            where id!=3 and "First Name"=='test'
+            group by "Last Name", id 
+            having count_first_name>5 and count_first_name<10
+            order by count_first_name, "Last Name""#,
+        ];
 
-    let roundtrip = |sql: &str| -> Result<String> {
+    for query in tests {
         let dialect = GenericDialect {};
-        let statement = Parser::new(&dialect).try_with_sql(sql)?.parse_statement()?;
+        let statement = Parser::new(&dialect)
+            .try_with_sql(query)?
+            .parse_statement()?;
 
         let context = MockContextProvider::default();
         let sql_to_rel = SqlToRel::new(&context);
-        let plan = sql_to_rel.sql_statement_to_plan(statement)?;
+        let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();
 
-        println!("{}", plan.display_indent());
+        let roundtrip_statement = plan_to_sql(&plan)?;
 
-        let ast = plan_to_sql(&plan)?;
+        let actual = format!("{}", &roundtrip_statement);
+        println!("roundtrip sql: {actual}");
 
-        println!("{ast}");
+        let plan_roundtrip = sql_to_rel
+            .sql_statement_to_plan(roundtrip_statement.clone())
+            .unwrap();
 
-        Ok(format!("{}", ast))
-    };
-
-    for (query, expected) in tests {
-        let actual = roundtrip(query).unwrap();
-        assert_eq!(actual, expected);
+        assert_eq!(plan, plan_roundtrip);
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4590,7 +4590,7 @@ fn roundtrip_statement() {
         group by first_name, id 
         having count(*)>5 and count(*)<10
         order by count(*)",
-        "SELECT person.id, COUNT(*), person.first_name FROM person WHERE ((person.id <> 3) AND (person.first_name = 'test')) GROUP BY person.first_name, person.id HAVING ((COUNT(*) > 5) AND (COUNT(*) < 10)) ORDER BY COUNT(*) ASC NULLS LAST"
+        " person.id, COUNT(*), person.first_name FROM person WHERE ((person.id <> 3) AND (person.first_name = 'test')) GROUP BY person.first_name, person.id HAVING ((COUNT(*) > 5) AND (COUNT(*) < 10)) ORDER BY COUNT(*) ASC NULLS LAST"
     )
     ];
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4594,6 +4594,11 @@ fn roundtrip_statement() -> Result<()> {
             order by count_first_name, "Last Name""#,
         ];
 
+    // For each test sql string, we transform as follows:
+    // sql -> ast::Statement (s1) -> LogicalPlan (p1) -> ast::Statement (s2) -> LogicalPlan (p2)
+    // We test not that s1==s2, but rather p1==p2. This ensures that unparser preserves the logical
+    // query information of the original sql string and disreguards other differences in syntax or
+    // quoting.
     for query in tests {
         let dialect = GenericDialect {};
         let statement = Parser::new(&dialect)

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4580,6 +4580,18 @@ fn roundtrip_statement() {
             "select id, count(*), first_name from person group by first_name, id",
             "SELECT person.id, COUNT(*), person.first_name FROM person GROUP BY person.first_name, person.id"
         ),
+        (
+            "select id, sum(age), first_name from person group by first_name, id",
+            "SELECT person.id, SUM(person.age), person.first_name FROM person GROUP BY person.first_name, person.id"
+        ),
+        ("select id, count(*), first_name 
+        from person 
+        where id!=3 and first_name=='test'
+        group by first_name, id 
+        having count(*)>5 and count(*)<10
+        order by count(*)",
+        "SELECT person.id, COUNT(*), person.first_name FROM person WHERE ((person.id <> 3) AND (person.first_name = 'test')) GROUP BY person.first_name, person.id HAVING ((COUNT(*) > 5) AND (COUNT(*) < 10)) ORDER BY COUNT(*) ASC NULLS LAST"
+    )
     ];
 
     let roundtrip = |sql: &str| -> Result<String> {

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4582,6 +4582,16 @@ fn roundtrip_statement() -> Result<()> {
             group by "Last Name", id 
             having count_first_name>5 and count_first_name<10
             order by count_first_name, "Last Name""#,
+            r#"select p.id, count("First Name") as count_first_name,
+            "Last Name", sum(qp.id/p.id - (select sum(id) from person_quoted_cols) ) / (select count(*) from person) 
+            from person_quoted_cols qp
+            inner join person p
+            on p.id = qp.id
+            where p.id!=3 and "First Name"=='test' and qp.id in 
+            (select id from (select id, count(*) from person group by id having count(*) > 0))
+            group by "Last Name", p.id 
+            having count_first_name>5 and count_first_name<10
+            order by count_first_name, "Last Name""#,
         ];
 
     for query in tests {

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4584,8 +4584,8 @@ fn roundtrip_statement() -> Result<()> {
             order by count_first_name, "Last Name""#,
             r#"select p.id, count("First Name") as count_first_name,
             "Last Name", sum(qp.id/p.id - (select sum(id) from person_quoted_cols) ) / (select count(*) from person) 
-            from person_quoted_cols qp
-            inner join person p
+            from (select id, "First Name", "Last Name" from person_quoted_cols) qp
+            inner join (select * from person) p
             on p.id = qp.id
             where p.id!=3 and "First Name"=='test' and qp.id in 
             (select id from (select id, count(*) from person group by id having count(*) > 0))
@@ -4608,6 +4608,7 @@ fn roundtrip_statement() -> Result<()> {
 
         let actual = format!("{}", &roundtrip_statement);
         println!("roundtrip sql: {actual}");
+        println!("plan {}", plan.display_indent());
 
         let plan_roundtrip = sql_to_rel
             .sql_statement_to_plan(roundtrip_statement.clone())


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to #9606

## Rationale for this change

Based on review comment from @seddonm1 I wanted to see if I could make examples like the following pass in unparser:

```
Sort: COUNT(*) ASC NULLS LAST
  Projection: person.id, COUNT(*), person.first_name
    Filter: COUNT(*) > Int64(5) AND COUNT(*) < Int64(10)
      Aggregate: groupBy=[[person.first_name, person.id]], aggr=[[COUNT(*)]]
        Filter: person.id != Int64(3) AND person.first_name = Utf8("test")
          TableScan: person
```

```SQL
select id, count(*), first_name 
from person 
where id!=3 and first_name=='test'
group by first_name, id 
having count(*)>5 and count(*)<10
order by count(*)
```

While working on this, I found that the implementation in #9606 was not doing what I  thought it was doing.  I was misled due to the string representation of two different AST's being the same. Namely the literal column expression `"COUNT(*)"` vs the aggregate expression `COUNT(*)` were represented by the same strings. This led me to believe the implementation was correct, when in fact is was not and would fail on more complex examples (such as aggregate expressions nested in the expression tree or with quoted identifiers). 

I have modified the round-trip testing strategy to avoid similar confusion in the future. Now, instead of looking at the round trip SQL string and comparing, we logically plan the round tripped AST and ensure it generates the same logical plan as the original sql string. E.g.

```rust
sql: &str -> s1: ast::Statement -> plan1: LogicalPlan -> s2: ast::Statement -> plan2: LogicalPlan

assert_eq!(plan1, plan2)
```

The new test condition ensures not that the sql string is literally the same post round trip, but they are logically equivalent. I believe this is the more meaningful condition to test. 

I have also spent time trying to come up with more complex queries to break the implementation. The most complete/complex test in the suite is:

```sql
select p.id, count("First Name") as count_first_name,
"Last Name", sum(qp.id/p.id - (select sum(id) from person_quoted_cols) ) / (select count(*) from person) 
from (select id, "First Name", "Last Name" from person_quoted_cols) qp
inner join (select * from person) p
on p.id = qp.id
where p.id!=3 and "First Name"=='test' and qp.id in 
(select id from (select id, count(*) from person group by id having count(*) > 0))
group by "Last Name", p.id 
having count_first_name>5 and count_first_name<10
order by count_first_name, "Last Name"
```

This seed sql string results in the following plan:

```
Projection: p.id, COUNT(qp.First Name) AS count_first_name, qp.Last Name, SUM(qp.id / p.id - SUM(person_quoted_cols.id)) / (<subquery>)
    Subquery:
      Projection: COUNT(*)
        Aggregate: groupBy=[[]], aggr=[[COUNT(*)]]
          TableScan: person
    Filter: COUNT(qp.First Name) > Int64(5) AND COUNT(qp.First Name) < Int64(10)
      Aggregate: groupBy=[[qp.Last Name, p.id]], aggr=[[COUNT(qp.First Name), SUM(qp.id / p.id - (<subquery>))]]
        Subquery:
          Projection: SUM(person_quoted_cols.id)
            Aggregate: groupBy=[[]], aggr=[[SUM(person_quoted_cols.id)]]
              TableScan: person_quoted_cols
        Filter: p.id != Int64(3) AND qp.First Name = Utf8("test") AND qp.id IN (<subquery>)
          Subquery:
            Projection: person.id
              Projection: person.id, COUNT(*)
                Filter: COUNT(*) > Int64(0)
                  Aggregate: groupBy=[[person.id]], aggr=[[COUNT(*)]]
                    TableScan: person
          Inner Join:  Filter: p.id = qp.id
            SubqueryAlias: qp
              Projection: person_quoted_cols.id, person_quoted_cols.First Name, person_quoted_cols.Last Name
                TableScan: person_quoted_cols
            SubqueryAlias: p
              Projection: person.id, person.first_name, person.last_name, person.age, person.state, person.salary, person.birth_date, person.😀
                TableScan: person
```

The plan is then transformed back into an `ast::Statement` and then that statement is planned and compared to be identical to the above plan. This verifies we have preserved all logical query information from the original SQL string in our round trip. Differences in syntax/quoting which do not affect the logic of the query are ignored.

## What changes are included in this PR?

1. Changes testing strategy as described above
2. Adds utility function for scanning for an `Aggregate` node that applies to a given Query under construction
3. Adds utility function for "unprojecting" aggregate expressions, potentially nested deeply within an expression tree.
4. Adds support for HAVING clause
5. Adds support for subquery  and insubquery expressions
6. Always quote identifiers (so identifiers with whitespace/special chars work without special handling).

## Are these changes tested?

Yes

## Are there any user-facing changes?

More complex SQL works with unparser now
