### PR TITLE
Optimize performance of substr_index and add tests

### DIFF
--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -112,18 +112,23 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
                     return Some(String::new());
                 }
 
-                let splitted: Box<dyn Iterator<Item = _>> = if n > 0 {
-                    Box::new(string.split(delimiter))
-                } else {
-                    Box::new(string.rsplit(delimiter))
-                };
                 let occurrences = usize::try_from(n.unsigned_abs()).unwrap_or(usize::MAX);
-                // The length of the substring covered by substr_index.
-                let length = splitted
-                    .take(occurrences) // at least 1 element, since n != 0
-                    .map(|s| s.len() + delimiter.len())
-                    .sum::<usize>()
-                    - delimiter.len();
+                let length;
+                if n > 0 {
+                    let splitted = string.split(delimiter);
+                    length = splitted
+                        .take(occurrences)
+                        .map(|s| s.len() + delimiter.len())
+                        .sum::<usize>()
+                        - delimiter.len();
+                } else {
+                    let splitted = string.rsplit(delimiter);
+                    length = splitted
+                        .take(occurrences)
+                        .map(|s| s.len() + delimiter.len())
+                        .sum::<usize>()
+                        - delimiter.len();
+                }
                 if n > 0 {
                     Some(string[..length].to_owned())
                 } else {

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -141,3 +141,69 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     Ok(Arc::new(result) as ArrayRef)
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{Array, StringArray};
+    use arrow::datatypes::DataType::Utf8;
+
+    use datafusion_common::{Result, ScalarValue};
+    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+
+    use crate::unicode::substrindex::SubstrIndexFunc;
+    use crate::utils::test::test_function;
+
+    #[test]
+    fn test_functions() -> Result<()> {
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+            ],
+            Ok(Some("www")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+            ],
+            Ok(Some("www.apache")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(-2i64)),
+            ],
+            Ok(Some("apache.org")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(-1i64)),
+            ],
+            Ok(Some("org")),
+            &str,
+            Utf8,
+            StringArray
+        );
+
+        Ok(())
+    }
+}

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -18,7 +18,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, OffsetSizeTrait, StringBuilder};
+use arrow::array::{ArrayBuilder, ArrayRef, OffsetSizeTrait, StringBuilder};
 use arrow::datatypes::DataType;
 
 use datafusion_common::cast::{as_generic_string_array, as_int64_array};
@@ -145,6 +145,9 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             }
         });
 
+    if builder.is_empty() {
+        builder.append_null();
+    }
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -113,22 +113,21 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
                 }
 
                 let occurrences = usize::try_from(n.unsigned_abs()).unwrap_or(usize::MAX);
-                let length;
-                if n > 0 {
+                let length = if n > 0 {
                     let splitted = string.split(delimiter);
-                    length = splitted
+                    splitted
                         .take(occurrences)
                         .map(|s| s.len() + delimiter.len())
                         .sum::<usize>()
-                        - delimiter.len();
+                        - delimiter.len()
                 } else {
                     let splitted = string.rsplit(delimiter);
-                    length = splitted
+                    splitted
                         .take(occurrences)
                         .map(|s| s.len() + delimiter.len())
                         .sum::<usize>()
-                        - delimiter.len();
-                }
+                        - delimiter.len()
+                };
                 if n > 0 {
                     Some(string[..length].to_owned())
                 } else {

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -207,6 +207,42 @@ mod tests {
             Utf8,
             StringArray
         );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+            ],
+            Ok(Some("")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("")),
+                ColumnarValue::Scalar(ScalarValue::from(".")),
+                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+            ],
+            Ok(Some("")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            SubstrIndexFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
+                ColumnarValue::Scalar(ScalarValue::from("")),
+                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+            ],
+            Ok(Some("")),
+            &str,
+            Utf8,
+            StringArray
+        );
 
         Ok(())
     }

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -106,8 +106,8 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .zip(delimiter_array.iter())
         .zip(count_array.iter())
-        .for_each(|((string, delimiter), n)| match (string, delimiter, n) {
-            (Some(string), Some(delimiter), Some(n)) => {
+        .for_each(|((string, delimiter), n)| {
+            if let (Some(string), Some(delimiter), Some(n)) = (string, delimiter, n) {
                 // In MySQL, these cases will return an empty string.
                 if n == 0 || string.is_empty() || delimiter.is_empty() {
                     builder.append_value("");
@@ -135,12 +135,14 @@ pub fn substr_index<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
                         builder.append_value(substring);
                     }
                 } else {
-                    if let Some(substring) = string.get(string.len().saturating_sub(length)..) {
+                    #[allow(clippy::collapsible_else_if)]
+                    if let Some(substring) =
+                        string.get(string.len().saturating_sub(length)..)
+                    {
                         builder.append_value(substring);
                     }
                 }
             }
-            _ => (),
         });
 
     Ok(Arc::new(builder.finish()) as ArrayRef)

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -940,7 +940,8 @@ SELECT str, n, substring_index(str, '.', n) AS c FROM
   (VALUES
     ROW('arrow.apache.org'),
     ROW('.'),
-    ROW('...')
+    ROW('...'),
+    ROW(NULL)
   ) AS strings(str),
   (VALUES
     ROW(1),
@@ -954,6 +955,14 @@ SELECT str, n, substring_index(str, '.', n) AS c FROM
   ) AS occurrences(n)
 ORDER BY str DESC, n;
 ----
+NULL -100 NULL
+NULL -3 NULL
+NULL -2 NULL
+NULL -1 NULL
+NULL 1 NULL
+NULL 2 NULL
+NULL 3 NULL
+NULL 100 NULL
 arrow.apache.org -100 arrow.apache.org
 arrow.apache.org -3 arrow.apache.org
 arrow.apache.org -2 apache.org
@@ -1024,25 +1033,6 @@ SELECT
   substring_index('arrow.apache.org', '', 1)
 ----
 (empty) (empty)
-
-# Test substring_index with NULL values and multiple rows
-query TIT
-SELECT str, n, substring_index(str, '.', n) AS c FROM
-  (VALUES
-    ROW(NULL)
-  ) AS strings(str),
-  (VALUES
-    ROW(1),
-    ROW(2),
-    ROW(-1),
-    ROW(-2)
-  ) AS occurrences(n)
-ORDER BY str, n;
-----
-NULL -2 NULL
-NULL -1 NULL
-NULL  1 NULL
-NULL  2 NULL
 
 # Test substring_index with 0 occurrence
 query T

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -1025,6 +1025,25 @@ SELECT
 ----
 (empty) (empty)
 
+# Test substring_index with NULL values and multiple rows
+query TIT
+SELECT str, n, substring_index(str, '.', n) AS c FROM
+  (VALUES
+    ROW(NULL)
+  ) AS strings(str),
+  (VALUES
+    ROW(1),
+    ROW(2),
+    ROW(-1),
+    ROW(-2)
+  ) AS occurrences(n)
+ORDER BY str, n;
+----
+NULL -2 NULL
+NULL -1 NULL
+NULL  1 NULL
+NULL  2 NULL
+
 # Test substring_index with 0 occurrence
 query T
 SELECT substring_index('arrow.apache.org', 'ac', 0)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #9890 

## Rationale for this change

We were using dynamic dispatch when deciding whether to do `string.split()` or `string.rsplit()` (depending on the `count` argument) because the exact type of iterator is not known at compile time, plus it allocates memory on the heap for the boxed iterator, which introduces considerable overhead. 

Instead, we can avoid doing this and handle the two cases with an if else statement, which removes that overhead and potentially enable further optimizations by the compiler.

Another major overhead is pointed to in https://github.com/apache/arrow-datafusion/pull/9973#discussion_r1554566944. Instead, we can avoid `String` creation at every iteration of `map` by using `StringBuilder` to build the output.

### Benchmarks
```bash
substr_index_array_array_1000
                        time:   [57.082 µs 57.407 µs 57.770 µs]
                        change: [-53.118% -52.034% -51.077%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```

No more time wasted on `malloc` and `free` now if we see the [flamegraph](https://github.com/apache/arrow-datafusion/assets/69668484/e5a847da-4597-42ab-9dc6-45cc58bf741d):
<img width="1147" alt="Screen Shot 2024-04-07 at 03 36 49" src="https://github.com/apache/arrow-datafusion/assets/69668484/b832c16d-73e6-4e02-bcf3-dfbe969c88ae">



## What changes are included in this PR?

## Are these changes tested?

Yes. I added new unit tests as well for `substr_index` since there were none before.

## Are there any user-facing changes?
