### PR TITLE
modify emit() of TopK to emit on `batch_size` rather than `batch_size-1`

### DIFF
--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -208,7 +208,7 @@ impl TopK {
         // break into record batches as needed
         let mut batches = vec![];
         loop {
-            if batch.num_rows() < batch_size {
+            if batch.num_rows() <= batch_size {
                 batches.push(Ok(batch));
                 break;
             } else {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Simply modify the logic of "break into record batches as needed". This modification avoid generating an empty RecordBatch where the batch.num_rows() eq batch_size.

https://github.com/apache/arrow-datafusion/blob/03d8ba1f0d94bac6bb8bb33e95f00f9f6fb5275a/datafusion/physical-plan/src/topk/mod.rs#L210-L219

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
