### PR TITLE
Minor: Add ParquetExec::table_parquet_options accessor

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -1362,6 +1362,8 @@ impl TableOptions {
     }
 }
 
+/// Options that control how Parquet files are read, including global options
+/// that apply to all columns and optional column-specific overrides
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct TableParquetOptions {
     /// Global Parquet options that propagates to all columns.


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9908

## Rationale for this change

See rationale on https://github.com/apache/arrow-datafusion/issues/9908


## What changes are included in this PR?

1. Add ParquetExec::table_parquet_options accessor
2. Improve some comments
3. Improve field name

## Are these changes tested?
By existing CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
