### PR TITLE
Simplify Expr::map_children

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -534,6 +534,18 @@ impl<T> Transformed<T> {
 
 /// Transformation helper to process sequence of iterable tree nodes that are siblings.
 pub trait TransformedIterator: Iterator {
+    /// Apples `f` to each item in this iterator
+    /// 
+    /// Visits all items in the iterator unless
+    /// `f` returns an error or `f` returns TreeNodeRecursion::stop.
+    ///
+    /// # Returns 
+    /// Error if f returns an error 
+    ///
+    /// Ok(Transformed) such that: 
+    /// 1. `transformed` is true if any return from `f` had transformed true
+    /// 2. `data` from the last invocation of `f`
+    /// 3. `tnr` from the last invocation of `f` or `Continue` if the iterator is empty
     fn map_until_stop_and_collect<
         F: FnMut(Self::Item) -> Result<Transformed<Self::Item>>,
     >(

--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -616,7 +616,7 @@ macro_rules! map_until_stop_and_collect {
                     },
                 )*
             );
-            Ok(Transformed::new(data, transformed, tnr))
+            Ok(Transformed::new(all_datas, transformed, tnr))
         })
     }}
 }

--- a/datafusion/expr/src/tree_node/expr.rs
+++ b/datafusion/expr/src/tree_node/expr.rs
@@ -28,8 +28,7 @@ use datafusion_common::tree_node::{
     Transformed, TransformedIterator, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::{
-    handle_visit_recursion, internal_err, map_until_stop_and_collect, DataFusionError,
-    Result,
+    handle_visit_recursion, internal_err, map_until_stop_and_collect, Result,
 };
 
 impl TreeNode for Expr {

--- a/datafusion/expr/src/tree_node/expr.rs
+++ b/datafusion/expr/src/tree_node/expr.rs
@@ -170,11 +170,10 @@ impl TreeNode for Expr {
             }),
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
                 map_until_stop_and_collect!(
-                    left,
-                    |left| transform_box(left, &mut f),
+                    transform_box(left, &mut f),
                     right,
-                    |right| transform_box(right, &mut f)
-                )
+                    transform_box(right, &mut f)
+                )?
                 .update_data(|(new_left, new_right)| {
                     Expr::BinaryExpr(BinaryExpr::new(new_left, op, new_right))
                 })
@@ -186,11 +185,10 @@ impl TreeNode for Expr {
                 escape_char,
                 case_insensitive,
             }) => map_until_stop_and_collect!(
-                expr,
-                |expr| transform_box(expr, &mut f),
+                transform_box(expr, &mut f),
                 pattern,
-                |pattern| transform_box(pattern, &mut f)
-            )
+                transform_box(pattern, &mut f)
+            )?
             .update_data(|(new_expr, new_pattern)| {
                 Expr::Like(Like::new(
                     negated,
@@ -207,11 +205,10 @@ impl TreeNode for Expr {
                 escape_char,
                 case_insensitive,
             }) => map_until_stop_and_collect!(
-                expr,
-                |expr| transform_box(expr, &mut f),
+                transform_box(expr, &mut f),
                 pattern,
-                |pattern| transform_box(pattern, &mut f)
-            )
+                transform_box(pattern, &mut f)
+            )?
             .update_data(|(new_expr, new_pattern)| {
                 Expr::SimilarTo(Like::new(
                     negated,
@@ -251,13 +248,12 @@ impl TreeNode for Expr {
                 low,
                 high,
             }) => map_until_stop_and_collect!(
-                expr,
-                |expr| transform_box(expr, &mut f),
+                transform_box(expr, &mut f),
                 low,
-                |low| transform_box(low, &mut f),
+                transform_box(low, &mut f),
                 high,
-                |high| transform_box(high, &mut f)
-            )
+                transform_box(high, &mut f)
+            )?
             .update_data(|(new_expr, new_low, new_high)| {
                 Expr::Between(Between::new(new_expr, negated, new_low, new_high))
             }),
@@ -266,22 +262,20 @@ impl TreeNode for Expr {
                 when_then_expr,
                 else_expr,
             }) => map_until_stop_and_collect!(
-                expr,
-                |expr| transform_option_box(expr, &mut f),
+                transform_option_box(expr, &mut f),
                 when_then_expr,
-                |when_then_expr: Vec<(Box<Expr>, Box<Expr>)>| when_then_expr
+                when_then_expr
                     .into_iter()
                     .map_until_stop_and_collect(|(when, then)| {
-                        Ok(map_until_stop_and_collect!(
-                            when,
-                            |when| transform_box(when, &mut f),
+                        map_until_stop_and_collect!(
+                            transform_box(when, &mut f),
                             then,
-                            |then| transform_box(then, &mut f)
-                        ))
+                            transform_box(then, &mut f)
+                        )
                     }),
                 else_expr,
-                |else_expr| transform_option_box(else_expr, &mut f)
-            )
+                transform_option_box(else_expr, &mut f)
+            )?
             .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
                 Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
             }),
@@ -316,13 +310,12 @@ impl TreeNode for Expr {
                 window_frame,
                 null_treatment,
             }) => map_until_stop_and_collect!(
-                args,
-                |args| transform_vec(args, &mut f),
+                transform_vec(args, &mut f),
                 partition_by,
-                |partition_by| transform_vec(partition_by, &mut f),
+                transform_vec(partition_by, &mut f),
                 order_by,
-                |order_by| transform_vec(order_by, &mut f)
-            )
+                transform_vec(order_by, &mut f)
+            )?
             .update_data(|(new_args, new_partition_by, new_order_by)| {
                 Expr::WindowFunction(WindowFunction::new(
                     fun,
@@ -341,13 +334,12 @@ impl TreeNode for Expr {
                 order_by,
                 null_treatment,
             }) => map_until_stop_and_collect!(
-                args,
-                |args| transform_vec(args, &mut f),
+                transform_vec(args, &mut f),
                 filter,
-                |filter| transform_option_box(filter, &mut f),
+                transform_option_box(filter, &mut f),
                 order_by,
-                |order_by| transform_option_vec(order_by, &mut f)
-            )
+                transform_option_vec(order_by, &mut f)
+            )?
             .map_data(
                 |(new_args, new_filter, new_order_by)| match func_def {
                     AggregateFunctionDefinition::BuiltIn(fun) => {
@@ -391,11 +383,10 @@ impl TreeNode for Expr {
                 list,
                 negated,
             }) => map_until_stop_and_collect!(
-                expr,
-                |expr| transform_box(expr, &mut f),
+                transform_box(expr, &mut f),
                 list,
-                |list| transform_vec(list, &mut f)
-            )
+                transform_vec(list, &mut f)
+            )?
             .update_data(|(new_expr, new_list)| {
                 Expr::InList(InList::new(new_expr, new_list, negated))
             }),

--- a/datafusion/expr/src/tree_node/expr.rs
+++ b/datafusion/expr/src/tree_node/expr.rs
@@ -27,7 +27,10 @@ use crate::{Expr, GetFieldAccess};
 use datafusion_common::tree_node::{
     Transformed, TransformedIterator, TreeNode, TreeNodeRecursion,
 };
-use datafusion_common::{handle_visit_recursion, internal_err, Result};
+use datafusion_common::{
+    handle_visit_recursion, internal_err, map_until_stop_and_collect, DataFusionError,
+    Result,
+};
 
 impl TreeNode for Expr {
     fn apply_children<F: FnMut(&Self) -> Result<TreeNodeRecursion>>(
@@ -167,15 +170,15 @@ impl TreeNode for Expr {
                 Expr::InSubquery(InSubquery::new(be, subquery, negated))
             }),
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-                transform_box(left, &mut f)?
-                    .update_data(|new_left| (new_left, right))
-                    .try_transform_node(|(new_left, right)| {
-                        Ok(transform_box(right, &mut f)?
-                            .update_data(|new_right| (new_left, new_right)))
-                    })?
-                    .update_data(|(new_left, new_right)| {
-                        Expr::BinaryExpr(BinaryExpr::new(new_left, op, new_right))
-                    })
+                map_until_stop_and_collect!(
+                    left,
+                    |left| transform_box(left, &mut f),
+                    right,
+                    |right| transform_box(right, &mut f)
+                )
+                .update_data(|(new_left, new_right)| {
+                    Expr::BinaryExpr(BinaryExpr::new(new_left, op, new_right))
+                })
             }
             Expr::Like(Like {
                 negated,
@@ -183,42 +186,42 @@ impl TreeNode for Expr {
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => transform_box(expr, &mut f)?
-                .update_data(|new_expr| (new_expr, pattern))
-                .try_transform_node(|(new_expr, pattern)| {
-                    Ok(transform_box(pattern, &mut f)?
-                        .update_data(|new_pattern| (new_expr, new_pattern)))
-                })?
-                .update_data(|(new_expr, new_pattern)| {
-                    Expr::Like(Like::new(
-                        negated,
-                        new_expr,
-                        new_pattern,
-                        escape_char,
-                        case_insensitive,
-                    ))
-                }),
+            }) => map_until_stop_and_collect!(
+                expr,
+                |expr| transform_box(expr, &mut f),
+                pattern,
+                |pattern| transform_box(pattern, &mut f)
+            )
+            .update_data(|(new_expr, new_pattern)| {
+                Expr::Like(Like::new(
+                    negated,
+                    new_expr,
+                    new_pattern,
+                    escape_char,
+                    case_insensitive,
+                ))
+            }),
             Expr::SimilarTo(Like {
                 negated,
                 expr,
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => transform_box(expr, &mut f)?
-                .update_data(|new_expr| (new_expr, pattern))
-                .try_transform_node(|(new_expr, pattern)| {
-                    Ok(transform_box(pattern, &mut f)?
-                        .update_data(|new_pattern| (new_expr, new_pattern)))
-                })?
-                .update_data(|(new_expr, new_pattern)| {
-                    Expr::SimilarTo(Like::new(
-                        negated,
-                        new_expr,
-                        new_pattern,
-                        escape_char,
-                        case_insensitive,
-                    ))
-                }),
+            }) => map_until_stop_and_collect!(
+                expr,
+                |expr| transform_box(expr, &mut f),
+                pattern,
+                |pattern| transform_box(pattern, &mut f)
+            )
+            .update_data(|(new_expr, new_pattern)| {
+                Expr::SimilarTo(Like::new(
+                    negated,
+                    new_expr,
+                    new_pattern,
+                    escape_char,
+                    case_insensitive,
+                ))
+            }),
             Expr::Not(expr) => transform_box(expr, &mut f)?.update_data(Expr::Not),
             Expr::IsNotNull(expr) => {
                 transform_box(expr, &mut f)?.update_data(Expr::IsNotNull)
@@ -248,48 +251,41 @@ impl TreeNode for Expr {
                 negated,
                 low,
                 high,
-            }) => transform_box(expr, &mut f)?
-                .update_data(|new_expr| (new_expr, low, high))
-                .try_transform_node(|(new_expr, low, high)| {
-                    Ok(transform_box(low, &mut f)?
-                        .update_data(|new_low| (new_expr, new_low, high)))
-                })?
-                .try_transform_node(|(new_expr, new_low, high)| {
-                    Ok(transform_box(high, &mut f)?
-                        .update_data(|new_high| (new_expr, new_low, new_high)))
-                })?
-                .update_data(|(new_expr, new_low, new_high)| {
-                    Expr::Between(Between::new(new_expr, negated, new_low, new_high))
-                }),
+            }) => map_until_stop_and_collect!(
+                expr,
+                |expr| transform_box(expr, &mut f),
+                low,
+                |low| transform_box(low, &mut f),
+                high,
+                |high| transform_box(high, &mut f)
+            )
+            .update_data(|(new_expr, new_low, new_high)| {
+                Expr::Between(Between::new(new_expr, negated, new_low, new_high))
+            }),
             Expr::Case(Case {
                 expr,
                 when_then_expr,
                 else_expr,
-            }) => transform_option_box(expr, &mut f)?
-                .update_data(|new_expr| (new_expr, when_then_expr, else_expr))
-                .try_transform_node(|(new_expr, when_then_expr, else_expr)| {
-                    Ok(when_then_expr
-                        .into_iter()
-                        .map_until_stop_and_collect(|(when, then)| {
-                            transform_box(when, &mut f)?
-                                .update_data(|new_when| (new_when, then))
-                                .try_transform_node(|(new_when, then)| {
-                                    Ok(transform_box(then, &mut f)?
-                                        .update_data(|new_then| (new_when, new_then)))
-                                })
-                        })?
-                        .update_data(|new_when_then_expr| {
-                            (new_expr, new_when_then_expr, else_expr)
-                        }))
-                })?
-                .try_transform_node(|(new_expr, new_when_then_expr, else_expr)| {
-                    Ok(transform_option_box(else_expr, &mut f)?.update_data(
-                        |new_else_expr| (new_expr, new_when_then_expr, new_else_expr),
-                    ))
-                })?
-                .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
-                    Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
-                }),
+            }) => map_until_stop_and_collect!(
+                expr,
+                |expr| transform_option_box(expr, &mut f),
+                when_then_expr,
+                |when_then_expr: Vec<(Box<Expr>, Box<Expr>)>| when_then_expr
+                    .into_iter()
+                    .map_until_stop_and_collect(|(when, then)| {
+                        Ok(map_until_stop_and_collect!(
+                            when,
+                            |when| transform_box(when, &mut f),
+                            then,
+                            |then| transform_box(then, &mut f)
+                        ))
+                    }),
+                else_expr,
+                |else_expr| transform_option_box(else_expr, &mut f)
+            )
+            .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
+                Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
+            }),
             Expr::Cast(Cast { expr, data_type }) => transform_box(expr, &mut f)?
                 .update_data(|be| Expr::Cast(Cast::new(be, data_type))),
             Expr::TryCast(TryCast { expr, data_type }) => transform_box(expr, &mut f)?
@@ -320,30 +316,24 @@ impl TreeNode for Expr {
                 order_by,
                 window_frame,
                 null_treatment,
-            }) => transform_vec(args, &mut f)?
-                .update_data(|new_args| (new_args, partition_by, order_by))
-                .try_transform_node(|(new_args, partition_by, order_by)| {
-                    Ok(transform_vec(partition_by, &mut f)?.update_data(
-                        |new_partition_by| (new_args, new_partition_by, order_by),
-                    ))
-                })?
-                .try_transform_node(|(new_args, new_partition_by, order_by)| {
-                    Ok(
-                        transform_vec(order_by, &mut f)?.update_data(|new_order_by| {
-                            (new_args, new_partition_by, new_order_by)
-                        }),
-                    )
-                })?
-                .update_data(|(new_args, new_partition_by, new_order_by)| {
-                    Expr::WindowFunction(WindowFunction::new(
-                        fun,
-                        new_args,
-                        new_partition_by,
-                        new_order_by,
-                        window_frame,
-                        null_treatment,
-                    ))
-                }),
+            }) => map_until_stop_and_collect!(
+                args,
+                |args| transform_vec(args, &mut f),
+                partition_by,
+                |partition_by| transform_vec(partition_by, &mut f),
+                order_by,
+                |order_by| transform_vec(order_by, &mut f)
+            )
+            .update_data(|(new_args, new_partition_by, new_order_by)| {
+                Expr::WindowFunction(WindowFunction::new(
+                    fun,
+                    new_args,
+                    new_partition_by,
+                    new_order_by,
+                    window_frame,
+                    null_treatment,
+                ))
+            }),
             Expr::AggregateFunction(AggregateFunction {
                 args,
                 func_def,
@@ -351,17 +341,16 @@ impl TreeNode for Expr {
                 filter,
                 order_by,
                 null_treatment,
-            }) => transform_vec(args, &mut f)?
-                .update_data(|new_args| (new_args, filter, order_by))
-                .try_transform_node(|(new_args, filter, order_by)| {
-                    Ok(transform_option_box(filter, &mut f)?
-                        .update_data(|new_filter| (new_args, new_filter, order_by)))
-                })?
-                .try_transform_node(|(new_args, new_filter, order_by)| {
-                    Ok(transform_option_vec(order_by, &mut f)?
-                        .update_data(|new_order_by| (new_args, new_filter, new_order_by)))
-                })?
-                .map_data(|(new_args, new_filter, new_order_by)| match func_def {
+            }) => map_until_stop_and_collect!(
+                args,
+                |args| transform_vec(args, &mut f),
+                filter,
+                |filter| transform_option_box(filter, &mut f),
+                order_by,
+                |order_by| transform_option_vec(order_by, &mut f)
+            )
+            .map_data(
+                |(new_args, new_filter, new_order_by)| match func_def {
                     AggregateFunctionDefinition::BuiltIn(fun) => {
                         Ok(Expr::AggregateFunction(AggregateFunction::new(
                             fun,
@@ -384,7 +373,8 @@ impl TreeNode for Expr {
                     AggregateFunctionDefinition::Name(_) => {
                         internal_err!("Function `Expr` with name should be resolved.")
                     }
-                })?,
+                },
+            )?,
             Expr::GroupingSet(grouping_set) => match grouping_set {
                 GroupingSet::Rollup(exprs) => transform_vec(exprs, &mut f)?
                     .update_data(|ve| Expr::GroupingSet(GroupingSet::Rollup(ve))),
@@ -401,15 +391,15 @@ impl TreeNode for Expr {
                 expr,
                 list,
                 negated,
-            }) => transform_box(expr, &mut f)?
-                .update_data(|new_expr| (new_expr, list))
-                .try_transform_node(|(new_expr, list)| {
-                    Ok(transform_vec(list, &mut f)?
-                        .update_data(|new_list| (new_expr, new_list)))
-                })?
-                .update_data(|(new_expr, new_list)| {
-                    Expr::InList(InList::new(new_expr, new_list, negated))
-                }),
+            }) => map_until_stop_and_collect!(
+                expr,
+                |expr| transform_box(expr, &mut f),
+                list,
+                |list| transform_vec(list, &mut f)
+            )
+            .update_data(|(new_expr, new_list)| {
+                Expr::InList(InList::new(new_expr, new_list, negated))
+            }),
             Expr::GetIndexedField(GetIndexedField { expr, field }) => {
                 transform_box(expr, &mut f)?.update_data(|be| {
                     Expr::GetIndexedField(GetIndexedField::new(be, field))


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9457, part of https://github.com/apache/arrow-datafusion/issues/8913

## Rationale for this change

The current implementation of `Expr::map_children()` is very complex, this PR tries to simplify its code.

## What changes are included in this PR?

This PR adds a `map_until_stop_and_collect()` macro, which is similar to `TransformedIterator::map_until_stop_and_collect()` to process sibling tree nodes, but it can process heterogeneous tree node containing expressions.

## Are these changes tested?

Yes, with existing UTs.

## Are there any user-facing changes?

No.
