### PR TITLE
datafusion-cli support for multiple commands in a single line

### DIFF
--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -330,4 +330,39 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_split_from_semicolon() {
+        let sql = "SELECT 1; SELECT 2;";
+        let expected = vec!["SELECT 1;", "SELECT 2;"];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = r#"SELECT ";";"#;
+        let expected = vec![r#"SELECT ";";"#];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = "SELECT ';';";
+        let expected = vec!["SELECT ';';"];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = r#"SELECT 1; SELECT 'value;value'; SELECT 1 as "text;text";"#;
+        let expected = vec![
+            "SELECT 1;",
+            "SELECT 'value;value';",
+            r#"SELECT 1 as "text;text";"#,
+        ];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = "";
+        let expected: Vec<String> = Vec::new();
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = "SELECT 1";
+        let expected = vec!["SELECT 1;"];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+
+        let sql = "SELECT 1;   ";
+        let expected = vec!["SELECT 1;"];
+        assert_eq!(split_from_semicolon(sql.to_string()), expected);
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While we can write CLI commands sequentially such as:
```
CREATE TABLE test1 (
    c1 VARCHAR(255),
    c2 INT,
    c3 INT
);

INSERT INTO test1 (c1, c2, c3) VALUES ('c', 2, 1);

SELECT * FROM test1;
```

CLI gives error to write more commands after "CREATE EXTERNAL TABLE":
```
CREATE EXTERNAL TABLE test1 (
    c1 VARCHAR(255),
    c2 INT,
    c3 INT,
    ...
)
STORED AS CSV
WITH HEADER ROW
LOCATION '/Users/berkaysahin/Desktop/datafusion-upstream/testing/data/csv/aggregate_test_100.csv';

SELECT * FROM test1;
```
`🤔 Invalid statement: sql parser error: Expected end of statement, found: SELECT`

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR addresses the issue that we needed to enter commands one by one for creating external tables. It resolves this by splitting the entire string at semicolons, ensuring each segment passes parser checks one by one, and then executing them sequentially.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
