### PR TITLE
Refactor `EliminateOuterJoin` to implement `OptimizerRule::rewrite()`

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -53,7 +53,7 @@ impl OptimizerRule for SimplifyExpressions {
         _plan: &LogicalPlan,
         _config: &dyn OptimizerConfig,
     ) -> Result<Option<LogicalPlan>> {
-        internal_err!("Should have called SimplifyExpressions::try_optimize_owned")
+        internal_err!("Should have called SimplifyExpressions::rewrite")
     }
 
     fn name(&self) -> &str {


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/arrow-datafusion/issues/9637.

## Rationale for this change

Eliminates a `LogicalPlan::with_new_exprs()` call and so `Expr` cloning.

## What changes are included in this PR?

This PR:
- Refactors `EliminateOuterJoin::try_optimize()` to `EliminateOuterJoin::rewrite()`.
- Contains minor cleanup of `eliminate_outer()`.
- Fixes typo in `SimplifyExpressions`.

## Are these changes tested?

Yes, with existing UTs.

## Are there any user-facing changes?

No.
