### PR TITLE
Simplify TreeNode recursions

### DIFF
--- a/datafusion/optimizer/src/analyzer/subquery.rs
+++ b/datafusion/optimizer/src/analyzer/subquery.rs
@@ -146,7 +146,7 @@ fn check_inner_plan(
     // We want to support as many operators as possible inside the correlated subquery
     match inner_plan {
         LogicalPlan::Aggregate(_) => {
-            inner_plan.apply_children(&mut |plan| {
+            inner_plan.apply_children(|plan| {
                 check_inner_plan(plan, is_scalar, true, can_contain_outer_ref)?;
                 Ok(TreeNodeRecursion::Continue)
             })?;
@@ -171,7 +171,7 @@ fn check_inner_plan(
         }
         LogicalPlan::Window(window) => {
             check_mixed_out_refer_in_window(window)?;
-            inner_plan.apply_children(&mut |plan| {
+            inner_plan.apply_children(|plan| {
                 check_inner_plan(plan, is_scalar, is_aggregate, can_contain_outer_ref)?;
                 Ok(TreeNodeRecursion::Continue)
             })?;
@@ -188,7 +188,7 @@ fn check_inner_plan(
         | LogicalPlan::Values(_)
         | LogicalPlan::Subquery(_)
         | LogicalPlan::SubqueryAlias(_) => {
-            inner_plan.apply_children(&mut |plan| {
+            inner_plan.apply_children(|plan| {
                 check_inner_plan(plan, is_scalar, is_aggregate, can_contain_outer_ref)?;
                 Ok(TreeNodeRecursion::Continue)
             })?;
@@ -201,7 +201,7 @@ fn check_inner_plan(
             ..
         }) => match join_type {
             JoinType::Inner => {
-                inner_plan.apply_children(&mut |plan| {
+                inner_plan.apply_children(|plan| {
                     check_inner_plan(
                         plan,
                         is_scalar,
@@ -221,7 +221,7 @@ fn check_inner_plan(
                 check_inner_plan(right, is_scalar, is_aggregate, can_contain_outer_ref)
             }
             JoinType::Full => {
-                inner_plan.apply_children(&mut |plan| {
+                inner_plan.apply_children(|plan| {
                     check_inner_plan(plan, is_scalar, is_aggregate, false)?;
                     Ok(TreeNodeRecursion::Continue)
                 })?;


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/8913.

## Rationale for this change

This PR simplifies `TreeNode` recursion declarations by adding 
- `TreeNodeRecursion::visit_children()`,
- `TreeNodeRecursion::visit_sibling()` and
- `TreeNodeRecursion::visit_parent()`

helpers to simplify handling of the current `TreeNodeRecursion` with continuation closures by specifying the next node position relative to the current one.

Similarly, the transforming recursions are simplified with
- `Transfomed::visit_children()`,
- `Transfomed::visit_sibling()` and
- `Transfomed::visit_parent()`

helpers.

After this PR recursion definition of `TreeNode::visit()` is as simple as that:
```
visitor.f_down(self)?
    .visit_children(|| self.apply_children(|c| c.visit(visitor)))?
    .visit_parent(|| visitor.f_up(self))
```
and `TreeNode::rewrite()` became:
```
rewriter.f_down(self)?
    .transform_children(|n| n.map_children(|c| c.rewrite(rewriter)))?
    .transform_parent(|n| rewriter.f_up(n))
```

## What changes are included in this PR?

This PR:
- Adds the above helpers and contains some other minor code cleanup.
- Renames `TransformedIterator` to `TreeNodeIterator` and adds a new `TreeNodeIterator::apply_until_stop()` helper to simplify `TreeNode::apply_children()` implementations.

## Are these changes tested?

Yes, with existint UTs.

## Are there any user-facing changes?

No.
