### PR TITLE
Minor: Make `LogicalPlan::apply_subqueries` and `LogicalPlan::apply_subqueries` pub

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1434,7 +1434,7 @@ impl LogicalPlan {
         )
     }
 
-    fn apply_subqueries<F: FnMut(&Self) -> Result<TreeNodeRecursion>>(
+    pub fn apply_subqueries<F: FnMut(&Self) -> Result<TreeNodeRecursion>>(
         &self,
         mut f: F,
     ) -> Result<TreeNodeRecursion> {
@@ -1453,7 +1453,7 @@ impl LogicalPlan {
         })
     }
 
-    fn map_subqueries<F: FnMut(Self) -> Result<Transformed<Self>>>(
+    pub fn map_subqueries<F: FnMut(Self) -> Result<Transformed<Self>>>(
         self,
         mut f: F,
     ) -> Result<Transformed<Self>> {


### PR DESCRIPTION

## Which issue does this PR close?
Part of https://github.com/apache/arrow-datafusion/issues/9994


## Rationale for this change

These methods were  introduced in  https://github.com/apache/arrow-datafusion/pull/9913 by @peter-toth  but not marked pub


## What changes are included in this PR?

1. Mark `apply_subqueries` and `map_subueries` `pub` 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
New pub APIs (documented in https://github.com/apache/arrow-datafusion/pull/9996)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
