### PR TITLE
test: fix intermittent failure in cte.slt

### DIFF
--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -748,7 +748,7 @@ RecursiveQueryExec: name=recursive_cte, is_distinct=false
 
 # Test issue: https://github.com/apache/arrow-datafusion/issues/9794
 # Non-recursive term and recursive term have different types
-query IT
+query IT rowsort
 WITH RECURSIVE my_cte AS(
     SELECT 1::int AS a
     UNION ALL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9930.

## Rationale for this change
The `RepartitionExec` above `RecursiveQueryExec` may cause the result of this query to be non-deterministic.
```sh
DataFusion CLI v37.0.0
❯ explain WITH RECURSIVE my_cte AS(
    SELECT 1::int AS a
    UNION ALL
    SELECT a::bigint+2 FROM my_cte WHERE a<3
) SELECT *, arrow_typeof(a) FROM my_cte;
+---------------+---------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                        |
+---------------+---------------------------------------------------------------------------------------------+
| physical_plan | ProjectionExec: expr=[a@0 as a, arrow_typeof(a@0) as arrow_typeof(my_cte.a)]                |
|               |   RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1                     |
|               |     RecursiveQueryExec: name=my_cte, is_distinct=false                                      |
|               |       ProjectionExec: expr=[1 as a]                                                         |
|               |         PlaceholderRowExec                                                                  |
|               |       CoalescePartitionsExec                                                                |
|               |         ProjectionExec: expr=[CAST(CAST(a@0 AS Int64) + 2 AS Int32) as my_cte.a + Int64(2)] |
|               |           CoalesceBatchesExec: target_batch_size=8192                                       |
|               |             FilterExec: a@0 < 3                                                             |
|               |               RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1         |
|               |                 WorkTableExec: name=my_cte                                                  |
|               |                                                                                             |
+---------------+---------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.018 seconds.
```

## What changes are included in this PR?
Add `rowsort` to make the query result deterministic.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
