### PR TITLE
Minor: Run ScalarValue size test on aarch again

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4528,8 +4528,6 @@ mod tests {
         assert_eq!(expected, data_type.try_into().unwrap())
     }
 
-    // this test fails on aarch, so don't run it there
-    #[cfg(not(target_arch = "aarch64"))]
     #[test]
     fn size_of_scalar() {
         // Since ScalarValues are used in a non trivial number of places,
@@ -4539,7 +4537,7 @@ mod tests {
         // The alignment requirements differ across architectures and
         // thus the size of the enum appears to as well
 
-        // The value can be changed depending on rust version
+        // The value may also change depending on rust version
         assert_eq!(std::mem::size_of::<ScalarValue>(), 64);
     }
 

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4534,6 +4534,8 @@ mod tests {
         // making it larger means significant more memory consumption
         // per distinct value.
         //
+        // Thus this test ensures that no code change makes ScalarValue larger
+        //
         // The alignment requirements differ across architectures and
         // thus the size of the enum appears to as well
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/9725


Closes #.

## Rationale for this change

The size of `ScalarValue` appears to have changed on Linux to be the same as aarch64. Thus we can now run the ScalarValue size test again:

See details here: https://github.com/apache/arrow-datafusion/pull/9725/files#r1534400422

The point of the test was to ensure that the size of ScalarValue didn't change with PRs, but the Rust compiler may change how types are laid out. 

## What changes are included in this PR?

Update comments and run the test on all platforms again

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
