### PR TITLE
Minor: Return InternalError rather than panic for `NamedStructField should be rewritten in OperatorToFunction`

### DIFF
--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -283,29 +283,23 @@ pub fn create_physical_expr(
             input_dfschema,
             execution_props,
         )?),
-        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => {
-            match field {
-                GetFieldAccess::NamedStructField { name: _ } => {
-                    return internal_err!(
-                        "NamedStructField should be rewritten in OperatorToFunction"
-                    )
-                }
-                GetFieldAccess::ListIndex { key: _ } => {
-                    return internal_err!(
-                        "ListIndex should be rewritten in OperatorToFunction"
-                    )
-                }
-                GetFieldAccess::ListRange {
-                    start: _,
-                    stop: _,
-                    stride: _,
-                } => {
-                    return internal_err!(
-                        "ListRange should be rewritten in OperatorToFunction"
-                    )
-                }
-            };
-        }
+        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => match field {
+            GetFieldAccess::NamedStructField { name: _ } => {
+                internal_err!(
+                    "NamedStructField should be rewritten in OperatorToFunction"
+                )
+            }
+            GetFieldAccess::ListIndex { key: _ } => {
+                internal_err!("ListIndex should be rewritten in OperatorToFunction")
+            }
+            GetFieldAccess::ListRange {
+                start: _,
+                stop: _,
+                stride: _,
+            } => {
+                internal_err!("ListRange should be rewritten in OperatorToFunction")
+            }
+        },
 
         Expr::ScalarFunction(ScalarFunction { func_def, args }) => {
             let physical_args =

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -286,19 +286,23 @@ pub fn create_physical_expr(
         Expr::GetIndexedField(GetIndexedField { expr: _, field }) => {
             match field {
                 GetFieldAccess::NamedStructField { name: _ } => {
-                    unreachable!(
+                    return internal_err!(
                         "NamedStructField should be rewritten in OperatorToFunction"
                     )
                 }
                 GetFieldAccess::ListIndex { key: _ } => {
-                    unreachable!("ListIndex should be rewritten in OperatorToFunction")
+                    return internal_err!(
+                        "ListIndex should be rewritten in OperatorToFunction"
+                    )
                 }
                 GetFieldAccess::ListRange {
                     start: _,
                     stop: _,
                     stride: _,
                 } => {
-                    unreachable!("ListRange should be rewritten in OperatorToFunction")
+                    return internal_err!(
+                        "ListRange should be rewritten in OperatorToFunction"
+                    )
                 }
             };
         }


### PR DESCRIPTION


## Which issue does this PR close?

N/A

## Rationale for this change

When upgrading DataFusion internally we actually saw Panic's (due to a bug in our code): 

> level=error msg="Thread panic" panic_type=unknown panic_message="internal error: entered unreachable code: NamedStructField should be rewritten in OperatorToFunction" panic_file=/usr/local/cargo/git/checkouts/arrow-datafusion-cd9c4a788846b2bd/f16c211/datafusion/physical-expr/src/planner.rs panic_line=233 panic_column=21 target="panic_logging" location="panic_logging/src/lib.rs:54" time=1712340032101586067

## What changes are included in this PR?
Convert the errors from panic to internal error

## Are these changes tested?
No
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
