### PR TITLE
Minor: get mutable ref to `SessionConfig` in `SessionState`

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1952,6 +1952,11 @@ impl SessionState {
         &self.config
     }
 
+    /// Return the mutable [`SessionConfig`].
+    pub fn config_mut(&mut self) -> &mut SessionConfig {
+        &mut self.config
+    }
+
     /// Return the physical optimizers
     pub fn physical_optimizers(&self) -> &[Arc<dyn PhysicalOptimizerRule + Send + Sync>] {
         &self.physical_optimizers.rules

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -483,11 +483,11 @@ impl SessionConfig {
     /// let ext1b = Arc::new(Ext1(11));
     /// let ext2 = Arc::new(Ext2(2));
     ///
-    /// let mut cfg = SessionConfig::default();
-    /// // will only remember the last Ext1
-    /// cfg.with_extension(Arc::clone(&ext1a))
-    ///    .with_extension(Arc::clone(&ext1b))
-    ///    .with_extension(Arc::clone(&ext2));
+    /// let cfg = SessionConfig::default()
+    ///     // will only remember the last Ext1
+    ///     .with_extension(Arc::clone(&ext1a))
+    ///     .with_extension(Arc::clone(&ext1b))
+    ///     .with_extension(Arc::clone(&ext2));
     ///
     /// let ext1_received = cfg.get_extension::<Ext1>().unwrap();
     /// assert!(!Arc::ptr_eq(&ext1_received, &ext1a));
@@ -500,14 +500,55 @@ impl SessionConfig {
     /// ```
     ///
     /// [^1]: Compare that to [`ConfigOptions`] which only supports [`ScalarValue`] payloads.
-    pub fn with_extension<T>(&mut self, ext: Arc<T>) -> &mut Self
+    pub fn with_extension<T>(mut self, ext: Arc<T>) -> Self
+    where
+        T: Send + Sync + 'static,
+    {
+        self.set_extension(ext);
+        self
+    }
+
+    /// Set extension. Pretty much the same as [`with_extension`](Self::with_extension), but take
+    /// mutable reference instead of owning it. Useful if you want to add another extension after
+    /// the [`SessionConfig`] is created.
+    ///
+    /// # Example
+    /// ```
+    /// use std::sync::Arc;
+    /// use datafusion_execution::config::SessionConfig;
+    ///
+    /// // application-specific extension types
+    /// struct Ext1(u8);
+    /// struct Ext2(u8);
+    /// struct Ext3(u8);
+    ///
+    /// let ext1a = Arc::new(Ext1(10));
+    /// let ext1b = Arc::new(Ext1(11));
+    /// let ext2 = Arc::new(Ext2(2));
+    ///
+    /// let mut cfg = SessionConfig::default();
+    ///
+    /// // will only remember the last Ext1
+    /// cfg.set_extension(Arc::clone(&ext1a));
+    /// cfg.set_extension(Arc::clone(&ext1b));
+    /// cfg.set_extension(Arc::clone(&ext2));
+    ///
+    /// let ext1_received = cfg.get_extension::<Ext1>().unwrap();
+    /// assert!(!Arc::ptr_eq(&ext1_received, &ext1a));
+    /// assert!(Arc::ptr_eq(&ext1_received, &ext1b));
+    ///
+    /// let ext2_received = cfg.get_extension::<Ext2>().unwrap();
+    /// assert!(Arc::ptr_eq(&ext2_received, &ext2));
+    ///
+    /// assert!(cfg.get_extension::<Ext3>().is_none());
+    /// ```
+    pub fn set_extension<T>(&mut self, ext: Arc<T>)
     where
         T: Send + Sync + 'static,
     {
         let ext = ext as Arc<dyn Any + Send + Sync + 'static>;
         let id = TypeId::of::<T>();
         self.extensions.insert(id, ext);
-        self
     }
 
     /// Get extension, if any for the specified type `T` exists.

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -500,7 +500,7 @@ impl SessionConfig {
     /// ```
     ///
     /// [^1]: Compare that to [`ConfigOptions`] which only supports [`ScalarValue`] payloads.
-    pub fn with_extension<T>(mut self, ext: Arc<T>) -> Self
+    pub fn with_extension<T>(&mut self, ext: Arc<T>) -> &mut Self
     where
         T: Send + Sync + 'static,
     {

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -483,11 +483,11 @@ impl SessionConfig {
     /// let ext1b = Arc::new(Ext1(11));
     /// let ext2 = Arc::new(Ext2(2));
     ///
-    /// let cfg = SessionConfig::default()
-    ///     // will only remember the last Ext1
-    ///     .with_extension(Arc::clone(&ext1a))
-    ///     .with_extension(Arc::clone(&ext1b))
-    ///     .with_extension(Arc::clone(&ext2));
+    /// let mut cfg = SessionConfig::default();
+    /// // will only remember the last Ext1
+    /// cfg.with_extension(Arc::clone(&ext1a))
+    ///    .with_extension(Arc::clone(&ext1b))
+    ///    .with_extension(Arc::clone(&ext2));
     ///
     /// let ext1_received = cfg.get_extension::<Ext1>().unwrap();
     /// assert!(!Arc::ptr_eq(&ext1_received, &ext1a));


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The `SessionConfig` has an "`extensions: AnyMap`", can be used "... to attach extra data to the session config -- e.g. tracing information or caches."(from `with_extension`'s docs). However, there's no place to add an extension from the `SessionState` site, which limits its functionality, especially when the attached extra data is wanted in optimizing physical plan stage.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds a `config_mut` in `SessionState` to get the mutable ref to `SessionConfig` to resolve the issue above.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered, and in doc-test.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Two new methods are added, no breaking.