### PR TITLE
doc: Add `Spice.ai` to Known Users

### DIFF
--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -116,6 +116,7 @@ Here are some active projects using DataFusion:
 - [Restate](https://github.com/restatedev) Easily build resilient applications using distributed durable async/await
 - [ROAPI](https://github.com/roapi/roapi)
 - [Seafowl](https://github.com/splitgraph/seafowl) CDN-friendly analytical database
+- [Spice.ai](https://github.com/spiceai/spiceai) Unified SQL query interface & materialization engine
 - [Synnada](https://synnada.ai/) Streaming-first framework for data products
 - [VegaFusion](https://vegafusion.io/) Server-side acceleration for the [Vega](https://vega.github.io/) visualization grammar
 - [ZincObserve](https://github.com/zinclabs/zincobserve) Distributed cloud native observability platform
@@ -146,6 +147,7 @@ Here are some less active projects that used DataFusion:
 [qv]: https://github.com/timvw/qv
 [roapi]: https://github.com/roapi/roapi
 [seafowl]: https://github.com/splitgraph/seafowl
+[spice.ai]: https://github.com/spiceai/spiceai
 [synnada]: https://synnada.ai/
 [tensorbase]: https://github.com/tensorbase/tensorbase
 [vegafusion]: https://vegafusion.io/


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Adds [`Spice.ai`](https://github.com/spiceai/spiceai) to the list of known DataFusion users.

## What changes are included in this PR?

Update https://arrow.apache.org/datafusion/user-guide/introduction.html#known-users to add Spice.ai as a Known User. 

## Are these changes tested?

## Are there any user-facing changes?