### PR TITLE
Minor: remove an outdated TODO in `TypeCoercion`

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -47,8 +47,8 @@ use datafusion_expr::utils::merge_schema;
 use datafusion_expr::{
     is_false, is_not_false, is_not_true, is_not_unknown, is_true, is_unknown, not,
     type_coercion, AggregateFunction, Expr, ExprSchemable, LogicalPlan, Operator,
-    Projection, ScalarFunctionDefinition, ScalarUDF, Signature, WindowFrame,
-    WindowFrameBound, WindowFrameUnits,
+    ScalarFunctionDefinition, ScalarUDF, Signature, WindowFrame, WindowFrameBound,
+    WindowFrameUnits,
 };
 
 #[derive(Default)]
@@ -76,7 +76,7 @@ fn analyze_internal(
     plan: &LogicalPlan,
 ) -> Result<LogicalPlan> {
     // optimize child plans first
-    let mut new_inputs = plan
+    let new_inputs = plan
         .inputs()
         .iter()
         .map(|p| analyze_internal(external_schema, p))
@@ -110,14 +110,7 @@ fn analyze_internal(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // TODO: with_new_exprs can't change the schema, so we need to do this here
-    match &plan {
-        LogicalPlan::Projection(_) => Ok(LogicalPlan::Projection(Projection::try_new(
-            new_expr,
-            Arc::new(new_inputs.swap_remove(0)),
-        )?)),
-        _ => plan.with_new_exprs(new_expr, new_inputs),
-    }
+    plan.with_new_exprs(new_expr, new_inputs)
 }
 
 pub(crate) struct TypeCoercionRewriter {


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

This TODO has already been implemented in `LogicalPlan::with_new_exprs`.

https://github.com/apache/arrow-datafusion/blob/6c6305159711fbca43ff7798faa52aaebcb2e7d3/datafusion/expr/src/logical_plan/plan.rs#L547-L558

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes. By existing tests.

## Are there any user-facing changes?
No