### PR TITLE
Minor: Remove the bench most likely to cause OOM in CI

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -47,7 +47,6 @@ jobs:
           ./bench.sh run tpch
           ./bench.sh run tpch_mem
           ./bench.sh run tpch10
-          ./bench.sh run tpch_mem10
           
           # For some reason this step doesn't seem to propagate the env var down into the script
           if [ -d "results/HEAD" ]; then
@@ -70,7 +69,6 @@ jobs:
           ./bench.sh run tpch
           ./bench.sh run tpch_mem
           ./bench.sh run tpch10
-          ./bench.sh run tpch_mem10
           
           echo ${{ github.event.issue.number }} > pr
           


### PR DESCRIPTION
## Which issue does this PR close?

Addresses issue found in https://github.com/apache/arrow-datafusion/pull/9800#issuecomment-2026073276.

Closes https://github.com/apache/arrow-datafusion/pull/9856

Part of https://github.com/apache/arrow-datafusion/issues/5504

## Rationale for this change

TPC-H 10 in-mem is probably to large to handle inside shared runners.

## What changes are included in this PR?

Remove the recently added tpch_mem10 bench.

## Are these changes tested?

## Are there any user-facing changes?

Only for devs (should see TPC-H 1, 1-mem and 10 benches now only).
