### PR TITLE
Minor: Remove TPCH scale factor 10 from PR benchmark checks

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -28,9 +28,8 @@ jobs:
           cd benchmarks
           mkdir data
           
-          # Setup the TPC-H data sets for scale factors 1 and 10
+          # Setup the TPC-H data sets for scale factor 1
           ./bench.sh data tpch
-          ./bench.sh data tpch10
 
       - name: Generate unique result names
         run: |
@@ -46,8 +45,6 @@ jobs:
 
           ./bench.sh run tpch
           ./bench.sh run tpch_mem
-          ./bench.sh run tpch10
-          ./bench.sh run tpch_mem10
           
           # For some reason this step doesn't seem to propagate the env var down into the script
           if [ -d "results/HEAD" ]; then


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Suggested by @gruuya on https://github.com/apache/arrow-datafusion/pull/9855#issuecomment-2027109546

The TPCH SF10 benchmarks OOM on github runners -- https://github.com/apache/arrow-datafusion/pull/9800#issuecomment-2026073276

## What changes are included in this PR?

Partially revert https://github.com/apache/arrow-datafusion/pull/9822 to not run TPCH 


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
