### PR TITLE
Minor: Move depcheck out of datafusion crate (200 less crates to compile)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,6 +164,25 @@ jobs:
       - name: Verify Working Directory Clean
         run: git diff --exit-code
 
+  depcheck:
+    name: circular dependency check
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check dependencies
+        run: |
+          cd dev/depcheck
+          cargo run 
+
   # Run `cargo test doc` (test documentation examples)
   linux-test-doc:
     name: cargo test doc (amd64)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [workspace]
-exclude = ["datafusion-cli"]
+exclude = ["datafusion-cli", "dev/depcheck"]
 members = [
     "datafusion/common",
     "datafusion/common-runtime",

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -130,7 +130,6 @@ zstd = { version = "0.13", optional = true, default-features = false }
 [dev-dependencies]
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }
-cargo = "0.78.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
 csv = "1.1.6"
 ctor = { workspace = true }

--- a/dev/depcheck/Cargo.toml
+++ b/dev/depcheck/Cargo.toml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Circular dependency checker for DataFusion
+[package]
+name = "depcheck"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cargo = "0.78.1"

--- a/dev/depcheck/README.md
+++ b/dev/depcheck/README.md
@@ -21,6 +21,6 @@ This directory contains a tool that ensures there are no circular dependencies
 in the DataFusion codebase.
 
 Specifically, it checks that no create's tests depend on another crate which
-depends on the first, which prevents publishing to crates.io, for exmample
+depends on the first, which prevents publishing to crates.io, for example
 
 [issue 9272]: https://github.com/apache/arrow-datafusion/issues/9277:

--- a/dev/depcheck/README.md
+++ b/dev/depcheck/README.md
@@ -1,0 +1,26 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+This directory contains a tool that ensures there are no circular dependencies
+in the DataFusion codebase.
+
+Specifically, it checks that no create's tests depend on another crate which
+depends on the first, which prevents publishing to crates.io, for exmample
+
+[issue 9272]: https://github.com/apache/arrow-datafusion/issues/9277:


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/9278, follow on to https://github.com/apache/arrow-datafusion/pull/9292


## Rationale for this change
I want DataFusion to compile quickly and be a nice development experience, so the faster the compilation / fewer dependencies the better in general. 


I have been wondering why compiling datafusion takes so long and requires compiling crates like gix (which is an implementation of git) https://github.com/apache/arrow-datafusion/pull/9844#pullrequestreview-1968625669 got me inspired to look into this:
```
...
   Compiling gix-attributes v0.20.1
   Compiling gix-credentials v0.22.0
   Compiling gix-ignore v0.9.1
...
```

It turns out the dependencies were needed by the `depcheck` test, added in https://github.com/apache/arrow-datafusion/pull/9292.  There is no need to compile 200 extra crates everytime someone runs `cargo test`, I think it is enough if this tool runs as part of CI.


## What changes are included in this PR?
move the `depcheck` test into its own binary (not part of the main workspace) and only run that as part of CI

## Are these changes tested?

There is a new CI job and I manually tested that it catches issues

<details><summary>Manual Testing Details</summary>
<p>


### Negative Test
I locally introduced a circular dependency:

```diff
diff --git a/datafusion/functions/Cargo.toml b/datafusion/functions/Cargo.toml
index 3ae306101..cde0742fc 100644
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -83,6 +83,7 @@ uuid = { version = "1.7", features = ["v4"], optional = true }

 [dev-dependencies]
 criterion = "0.5"
+datafusion = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 ```

The test now fails

```shell
 andrewlamb@Andrews-MacBook-Pro:~/Software/arrow-datafusion2$ (cd dev/depcheck && cargo run)
    Compiling depcheck v0.0.0 (/Users/andrewlamb/Software/arrow-datafusion2/dev/depcheck)
     Finished dev [unoptimized + debuginfo] target(s) in 0.49s
      Running `target/debug/depcheck`
 Checking for circular dependencies in /Users/andrewlamb/Software/arrow-datafusion2/Cargo.toml
 thread 'main' panicked at src/main.rs:84:9:
 circular dependency detected from datafusion to self via one of {"datafusion-functions", "datafusion-execution", "datafusion-common-runtime", "datafusion-expr", "datafusion-common"}
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

When I remove the local dependency, the test passes:
```shell
andrewlamb@Andrews-MacBook-Pro:~/Software/arrow-datafusion2$ (cd dev/depcheck && cargo run)
   Compiling depcheck v0.0.0 (/Users/andrewlamb/Software/arrow-datafusion2/dev/depcheck)
    Finished dev [unoptimized + debuginfo] target(s) in 0.50s
     Running `target/debug/depcheck`
Checking for circular dependencies in /Users/andrewlamb/Software/arrow-datafusion2/Cargo.toml
No circular dependencies found
```


</p>
</details> 


## Are there any user-facing changes?
Faster compilation times (200 less crates to compile!)

Previously, running `cargo test` required compiling 838 crates!

With this change we are down to 647 crates (still a crazy number)

It also seems to make the CI jobs significantly faster:
1. [before this PR](https://github.com/apache/arrow-datafusion/actions/runs/8481892233/job/23240381441): 11m4s
2. [after this PR](https://github.com/apache/arrow-datafusion/actions/runs/8482181379/job/23241096554?pr=9865): 915s

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
