### PR TITLE
refactor: Apply minor refactorings to `functions-array` crate

### DIFF
--- a/datafusion/functions-array/README.md
+++ b/datafusion/functions-array/README.md
@@ -21,7 +21,7 @@
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate contains functions for working with arrays, such as `array_append` that works with
+This crate contains functions for working with arrays, such as `array_append` that work with
 `ListArray`, `LargeListArray` and `FixedListArray` types from the `arrow` crate.
 
 [df]: https://crates.io/crates/datafusion

--- a/datafusion/functions-array/README.md
+++ b/datafusion/functions-array/README.md
@@ -21,7 +21,7 @@
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate contains functions for working with arrays, such as `array_append` that work with
+This crate contains functions for working with arrays, such as `array_append` that works with
 `ListArray`, `LargeListArray` and `FixedListArray` types from the `arrow` crate.
 
 [df]: https://crates.io/crates/datafusion

--- a/datafusion/functions-array/src/array_has.rs
+++ b/datafusion/functions-array/src/array_has.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! [`ScalarUDFImpl`] definitions for array functions.
+//! [`ScalarUDFImpl`] definitions for array_has, array_has_all and array_has_any functions.
 
 use arrow::array::{Array, ArrayRef, BooleanArray, OffsetSizeTrait};
 use arrow::datatypes::DataType;
@@ -85,11 +85,11 @@ impl ScalarUDFImpl for ArrayHas {
         &self.signature
     }
 
-    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let args = ColumnarValue::values_to_arrays(args)?;
 
         if args.len() != 2 {
@@ -147,11 +147,11 @@ impl ScalarUDFImpl for ArrayHasAll {
         &self.signature
     }
 
-    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let args = ColumnarValue::values_to_arrays(args)?;
         if args.len() != 2 {
             return exec_err!("array_has_all needs two arguments");
@@ -204,11 +204,11 @@ impl ScalarUDFImpl for ArrayHasAny {
         &self.signature
     }
 
-    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let args = ColumnarValue::values_to_arrays(args)?;
 
         if args.len() != 2 {

--- a/datafusion/functions-array/src/concat.rs
+++ b/datafusion/functions-array/src/concat.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Includes `array append`, `array prepend`, and `array concat` functions
+//! [`ScalarUDFImpl`] definitions for `array_append`, `array_prepend` and `array_concat` functions.
 
 use std::{any::Any, cmp::Ordering, sync::Arc};
 
@@ -39,7 +39,7 @@ use crate::utils::{align_array_dimensions, check_datatypes, make_scalar_function
 make_udf_function!(
     ArrayAppend,
     array_append,
-    array element,                                         // arg name
+    array element,                                // arg name
     "appends an element to the end of an array.", // doc
     array_append_udf                              // internal function name
 );
@@ -283,9 +283,9 @@ fn concat_internal<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
                 .collect::<Vec<&dyn Array>>();
 
             // Concatenated array on i-th row
-            let concated_array = arrow::compute::concat(elements.as_slice())?;
-            array_lengths.push(concated_array.len());
-            arrays.push(concated_array);
+            let concatenated_array = arrow::compute::concat(elements.as_slice())?;
+            array_lengths.push(concatenated_array.len());
+            arrays.push(concatenated_array);
             valid.append(true);
         }
     }

--- a/datafusion/functions-array/src/empty.rs
+++ b/datafusion/functions-array/src/empty.rs
@@ -22,7 +22,7 @@ use arrow_array::{ArrayRef, BooleanArray, OffsetSizeTrait};
 use arrow_schema::DataType;
 use arrow_schema::DataType::{Boolean, FixedSizeList, LargeList, List};
 use datafusion_common::cast::{as_generic_list_array, as_null_array};
-use datafusion_common::{exec_err, plan_err};
+use datafusion_common::{exec_err, plan_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -62,7 +62,7 @@ impl ScalarUDFImpl for ArrayEmpty {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(match arg_types[0] {
             List(_) | LargeList(_) | FixedSizeList(_, _) => Boolean,
             _ => {
@@ -71,7 +71,7 @@ impl ScalarUDFImpl for ArrayEmpty {
         })
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_empty_inner)(args)
     }
 
@@ -81,7 +81,7 @@ impl ScalarUDFImpl for ArrayEmpty {
 }
 
 /// Array_empty SQL function
-pub fn array_empty_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_empty_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 1 {
         return exec_err!("array_empty expects one argument");
     }
@@ -99,9 +99,7 @@ pub fn array_empty_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRe
     }
 }
 
-fn general_array_empty<O: OffsetSizeTrait>(
-    array: &ArrayRef,
-) -> datafusion_common::Result<ArrayRef> {
+fn general_array_empty<O: OffsetSizeTrait>(array: &ArrayRef) -> Result<ArrayRef> {
     let array = as_generic_list_array::<O>(array)?;
     let builder = array
         .iter()

--- a/datafusion/functions-array/src/except.rs
+++ b/datafusion/functions-array/src/except.rs
@@ -17,7 +17,7 @@
 
 //! [`ScalarUDFImpl`] definitions for array_except function.
 
-use crate::utils::check_datatypes;
+use crate::utils::{check_datatypes, make_scalar_function};
 use arrow::row::{RowConverter, SortField};
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
@@ -74,8 +74,7 @@ impl ScalarUDFImpl for ArrayExcept {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
-        let args = ColumnarValue::values_to_arrays(args)?;
-        array_except_inner(&args).map(ColumnarValue::Array)
+        make_scalar_function(array_except_inner)(args)
     }
 
     fn aliases(&self) -> &[String] {

--- a/datafusion/functions-array/src/except.rs
+++ b/datafusion/functions-array/src/except.rs
@@ -23,7 +23,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::OffsetBuffer;
 use arrow_schema::{DataType, FieldRef};
-use datafusion_common::{exec_err, internal_err};
+use datafusion_common::{exec_err, internal_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::Expr;
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
@@ -66,14 +66,14 @@ impl ScalarUDFImpl for ArrayExcept {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match (&arg_types[0].clone(), &arg_types[1].clone()) {
             (DataType::Null, _) | (_, DataType::Null) => Ok(arg_types[0].clone()),
             (dt, _) => Ok(dt.clone()),
         }
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_except_inner)(args)
     }
 
@@ -83,7 +83,7 @@ impl ScalarUDFImpl for ArrayExcept {
 }
 
 /// Array_except SQL function
-pub fn array_except_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_except_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 2 {
         return exec_err!("array_except needs two arguments");
     }
@@ -117,7 +117,7 @@ fn general_except<OffsetSize: OffsetSizeTrait>(
     l: &GenericListArray<OffsetSize>,
     r: &GenericListArray<OffsetSize>,
     field: &FieldRef,
-) -> datafusion_common::Result<GenericListArray<OffsetSize>> {
+) -> Result<GenericListArray<OffsetSize>> {
     let converter = RowConverter::new(vec![SortField::new(l.value_type())])?;
 
     let l_values = l.values().to_owned();

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Array Element and Array Slice
+//! [`ScalarUDFImpl`] definitions for array_element, array_slice, array_pop_front and array_pop_back functions.
 
 use arrow::array::Array;
 use arrow::array::ArrayRef;
@@ -27,6 +27,7 @@ use arrow::array::MutableArrayData;
 use arrow::array::OffsetSizeTrait;
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::DataType;
+use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::Field;
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::cast::as_large_list_array;
@@ -110,7 +111,6 @@ impl ScalarUDFImpl for ArrayElement {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        use DataType::*;
         match &arg_types[0] {
             List(field)
             | LargeList(field)
@@ -137,18 +137,18 @@ impl ScalarUDFImpl for ArrayElement {
 ///
 /// For example:
 /// > array_element(\[1, 2, 3], 2) -> 2
-fn array_element_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+fn array_element_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 2 {
         return exec_err!("array_element needs two arguments");
     }
 
     match &args[0].data_type() {
-        DataType::List(_) => {
+        List(_) => {
             let array = as_list_array(&args[0])?;
             let indexes = as_int64_array(&args[1])?;
             general_array_element::<i32>(array, indexes)
         }
-        DataType::LargeList(_) => {
+        LargeList(_) => {
             let array = as_large_list_array(&args[0])?;
             let indexes = as_int64_array(&args[1])?;
             general_array_element::<i64>(array, indexes)
@@ -163,7 +163,7 @@ fn array_element_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef>
 fn general_array_element<O: OffsetSizeTrait>(
     array: &GenericListArray<O>,
     indexes: &Int64Array,
-) -> datafusion_common::Result<ArrayRef>
+) -> Result<ArrayRef>
 where
     i64: TryInto<O>,
 {
@@ -175,10 +175,7 @@ where
     let mut mutable =
         MutableArrayData::with_capacities(vec![&original_data], true, capacity);
 
-    fn adjusted_array_index<O: OffsetSizeTrait>(
-        index: i64,
-        len: O,
-    ) -> datafusion_common::Result<Option<O>>
+    fn adjusted_array_index<O: OffsetSizeTrait>(index: i64, len: O) -> Result<Option<O>>
     where
         i64: TryInto<O>,
     {
@@ -302,11 +299,11 @@ fn array_slice_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let array_data_type = args[0].data_type();
     match array_data_type {
-        DataType::List(_) => {
+        List(_) => {
             let array = as_list_array(&args[0])?;
             general_array_slice::<i32>(array, from_array, to_array, stride)
         }
-        DataType::LargeList(_) => {
+        LargeList(_) => {
             let array = as_large_list_array(&args[0])?;
             let from_array = as_int64_array(&args[1])?;
             let to_array = as_int64_array(&args[2])?;
@@ -545,11 +542,11 @@ impl ScalarUDFImpl for ArrayPopFront {
 fn array_pop_front_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let array_data_type = args[0].data_type();
     match array_data_type {
-        DataType::List(_) => {
+        List(_) => {
             let array = as_list_array(&args[0])?;
             general_pop_front_list::<i32>(array)
         }
-        DataType::LargeList(_) => {
+        LargeList(_) => {
             let array = as_large_list_array(&args[0])?;
             general_pop_front_list::<i64>(array)
         }
@@ -627,11 +624,11 @@ fn array_pop_back_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let array_data_type = args[0].data_type();
     match array_data_type {
-        DataType::List(_) => {
+        List(_) => {
             let array = as_list_array(&args[0])?;
             general_pop_back_list::<i32>(array)
         }
-        DataType::LargeList(_) => {
+        LargeList(_) => {
             let array = as_large_list_array(&args[0])?;
             general_pop_back_list::<i64>(array)
         }

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -32,11 +32,9 @@ use arrow_schema::Field;
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::cast::as_large_list_array;
 use datafusion_common::cast::as_list_array;
-use datafusion_common::exec_err;
-use datafusion_common::internal_datafusion_err;
-use datafusion_common::plan_err;
-use datafusion_common::DataFusionError;
-use datafusion_common::Result;
+use datafusion_common::{
+    exec_err, internal_datafusion_err, plan_err, DataFusionError, Result,
+};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::Expr;
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};

--- a/datafusion/functions-array/src/lib.rs
+++ b/datafusion/functions-array/src/lib.rs
@@ -31,13 +31,13 @@ pub mod macros;
 mod array_has;
 mod cardinality;
 mod concat;
-mod core;
 mod dimension;
 mod empty;
 mod except;
 mod extract;
 mod flatten;
 mod length;
+mod make_array;
 mod position;
 mod range;
 mod remove;
@@ -66,7 +66,6 @@ pub mod expr_fn {
     pub use super::concat::array_append;
     pub use super::concat::array_concat;
     pub use super::concat::array_prepend;
-    pub use super::core::make_array;
     pub use super::dimension::array_dims;
     pub use super::dimension::array_ndims;
     pub use super::empty::array_empty;
@@ -77,6 +76,7 @@ pub mod expr_fn {
     pub use super::extract::array_slice;
     pub use super::flatten::flatten;
     pub use super::length::array_length;
+    pub use super::make_array::make_array;
     pub use super::position::array_position;
     pub use super::position::array_positions;
     pub use super::range::gen_series;
@@ -116,7 +116,7 @@ pub fn register_all(registry: &mut dyn FunctionRegistry) -> Result<()> {
         extract::array_pop_back_udf(),
         extract::array_pop_front_udf(),
         extract::array_slice_udf(),
-        core::make_array_udf(),
+        make_array::make_array_udf(),
         array_has::array_has_udf(),
         array_has::array_has_all_udf(),
         array_has::array_has_any_udf(),

--- a/datafusion/functions-array/src/make_array.rs
+++ b/datafusion/functions-array/src/make_array.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// core array function like `make_array`
+//! [`ScalarUDFImpl`] definitions for `make_array` function.
 
 use std::{any::Any, sync::Arc};
 
@@ -24,6 +24,7 @@ use arrow_array::{
     new_null_array, Array, ArrayRef, GenericListArray, NullArray, OffsetSizeTrait,
 };
 use arrow_buffer::OffsetBuffer;
+use arrow_schema::DataType::{LargeList, List, Null};
 use arrow_schema::{DataType, Field};
 use datafusion_common::Result;
 use datafusion_common::{plan_err, utils::array_into_list_array};
@@ -73,7 +74,7 @@ impl ScalarUDFImpl for MakeArray {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match arg_types.len() {
             0 => Ok(DataType::List(Arc::new(Field::new(
                 "item",
@@ -89,9 +90,7 @@ impl ScalarUDFImpl for MakeArray {
                     }
                 }
 
-                Ok(DataType::List(Arc::new(Field::new(
-                    "item", expr_type, true,
-                ))))
+                Ok(List(Arc::new(Field::new("item", expr_type, true))))
             }
         }
     }
@@ -109,10 +108,10 @@ impl ScalarUDFImpl for MakeArray {
 /// Constructs an array using the input `data` as `ArrayRef`.
 /// Returns a reference-counted `Array` instance result.
 pub(crate) fn make_array_inner(arrays: &[ArrayRef]) -> Result<ArrayRef> {
-    let mut data_type = DataType::Null;
+    let mut data_type = Null;
     for arg in arrays {
         let arg_data_type = arg.data_type();
-        if !arg_data_type.equals_datatype(&DataType::Null) {
+        if !arg_data_type.equals_datatype(&Null) {
             data_type = arg_data_type.clone();
             break;
         }
@@ -120,12 +119,11 @@ pub(crate) fn make_array_inner(arrays: &[ArrayRef]) -> Result<ArrayRef> {
 
     match data_type {
         // Either an empty array or all nulls:
-        DataType::Null => {
-            let array =
-                new_null_array(&DataType::Null, arrays.iter().map(|a| a.len()).sum());
+        Null => {
+            let array = new_null_array(&Null, arrays.iter().map(|a| a.len()).sum());
             Ok(Arc::new(array_into_list_array(array)))
         }
-        DataType::LargeList(..) => array_array::<i64>(arrays, data_type),
+        LargeList(..) => array_array::<i64>(arrays, data_type),
         _ => array_array::<i32>(arrays, data_type),
     }
 }

--- a/datafusion/functions-array/src/make_array.rs
+++ b/datafusion/functions-array/src/make_array.rs
@@ -26,8 +26,7 @@ use arrow_array::{
 use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{LargeList, List, Null};
 use arrow_schema::{DataType, Field};
-use datafusion_common::Result;
-use datafusion_common::{plan_err, utils::array_into_list_array};
+use datafusion_common::{plan_err, utils::array_into_list_array, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::Expr;
 use datafusion_expr::{

--- a/datafusion/functions-array/src/range.rs
+++ b/datafusion/functions-array/src/range.rs
@@ -25,6 +25,7 @@ use std::any::Any;
 use crate::utils::make_scalar_function;
 use arrow_array::types::{Date32Type, IntervalMonthDayNanoType};
 use arrow_array::Date32Array;
+use arrow_schema::DataType::{Date32, Int64, Interval, List};
 use arrow_schema::IntervalUnit::MonthDayNano;
 use datafusion_common::cast::{as_date32_array, as_int64_array, as_interval_mdn_array};
 use datafusion_common::{exec_err, not_impl_datafusion_err, Result};
@@ -49,7 +50,6 @@ pub(super) struct Range {
 }
 impl Range {
     pub fn new() -> Self {
-        use DataType::*;
         Self {
             signature: Signature::one_of(
                 vec![
@@ -77,7 +77,6 @@ impl ScalarUDFImpl for Range {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        use DataType::*;
         Ok(List(Arc::new(Field::new(
             "item",
             arg_types[0].clone(),
@@ -87,12 +86,8 @@ impl ScalarUDFImpl for Range {
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match args[0].data_type() {
-            DataType::Int64 => {
-                make_scalar_function(|args| gen_range_inner(args, false))(args)
-            }
-            DataType::Date32 => {
-                make_scalar_function(|args| gen_range_date(args, false))(args)
-            }
+            Int64 => make_scalar_function(|args| gen_range_inner(args, false))(args),
+            Date32 => make_scalar_function(|args| gen_range_date(args, false))(args),
             _ => {
                 exec_err!("unsupported type for range")
             }
@@ -118,7 +113,6 @@ pub(super) struct GenSeries {
 }
 impl GenSeries {
     pub fn new() -> Self {
-        use DataType::*;
         Self {
             signature: Signature::one_of(
                 vec![
@@ -146,7 +140,6 @@ impl ScalarUDFImpl for GenSeries {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        use DataType::*;
         Ok(List(Arc::new(Field::new(
             "item",
             arg_types[0].clone(),
@@ -156,12 +149,8 @@ impl ScalarUDFImpl for GenSeries {
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match args[0].data_type() {
-            DataType::Int64 => {
-                make_scalar_function(|args| gen_range_inner(args, true))(args)
-            }
-            DataType::Date32 => {
-                make_scalar_function(|args| gen_range_date(args, true))(args)
-            }
+            Int64 => make_scalar_function(|args| gen_range_inner(args, true))(args),
+            Date32 => make_scalar_function(|args| gen_range_date(args, true))(args),
             _ => {
                 exec_err!("unsupported type for range")
             }
@@ -242,7 +231,7 @@ pub(super) fn gen_range_inner(
         };
     }
     let arr = Arc::new(ListArray::try_new(
-        Arc::new(Field::new("item", DataType::Int64, true)),
+        Arc::new(Field::new("item", Int64, true)),
         OffsetBuffer::new(offsets.into()),
         Arc::new(Int64Array::from(values)),
         Some(NullBuffer::new(valid.finish())),
@@ -330,7 +319,7 @@ fn gen_range_date(args: &[ArrayRef], include_upper: bool) -> Result<ArrayRef> {
     }
 
     let arr = Arc::new(ListArray::try_new(
-        Arc::new(Field::new("item", DataType::Date32, true)),
+        Arc::new(Field::new("item", Date32, true)),
         OffsetBuffer::new(offsets.into()),
         Arc::new(Date32Array::from(values)),
         None,

--- a/datafusion/functions-array/src/remove.rs
+++ b/datafusion/functions-array/src/remove.rs
@@ -26,7 +26,7 @@ use arrow_array::{
 use arrow_buffer::OffsetBuffer;
 use arrow_schema::{DataType, Field};
 use datafusion_common::cast::as_int64_array;
-use datafusion_common::exec_err;
+use datafusion_common::{exec_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -68,11 +68,11 @@ impl ScalarUDFImpl for ArrayRemove {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(arg_types[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_remove_inner)(args)
     }
 
@@ -117,11 +117,11 @@ impl ScalarUDFImpl for ArrayRemoveN {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(arg_types[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_remove_n_inner)(args)
     }
 
@@ -169,11 +169,11 @@ impl ScalarUDFImpl for ArrayRemoveAll {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(arg_types[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_remove_all_inner)(args)
     }
 
@@ -183,7 +183,7 @@ impl ScalarUDFImpl for ArrayRemoveAll {
 }
 
 /// Array_remove SQL function
-pub fn array_remove_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_remove_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 2 {
         return exec_err!("array_remove expects two arguments");
     }
@@ -193,7 +193,7 @@ pub fn array_remove_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayR
 }
 
 /// Array_remove_n SQL function
-pub fn array_remove_n_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_remove_n_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 3 {
         return exec_err!("array_remove_n expects three arguments");
     }
@@ -203,7 +203,7 @@ pub fn array_remove_n_inner(args: &[ArrayRef]) -> datafusion_common::Result<Arra
 }
 
 /// Array_remove_all SQL function
-pub fn array_remove_all_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_remove_all_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 2 {
         return exec_err!("array_remove_all expects two arguments");
     }
@@ -216,7 +216,7 @@ fn array_remove_internal(
     array: &ArrayRef,
     element_array: &ArrayRef,
     arr_n: Vec<i64>,
-) -> datafusion_common::Result<ArrayRef> {
+) -> Result<ArrayRef> {
     match array.data_type() {
         DataType::List(_) => {
             let list_array = array.as_list::<i32>();
@@ -253,7 +253,7 @@ fn general_remove<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     element_array: &ArrayRef,
     arr_n: Vec<i64>,
-) -> datafusion_common::Result<ArrayRef> {
+) -> Result<ArrayRef> {
     let data_type = list_array.value_type();
     let mut new_values = vec![];
     // Build up the offsets for the final output array

--- a/datafusion/functions-array/src/remove.rs
+++ b/datafusion/functions-array/src/remove.rs
@@ -18,6 +18,7 @@
 //! [`ScalarUDFImpl`] definitions for array_remove, array_remove_n, array_remove_all functions.
 
 use crate::utils;
+use crate::utils::make_scalar_function;
 use arrow_array::cast::AsArray;
 use arrow_array::{
     new_empty_array, Array, ArrayRef, BooleanArray, GenericListArray, OffsetSizeTrait,
@@ -58,6 +59,7 @@ impl ScalarUDFImpl for ArrayRemove {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_remove"
     }
@@ -71,8 +73,7 @@ impl ScalarUDFImpl for ArrayRemove {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
-        let args = ColumnarValue::values_to_arrays(args)?;
-        array_remove_inner(&args).map(ColumnarValue::Array)
+        make_scalar_function(array_remove_inner)(args)
     }
 
     fn aliases(&self) -> &[String] {
@@ -107,6 +108,7 @@ impl ScalarUDFImpl for ArrayRemoveN {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_remove_n"
     }
@@ -120,8 +122,7 @@ impl ScalarUDFImpl for ArrayRemoveN {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
-        let args = ColumnarValue::values_to_arrays(args)?;
-        array_remove_n_inner(&args).map(ColumnarValue::Array)
+        make_scalar_function(array_remove_n_inner)(args)
     }
 
     fn aliases(&self) -> &[String] {
@@ -159,6 +160,7 @@ impl ScalarUDFImpl for ArrayRemoveAll {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_remove_all"
     }
@@ -172,8 +174,7 @@ impl ScalarUDFImpl for ArrayRemoveAll {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
-        let args = ColumnarValue::values_to_arrays(args)?;
-        array_remove_all_inner(&args).map(ColumnarValue::Array)
+        make_scalar_function(array_remove_all_inner)(args)
     }
 
     fn aliases(&self) -> &[String] {

--- a/datafusion/functions-array/src/repeat.rs
+++ b/datafusion/functions-array/src/repeat.rs
@@ -60,6 +60,7 @@ impl ScalarUDFImpl for ArrayRepeat {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_repeat"
     }

--- a/datafusion/functions-array/src/repeat.rs
+++ b/datafusion/functions-array/src/repeat.rs
@@ -28,7 +28,7 @@ use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{LargeList, List};
 use arrow_schema::{DataType, Field};
 use datafusion_common::cast::{as_int64_array, as_large_list_array, as_list_array};
-use datafusion_common::exec_err;
+use datafusion_common::{exec_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -69,7 +69,7 @@ impl ScalarUDFImpl for ArrayRepeat {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(List(Arc::new(Field::new(
             "item",
             arg_types[0].clone(),
@@ -77,7 +77,7 @@ impl ScalarUDFImpl for ArrayRepeat {
         ))))
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_repeat_inner)(args)
     }
 
@@ -87,7 +87,7 @@ impl ScalarUDFImpl for ArrayRepeat {
 }
 
 /// Array_repeat SQL function
-pub fn array_repeat_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_repeat_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.len() != 2 {
         return exec_err!("array_repeat expects two arguments");
     }
@@ -123,7 +123,7 @@ pub fn array_repeat_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayR
 fn general_repeat<O: OffsetSizeTrait>(
     array: &ArrayRef,
     count_array: &Int64Array,
-) -> datafusion_common::Result<ArrayRef> {
+) -> Result<ArrayRef> {
     let data_type = array.data_type();
     let mut new_values = vec![];
 
@@ -177,7 +177,7 @@ fn general_repeat<O: OffsetSizeTrait>(
 fn general_list_repeat<O: OffsetSizeTrait>(
     list_array: &GenericListArray<O>,
     count_array: &Int64Array,
-) -> datafusion_common::Result<ArrayRef> {
+) -> Result<ArrayRef> {
     let data_type = list_array.data_type();
     let value_type = list_array.value_type();
     let mut new_values = vec![];

--- a/datafusion/functions-array/src/replace.rs
+++ b/datafusion/functions-array/src/replace.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! [`ScalarUDFImpl`] definitions for array functions.
+//! [`ScalarUDFImpl`] definitions for array_replace, array_replace_n and array_replace_all functions.
 
 use arrow::array::{
     Array, ArrayRef, AsArray, Capacities, MutableArrayData, OffsetSizeTrait,
@@ -76,6 +76,7 @@ impl ScalarUDFImpl for ArrayReplace {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_replace"
     }
@@ -84,11 +85,11 @@ impl ScalarUDFImpl for ArrayReplace {
         &self.signature
     }
 
-    fn return_type(&self, args: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
         Ok(args[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_replace_inner)(args)
     }
 
@@ -119,6 +120,7 @@ impl ScalarUDFImpl for ArrayReplaceN {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_replace_n"
     }
@@ -127,11 +129,11 @@ impl ScalarUDFImpl for ArrayReplaceN {
         &self.signature
     }
 
-    fn return_type(&self, args: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
         Ok(args[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_replace_n_inner)(args)
     }
 
@@ -162,6 +164,7 @@ impl ScalarUDFImpl for ArrayReplaceAll {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_replace_all"
     }
@@ -170,11 +173,11 @@ impl ScalarUDFImpl for ArrayReplaceAll {
         &self.signature
     }
 
-    fn return_type(&self, args: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
         Ok(args[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_replace_all_inner)(args)
     }
 
@@ -183,7 +186,7 @@ impl ScalarUDFImpl for ArrayReplaceAll {
     }
 }
 
-/// For each element of `list_array[i]`, replaces up to `arr_n[i]`  occurences
+/// For each element of `list_array[i]`, replaces up to `arr_n[i]`  occurrences
 /// of `from_array[i]`, `to_array[i]`.
 ///
 /// The type of each **element** in `list_array` must be the same as the type of
@@ -299,7 +302,7 @@ pub(crate) fn array_replace_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         return exec_err!("array_replace expects three arguments");
     }
 
-    // replace at most one occurence for each element
+    // replace at most one occurrence for each element
     let arr_n = vec![1; args[0].len()];
     let array = &args[0];
     match array.data_type() {
@@ -320,7 +323,7 @@ pub(crate) fn array_replace_n_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         return exec_err!("array_replace_n expects four arguments");
     }
 
-    // replace the specified number of occurences
+    // replace the specified number of occurrences
     let arr_n = as_int64_array(&args[3])?.values().to_vec();
     let array = &args[0];
     match array.data_type() {

--- a/datafusion/functions-array/src/resize.rs
+++ b/datafusion/functions-array/src/resize.rs
@@ -57,6 +57,7 @@ impl ScalarUDFImpl for ArrayResize {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_resize"
     }
@@ -85,7 +86,9 @@ impl ScalarUDFImpl for ArrayResize {
 }
 
 /// array_resize SQL function
-pub fn array_resize_inner(arg: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub(crate) fn array_resize_inner(
+    arg: &[ArrayRef],
+) -> datafusion_common::Result<ArrayRef> {
     if arg.len() < 2 || arg.len() > 3 {
         return exec_err!("array_resize needs two or three arguments");
     }
@@ -98,11 +101,11 @@ pub fn array_resize_inner(arg: &[ArrayRef]) -> datafusion_common::Result<ArrayRe
     };
 
     match &arg[0].data_type() {
-        DataType::List(field) => {
+        List(field) => {
             let array = as_list_array(&arg[0])?;
             general_list_resize::<i32>(array, new_len, field, new_element)
         }
-        DataType::LargeList(field) => {
+        LargeList(field) => {
             let array = as_large_list_array(&arg[0])?;
             general_list_resize::<i64>(array, new_len, field, new_element)
         }

--- a/datafusion/functions-array/src/resize.rs
+++ b/datafusion/functions-array/src/resize.rs
@@ -24,7 +24,7 @@ use arrow_buffer::{ArrowNativeType, OffsetBuffer};
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_large_list_array, as_list_array};
-use datafusion_common::{exec_err, internal_datafusion_err, ScalarValue};
+use datafusion_common::{exec_err, internal_datafusion_err, Result, ScalarValue};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -66,7 +66,7 @@ impl ScalarUDFImpl for ArrayResize {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match &arg_types[0] {
             List(field) | FixedSizeList(field, _) => Ok(List(field.clone())),
             LargeList(field) => Ok(LargeList(field.clone())),
@@ -76,7 +76,7 @@ impl ScalarUDFImpl for ArrayResize {
         }
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_resize_inner)(args)
     }
 
@@ -86,9 +86,7 @@ impl ScalarUDFImpl for ArrayResize {
 }
 
 /// array_resize SQL function
-pub(crate) fn array_resize_inner(
-    arg: &[ArrayRef],
-) -> datafusion_common::Result<ArrayRef> {
+pub(crate) fn array_resize_inner(arg: &[ArrayRef]) -> Result<ArrayRef> {
     if arg.len() < 2 || arg.len() > 3 {
         return exec_err!("array_resize needs two or three arguments");
     }
@@ -119,7 +117,7 @@ fn general_list_resize<O: OffsetSizeTrait>(
     count_array: &Int64Array,
     field: &FieldRef,
     default_element: Option<ArrayRef>,
-) -> datafusion_common::Result<ArrayRef>
+) -> Result<ArrayRef>
 where
     O: TryInto<i64>,
 {

--- a/datafusion/functions-array/src/reverse.rs
+++ b/datafusion/functions-array/src/reverse.rs
@@ -24,7 +24,7 @@ use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{LargeList, List, Null};
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::cast::{as_large_list_array, as_list_array};
-use datafusion_common::exec_err;
+use datafusion_common::{exec_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -66,11 +66,11 @@ impl ScalarUDFImpl for ArrayReverse {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         Ok(arg_types[0].clone())
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_reverse_inner)(args)
     }
 
@@ -80,7 +80,7 @@ impl ScalarUDFImpl for ArrayReverse {
 }
 
 /// array_reverse SQL function
-pub fn array_reverse_inner(arg: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_reverse_inner(arg: &[ArrayRef]) -> Result<ArrayRef> {
     if arg.len() != 1 {
         return exec_err!("array_reverse needs one argument");
     }
@@ -102,7 +102,7 @@ pub fn array_reverse_inner(arg: &[ArrayRef]) -> datafusion_common::Result<ArrayR
 fn general_array_reverse<O: OffsetSizeTrait>(
     array: &GenericListArray<O>,
     field: &FieldRef,
-) -> datafusion_common::Result<ArrayRef>
+) -> Result<ArrayRef>
 where
     O: TryFrom<i64>,
 {

--- a/datafusion/functions-array/src/reverse.rs
+++ b/datafusion/functions-array/src/reverse.rs
@@ -21,6 +21,7 @@ use crate::utils::make_scalar_function;
 use arrow::array::{Capacities, MutableArrayData};
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::OffsetBuffer;
+use arrow_schema::DataType::{LargeList, List, Null};
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::cast::{as_large_list_array, as_list_array};
 use datafusion_common::exec_err;
@@ -56,6 +57,7 @@ impl ScalarUDFImpl for ArrayReverse {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_reverse"
     }
@@ -84,15 +86,15 @@ pub fn array_reverse_inner(arg: &[ArrayRef]) -> datafusion_common::Result<ArrayR
     }
 
     match &arg[0].data_type() {
-        DataType::List(field) => {
+        List(field) => {
             let array = as_list_array(&arg[0])?;
             general_array_reverse::<i32>(array, field)
         }
-        DataType::LargeList(field) => {
+        LargeList(field) => {
             let array = as_large_list_array(&arg[0])?;
             general_array_reverse::<i64>(array, field)
         }
-        DataType::Null => Ok(arg[0].clone()),
+        Null => Ok(arg[0].clone()),
         array_type => exec_err!("array_reverse does not support type '{array_type:?}'."),
     }
 }

--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -23,6 +23,7 @@ use crate::extract::{array_element, array_slice};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::Transformed;
 use datafusion_common::utils::list_ndims;
+use datafusion_common::Result;
 use datafusion_common::{Column, DFSchema};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::expr_rewriter::FunctionRewrite;
@@ -42,7 +43,7 @@ impl FunctionRewrite for ArrayFunctionRewriter {
         expr: Expr,
         schema: &DFSchema,
         _config: &ConfigOptions,
-    ) -> datafusion_common::Result<Transformed<Expr>> {
+    ) -> Result<Transformed<Expr>> {
         let transformed = match expr {
             // array1 @> array2 -> array_has_all(array1, array2)
             Expr::BinaryExpr(BinaryExpr { left, op, right })

--- a/datafusion/functions-array/src/sort.rs
+++ b/datafusion/functions-array/src/sort.rs
@@ -57,6 +57,7 @@ impl ScalarUDFImpl for ArraySort {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn name(&self) -> &str {
         "array_sort"
     }

--- a/datafusion/functions-array/src/sort.rs
+++ b/datafusion/functions-array/src/sort.rs
@@ -24,7 +24,7 @@ use arrow_buffer::{BooleanBufferBuilder, NullBuffer, OffsetBuffer};
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::{DataType, Field, SortOptions};
 use datafusion_common::cast::{as_list_array, as_string_array};
-use datafusion_common::exec_err;
+use datafusion_common::{exec_err, Result};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
@@ -66,7 +66,7 @@ impl ScalarUDFImpl for ArraySort {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match &arg_types[0] {
             List(field) | FixedSizeList(field, _) => Ok(List(Arc::new(Field::new(
                 "item",
@@ -84,7 +84,7 @@ impl ScalarUDFImpl for ArraySort {
         }
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion_common::Result<ColumnarValue> {
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(array_sort_inner)(args)
     }
 
@@ -94,7 +94,7 @@ impl ScalarUDFImpl for ArraySort {
 }
 
 /// Array_sort SQL function
-pub fn array_sort_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.is_empty() || args.len() > 3 {
         return exec_err!("array_sort expects one to three arguments");
     }
@@ -158,7 +158,7 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef
     Ok(Arc::new(list_arr))
 }
 
-fn order_desc(modifier: &str) -> datafusion_common::Result<bool> {
+fn order_desc(modifier: &str) -> Result<bool> {
     match modifier.to_uppercase().as_str() {
         "DESC" => Ok(true),
         "ASC" => Ok(false),
@@ -166,7 +166,7 @@ fn order_desc(modifier: &str) -> datafusion_common::Result<bool> {
     }
 }
 
-fn order_nulls_first(modifier: &str) -> datafusion_common::Result<bool> {
+fn order_nulls_first(modifier: &str) -> Result<bool> {
     match modifier.to_uppercase().as_str() {
         "NULLS FIRST" => Ok(true),
         "NULLS LAST" => Ok(false),


### PR DESCRIPTION
## Which issue does this PR close?
Closes #9787.

## What changes are included in this PR?
This PR aims to do following refactoring:
1- Being added `make_scalar_function` support to missed `invoke` functions,
2- Aligning rust-doc across array functions,
3- Removing redundant imports,
4- Fixing typo problems,
5- Rename `core.rs` -> `make_array.rs`.

## Are these changes tested?
Yes, all `array.slt` tests pass.

## Are there any user-facing changes?
No