### PR TITLE
ci: Use toolchain file to pin to specific toolchain version

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -30,14 +30,14 @@ runs:
       run: |
         apt-get update
         apt-get install -y protobuf-compiler
-    - name: Setup Rust toolchain
-      shell: bash
-      # rustfmt is needed for the substrait build script
-      run: |
-        echo "Installing ${{ inputs.rust-version }}"
-        rustup toolchain install ${{ inputs.rust-version }}
-        rustup default ${{ inputs.rust-version }}
-        rustup component add rustfmt
+#    - name: Setup Rust toolchain
+#      shell: bash
+#      # rustfmt is needed for the substrait build script
+#      run: |
+#        echo "Installing ${{ inputs.rust-version }}"
+#        rustup toolchain install ${{ inputs.rust-version }}
+#        rustup default ${{ inputs.rust-version }}
+#        rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime
     - name: Fixup git permissions

--- a/.github/actions/setup-macos-aarch64-builder/action.yaml
+++ b/.github/actions/setup-macos-aarch64-builder/action.yaml
@@ -36,12 +36,12 @@ runs:
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin
         protoc --version
-    - name: Setup Rust toolchain
-      shell: bash
-      run: |
-        rustup update stable
-        rustup toolchain install stable
-        rustup default stable
-        rustup component add rustfmt
+#    - name: Setup Rust toolchain
+#      shell: bash
+#      run: |
+#        rustup update stable
+#        rustup toolchain install stable
+#        rustup default stable
+#        rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime        

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -36,12 +36,12 @@ runs:
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin
         protoc --version
-    - name: Setup Rust toolchain
-      shell: bash
-      run: |
-        rustup update stable
-        rustup toolchain install stable
-        rustup default stable
-        rustup component add rustfmt
+#    - name: Setup Rust toolchain
+#      shell: bash
+#      run: |
+#        rustup update stable
+#        rustup toolchain install stable
+#        rustup default stable
+#        rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime        

--- a/.github/actions/setup-windows-builder/action.yaml
+++ b/.github/actions/setup-windows-builder/action.yaml
@@ -41,6 +41,6 @@ runs:
 #        # Avoid self update to avoid CI failures: https://github.com/apache/arrow-datafusion/issues/9653
 #        rustup toolchain install stable --no-self-update
 #        rustup default stable
-        rustup component add rustfmt
+#        rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime        

--- a/.github/actions/setup-windows-builder/action.yaml
+++ b/.github/actions/setup-windows-builder/action.yaml
@@ -35,12 +35,12 @@ runs:
         unzip $PROTO_ZIP
         export PATH=$PATH:$HOME/d/protoc/bin
         protoc.exe --version
-    - name: Setup Rust toolchain
-      shell: bash
-      run: |
-        # Avoid self update to avoid CI failures: https://github.com/apache/arrow-datafusion/issues/9653
-        rustup toolchain install stable --no-self-update
-        rustup default stable
+#    - name: Setup Rust toolchain
+#      shell: bash
+#      run: |
+#        # Avoid self update to avoid CI failures: https://github.com/apache/arrow-datafusion/issues/9653
+#        rustup toolchain install stable --no-self-update
+#        rustup default stable
         rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime        

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -355,8 +355,6 @@ jobs:
           python -m pip install pyarrow
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
       - name: Run datafusion-common tests
         run: cargo test -p datafusion-common --features=pyarrow
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -356,7 +356,7 @@ jobs:
       - name: Remove preinstall clippy
         run: |
           mv rust-toolchain.toml rust-toolchain.toml.bak
-          rustup component remove clippy
+          rustup component remove clippy-preview
           mv rust-toolchain.toml.bak rust-toolchain.toml
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -355,7 +355,9 @@ jobs:
           python -m pip install pyarrow
       - name: Remove preinstall clippy
         run: |
+          mv rust-toolchain.toml rust-toolchain.toml.bak
           rustup component remove clippy
+          mv rust-toolchain.toml.bak rust-toolchain.toml
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - name: Run datafusion-common tests
@@ -488,7 +490,7 @@ jobs:
         with:
           rust-version: stable
       - name: Install taplo
-        run: cargo +stable install taplo-cli --version ^0.9 --locked
+        run: cargo install taplo-cli --version ^0.9 --locked
       # if you encounter an error, try running 'taplo format' to fix the formatting automatically.
       - name: Check Cargo.toml formatting
         run: taplo format --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -353,6 +353,9 @@ jobs:
         run: |
           echo "LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
           python -m pip install pyarrow
+      - name: Remove preinstall clippy
+        run: |
+          rustup component remove clippy
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - name: Run datafusion-common tests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[toolchain]
+channel = "1.77.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Currently our ci/build scripts uses latest stable toolchain, which makes our build non-reproducible. For example, when rust released a new version and clippy introduced a new rule, a pr may need to fix irrelevant problems caused by toolchain update.

## What changes are included in this PR?

This pr pings rust toolchain to some specific version, so that the build is reproducible.

## Are these changes tested?

Tested in local.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->


