### PR TITLE
feat: pass SessionState not SessionConfig to FunctionFactory::create

### DIFF
--- a/datafusion-examples/examples/function_factory.rs
+++ b/datafusion-examples/examples/function_factory.rs
@@ -16,8 +16,9 @@
 // under the License.
 
 use datafusion::error::Result;
-use datafusion::execution::config::SessionConfig;
-use datafusion::execution::context::{FunctionFactory, RegisterFunction, SessionContext};
+use datafusion::execution::context::{
+    FunctionFactory, RegisterFunction, SessionContext, SessionState,
+};
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::{exec_err, internal_err, DataFusionError};
 use datafusion_expr::simplify::ExprSimplifyResult;
@@ -91,7 +92,7 @@ impl FunctionFactory for CustomFunctionFactory {
     /// the function instance.
     async fn create(
         &self,
-        _state: &SessionConfig,
+        _state: &SessionState,
         statement: CreateFunction,
     ) -> Result<RegisterFunction> {
         let f: ScalarFunctionWrapper = statement.try_into()?;

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -794,7 +794,7 @@ impl SessionContext {
             let function_factory = &state.function_factory;
 
             match function_factory {
-                Some(f) => f.create(state.config(), stmt).await?,
+                Some(f) => f.create(&state, stmt).await?,
                 _ => Err(DataFusionError::Configuration(
                     "Function factory has not been configured".into(),
                 ))?,
@@ -1288,7 +1288,7 @@ pub trait FunctionFactory: Sync + Send {
     /// Handles creation of user defined function specified in [CreateFunction] statement
     async fn create(
         &self,
-        state: &SessionConfig,
+        state: &SessionState,
         statement: CreateFunction,
     ) -> Result<RegisterFunction>;
 }

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -747,7 +747,7 @@ struct CustomFunctionFactory {}
 impl FunctionFactory for CustomFunctionFactory {
     async fn create(
         &self,
-        _state: &SessionConfig,
+        _state: &SessionState,
         statement: CreateFunction,
     ) -> Result<RegisterFunction> {
         let f: ScalarFunctionWrapper = statement.try_into()?;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9838.

## Rationale for this change

Right now `FunctionFactory::create` takes a `&SessionConfig` and not a `&SessionState`. This limits some of its utility (e.g. access to the object store) and makes it currently out of line with at least `TableProviderFactory`, which takes a `&SessionState` as well. The name of the parameter is also `state` which makes me think that was the original intention.

## What changes are included in this PR?

Update the trait signature for `FunctionFactory::create` so that gets passed `&SessionState`.

## Are these changes tested?

Existing tests around `FunctionFactory` are mostly unchanged.

## Are there any user-facing changes?

Users of `FunctionFactory` will have to update their code.

Edit: I can't add the api-change label or I would.