### PR TITLE
Improve the performance of ltrim/rtrim/btrim

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -112,3 +112,8 @@ required-features = ["datetime_expressions"]
 harness = false
 name = "substr_index"
 required-features = ["unicode_expressions"]
+
+[[bench]]
+harness = false
+name = "ltrim"
+required-features = ["string_expressions"]

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::array::{ArrayRef, StringArray};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_common::ScalarValue;
+use datafusion_expr::ColumnarValue;
+use datafusion_functions::string;
+use std::sync::Arc;
+
+fn create_args(size: usize, characters: &str) -> Vec<ColumnarValue> {
+    let iter =
+        std::iter::repeat(format!("{}datafusion{}", characters, characters)).take(size);
+    let array = Arc::new(StringArray::from_iter_values(iter)) as ArrayRef;
+    vec![
+        ColumnarValue::Array(array),
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(characters.to_string()))),
+    ]
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let ltrim = string::ltrim();
+    for char in ["\"", "Header:"] {
+        for size in [1024, 4096, 8192] {
+            let args = create_args(size, char);
+            c.bench_function(&format!("ltrim {}: {}", char, size), |b| {
+                b.iter(|| black_box(ltrim.invoke(&args)))
+            });
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/string/btrim.rs
+++ b/datafusion/functions/src/string/btrim.rs
@@ -24,6 +24,7 @@ use datafusion_common::{exec_err, Result};
 use datafusion_expr::TypeSignature::*;
 use datafusion_expr::{ColumnarValue, Volatility};
 use datafusion_expr::{ScalarUDFImpl, Signature};
+use datafusion_physical_expr::functions::Hint;
 
 use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
@@ -72,8 +73,14 @@ impl ScalarUDFImpl for BTrimFunc {
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match args[0].data_type() {
-            DataType::Utf8 => make_scalar_function(btrim::<i32>, vec![])(args),
-            DataType::LargeUtf8 => make_scalar_function(btrim::<i64>, vec![])(args),
+            DataType::Utf8 => make_scalar_function(
+                btrim::<i32>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
+            DataType::LargeUtf8 => make_scalar_function(
+                btrim::<i64>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
             other => exec_err!("Unsupported data type {other:?} for function btrim"),
         }
     }

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -78,6 +78,15 @@ pub(crate) fn general_trim<T: OffsetSizeTrait>(
         2 => {
             let characters_array = as_generic_string_array::<T>(&args[1])?;
 
+            if characters_array.len() == 1 {
+                let characters = characters_array.value(0);
+                let result = string_array
+                    .iter()
+                    .map(|item| item.map(|string| func(string, characters)))
+                    .collect::<GenericStringArray<T>>();
+                return Ok(Arc::new(result) as ArrayRef);
+            }
+
             let result = string_array
                 .iter()
                 .zip(characters_array.iter())

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -18,7 +18,9 @@
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
+use arrow::array::{
+    new_null_array, Array, ArrayRef, GenericStringArray, OffsetSizeTrait,
+};
 use arrow::datatypes::DataType;
 
 use datafusion_common::cast::as_generic_string_array;
@@ -79,6 +81,10 @@ pub(crate) fn general_trim<T: OffsetSizeTrait>(
             let characters_array = as_generic_string_array::<T>(&args[1])?;
 
             if characters_array.len() == 1 {
+                if characters_array.is_null(0) {
+                    return Ok(new_null_array(args[0].data_type(), args[0].len()));
+                }
+
                 let characters = characters_array.value(0);
                 let result = string_array
                     .iter()

--- a/datafusion/functions/src/string/ltrim.rs
+++ b/datafusion/functions/src/string/ltrim.rs
@@ -24,6 +24,7 @@ use datafusion_common::{exec_err, Result};
 use datafusion_expr::TypeSignature::*;
 use datafusion_expr::{ColumnarValue, Volatility};
 use datafusion_expr::{ScalarUDFImpl, Signature};
+use datafusion_physical_expr::functions::Hint;
 
 use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
@@ -70,8 +71,14 @@ impl ScalarUDFImpl for LtrimFunc {
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match args[0].data_type() {
-            DataType::Utf8 => make_scalar_function(ltrim::<i32>, vec![])(args),
-            DataType::LargeUtf8 => make_scalar_function(ltrim::<i64>, vec![])(args),
+            DataType::Utf8 => make_scalar_function(
+                ltrim::<i32>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
+            DataType::LargeUtf8 => make_scalar_function(
+                ltrim::<i64>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
             other => exec_err!("Unsupported data type {other:?} for function ltrim"),
         }
     }

--- a/datafusion/functions/src/string/rtrim.rs
+++ b/datafusion/functions/src/string/rtrim.rs
@@ -24,6 +24,7 @@ use datafusion_common::{exec_err, Result};
 use datafusion_expr::TypeSignature::*;
 use datafusion_expr::{ColumnarValue, Volatility};
 use datafusion_expr::{ScalarUDFImpl, Signature};
+use datafusion_physical_expr::functions::Hint;
 
 use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
@@ -70,8 +71,14 @@ impl ScalarUDFImpl for RtrimFunc {
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match args[0].data_type() {
-            DataType::Utf8 => make_scalar_function(rtrim::<i32>, vec![])(args),
-            DataType::LargeUtf8 => make_scalar_function(rtrim::<i64>, vec![])(args),
+            DataType::Utf8 => make_scalar_function(
+                rtrim::<i32>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
+            DataType::LargeUtf8 => make_scalar_function(
+                rtrim::<i64>,
+                vec![Hint::Pad, Hint::AcceptsSingular],
+            )(args),
             other => exec_err!("Unsupported data type {other:?} for function rtrim"),
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/10007

## Rationale for this change

If the `trim` function includes a second argument, I believe it is predominantly a Scalar rather than an Array. Expanding the second argument into an Array would lead to performance degradation, and more critically, the code `arg.clone().into_array(expansion_len)` would be invoked for every computation.

### Benchmark

```shell
Gnuplot not found, using plotters backend
ltrim ": 1024           time:   [23.495 µs 23.520 µs 23.554 µs]
                        change: [-11.992% -11.922% -11.854%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

ltrim ": 4096           time:   [92.348 µs 92.489 µs 92.669 µs]
                        change: [-10.305% -10.123% -9.9762%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

ltrim ": 8192           time:   [189.78 µs 190.59 µs 191.57 µs]
                        change: [-6.1871% -5.8626% -5.5516%] (p = 0.00 < 0.05)
                        Performance has improved.

ltrim Header:: 1024     time:   [80.256 µs 80.276 µs 80.300 µs]
                        change: [-7.5562% -7.0325% -6.6364%] (p = 0.00 < 0.05)
                        Performance has improved.

ltrim Header:: 4096     time:   [318.94 µs 319.04 µs 319.15 µs]
                        change: [-5.5723% -5.4562% -5.3322%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

ltrim Header:: 8192     time:   [643.04 µs 643.69 µs 644.34 µs]
                        change: [-4.9289% -4.7291% -4.5327%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
