### PR TITLE
Add Minimum Supported Rust Version policy to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Optional features:
 [apache avro]: https://avro.apache.org/
 [apache parquet]: https://parquet.apache.org/
 
-## Rust Version Compatibility
+## Rust Version Compatibility Policy
 
-Datafusion crate is tested with the [minimum required stable Rust version](https://github.com/search?q=repo%3Aapache%2Farrow-datafusion+rust-version+language%3ATOML+path%3A%2F%5ECargo.toml%2F&type=code)
+DataFusion's Minimum Required Stable Rust Version (MSRV) policy is to support
+each stable Rust version for 6 months after it is
+[released](https://github.com/rust-lang/rust/blob/master/RELEASES.md). This
+generally translates to support for the most recent 3 to 4 stable Rust versions.
+
+We enforce this policy using a [MSRV CI Check](https://github.com/search?q=repo%3Aapache%2Farrow-datafusion+rust-version+language%3ATOML+path%3A%2F%5ECargo.toml%2F&type=code)


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9082

## Rationale for this change

We discussed the policy and seemed to have reasonable consensus on 6 months as part of  https://github.com/apache/arrow-datafusion/issues/9082.

However, we never documented it and so we got at least one PR that proposed to break the MSRV: https://github.com/apache/arrow-datafusion/pull/9659

## What changes are included in this PR?

1. Document the "6 months MSRV policy"

## Are these changes tested?

CI


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
