### PR TITLE
fix: ensure mutual compatibility of the two input schemas from recursive CTEs

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -51,9 +51,9 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use datafusion_common::config::FormatOptions;
 use datafusion_common::display::ToStringifiedPlan;
 use datafusion_common::{
-    get_target_functional_dependencies, plan_datafusion_err, plan_err, Column, DFField,
-    DFSchema, DFSchemaRef, DataFusionError, OwnedTableReference, Result, ScalarValue,
-    TableReference, ToDFSchema, UnnestOptions,
+    get_target_functional_dependencies, not_impl_err, plan_datafusion_err, plan_err,
+    Column, DFField, DFSchema, DFSchemaRef, DataFusionError, OwnedTableReference, Result,
+    ScalarValue, TableReference, ToDFSchema, UnnestOptions,
 };
 
 /// Default table name for unnamed table
@@ -132,14 +132,26 @@ impl LogicalPlanBuilder {
     ) -> Result<Self> {
         // TODO: we need to do a bunch of validation here. Maybe more.
         if is_distinct {
-            return Err(DataFusionError::NotImplemented(
-                "Recursive queries with a distinct 'UNION' (in which the previous iteration's results will be de-duplicated) is not supported".to_string(),
-            ));
+            return not_impl_err!(
+                "Recursive queries with a distinct 'UNION' (in which the previous iteration's results will be de-duplicated) is not supported"
+            );
         }
+        // Ensure that the static term and the recursive term have the same number of fields
+        let static_fields_len = self.plan.schema().fields().len();
+        let recurive_fields_len = recursive_term.schema().fields().len();
+        if static_fields_len != recurive_fields_len {
+            return plan_err!(
+                "Non-recursive term and recursive term must have the same number of columns ({} != {})",
+                static_fields_len, recurive_fields_len
+            );
+        }
+        // Ensure that the recursive term has the same field types as the static term
+        let coerced_recusive_term =
+            coerce_plan_expr_for_schema(&recursive_term, self.plan.schema())?;
         Ok(Self::from(LogicalPlan::RecursiveQuery(RecursiveQuery {
             name,
             static_term: Arc::new(self.plan.clone()),
-            recursive_term: Arc::new(recursive_term),
+            recursive_term: Arc::new(coerced_recusive_term),
             is_distinct,
         })))
     }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -146,12 +146,12 @@ impl LogicalPlanBuilder {
             );
         }
         // Ensure that the recursive term has the same field types as the static term
-        let coerced_recusive_term =
+        let coerced_recursive_term =
             coerce_plan_expr_for_schema(&recursive_term, self.plan.schema())?;
         Ok(Self::from(LogicalPlan::RecursiveQuery(RecursiveQuery {
             name,
             static_term: Arc::new(self.plan.clone()),
-            recursive_term: Arc::new(coerced_recusive_term),
+            recursive_term: Arc::new(coerced_recursive_term),
             is_distinct,
         })))
     }

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -714,3 +714,33 @@ RecursiveQueryExec: name=recursive_cte, is_distinct=false
 --------------WorkTableExec: name=recursive_cte
 ------ProjectionExec: expr=[2 as val]
 --------PlaceholderRowExec
+
+# Test issue: https://github.com/apache/arrow-datafusion/issues/9794
+# Non-recursive term and recursive term have different types
+query IT
+WITH RECURSIVE my_cte AS(
+    SELECT 1::int AS a
+    UNION ALL
+    SELECT a::bigint+2 FROM my_cte WHERE a<3
+) SELECT *, arrow_typeof(a) FROM my_cte;
+----
+1 Int32
+3 Int32
+
+# Test issue: https://github.com/apache/arrow-datafusion/issues/9794
+# Non-recursive term and recursive term have different number of columns
+query error DataFusion error: Error during planning: Non\-recursive term and recursive term must have the same number of columns \(1 != 3\)
+WITH RECURSIVE my_cte AS (
+    SELECT 1::bigint AS a
+    UNION ALL
+    SELECT a+2, 'a','c' FROM my_cte WHERE a<3
+) SELECT * FROM my_cte;
+
+# Test issue: https://github.com/apache/arrow-datafusion/issues/9794
+# Non-recursive term and recursive term have different types, and cannot be casted
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'abc' to value of Int64 type
+WITH RECURSIVE my_cte AS (
+    SELECT 1 AS a
+    UNION ALL
+    SELECT 'abc' FROM my_cte WHERE CAST(a AS text) !='abc'
+) SELECT * FROM my_cte;


### PR DESCRIPTION
## Which issue does this PR close?
Closes #9794.

## Rationale for this change
Make the schema of the recursive term compatible with  the static term.

This differs from the handling of the ordinary [union](https://github.com/apache/arrow-datafusion/blob/ad89ff82421e9c4670f4440dd5a6fa6fb55c40c3/datafusion/expr/src/logical_plan/builder.rs#L1323) operator. We can't change the static term's schema, otherwise we would have to recreate the logic plan of the recursive term, as it depends on the static term through the work table.

That is to say, we use the schema of the static term as the final schema for CTE. 
DuckDB also adopted a similar approach.
```sh
D WITH RECURSIVE my_cte AS(
        SELECT 1::int AS a
        UNION ALL
        SELECT a::bigint+2 FROM my_cte WHERE a<3
    ) SELECT a,typeof(a) FROM my_cte;
┌───────┬───────────┐
│   a   │ typeof(a) │
│ int32 │  varchar  │
├───────┼───────────┤
│     1 │ INTEGER   │
│     3 │ INTEGER   │
└───────┴───────────┘
```
The output type is `INTEGER` from the static term, not `BIGINT`.

## What changes are included in this PR?
Check and coerce the schemas of recursive CTE's inputs.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No