### PR TITLE
Fix tpcds planning stack overflows - Join planning refactoring

### DIFF
--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -30,12 +30,9 @@ runs:
       # 
       # Set debuginfo=line-tables-only as debuginfo=0 causes immensely slow build
       # See for more details: https://github.com/rust-lang/rust/issues/119560
-      #
-      # set RUST_MIN_STACK to avoid rust stack overflows on tpc-ds tests
       run: |
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV  
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
-        echo "RUST_MIN_STACK=3000000" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
      

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -978,61 +978,7 @@ impl DefaultPhysicalPlanner {
                             && matches!(r, Expr::Column(_)))
                     });
                     if has_expr_join_key {
-                        let left_keys = keys
-                            .iter()
-                            .map(|(l, _r)| l)
-                            .cloned()
-                            .collect::<Vec<_>>();
-                        let right_keys = keys
-                            .iter()
-                            .map(|(_l, r)| r)
-                            .cloned()
-                            .collect::<Vec<_>>();
-                        let (left, right, column_on, added_project) = {
-                            let (left, left_col_keys, left_projected) =
-                                wrap_projection_for_join_if_necessary(
-                                    left_keys.as_slice(),
-                                    left.as_ref().clone(),
-                                )?;
-                            let (right, right_col_keys, right_projected) =
-                                wrap_projection_for_join_if_necessary(
-                                    &right_keys,
-                                    right.as_ref().clone(),
-                                )?;
-                            (
-                                left,
-                                right,
-                                (left_col_keys, right_col_keys),
-                                left_projected || right_projected,
-                            )
-                        };
-
-                        let join_plan =
-                            LogicalPlan::Join(Join::try_new_with_project_input(
-                                logical_plan,
-                                Arc::new(left),
-                                Arc::new(right),
-                                column_on,
-                            )?);
-
-                        // Remove temporary projected columns
-                        let join_plan = if added_project {
-                            let final_join_result = join_schema
-                                .iter()
-                                .map(|(qualifier, field)| {
-                                    Expr::Column(datafusion_common::Column::from((qualifier, field.as_ref())))
-                                })
-                                .collect::<Vec<_>>();
-                            let projection =
-                                Projection::try_new(
-                                    final_join_result,
-                                    Arc::new(join_plan),
-                                )?;
-                            LogicalPlan::Projection(projection)
-                        } else {
-                            join_plan
-                        };
-
+                        let join_plan = has_expr_join_key_func(keys,left,right,logical_plan,join_schema)?;
                         return self
                             .create_initial_plan(&join_plan, session_state)
                             .await;
@@ -1999,6 +1945,54 @@ fn tuple_err<T, R>(value: (Result<T>, Result<R>)) -> Result<(T, R)> {
         (Err(e), Ok(_)) => Err(e),
         (Ok(_), Err(e1)) => Err(e1),
         (Err(e), Err(_)) => Err(e),
+    }
+}
+
+// TODO: fix name, add docs
+fn has_expr_join_key_func(
+    keys: &[(Expr, Expr)],
+    left: &Arc<LogicalPlan>,
+    right: &Arc<LogicalPlan>,
+    logical_plan: &LogicalPlan,
+    join_schema: &Arc<DFSchema>,
+) -> Result<LogicalPlan> {
+    let left_keys = keys.iter().map(|(l, _r)| l).cloned().collect::<Vec<_>>();
+    let right_keys = keys.iter().map(|(_l, r)| r).cloned().collect::<Vec<_>>();
+    let (left, right, column_on, added_project) = {
+        let (left, left_col_keys, left_projected) =
+            wrap_projection_for_join_if_necessary(
+                left_keys.as_slice(),
+                left.as_ref().clone(),
+            )?;
+        let (right, right_col_keys, right_projected) =
+            wrap_projection_for_join_if_necessary(&right_keys, right.as_ref().clone())?;
+        (
+            left,
+            right,
+            (left_col_keys, right_col_keys),
+            left_projected || right_projected,
+        )
+    };
+
+    let join_plan = LogicalPlan::Join(Join::try_new_with_project_input(
+        logical_plan,
+        Arc::new(left),
+        Arc::new(right),
+        column_on,
+    )?);
+
+    // Remove temporary projected columns
+    if added_project {
+        let final_join_result = join_schema
+            .iter()
+            .map(|(qualifier, field)| {
+                Expr::Column(datafusion_common::Column::from((qualifier, field.as_ref())))
+            })
+            .collect::<Vec<_>>();
+        let projection = Projection::try_new(final_join_result, Arc::new(join_plan))?;
+        Ok(LogicalPlan::Projection(projection))
+    } else {
+        Ok(join_plan)
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8837

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Thanks to the previous analysis from #1047 and with some lldb debugging, was able to identify that `create_initial_plan(...)` and it's sibling `create_initial_plan_multi(...)` were the culprits for the stack overflow (also identified by this comment https://github.com/apache/arrow-datafusion/issues/8837#issuecomment-1991873404)

So went looking through it and found a place were there was a large number of local variables before the recursive call to `create_initial_plan(...)`/`create_initial_plan_multi(...)` and tested out extracting those into a separate function. This seems to resolve the issue.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Extract local variables and functionality in physical join planning in `create_initial_plan(...)` to a separate function to try reduce stack size before the recursive `create_initial_plan(...)` call

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
