### PR TITLE
WIP: Avoid copying LogicalPlans / Exprs during OptimizerPasses

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -175,7 +175,7 @@ impl DataFrame {
 
     /// Consume the DataFrame and produce a physical plan
     pub async fn create_physical_plan(self) -> Result<Arc<dyn ExecutionPlan>> {
-        self.session_state.create_physical_plan(&self.plan).await
+        self.session_state.create_physical_plan(self.plan).await
     }
 
     /// Filter the DataFrame by column. Returns a new DataFrame only containing the
@@ -989,7 +989,7 @@ impl DataFrame {
     /// [`Self::into_optimized_plan`] for more details.
     pub fn into_optimized_plan(self) -> Result<LogicalPlan> {
         // Optimize the plan first for better UX
-        self.session_state.optimize(&self.plan)
+        self.session_state.optimize(self.plan)
     }
 
     /// Converts this [`DataFrame`] into a [`TableProvider`] that can be registered
@@ -1466,7 +1466,7 @@ impl TableProvider for DataFrameTableProvider {
             expr = expr.limit(0, Some(l))?
         }
         let plan = expr.build()?;
-        state.create_physical_plan(&plan).await
+        state.create_physical_plan(plan).await
     }
 }
 

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -141,7 +141,7 @@ impl TableProvider for ViewTable {
             plan = plan.limit(0, Some(limit))?;
         }
 
-        state.create_physical_plan(&plan.build()?).await
+        state.create_physical_plan(plan.build()?).await
     }
 }
 

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1877,7 +1877,7 @@ impl SessionState {
 
             // optimize the child plan, capturing the output of each optimizer
             let optimized_plan = self.optimizer.optimize(
-                &analyzed_plan,
+                analyzed_plan,
                 self,
                 |optimized_plan, optimizer| {
                     let optimizer_name = optimizer.name().to_string();
@@ -1907,7 +1907,7 @@ impl SessionState {
             let analyzed_plan =
                 self.analyzer
                     .execute_and_check(plan, self.options(), |_, _| {})?;
-            self.optimizer.optimize(&analyzed_plan, self, |_, _| {})
+            self.optimizer.optimize(analyzed_plan, self, |_, _| {})
         }
     }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -361,6 +361,12 @@ impl LogicalPlan {
         }
     }
 
+    /// takes all inputs of this plan, unwrapping them if they are
+    /// not shared
+    pub fn take_inputs(&self) -> Vec<LogicalPlan> {
+        todo!()
+    }
+
     /// returns all inputs of this `LogicalPlan` node. Does not
     /// include inputs to inputs, or subqueries.
     pub fn inputs(&self) -> Vec<&LogicalPlan> {
@@ -515,6 +521,15 @@ impl LogicalPlan {
     #[deprecated(since = "35.0.0", note = "please use `with_new_exprs` instead")]
     pub fn with_new_inputs(&self, inputs: &[LogicalPlan]) -> Result<LogicalPlan> {
         self.with_new_exprs(self.expressions(), inputs.to_vec())
+    }
+
+    /// returns a new LogicalPlan with the new inputs (potentially rewritten)
+    ///
+    pub fn with_new_inputs2(
+        mut self,
+        new_inputs: Vec<LogicalPlan>,
+    ) -> Result<LogicalPlan> {
+        todo!()
     }
 
     /// Returns a new `LogicalPlan` based on `self` with inputs and

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -361,10 +361,12 @@ impl LogicalPlan {
         }
     }
 
-    /// takes all inputs of this plan, unwrapping them if they are
-    /// not shared
-    pub fn take_inputs(&self) -> Vec<LogicalPlan> {
-        todo!()
+    /// applies the closure `f` to each input of this node, replacing the existing inputs
+    /// with the result of the closure.
+    pub fn rewrite_inputs<F>(mut self, f: F) -> Result<Self>
+    where F: FnMut (LogicalPlan) -> Result<LogicalPlan>
+    {
+        todo!();
     }
 
     /// returns all inputs of this `LogicalPlan` node. Does not
@@ -521,15 +523,6 @@ impl LogicalPlan {
     #[deprecated(since = "35.0.0", note = "please use `with_new_exprs` instead")]
     pub fn with_new_inputs(&self, inputs: &[LogicalPlan]) -> Result<LogicalPlan> {
         self.with_new_exprs(self.expressions(), inputs.to_vec())
-    }
-
-    /// returns a new LogicalPlan with the new inputs (potentially rewritten)
-    ///
-    pub fn with_new_inputs2(
-        mut self,
-        new_inputs: Vec<LogicalPlan>,
-    ) -> Result<LogicalPlan> {
-        todo!()
     }
 
     /// Returns a new `LogicalPlan` based on `self` with inputs and

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -521,11 +521,11 @@ where
 
     let new_node = match Arc::try_unwrap(new_node) {
         Ok(node) => {
-            println!("Unwrapped arc yay");
+            //println!("Unwrapped arc yay");
             node
         }
         Err(node) => {
-            println!("Failed to unwrap arc boo");
+            //println!("Failed to unwrap arc boo");
             node.as_ref().clone()
         }
     };

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -294,7 +294,7 @@ impl Optimizer {
     /// invoking observer function after each call
     pub fn optimize<F>(
         &self,
-        plan: &LogicalPlan,
+        plan: LogicalPlan,
         config: &dyn OptimizerConfig,
         mut observer: F,
     ) -> Result<LogicalPlan>

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -48,10 +48,11 @@ use crate::utils::log_plan;
 use datafusion_common::alias::AliasGenerator;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::instant::Instant;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_expr::logical_plan::LogicalPlan;
 
 use chrono::{DateTime, Utc};
+use datafusion_common::tree_node::Transformed;
 use log::{debug, warn};
 
 /// `OptimizerRule` transforms one [`LogicalPlan`] into another which
@@ -84,6 +85,20 @@ pub trait OptimizerRule {
     /// If a rule use default None, it should traverse recursively plan inside itself
     fn apply_order(&self) -> Option<ApplyOrder> {
         None
+    }
+
+    /// does this rule support rewriting owned plans (to reduce copying)?
+    fn supports_owned(&self) -> bool {
+        false
+    }
+
+    /// if supports_owned returns true, calls try_optimize_owned
+    fn try_optimize_owned(
+        &self,
+        _plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>, DataFusionError> {
+        not_impl_err!("try_optimized_owned is not implemented for this rule")
     }
 }
 

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -414,7 +414,6 @@ impl Optimizer {
         mut plan: LogicalPlan,
         config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
-
         let mut transformed = false;
         let plan = plan.rewrite_inputs(|child| {
             let t = self.optimize_recursively(rule, child, config)?;

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -19,7 +19,8 @@
 
 use std::sync::Arc;
 
-use datafusion_common::{DFSchema, DFSchemaRef, Result};
+use datafusion_common::tree_node::Transformed;
+use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError, Result};
 use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_expr::logical_plan::LogicalPlan;
 use datafusion_expr::simplify::SimplifyContext;
@@ -58,6 +59,19 @@ impl OptimizerRule for SimplifyExpressions {
         let mut execution_props = ExecutionProps::new();
         execution_props.query_execution_start_time = config.query_execution_start_time();
         Ok(Some(Self::optimize_internal(plan, &execution_props)?))
+    }
+
+    fn supports_owned(&self) -> bool {
+        true
+    }
+
+    /// if supports_owned returns true, calls try_optimize_owned
+    fn try_optimize_owned(
+        &self,
+        _plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>, DataFusionError> {
+        todo!();
     }
 }
 

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -127,7 +127,14 @@ impl SimplifyExpressions {
             simplifier
         };
 
+        let is_filter = matches!(plan, LogicalPlan::Filter(_));
+
         let plan = plan.rewrite_exprs(|e| {
+            // no aliasing for filters
+            if is_filter {
+                return simplifier.simplify(e);
+            }
+
             // TODO: unify with `rewrite_preserving_name`
             // todo track if e was rewritten
             let original_name = e.name_for_alias()?;

--- a/datafusion/sqllogictest/test_files/aal.slt
+++ b/datafusion/sqllogictest/test_files/aal.slt
@@ -12,8 +12,8 @@ query TT
 explain select column1 + column1, 2+3 from t;
 ----
 logical_plan
-Projection: t.column1 + t.column1
+Projection: t.column1 + t.column1, Int64(5) AS Int64(2) + Int64(3)
 --TableScan: t projection=[column1]
 physical_plan
-ProjectionExec: expr=[column1@0 + column1@0 as t.column1 + t.column1]
+ProjectionExec: expr=[column1@0 + column1@0 as t.column1 + t.column1, 5 as Int64(2) + Int64(3)]
 --MemoryExec: partitions=1, partition_sizes=[1]

--- a/datafusion/sqllogictest/test_files/aal.slt
+++ b/datafusion/sqllogictest/test_files/aal.slt
@@ -2,5 +2,18 @@
 statement ok
 create table t as values (1), (2);
 
-query
+query I
 select column1 + column1 from t;
+----
+2
+4
+
+query TT
+explain select column1 + column1 from t;
+----
+logical_plan
+Projection: t.column1 + t.column1
+--TableScan: t projection=[column1]
+physical_plan
+ProjectionExec: expr=[column1@0 + column1@0 as t.column1 + t.column1]
+--MemoryExec: partitions=1, partition_sizes=[1]

--- a/datafusion/sqllogictest/test_files/aal.slt
+++ b/datafusion/sqllogictest/test_files/aal.slt
@@ -9,7 +9,7 @@ select column1 + column1 from t;
 4
 
 query TT
-explain select column1 + column1 from t;
+explain select column1 + column1, 2+3 from t;
 ----
 logical_plan
 Projection: t.column1 + t.column1

--- a/datafusion/sqllogictest/test_files/aal.slt
+++ b/datafusion/sqllogictest/test_files/aal.slt
@@ -1,0 +1,6 @@
+
+statement ok
+create table t as values (1), (2);
+
+query
+select column1 + column1 from t;


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/9637

## Rationale for this change

@jayzhan211  @mustafasrepo  and I have been discussing how to speed up planning by avoiding copying Exprs  / LogicalPlans


## What changes are included in this PR?

This PR is a prototype of a suggestion here https://github.com/apache/arrow-datafusion/issues/9637#issuecomment-2002396168 to see if I can get a significant boost in Expr simplify

The theory is that if I can rerite the optimizer to take ownership of the plans they can be rewritten in place

If this works out, I'll turn this into an actual PR for review. 

Update: this approach improves planning speed by 25%

## Are these changes tested?

NA

Timings (main):
```
cargo bench   --bench sql_planner -- physical_plan_tpch_all

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.4s, or reduce sample count to 60.
physical_plan_tpch_all  time:   [70.511 ms 71.102 ms 71.828 ms]
                        change: [-1.3186% +2.1648% +4.6865%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
```

This branch
```
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, or reduce sample count to 90.
physical_plan_tpch_all  time:   [54.371 ms 54.512 ms 54.675 ms]
                        change: [-24.152% -23.333% -22.648%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
