### PR TITLE
Add explicit move of PR bench results if they were placed in HEAD dir

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -44,6 +44,12 @@ jobs:
           cd benchmarks
 
           ./bench.sh run tpch
+          
+          # For some reason this step doesn't seem to propagate the env var down into the script
+          if [ -d "results/HEAD" ]; then
+            echo "Moving results into ${{ env.HEAD_SHORT_SHA }}"
+            mv results/HEAD results/${{ env.HEAD_SHORT_SHA }}
+          fi
 
       - name: Checkout base commit
         uses: actions/checkout@v4


### PR DESCRIPTION
## Which issue does this PR close?

Yet another attempt at #9620.

## Rationale for this change

For some reason GHA doesn't propagate the env var down into the script even though it lists it at the beginning of the step.

## What changes are included in this PR?

## Are these changes tested?

## Are there any user-facing changes?
