### PR TITLE
Bump sccache-action to v0.0.4

### DIFF
--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3   
+      uses: mozilla-actions/sccache-action@v0.0.4
     - name: Configure runtime env
       shell: bash
       # do not produce debug symbols to keep memory usage down


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Fixes this warning that occurs in GitHub Actions, by upgrading `mozilla-actions/sccache-action` to `v0.0.4` which runs using node20.

<img width="1188" alt="Screenshot 2024-04-12 at 9 42 53 PM" src="https://github.com/apache/arrow-datafusion/assets/879445/0990ec0c-6fe0-4055-97a9-d884671babf3">

## What changes are included in this PR?

Bump `mozilla-actions/sccache-action` to `v0.0.4`

## Are these changes tested?

They will be once CI runs for this PR.

## Are there any user-facing changes?

No