### PR TITLE
Enable TTY during bench data generation

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -22,6 +22,8 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Setup data and generate unique result names
+        # Workaround for `the input device is not a TTY`, appropriated from https://github.com/actions/runner/issues/241
+        shell: 'script -q -e -c "bash -e {0}"'
         run: |
           cd benchmarks
           mkdir data

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -150,6 +150,8 @@ Benchmark tpch_mem.json
 └──────────────┴──────────────┴──────────────┴───────────────┘
 ```
 
+Note that you can also execute an automatic comparison of the changes in a given PR against the base 
+just by including the trigger `/benchmark` in any comment.
 
 ### Running Benchmarks Manually
 

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -280,7 +280,7 @@ data_tpch() {
         echo " tbl files exist ($FILE exists)."
     else
         echo " creating tbl files with tpch_dbgen..."
-        docker run -v "${TPCH_DIR}":/data --rm ghcr.io/scalytics/tpch-docker:main -vf -s ${SCALE_FACTOR}
+        docker run -v "${TPCH_DIR}":/data -it --rm ghcr.io/scalytics/tpch-docker:main -vf -s ${SCALE_FACTOR}
     fi
 
     # Copy expected answers into the ./data/answers directory if it does not already exist
@@ -290,7 +290,7 @@ data_tpch() {
     else
         echo " Copying answers to ${TPCH_DIR}/answers"
         mkdir -p "${TPCH_DIR}/answers"
-        docker run -v "${TPCH_DIR}":/data --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
+        docker run -v "${TPCH_DIR}":/data -it --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
     fi
 
     # Create 'parquet' files from tbl


### PR DESCRIPTION
## Which issue does this PR close?

Should close #9620.

## Rationale for this change

Try a workaround for missing TTY from https://github.com/actions/runner/issues/241

## What changes are included in this PR?

Shell used to run the bench data gen step.

## Are these changes tested?

They are on our fork (though that worked before too): https://github.com/splitgraph/arrow-datafusion/pull/2

## Are there any user-facing changes?
