### PR TITLE
add schema to SQL ast builder

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -123,13 +123,9 @@ impl Unparser<'_> {
                 let mut builder = TableRelationBuilder::default();
                 let mut table_parts = vec![];
                 if let Some(schema_name) = scan.table_name.schema() {
-                    table_parts.push(self.new_ident(
-                        schema_name.to_string(),
-                    ));
+                    table_parts.push(self.new_ident(schema_name.to_string()));
                 }
-                table_parts.push(
-                    self.new_ident(scan.table_name.table().to_string())
-                );
+                table_parts.push(self.new_ident(scan.table_name.table().to_string()));
                 builder.name(ast::ObjectName(table_parts));
                 relation.table(builder);
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -121,9 +121,16 @@ impl Unparser<'_> {
         match plan {
             LogicalPlan::TableScan(scan) => {
                 let mut builder = TableRelationBuilder::default();
-                builder.name(ast::ObjectName(vec![
+                let mut table_parts = vec![];
+                if let Some(schema_name) = scan.table_name.schema() {
+                    table_parts.push(self.new_ident(
+                        schema_name.to_string(),
+                    ));
+                }
+                table_parts.push(
                     self.new_ident(scan.table_name.table().to_string())
-                ]));
+                );
+                builder.name(ast::ObjectName(table_parts));
                 relation.table(builder);
 
                 Ok(())

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -44,6 +44,15 @@ use rstest::rstest;
 use sqlparser::parser::Parser;
 
 #[test]
+fn test_schema_support() {
+    quick_test(
+        "SELECT * FROM s1.test",
+        "Projection: s1.test.t_date32, s1.test.t_date64\
+             \n  TableScan: s1.test",
+    );
+}
+
+#[test]
 fn parse_decimals() {
     let test_data = [
         ("1", "Int64(1)"),


### PR DESCRIPTION
This PR is meant to upstream this PR: https://github.com/datafusion-contrib/datafusion-federation/pull/26

SQL languages will typically have schemas, so add support for schema names to the table scan AST builder.
