### PR TITLE
perf: Use `Arc<str>` instead of `Cow<&'a>` in the analyzer

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -165,8 +165,8 @@ impl DFSchema {
     ///
     /// To create a schema from an Arrow schema without a qualifier, use
     /// `DFSchema::try_from`.
-    pub fn try_from_qualified_schema<'a>(
-        qualifier: impl Into<TableReference<'a>>,
+    pub fn try_from_qualified_schema(
+        qualifier: impl Into<TableReference>,
         schema: &Schema,
     ) -> Result<Self> {
         let qualifier = qualifier.into();
@@ -181,8 +181,8 @@ impl DFSchema {
     }
 
     /// Create a `DFSchema` from an Arrow schema where all the fields have a given qualifier
-    pub fn from_field_specific_qualified_schema<'a>(
-        qualifiers: Vec<Option<impl Into<TableReference<'a>>>>,
+    pub fn from_field_specific_qualified_schema(
+        qualifiers: Vec<Option<impl Into<TableReference>>>,
         schema: &SchemaRef,
     ) -> Result<Self> {
         let owned_qualifiers = qualifiers

--- a/datafusion/common/src/schema_reference.rs
+++ b/datafusion/common/src/schema_reference.rs
@@ -15,17 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::borrow::Cow;
+use std::{marker::PhantomData, sync::Arc};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SchemaReference<'a> {
-    Bare {
-        schema: Cow<'a, str>,
-    },
-    Full {
-        schema: Cow<'a, str>,
-        catalog: Cow<'a, str>,
-    },
+    Bare { schema: Arc<str> },
+    Full { schema: Arc<str>, catalog: Arc<str> },
+    X { phantom: PhantomData<&'a bool> },
 }
 
 impl SchemaReference<'_> {
@@ -34,6 +30,7 @@ impl SchemaReference<'_> {
         match self {
             SchemaReference::Bare { schema } => schema,
             SchemaReference::Full { schema, catalog: _ } => schema,
+            _ => todo!(),
         }
     }
 }
@@ -45,6 +42,7 @@ impl std::fmt::Display for SchemaReference<'_> {
         match self {
             Self::Bare { schema } => write!(f, "{schema}"),
             Self::Full { schema, catalog } => write!(f, "{catalog}.{schema}"),
+            _ => todo!(),
         }
     }
 }
@@ -53,12 +51,13 @@ impl<'a> From<&'a OwnedSchemaReference> for SchemaReference<'a> {
     fn from(value: &'a OwnedSchemaReference) -> Self {
         match value {
             SchemaReference::Bare { schema } => SchemaReference::Bare {
-                schema: Cow::Borrowed(schema),
+                schema: schema.clone(),
             },
             SchemaReference::Full { schema, catalog } => SchemaReference::Full {
-                schema: Cow::Borrowed(schema),
-                catalog: Cow::Borrowed(catalog),
+                schema: schema.clone(),
+                catalog: catalog.clone(),
             },
+            _ => todo!(),
         }
     }
 }

--- a/datafusion/common/src/schema_reference.rs
+++ b/datafusion/common/src/schema_reference.rs
@@ -19,13 +19,8 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SchemaReference {
-    Bare {
-        schema: Arc<String>,
-    },
-    Full {
-        schema: Arc<String>,
-        catalog: Arc<String>,
-    },
+    Bare { schema: Arc<str> },
+    Full { schema: Arc<str>, catalog: Arc<str> },
 }
 
 impl SchemaReference {

--- a/datafusion/common/src/schema_reference.rs
+++ b/datafusion/common/src/schema_reference.rs
@@ -15,49 +15,42 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum SchemaReference<'a> {
-    Bare { schema: Arc<str> },
-    Full { schema: Arc<str>, catalog: Arc<str> },
-    X { phantom: PhantomData<&'a bool> },
+pub enum SchemaReference {
+    Bare {
+        schema: Arc<String>,
+    },
+    Full {
+        schema: Arc<String>,
+        catalog: Arc<String>,
+    },
 }
 
-impl SchemaReference<'_> {
+impl SchemaReference {
     /// Get only the schema name that this references.
     pub fn schema_name(&self) -> &str {
         match self {
             SchemaReference::Bare { schema } => schema,
             SchemaReference::Full { schema, catalog: _ } => schema,
-            _ => todo!(),
         }
     }
 }
 
-pub type OwnedSchemaReference = SchemaReference<'static>;
+pub type OwnedSchemaReference = SchemaReference;
 
-impl std::fmt::Display for SchemaReference<'_> {
+impl std::fmt::Display for SchemaReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Bare { schema } => write!(f, "{schema}"),
             Self::Full { schema, catalog } => write!(f, "{catalog}.{schema}"),
-            _ => todo!(),
         }
     }
 }
 
-impl<'a> From<&'a OwnedSchemaReference> for SchemaReference<'a> {
+impl<'a> From<&'a OwnedSchemaReference> for SchemaReference {
     fn from(value: &'a OwnedSchemaReference) -> Self {
-        match value {
-            SchemaReference::Bare { schema } => SchemaReference::Bare {
-                schema: schema.clone(),
-            },
-            SchemaReference::Full { schema, catalog } => SchemaReference::Full {
-                schema: schema.clone(),
-                catalog: catalog.clone(),
-            },
-            _ => todo!(),
-        }
+        value.clone()
     }
 }

--- a/datafusion/common/src/table_reference.rs
+++ b/datafusion/common/src/table_reference.rs
@@ -345,7 +345,7 @@ impl<'a> From<&'a String> for TableReference {
     }
 }
 
-impl<'a> From<ResolvedTableReference> for TableReference {
+impl From<ResolvedTableReference> for TableReference {
     fn from(resolved: ResolvedTableReference) -> Self {
         Self::Full {
             catalog: resolved.catalog,

--- a/datafusion/common/src/table_reference.rs
+++ b/datafusion/common/src/table_reference.rs
@@ -22,11 +22,11 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct ResolvedTableReference {
     /// The catalog (aka database) containing the table
-    pub catalog: Arc<String>,
+    pub catalog: Arc<str>,
     /// The schema containing the table
-    pub schema: Arc<String>,
+    pub schema: Arc<str>,
     /// The table name
-    pub table: Arc<String>,
+    pub table: Arc<str>,
 }
 
 impl std::fmt::Display for ResolvedTableReference {
@@ -72,23 +72,23 @@ pub enum TableReference {
     /// An unqualified table reference, e.g. "table"
     Bare {
         /// The table name
-        table: Arc<String>,
+        table: Arc<str>,
     },
     /// A partially resolved table reference, e.g. "schema.table"
     Partial {
         /// The schema containing the table
-        schema: Arc<String>,
+        schema: Arc<str>,
         /// The table name
-        table: Arc<String>,
+        table: Arc<str>,
     },
     /// A fully resolved table reference, e.g. "catalog.schema.table"
     Full {
         /// The catalog (aka database) containing the table
-        catalog: Arc<String>,
+        catalog: Arc<str>,
         /// The schema containing the table
-        schema: Arc<String>,
+        schema: Arc<str>,
         /// The table name
-        table: Arc<String>,
+        table: Arc<str>,
     },
 }
 
@@ -133,7 +133,7 @@ impl TableReference {
     /// "Foo.Bar" (rather than "foo"."bar")
     pub fn bare(table: &str) -> TableReference {
         TableReference::Bare {
-            table: Arc::new(table.into()),
+            table: table.into(),
         }
     }
 
@@ -142,8 +142,8 @@ impl TableReference {
     /// As described on [`TableReference`] this does *NO* parsing at all.
     pub fn partial(schema: &str, table: &str) -> TableReference {
         TableReference::Partial {
-            schema: Arc::new(schema.into()),
-            table: Arc::new(table.into()),
+            schema: schema.into(),
+            table: table.into(),
         }
     }
 
@@ -152,9 +152,9 @@ impl TableReference {
     /// As described on [`TableReference`] this does *NO* parsing at all.
     pub fn full(catalog: &str, schema: &str, table: &str) -> TableReference {
         TableReference::Full {
-            catalog: Arc::new(catalog.into()),
-            schema: Arc::new(schema.into()),
-            table: Arc::new(table.into()),
+            catalog: catalog.into(),
+            schema: schema.into(),
+            table: table.into(),
         }
     }
 
@@ -225,13 +225,13 @@ impl TableReference {
                 table,
             },
             Self::Partial { schema, table } => ResolvedTableReference {
-                catalog: Arc::new(default_catalog.into()),
+                catalog: default_catalog.into(),
                 schema,
                 table,
             },
             Self::Bare { table } => ResolvedTableReference {
-                catalog: Arc::new(default_catalog.into()),
-                schema: Arc::new(default_schema.into()),
+                catalog: default_catalog.into(),
+                schema: default_schema.into(),
                 table,
             },
         }
@@ -291,9 +291,7 @@ impl TableReference {
                 schema: parts.remove(0).into(),
                 table: parts.remove(0).into(),
             },
-            _ => Self::Bare {
-                table: Arc::new(s.into()),
-            },
+            _ => Self::Bare { table: s.into() },
         }
     }
 
@@ -362,29 +360,29 @@ mod tests {
     #[test]
     fn test_table_reference_from_str_normalizes() {
         let expected = TableReference::Full {
-            catalog: Arc::new("catalog".into()),
-            schema: Arc::new("FOO\".bar".into()),
-            table: Arc::new("table".into()),
+            catalog: "catalog".into(),
+            schema: "FOO\".bar".into(),
+            table: "table".into(),
         };
         let actual = TableReference::from("catalog.\"FOO\"\".bar\".TABLE");
         assert_eq!(expected, actual);
 
         let expected = TableReference::Partial {
-            schema: Arc::new("FOO\".bar".into()),
-            table: Arc::new("table".into()),
+            schema: "FOO\".bar".into(),
+            table: "table".into(),
         };
         let actual = TableReference::from("\"FOO\"\".bar\".TABLE");
         assert_eq!(expected, actual);
 
         let expected = TableReference::Bare {
-            table: Arc::new("table".into()),
+            table: "table".into(),
         };
         let actual = TableReference::from("TABLE");
         assert_eq!(expected, actual);
 
         // if fail to parse, take entire input string as identifier
         let expected = TableReference::Bare {
-            table: Arc::new("TABLE()".into()),
+            table: "TABLE()".into(),
         };
         let actual = TableReference::from("TABLE()");
         assert_eq!(expected, actual);

--- a/datafusion/core/src/catalog/listing_schema.rs
+++ b/datafusion/core/src/catalog/listing_schema.rs
@@ -129,7 +129,7 @@ impl ListingSchemaProvider {
             if !self.table_exist(table_name) {
                 let table_url = format!("{}/{}", self.authority, table_path);
 
-                let name = OwnedTableReference::bare(table_name.to_string());
+                let name = OwnedTableReference::bare(table_name);
                 let provider = self
                     .factory
                     .create(

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -184,7 +184,7 @@ mod tests {
         let factory = ListingTableFactory::new();
         let context = SessionContext::new();
         let state = context.state();
-        let name = OwnedTableReference::bare("foo".to_string());
+        let name = OwnedTableReference::bare("foo");
         let cmd = CreateExternalTable {
             name,
             location: csv_file.path().to_str().unwrap().to_string(),
@@ -222,7 +222,7 @@ mod tests {
         let factory = ListingTableFactory::new();
         let context = SessionContext::new();
         let state = context.state();
-        let name = OwnedTableReference::bare("foo".to_string());
+        let name = OwnedTableReference::bare("foo");
 
         let mut options = HashMap::new();
         options.insert("format.schema_infer_max_rec".to_owned(), "1000".to_owned());

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -704,6 +704,7 @@ impl SessionContext {
                 SchemaReference::Bare { .. } => {
                     state.config_options().catalog.default_catalog.to_string()
                 }
+                _ => todo!(),
             };
             if let Some(catalog) = state.catalog_list.catalog(&catalog_name) {
                 catalog
@@ -1533,7 +1534,8 @@ impl SessionState {
         table_ref: impl Into<TableReference<'a>>,
     ) -> Result<Arc<dyn SchemaProvider>> {
         let resolved_ref = self.resolve_table_ref(table_ref);
-        if self.config.information_schema() && resolved_ref.schema == INFORMATION_SCHEMA {
+        if self.config.information_schema() && *resolved_ref.schema == *INFORMATION_SCHEMA
+        {
             return Ok(Arc::new(InformationSchemaProvider::new(
                 self.catalog_list.clone(),
             )));

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -344,7 +344,7 @@ impl SessionContext {
         let table = MemTable::try_new(batch.schema(), vec![vec![batch]])?;
         self.register_table(
             TableReference::Bare {
-                table: Arc::new(table_name.into()),
+                table: table_name.into(),
             },
             Arc::new(table),
         )
@@ -1039,9 +1039,7 @@ impl SessionContext {
             .with_schema(resolved_schema);
         let table = ListingTable::try_new(config)?.with_definition(sql_definition);
         self.register_table(
-            TableReference::Bare {
-                table: Arc::new(name.into()),
-            },
+            TableReference::Bare { table: name.into() },
             Arc::new(table),
         )?;
         Ok(())

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -65,7 +65,7 @@ pub fn scan_empty(
 ) -> Result<LogicalPlanBuilder> {
     let table_schema = Arc::new(table_schema.clone());
     let provider = Arc::new(EmptyTable::new(table_schema));
-    let name = TableReference::bare(name.unwrap_or(UNNAMED_TABLE).to_string());
+    let name = TableReference::bare(name.unwrap_or(UNNAMED_TABLE));
     LogicalPlanBuilder::scan(name, provider_as_source(provider), projection)
 }
 
@@ -78,7 +78,7 @@ pub fn scan_empty_with_partitions(
 ) -> Result<LogicalPlanBuilder> {
     let table_schema = Arc::new(table_schema.clone());
     let provider = Arc::new(EmptyTable::new(table_schema).with_partitions(partitions));
-    let name = TableReference::bare(name.unwrap_or(UNNAMED_TABLE).to_string());
+    let name = TableReference::bare(name.unwrap_or(UNNAMED_TABLE));
     LogicalPlanBuilder::scan(name, provider_as_source(provider), projection)
 }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1424,8 +1424,8 @@ pub fn subquery_alias(
 
 /// Create a LogicalPlanBuilder representing a scan of a table with the provided name and schema.
 /// This is mostly used for testing and documentation.
-pub fn table_scan<'a>(
-    name: Option<impl Into<TableReference<'a>>>,
+pub fn table_scan(
+    name: Option<impl Into<TableReference>>,
     table_schema: &Schema,
     projection: Option<Vec<usize>>,
 ) -> Result<LogicalPlanBuilder> {
@@ -1435,8 +1435,8 @@ pub fn table_scan<'a>(
 /// Create a LogicalPlanBuilder representing a scan of a table with the provided name and schema,
 /// and inlined filters.
 /// This is mostly used for testing and documentation.
-pub fn table_scan_with_filters<'a>(
-    name: Option<impl Into<TableReference<'a>>>,
+pub fn table_scan_with_filters(
+    name: Option<impl Into<TableReference>>,
     table_schema: &Schema,
     projection: Option<Vec<usize>>,
     filters: Vec<Expr>,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1911,7 +1911,7 @@ mod tests {
                 },
                 _,
             )) => {
-                assert_eq!("employee_csv", table);
+                assert_eq!(*"employee_csv", *table);
                 assert_eq!("id", &name);
                 Ok(())
             }
@@ -1941,7 +1941,7 @@ mod tests {
                 },
                 _,
             )) => {
-                assert_eq!("employee_csv", table);
+                assert_eq!(*"employee_csv", *table);
                 assert_eq!("state", &name);
                 Ok(())
             }

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -223,17 +223,17 @@ impl TryFrom<protobuf::OwnedTableReference> for OwnedTableReference {
 
         match table_reference_enum {
             TableReferenceEnum::Bare(protobuf::BareTableReference { table }) => {
-                Ok(OwnedTableReference::bare(table))
+                Ok(OwnedTableReference::bare(&table))
             }
             TableReferenceEnum::Partial(protobuf::PartialTableReference {
                 schema,
                 table,
-            }) => Ok(OwnedTableReference::partial(schema, table)),
+            }) => Ok(OwnedTableReference::partial(&schema, &table)),
             TableReferenceEnum::Full(protobuf::FullTableReference {
                 catalog,
                 schema,
                 table,
-            }) => Ok(OwnedTableReference::full(catalog, schema, table)),
+            }) => Ok(OwnedTableReference::full(&catalog, &schema, &table)),
         }
     }
 }

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1488,7 +1488,6 @@ impl From<OwnedTableReference> for protobuf::OwnedTableReference {
                 schema: schema.to_string(),
                 table: table.to_string(),
             }),
-            _ => todo!(),
         };
 
         protobuf::OwnedTableReference {

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1488,6 +1488,7 @@ impl From<OwnedTableReference> for protobuf::OwnedTableReference {
                 schema: schema.to_string(),
                 table: table.to_string(),
             }),
+            _ => todo!(),
         };
 
         protobuf::OwnedTableReference {

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -245,22 +245,22 @@ fn form_identifier(idents: &[String]) -> Result<(Option<TableReference>, &String
         1 => Ok((None, &idents[0])),
         2 => Ok((
             Some(TableReference::Bare {
-                table: (&idents[0]).into(),
+                table: idents[0].clone().into(),
             }),
             &idents[1],
         )),
         3 => Ok((
             Some(TableReference::Partial {
-                schema: (&idents[0]).into(),
-                table: (&idents[1]).into(),
+                schema: idents[0].clone().into(),
+                table: idents[1].clone().into(),
             }),
             &idents[2],
         )),
         4 => Ok((
             Some(TableReference::Full {
-                catalog: (&idents[0]).into(),
-                schema: (&idents[1]).into(),
-                table: (&idents[2]).into(),
+                catalog: idents[0].clone().into(),
+                schema: idents[1].clone().into(),
+                table: idents[2].clone().into(),
             }),
             &idents[3],
         )),

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -338,7 +338,7 @@ mod test {
     // where ensure generated search terms are in correct order with correct values
     fn test_generate_schema_search_terms() -> Result<()> {
         type ExpectedItem = (
-            Option<TableReference<'static>>,
+            Option<TableReference>,
             &'static str,
             &'static [&'static str],
         );

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -307,7 +307,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let plan = self.apply_expr_alias(plan, alias.columns)?;
 
         LogicalPlanBuilder::from(plan)
-            .alias(TableReference::bare(self.normalizer.normalize(alias.name)))?
+            .alias(TableReference::bare(&self.normalizer.normalize(alias.name)))?
             .build()
     }
 
@@ -530,18 +530,18 @@ pub(crate) fn idents_to_table_reference(
     match taker.0.len() {
         1 => {
             let table = taker.take(enable_normalization);
-            Ok(OwnedTableReference::bare(table))
+            Ok(OwnedTableReference::bare(&table))
         }
         2 => {
             let table = taker.take(enable_normalization);
             let schema = taker.take(enable_normalization);
-            Ok(OwnedTableReference::partial(schema, table))
+            Ok(OwnedTableReference::partial(&schema, &table))
         }
         3 => {
             let table = taker.take(enable_normalization);
             let schema = taker.take(enable_normalization);
             let catalog = taker.take(enable_normalization);
-            Ok(OwnedTableReference::full(catalog, schema, table))
+            Ok(OwnedTableReference::full(&catalog, &schema, &table))
         }
         _ => plan_err!("Unsupported compound identifier '{:?}'", taker.0),
     }

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -55,7 +55,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .get_table_function_source(&tbl_func_name, args)?;
                     let plan = LogicalPlanBuilder::scan(
                         TableReference::Bare {
-                            table: std::borrow::Cow::Borrowed("tmp_table"),
+                            table: "tmp_table".into(),
                         },
                         provider,
                         None,

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{not_impl_err, plan_err, DFSchema, Result, TableReference};
 use datafusion_expr::{expr::Unnest, Expr, LogicalPlan, LogicalPlanBuilder};
@@ -55,7 +57,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .get_table_function_source(&tbl_func_name, args)?;
                     let plan = LogicalPlanBuilder::scan(
                         TableReference::Bare {
-                            table: "tmp_table".into(),
+                            table: Arc::new("tmp_table".into()),
                         },
                         provider,
                         None,

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
-
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_common::{not_impl_err, plan_err, DFSchema, Result, TableReference};
 use datafusion_expr::{expr::Unnest, Expr, LogicalPlan, LogicalPlanBuilder};
@@ -57,7 +55,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         .get_table_function_source(&tbl_func_name, args)?;
                     let plan = LogicalPlanBuilder::scan(
                         TableReference::Bare {
-                            table: Arc::new("tmp_table".into()),
+                            table: "tmp_table".into(),
                         },
                         provider,
                         None,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -396,7 +396,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             TableReference::Full { catalog: _, schema: _, table: _ } => {
                                 Err(ParserError("Invalid schema specifier (has 3 parts)".to_string()))
                             },
-                            _ => todo!(),
                         }?;
                         Ok(LogicalPlan::Ddl(DdlStatement::DropCatalogSchema(DropCatalogSchema {
                             name,
@@ -1511,8 +1510,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Return true if there is a table provider available for "schema.table"
     fn has_table(&self, schema: &str, table: &str) -> bool {
         let tables_reference = TableReference::Partial {
-            schema: schema.into(),
-            table: table.into(),
+            schema: Arc::new(schema.into()),
+            table: Arc::new(table.into()),
         };
         self.context_provider
             .get_table_source(tables_reference)

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -396,6 +396,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             TableReference::Full { catalog: _, schema: _, table: _ } => {
                                 Err(ParserError("Invalid schema specifier (has 3 parts)".to_string()))
                             },
+                            _ => todo!(),
                         }?;
                         Ok(LogicalPlan::Ddl(DdlStatement::DropCatalogSchema(DropCatalogSchema {
                             name,
@@ -994,7 +995,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             self.build_order_by(order_exprs, &df_schema, &mut planner_context)?;
 
         // External tables do not support schemas at the moment, so the name is just a table name
-        let name = OwnedTableReference::bare(name);
+        let name = OwnedTableReference::bare(&name);
         let constraints =
             Constraints::new_from_table_constraints(&all_constraints, &df_schema)?;
         Ok(LogicalPlan::Ddl(DdlStatement::CreateExternalTable(

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1510,8 +1510,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Return true if there is a table provider available for "schema.table"
     fn has_table(&self, schema: &str, table: &str) -> bool {
         let tables_reference = TableReference::Partial {
-            schema: Arc::new(schema.into()),
-            table: Arc::new(table.into()),
+            schema: schema.into(),
+            table: table.into(),
         };
         self.context_provider
             .get_table_source(tables_reference)

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -460,16 +460,16 @@ pub async fn from_substrait_rel(
                         return plan_err!("No table name found in NamedTable");
                     }
                     1 => TableReference::Bare {
-                        table: (&nt.names[0]).into(),
+                        table: nt.names[0].clone().into(),
                     },
                     2 => TableReference::Partial {
-                        schema: (&nt.names[0]).into(),
-                        table: (&nt.names[1]).into(),
+                        schema: nt.names[0].clone().into(),
+                        table: nt.names[1].clone().into(),
                     },
                     _ => TableReference::Full {
-                        catalog: (&nt.names[0]).into(),
-                        schema: (&nt.names[1]).into(),
-                        table: (&nt.names[2]).into(),
+                        catalog: nt.names[0].clone().into(),
+                        schema: nt.names[1].clone().into(),
+                        table: nt.names[2].clone().into(),
                     },
                 };
                 let t = ctx.table(table_reference).await?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes  #9764

## Rationale for this change
In the analyzer there are mostly immutable strings so we may want to use `Arc<str>` which performs better than `Cow<&'a str>` for immutable strings
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Replace datatype

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
