### PR TITLE
feat: Add display_pg_json for LogicalPlan

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "chrono",
  "datafusion-common",
  "paste",
+ "serde_json",
  "sqlparser",
  "strum 0.26.2",
  "strum_macros 0.26.2",

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -46,6 +46,7 @@ paste = "^1.0"
 sqlparser = { workspace = true }
 strum = { version = "0.26.1", features = ["derive"] }
 strum_macros = "0.26.0"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -43,10 +43,10 @@ arrow-array = { workspace = true }
 chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 paste = "^1.0"
+serde_json = { workspace = true }
 sqlparser = { workspace = true }
 strum = { version = "0.26.1", features = ["derive"] }
 strum_macros = "0.26.0"
-serde_json = { workspace = true }
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -16,14 +16,22 @@
 // under the License.
 //! This module provides logic for displaying LogicalPlans in various styles
 
+use std::collections::HashMap;
 use std::fmt;
 
-use crate::LogicalPlan;
+use crate::{
+    expr_vec_fmt, Aggregate, DescribeTable, Distinct, DistinctOn, DmlStatement, Expr,
+    Filter, Join, Limit, LogicalPlan, Partitioning, Prepare, Projection, RecursiveQuery,
+    Repartition, Sort, Subquery, SubqueryAlias, TableProviderFilterPushDown, TableScan,
+    Unnest, Values, Window,
+};
 
+use crate::dml::{CopyOptions, CopyTo};
 use arrow::datatypes::Schema;
 use datafusion_common::display::GraphvizBuilder;
 use datafusion_common::tree_node::{TreeNodeRecursion, TreeNodeVisitor};
 use datafusion_common::DataFusionError;
+use serde_json::json;
 
 /// Formats plans with a single line per node. For example:
 ///
@@ -218,6 +226,494 @@ impl<'a, 'b> TreeNodeVisitor for GraphvizVisitor<'a, 'b> {
         let res = self.parent_ids.pop();
         res.ok_or(DataFusionError::Internal("Fail to format".to_string()))
             .map(|_| TreeNodeRecursion::Continue)
+    }
+}
+
+/// Formats plans to display as postgresql plan json format.
+///
+/// There are already many existing visualizer for this format, for example [dalibo](https://explain.dalibo.com/).
+/// Unfortunately, there is no formal spec for this format, but it is widely used in the PostgreSQL community.
+///
+/// Here is an example of the format:
+///
+/// ```json
+/// [
+///     {
+///         "Plan": {
+///             "Node Type": "Sort",
+///             "Output": [
+///                 "question_1.id",
+///                 "question_1.title",
+///                 "question_1.text",
+///                 "question_1.file",
+///                 "question_1.type",
+///                 "question_1.source",
+///                 "question_1.exam_id"
+///             ],
+///             "Sort Key": [
+///                 "question_1.id"
+///             ],
+///             "Plans": [
+///                 {
+///                     "Node Type": "Seq Scan",
+///                     "Parent Relationship": "Left",
+///                     "Relation Name": "question",
+///                     "Schema": "public",
+///                     "Alias": "question_1",
+///                     "Output": [
+///                        "question_1.id",
+///                         "question_1.title",
+///                        "question_1.text",
+///                         "question_1.file",
+///                         "question_1.type",
+///                         "question_1.source",
+///                         "question_1.exam_id"
+///                     ],
+///                     "Filter": "(question_1.exam_id = 1)"
+///                 }
+///             ]
+///         }
+///     }
+/// ]
+/// ```
+pub struct PgJsonVisitor<'a, 'b> {
+    f: &'a mut fmt::Formatter<'b>,
+
+    /// A mapping from plan node id to the plan node json representation.
+    objects: HashMap<u32, serde_json::Value>,
+
+    next_id: u32,
+
+    /// If true, includes summarized schema information
+    with_schema: bool,
+
+    /// Holds the ids (as generated from `graphviz_builder` of all
+    /// parent nodes
+    parent_ids: Vec<u32>,
+}
+
+impl<'a, 'b> PgJsonVisitor<'a, 'b> {
+    pub fn new(f: &'a mut fmt::Formatter<'b>) -> Self {
+        Self {
+            f,
+            objects: HashMap::new(),
+            next_id: 0,
+            with_schema: false,
+            parent_ids: Vec::new(),
+        }
+    }
+
+    /// Sets a flag which controls if the output schema is displayed
+    pub fn with_schema(&mut self, with_schema: bool) {
+        self.with_schema = with_schema;
+    }
+
+    /// Converts a logical plan node to a json object.
+    fn to_json_value(node: &LogicalPlan) -> serde_json::Value {
+        match node {
+            LogicalPlan::EmptyRelation(_) => {
+                json!({
+                    "Node Type": "EmptyRelation",
+                })
+            }
+            LogicalPlan::RecursiveQuery(RecursiveQuery { is_distinct, .. }) => {
+                json!({
+                    "Node Type": "RecursiveQuery",
+                    "Is Distinct": is_distinct,
+                })
+            }
+            LogicalPlan::Values(Values { ref values, .. }) => {
+                let str_values = values
+                    .iter()
+                    // limit to only 5 values to avoid horrible display
+                    .take(5)
+                    .map(|row| {
+                        let item = row
+                            .iter()
+                            .map(|expr| expr.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("({item})")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                let elipse = if values.len() > 5 { "..." } else { "" };
+
+                let values_str = format!("{}{}", str_values, elipse);
+                json!({
+                    "Node Type": "Values",
+                    "Values": values_str
+                })
+            }
+            LogicalPlan::TableScan(TableScan {
+                ref source,
+                ref table_name,
+                ref filters,
+                ref fetch,
+                ..
+            }) => {
+                let mut object = json!({
+                    "Node Type": "TableScan",
+                    "Relation Name": table_name.table(),
+                });
+
+                if let Some(s) = table_name.schema() {
+                    object["Schema"] = serde_json::Value::String(s.to_string());
+                }
+
+                if let Some(c) = table_name.catalog() {
+                    object["Catalog"] = serde_json::Value::String(c.to_string());
+                }
+
+                if !filters.is_empty() {
+                    let mut full_filter = vec![];
+                    let mut partial_filter = vec![];
+                    let mut unsupported_filters = vec![];
+                    let filters: Vec<&Expr> = filters.iter().collect();
+
+                    if let Ok(results) = source.supports_filters_pushdown(&filters) {
+                        filters.iter().zip(results.iter()).for_each(
+                            |(x, res)| match res {
+                                TableProviderFilterPushDown::Exact => full_filter.push(x),
+                                TableProviderFilterPushDown::Inexact => {
+                                    partial_filter.push(x)
+                                }
+                                TableProviderFilterPushDown::Unsupported => {
+                                    unsupported_filters.push(x)
+                                }
+                            },
+                        );
+                    }
+
+                    if !full_filter.is_empty() {
+                        object["Full Filters"] = serde_json::Value::String(
+                            expr_vec_fmt!(full_filter).to_string(),
+                        );
+                    };
+                    if !partial_filter.is_empty() {
+                        object["Partial Filters"] = serde_json::Value::String(
+                            expr_vec_fmt!(partial_filter).to_string(),
+                        );
+                    }
+                    if !unsupported_filters.is_empty() {
+                        object["Unsupported Filters"] = serde_json::Value::String(
+                            expr_vec_fmt!(unsupported_filters).to_string(),
+                        );
+                    }
+                }
+
+                if let Some(f) = fetch {
+                    object["Fetch"] = serde_json::Value::Number((*f).into());
+                }
+
+                object
+            }
+            LogicalPlan::Projection(Projection { ref expr, .. }) => {
+                json!({
+                    "Node Type": "Projection",
+                    "Expressions": expr.iter().map(|e| e.to_string()).collect::<Vec<_>>()
+                })
+            }
+            LogicalPlan::Dml(DmlStatement { table_name, op, .. }) => {
+                json!({
+                    "Node Type": "Projection",
+                    "Operation": op.name(),
+                    "Table Name": table_name.table()
+                })
+            }
+            LogicalPlan::Copy(CopyTo {
+                input: _,
+                output_url,
+                file_format,
+                partition_by: _,
+                copy_options,
+            }) => {
+                let op_str = match copy_options {
+                    CopyOptions::SQLOptions(statement) => statement
+                        .clone()
+                        .into_inner()
+                        .iter()
+                        .map(|(k, v)| format!("{k} {v}"))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    CopyOptions::WriterOptions(_) => "".into(),
+                };
+
+                json!({
+                    "Node Type": "CopyTo",
+                    "Output URL": output_url,
+                    "File Format": format!("{}", file_format),
+                    "Options": op_str
+                })
+            }
+            LogicalPlan::Ddl(ddl) => {
+                json!({
+                    "Node Type": "Ddl",
+                    "Operation": format!("{}", ddl.display())
+                })
+            }
+            LogicalPlan::Filter(Filter {
+                predicate: ref expr,
+                ..
+            }) => {
+                json!({
+                    "Node Type": "Filter",
+                    "Condition": format!("{}", expr)
+                })
+            }
+            LogicalPlan::Window(Window {
+                ref window_expr, ..
+            }) => {
+                json!({
+                    "Node Type": "WindowAggr",
+                    "Expressions": expr_vec_fmt!(window_expr)
+                })
+            }
+            LogicalPlan::Aggregate(Aggregate {
+                ref group_expr,
+                ref aggr_expr,
+                ..
+            }) => {
+                json!({
+                    "Node Type": "Aggregate",
+                    "Group By": expr_vec_fmt!(group_expr),
+                    "Aggregates": expr_vec_fmt!(aggr_expr)
+                })
+            }
+            LogicalPlan::Sort(Sort { expr, fetch, .. }) => {
+                let mut object = json!({
+                    "Node Type": "Sort",
+                    "Sort Key": expr_vec_fmt!(expr),
+                });
+
+                if let Some(fetch) = fetch {
+                    object["Fetch"] = serde_json::Value::Number((*fetch).into());
+                }
+
+                object
+            }
+            LogicalPlan::Join(Join {
+                on: ref keys,
+                filter,
+                join_constraint,
+                join_type,
+                ..
+            }) => {
+                let join_expr: Vec<String> =
+                    keys.iter().map(|(l, r)| format!("{l} = {r}")).collect();
+                let filter_expr = filter
+                    .as_ref()
+                    .map(|expr| format!(" Filter: {expr}"))
+                    .unwrap_or_else(|| "".to_string());
+                json!({
+                    "Node Type": format!("{} Join", join_type),
+                    "Join Constraint": format!("{:?}", join_constraint),
+                    "Join Keys": join_expr.join(", "),
+                    "Filter": format!("{}", filter_expr)
+                })
+            }
+            LogicalPlan::CrossJoin(_) => {
+                json!({
+                    "Node Type": "Cross Join"
+                })
+            }
+            LogicalPlan::Repartition(Repartition {
+                partitioning_scheme,
+                ..
+            }) => match partitioning_scheme {
+                Partitioning::RoundRobinBatch(n) => {
+                    json!({
+                        "Node Type": "Repartition",
+                        "Partitioning Scheme": "RoundRobinBatch",
+                        "Partition Count": n
+                    })
+                }
+                Partitioning::Hash(expr, n) => {
+                    let hash_expr: Vec<String> =
+                        expr.iter().map(|e| format!("{e}")).collect();
+
+                    json!({
+                        "Node Type": "Repartition",
+                        "Partitioning Scheme": "Hash",
+                        "Partition Count": n,
+                        "Partitioning Key": hash_expr
+                    })
+                }
+                Partitioning::DistributeBy(expr) => {
+                    let dist_by_expr: Vec<String> =
+                        expr.iter().map(|e| format!("{e}")).collect();
+                    json!({
+                        "Node Type": "Repartition",
+                        "Partitioning Scheme": "DistributeBy",
+                        "Partitioning Key": dist_by_expr
+                    })
+                }
+            },
+            LogicalPlan::Limit(Limit {
+                ref skip,
+                ref fetch,
+                ..
+            }) => {
+                let mut object = serde_json::json!(
+                    {
+                        "Node Type": "Limit",
+                        "Skip": skip,
+                    }
+                );
+                if let Some(f) = fetch {
+                    object["Fetch"] = serde_json::Value::Number((*f).into());
+                };
+                object
+            }
+            LogicalPlan::Subquery(Subquery { .. }) => {
+                json!({
+                    "Node Type": "Subquery"
+                })
+            }
+            LogicalPlan::SubqueryAlias(SubqueryAlias { ref alias, .. }) => {
+                json!({
+                    "Node Type": "Subquery",
+                    "Alias": alias.table(),
+                })
+            }
+            LogicalPlan::Statement(statement) => {
+                json!({
+                    "Node Type": "Statement",
+                    "Statement": format!("{}", statement.display())
+                })
+            }
+            LogicalPlan::Distinct(distinct) => match distinct {
+                Distinct::All(_) => {
+                    json!({
+                        "Node Type": "DistinctAll"
+                    })
+                }
+                Distinct::On(DistinctOn {
+                    on_expr,
+                    select_expr,
+                    sort_expr,
+                    ..
+                }) => {
+                    let mut object = json!({
+                        "Node Type": "DistinctOn",
+                        "On": expr_vec_fmt!(on_expr),
+                        "Select": expr_vec_fmt!(select_expr),
+                    });
+                    if let Some(sort_expr) = sort_expr {
+                        object["Sort"] = serde_json::Value::String(
+                            expr_vec_fmt!(sort_expr).to_string(),
+                        );
+                    }
+
+                    object
+                }
+            },
+            LogicalPlan::Explain { .. } => {
+                json!({
+                    "Node Type": "Explain"
+                })
+            }
+            LogicalPlan::Analyze { .. } => {
+                json!({
+                    "Node Type": "Analyze"
+                })
+            }
+            LogicalPlan::Union(_) => {
+                json!({
+                    "Node Type": "Union"
+                })
+            }
+            LogicalPlan::Extension(e) => {
+                json!({
+                    "Node Type": e.node.name(),
+                    "Detail": format!("{:?}", e.node)
+                })
+            }
+            LogicalPlan::Prepare(Prepare {
+                name, data_types, ..
+            }) => {
+                json!({
+                    "Node Type": "Prepare",
+                    "Name": name,
+                    "Data Types": format!("{:?}", data_types)
+                })
+            }
+            LogicalPlan::DescribeTable(DescribeTable { .. }) => {
+                json!({
+                    "Node Type": "DescribeTable"
+                })
+            }
+            LogicalPlan::Unnest(Unnest { column, .. }) => {
+                json!({
+                    "Node Type": "Unnest",
+                    "Column": format!("{}", column)
+                })
+            }
+        }
+    }
+}
+
+impl<'a, 'b> TreeNodeVisitor for PgJsonVisitor<'a, 'b> {
+    type Node = LogicalPlan;
+
+    fn f_down(
+        &mut self,
+        node: &LogicalPlan,
+    ) -> datafusion_common::Result<TreeNodeRecursion> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let mut object = Self::to_json_value(node);
+
+        object["Plans"] = serde_json::Value::Array(vec![]);
+
+        if self.with_schema {
+            object["Output"] = serde_json::Value::Array(
+                node.schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().to_string())
+                    .map(serde_json::Value::String)
+                    .collect(),
+            );
+        };
+
+        self.objects.insert(id, object);
+        self.parent_ids.push(id);
+        Ok(TreeNodeRecursion::Continue)
+    }
+
+    fn f_up(
+        &mut self,
+        _node: &Self::Node,
+    ) -> datafusion_common::Result<TreeNodeRecursion> {
+        let id = self.parent_ids.pop().unwrap();
+
+        let current_node = self.objects.remove(&id).expect("Missing current node!");
+
+        if let Some(parent_id) = self.parent_ids.last() {
+            let parent_node = self
+                .objects
+                .get_mut(parent_id)
+                .expect("Missing parent node!");
+            let plans = parent_node
+                .get_mut("Plans")
+                .and_then(|p| p.as_array_mut())
+                .expect("Plans should be an array");
+
+            plans.push(current_node);
+        } else {
+            // This is the root node
+            let plan = serde_json::json!([{"Plan": current_node}]);
+            write!(
+                self.f,
+                "{}",
+                serde_json::to_string_pretty(&plan)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?
+            )?;
+        }
+
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -26,7 +26,7 @@ use crate::{
     Unnest, Values, Window,
 };
 
-use crate::dml::{CopyOptions, CopyTo};
+use crate::dml::CopyTo;
 use arrow::datatypes::Schema;
 use datafusion_common::display::GraphvizBuilder;
 use datafusion_common::tree_node::{TreeNodeRecursion, TreeNodeVisitor};
@@ -425,25 +425,19 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
             LogicalPlan::Copy(CopyTo {
                 input: _,
                 output_url,
-                file_format,
+                format_options,
                 partition_by: _,
-                copy_options,
+                options,
             }) => {
-                let op_str = match copy_options {
-                    CopyOptions::SQLOptions(statement) => statement
-                        .clone()
-                        .into_inner()
-                        .iter()
-                        .map(|(k, v)| format!("{k} {v}"))
-                        .collect::<Vec<String>>()
-                        .join(", "),
-                    CopyOptions::WriterOptions(_) => "".into(),
-                };
-
+                let op_str = options
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 json!({
                     "Node Type": "CopyTo",
                     "Output URL": output_url,
-                    "File Format": format!("{}", file_format),
+                    "Format Options": format!("{}", format_options),
                     "Options": op_str
                 })
             }

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -683,8 +683,9 @@ impl<'a, 'b> TreeNodeVisitor for PgJsonVisitor<'a, 'b> {
     ) -> datafusion_common::Result<TreeNodeRecursion> {
         let id = self.parent_ids.pop().unwrap();
 
-        let current_node = self.objects.remove(&id)
-            .ok_or_else(|| DataFusionError::Internal("Missing current node!".to_string()))?;
+        let current_node = self.objects.remove(&id).ok_or_else(|| {
+            DataFusionError::Internal("Missing current node!".to_string())
+        })?;
 
         if let Some(parent_id) = self.parent_ids.last() {
             let parent_node = self

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -683,7 +683,8 @@ impl<'a, 'b> TreeNodeVisitor for PgJsonVisitor<'a, 'b> {
     ) -> datafusion_common::Result<TreeNodeRecursion> {
         let id = self.parent_ids.pop().unwrap();
 
-        let current_node = self.objects.remove(&id).expect("Missing current node!");
+        let current_node = self.objects.remove(&id)
+            .ok_or_else(|| DataFusionError::Internal("Missing current node!".to_string()))?;
 
         if let Some(parent_id) = self.parent_ids.last() {
             let parent_node = self

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1303,7 +1303,7 @@ impl LogicalPlan {
         Wrapper(self)
     }
 
-    /// Return a `format`able structure that produces plan in postgresql JSON format.
+    /// Return a displayable structure that produces plan in postgresql JSON format.
     ///
     /// Users can use this format to visualize the plan in existing plan visualization tools, for example [dalibo](https://explain.dalibo.com/)
     pub fn display_pg_json(&self) -> impl Display + '_ {
@@ -2806,7 +2806,7 @@ digraph {
     fn test_display_pg_json() -> Result<()> {
         let plan = display_plan()?;
 
-        let expected_graphviz = r#"[
+        let expected_pg_json = r#"[
   {
     "Plan": {
       "Expressions": [
@@ -2856,13 +2856,10 @@ digraph {
     }
   }
 ]"#;
-        println!("{}", plan.display_pg_json());
 
-        // just test for a few key lines in the output rather than the
-        // whole thing to make test mainteance easier.
-        let graphviz = format!("{}", plan.display_pg_json());
+        let pg_json = format!("{}", plan.display_pg_json());
 
-        assert_eq!(expected_graphviz, graphviz);
+        assert_eq!(expected_pg_json, pg_json);
         Ok(())
     }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -54,6 +54,7 @@ use datafusion_common::{
 };
 
 // backwards compatibility
+use crate::display::PgJsonVisitor;
 pub use datafusion_common::display::{PlanType, StringifiedPlan, ToStringifiedPlan};
 pub use datafusion_common::{JoinConstraint, JoinType};
 
@@ -1293,6 +1294,26 @@ impl LogicalPlan {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 let with_schema = true;
                 let mut visitor = IndentVisitor::new(f, with_schema);
+                match self.0.visit(&mut visitor) {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err(fmt::Error),
+                }
+            }
+        }
+        Wrapper(self)
+    }
+
+    /// Return a `format`able structure that produces plan in postgresql JSON format.
+    ///
+    /// Users can use this format to visualize the plan in existing plan visualization tools, for example [dalibo](https://explain.dalibo.com/)
+    pub fn display_pg_json(&self) -> impl Display + '_ {
+        // Boilerplate structure to wrap LogicalPlan with something
+        // that that can be formatted
+        struct Wrapper<'a>(&'a LogicalPlan);
+        impl<'a> Display for Wrapper<'a> {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                let mut visitor = PgJsonVisitor::new(f);
+                visitor.with_schema(true);
                 match self.0.visit(&mut visitor) {
                     Ok(_) => Ok(()),
                     Err(_) => Err(fmt::Error),
@@ -2776,6 +2797,70 @@ digraph {
         // just test for a few key lines in the output rather than the
         // whole thing to make test mainteance easier.
         let graphviz = format!("{}", plan.display_graphviz());
+
+        assert_eq!(expected_graphviz, graphviz);
+        Ok(())
+    }
+
+    #[test]
+    fn test_display_pg_json() -> Result<()> {
+        let plan = display_plan()?;
+
+        let expected_graphviz = r#"[
+  {
+    "Plan": {
+      "Expressions": [
+        "employee_csv.id"
+      ],
+      "Node Type": "Projection",
+      "Output": [
+        "id"
+      ],
+      "Plans": [
+        {
+          "Condition": "employee_csv.state IN (<subquery>)",
+          "Node Type": "Filter",
+          "Output": [
+            "id",
+            "state"
+          ],
+          "Plans": [
+            {
+              "Node Type": "Subquery",
+              "Output": [
+                "state"
+              ],
+              "Plans": [
+                {
+                  "Node Type": "TableScan",
+                  "Output": [
+                    "state"
+                  ],
+                  "Plans": [],
+                  "Relation Name": "employee_csv"
+                }
+              ]
+            },
+            {
+              "Node Type": "TableScan",
+              "Output": [
+                "id",
+                "state"
+              ],
+              "Plans": [],
+              "Relation Name": "employee_csv"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]"#;
+        println!("{}", plan.display_pg_json());
+
+        // just test for a few key lines in the output rather than the
+        // whole thing to make test mainteance easier.
+        let graphviz = format!("{}", plan.display_pg_json());
 
         assert_eq!(expected_graphviz, graphviz);
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

Related #3606 

## Rationale for this change

[This comment](https://github.com/apache/arrow-datafusion/issues/3606#issuecomment-1259498728) reminds me to have a try on pg json plan, and the visualizer look great to me since we don't need to consider style, but just nodes.

## What changes are included in this PR?

Add a method to convert logical plan to postgresql json plan format, and tested in [dalibo](https://explain.dalibo.com/plan/9bedch8de5hghgc3). 

<img width="1157" alt="image" src="https://github.com/apache/arrow-datafusion/assets/2771941/be752712-93cd-44d4-bde1-cced246ee502">


## Are these changes tested?

Tested in unittest.

## Are there any user-facing changes?

No.
