### PR TITLE
make format prefix optional for format options in COPY

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -850,7 +850,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return plan_err!("Unsupported Value in COPY statement {}", value);
                 }
             };
-            if !(&key.contains(".")) {
+            if !(&key.contains('.')) {
                 // If config does not belong to any namespace, assume it is
                 // a format option and apply the format prefix for backwards
                 // compatibility.

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -850,7 +850,16 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     return plan_err!("Unsupported Value in COPY statement {}", value);
                 }
             };
-            options.insert(key.to_lowercase(), value_string.to_lowercase());
+            if !(&key.contains(".")) {
+                // If config does not belong to any namespace, assume it is
+                // a format option and apply the format prefix for backwards
+                // compatibility.
+
+                let renamed_key = format!("format.{}", key);
+                options.insert(renamed_key.to_lowercase(), value_string.to_lowercase());
+            } else {
+                options.insert(key.to_lowercase(), value_string.to_lowercase());
+            }
         }
 
         let file_type = if let Some(file_type) = statement.stored_as {

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -506,6 +506,13 @@ OPTIONS (
 ----
 2
 
+# Use unknown option with legacy format options to ensure error is sensible
+query error DataFusion error: Invalid or Unsupported Configuration: Config value "unknown_option" not found on CsvOptions
+COPY source_table to 'test_files/scratch/copy/format_table2.csv'
+OPTIONS (
+    unknown_option  false,
+);
+
 
 # Error cases:
 

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -474,6 +474,38 @@ select * from validate_arrow;
 1 Foo
 2 Bar
 
+# Legacy Format Options Support
+
+# Copy with legacy format options for Parquet
+query IT
+COPY source_table TO 'test_files/scratch/copy/format_table.parquet'
+OPTIONS (
+    compression snappy,
+    'compression::col1' 'zstd(5)'
+);
+----
+2
+
+# Copy with legacy format options for JSON
+query IT
+COPY source_table  to 'test_files/scratch/copy/format_table'
+STORED AS JSON OPTIONS (compression gzip);
+----
+2
+
+# Copy with legacy format options for CSV
+query IT
+COPY source_table to 'test_files/scratch/copy/format_table.csv'
+OPTIONS (
+    has_header false,
+    compression xz,
+    datetime_format '%FT%H:%M:%S.%9f',
+    delimiter ';',
+    null_value 'NULLVAL'
+);
+----
+2
+
 
 # Error cases:
 

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -474,9 +474,9 @@ select * from validate_arrow;
 1 Foo
 2 Bar
 
-# Legacy Format Options Support
+# Format Options Support without the 'format.' prefix
 
-# Copy with legacy format options for Parquet
+# Copy with format options for Parquet without the 'format.' prefix
 query IT
 COPY source_table TO 'test_files/scratch/copy/format_table.parquet'
 OPTIONS (
@@ -486,14 +486,14 @@ OPTIONS (
 ----
 2
 
-# Copy with legacy format options for JSON
+# Copy with format options for JSON without the 'format.' prefix
 query IT
 COPY source_table  to 'test_files/scratch/copy/format_table'
 STORED AS JSON OPTIONS (compression gzip);
 ----
 2
 
-# Copy with legacy format options for CSV
+# Copy with format options for CSV without the 'format.' prefix
 query IT
 COPY source_table to 'test_files/scratch/copy/format_table.csv'
 OPTIONS (
@@ -506,7 +506,7 @@ OPTIONS (
 ----
 2
 
-# Use unknown option with legacy format options to ensure error is sensible
+# Copy with unknown format options without the 'format.' prefix to ensure error is sensible
 query error DataFusion error: Invalid or Unsupported Configuration: Config value "unknown_option" not found on CsvOptions
 COPY source_table to 'test_files/scratch/copy/format_table2.csv'
 OPTIONS (


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9716 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

**Before this PR**
User has to prefix all format options they pass to the `COPY` command with `format`. For eg:

```
COPY source_table
to 'test_files/scratch/copy/table_csv_with_options'
STORED AS CSV OPTIONS (
	'format.has_header' false,
	'format.compression' uncompressed,
	'format.datetime_format' '%FT%H:%M:%S.%9f',
	'format.delimiter' ';',
	'format.null_value' 'NULLVAL'
);
```

This is repetitive & different from what Datafusion 36.0.0 offered. (See issue description for more details)

**After this PR**

User can use the format options for the `COPY` command without prefixing them with `format`:

```
COPY source_table to 'test_files/scratch/copy/format_table.csv'
OPTIONS (
    has_header false,
    compression xz,
    datetime_format '%FT%H:%M:%S.%9f',
    delimiter ';',
    null_value 'NULLVAL'
);
```


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

We're prefixing keys passed in options with `format` if they don't contain a namespace (signified by presence of `.`).

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. New tests are added to verify that options not prefixed by `format` work.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Current docs have the legacy format so updates aren't needed.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
