### PR TITLE
Minor: Improve documentation for `LogicalPlan::expressions`

### DIFF
--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -53,10 +53,11 @@ pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     /// Return the output schema of this logical plan node.
     fn schema(&self) -> &DFSchemaRef;
 
-    /// Returns all expressions in the current logical plan node. This
-    /// should not include expressions of any inputs (aka
-    /// non-recursively). These expressions are used for optimizer
-    /// passes and rewrites.
+    /// Returns all expressions in the current logical plan node. This should
+    /// not include expressions of any inputs (aka non-recursively).
+    ///
+    /// These expressions are used for optimizer
+    /// passes and rewrites. See [`LogicalPlan::expressions`] for more details.
     fn expressions(&self) -> Vec<Expr>;
 
     /// A list of output columns (e.g. the names of columns in

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -234,9 +234,17 @@ impl LogicalPlan {
         ])
     }
 
-    /// returns all expressions (non-recursively) in the current
-    /// logical plan node. This does not include expressions in any
-    /// children
+    /// Returns all expressions (non-recursively) evaluated by the current
+    /// logical plan node. This does not include expressions in any children
+    ///
+    /// The returned expressions do not necessarily represent or even
+    /// contributed to the output schema of this node. For example,
+    /// `LogicalPlan::Filter` returns the filter expression even though the
+    /// output of a Filter has the same columns as the input.
+    ///
+    /// The expressions do contain all the columns that are used by this plan,
+    /// so if there are columns not referenced by these expressions then
+    /// DataFusion's optimizer attempts to optimize them away.
     pub fn expressions(self: &LogicalPlan) -> Vec<Expr> {
         let mut exprs = vec![];
         self.inspect_expressions(|e| {


### PR DESCRIPTION
## Which issue does this PR close?

Part of #7013 

## Rationale for this change

While reviewing https://github.com/apache/arrow-datafusion/pull/9690 I had to review the code to remind myself exactly what `LogicalPlan::expressions` did, so I wanted to write that down as comments for my future self (and other users)

## What changes are included in this PR?
Add additional doc comments about `LogicalPlan::expressions`

## Are these changes tested?

N/A

## Are there any user-facing changes?
Better docs