### PR TITLE
Try fixing missing results name in the benchmark step

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
 
-      - name: Setup data and generate unique result names
+      - name: Setup test data
         # Workaround for `the input device is not a TTY`, appropriated from https://github.com/actions/runner/issues/241
         shell: 'script -q -e -c "bash -e {0}"'
         run: |
@@ -31,7 +31,8 @@ jobs:
           # Setup the TPC-H data set with a scale factor of 10
           ./bench.sh data tpch
           
-          # Generate a unique-ish identifiers for the results
+      - name: Generate unique result names
+        run: |
           echo "HEAD_LONG_SHA=$(git log -1 --format='%H')" >> "$GITHUB_ENV" 
           echo "HEAD_SHORT_SHA=$(git log -1 --format='%h' --abbrev=7)" >> "$GITHUB_ENV" 
           echo "BASE_SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Which issue does this PR close?

Addresses #9620.

## Rationale for this change

Env vars seem to be missing because of a different shell.

## What changes are included in this PR?

## Are these changes tested?

## Are there any user-facing changes?

