### PR TITLE
Minor: Avoid copying all expressions in `Analzyer` / `check_plan`

### DIFF
--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -26,7 +26,6 @@ use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::expr::Exists;
 use datafusion_expr::expr::InSubquery;
 use datafusion_expr::expr_rewriter::FunctionRewrite;
-use datafusion_expr::utils::inspect_expr_pre;
 use datafusion_expr::{Expr, LogicalPlan};
 
 use crate::analyzer::count_wildcard_rule::CountWildcardRule;
@@ -156,18 +155,21 @@ impl Analyzer {
 /// Do necessary check and fail the invalid plan
 fn check_plan(plan: &LogicalPlan) -> Result<()> {
     plan.apply(&mut |plan: &LogicalPlan| {
-        for expr in plan.expressions().iter() {
+        plan.inspect_expressions(|expr| {
             // recursively look for subqueries
-            inspect_expr_pre(expr, |expr| match expr {
-                Expr::Exists(Exists { subquery, .. })
-                | Expr::InSubquery(InSubquery { subquery, .. })
-                | Expr::ScalarSubquery(subquery) => {
-                    check_subquery_expr(plan, &subquery.subquery, expr)
-                }
-                _ => Ok(()),
+            expr.apply(&mut |expr| {
+                match expr {
+                    Expr::Exists(Exists { subquery, .. })
+                    | Expr::InSubquery(InSubquery { subquery, .. })
+                    | Expr::ScalarSubquery(subquery) => {
+                        check_subquery_expr(plan, &subquery.subquery, expr)?;
+                    }
+                    _ => {}
+                };
+                Ok(TreeNodeRecursion::Continue)
             })?;
-        }
-
+            Ok::<(), DataFusionError>(())
+        })?;
         Ok(TreeNodeRecursion::Continue)
     })?;
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #9637 

## Rationale for this change

I found this while working on https://github.com/apache/arrow-datafusion/pull/9913 with @peter-toth

Calling `LogicalPlan::expressions()` does a copy of the expressions, but this function simply needs to check them


## What changes are included in this PR?
1. Use `TreeNode` API to visit expressions rather than `LogicalPlan::expressions()`

## Are these changes tested?
Covered by existing unit tests

## Are there any user-facing changes?
(Slightly) faster planning, and fewer copies during planning

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
