### PR TITLE
fix: parallel parquet can underflow when max_record_batch_rows < execution.batch_size

### DIFF
--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -171,7 +171,7 @@ mod tests {
     async fn write_parquet_with_small_rg_size() -> Result<()> {
         let mut test_df = test_util::test_table().await?;
         // make the test data larger so there are multiple batches
-        for _ in 0..7{
+        for _ in 0..7 {
             test_df = test_df.clone().union(test_df)?;
         }
         let output_path = "file://local/test.parquet";
@@ -202,8 +202,7 @@ mod tests {
 
             let parquet_metadata = reader.metadata();
 
-            let written_rows =
-                parquet_metadata.row_group(0).num_rows();
+            let written_rows = parquet_metadata.row_group(0).num_rows();
 
             assert_eq!(written_rows as usize, rg_size);
         }

--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -171,6 +171,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_parquet_with_small_rg_size() -> Result<()> {
+        // This test verifies writing a parquet file with small rg size
+        // relative to datafusion.execution.batch_size does not panic
         let mut ctx = SessionContext::new_with_config(
             SessionConfig::from_string_hash_map(HashMap::from_iter(
                 [("datafusion.execution.batch_size", "10")]
@@ -183,7 +185,7 @@ mod tests {
 
         let output_path = "file://local/test.parquet";
 
-        for rg_size in (1..7).step_by(5) {
+        for rg_size in 1..10 {
             let df = test_df.clone();
             let tmp_dir = TempDir::new()?;
             let local = Arc::new(LocalFileSystem::new_with_prefix(&tmp_dir)?);

--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -152,7 +152,7 @@ mod tests {
             .await?;
 
             // Check that file actually used the specified compression
-            let file = std::fs::File::open(tmp_dir.into_path().join("test.parquet"))?;
+            let file = std::fs::File::open(tmp_dir.path().join("test.parquet"))?;
 
             let reader =
                 parquet::file::serialized_reader::SerializedFileReader::new(file)
@@ -203,7 +203,7 @@ mod tests {
             .await?;
 
             // Check that file actually used the correct rg size
-            let file = std::fs::File::open(tmp_dir.into_path().join("test.parquet"))?;
+            let file = std::fs::File::open(tmp_dir.path().join("test.parquet"))?;
 
             let reader =
                 parquet::file::serialized_reader::SerializedFileReader::new(file)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9736

## Rationale for this change

See issue

## What changes are included in this PR?

Parallel parquet writer can now handle the case when max_record_batch_rows < execution.batch_size by iteratively splitting the record batch rather than assuming it only needs to be split once. 

## Are these changes tested?

Yes, added new test that would panic prior to this PR

## Are there any user-facing changes?

Just bugfix