### PR TITLE
Fix panic in `struct` function with mixed scalar/array arguments

### DIFF
--- a/datafusion/functions/src/core/struct.rs
+++ b/datafusion/functions/src/core/struct.rs
@@ -47,17 +47,10 @@ fn array_struct(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     Ok(Arc::new(StructArray::from(vec)))
 }
+
 /// put values in a struct array.
 fn struct_expr(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let arrays = args
-        .iter()
-        .map(|x| {
-            Ok(match x {
-                ColumnarValue::Array(array) => array.clone(),
-                ColumnarValue::Scalar(scalar) => scalar.to_array()?.clone(),
-            })
-        })
-        .collect::<Result<Vec<ArrayRef>>>()?;
+    let arrays = ColumnarValue::values_to_arrays(args)?;
     Ok(ColumnarValue::Array(array_struct(arrays.as_slice())?))
 }
 #[derive(Debug)]

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -58,6 +58,15 @@ select struct(a, b, c) from values;
 {c0: 2, c1: 2.2, c2: b}
 {c0: 3, c1: 3.3, c2: c}
 
+# struct scalar function with columns and scalars
+query ?
+select struct(a, 'foo') from values;
+----
+{c0: 1, c1: foo}
+{c0: 2, c1: foo}
+{c0: 3, c1: foo}
+
+
 # explain struct scalar function with columns #1
 query TT
 explain select struct(a, b, c) from values;


### PR DESCRIPTION
## Which issue does this PR close?

Fixes https://github.com/apache/arrow-datafusion/issues/9773


## Rationale for this change
Bug (see https://github.com/apache/arrow-datafusion/issues/9773)

## What changes are included in this PR?

Fix bug by calling the correct api, add test

## Are these changes tested?
Yes, new test

## Are there any user-facing changes?
Less bugs


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
