### PR TITLE
Minor: only trigger dependency check on changes to Cargo.toml

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Dependencies
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  depcheck:
+    name: circular dependency check
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check dependencies
+        run: |
+          cd dev/depcheck
+          cargo run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,24 +195,7 @@ jobs:
       - name: Verify Working Directory Clean
         run: git diff --exit-code
 
-  depcheck:
-    name: circular dependency check
-    needs: [ linux-build-lib ]
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - name: Check dependencies
-        run: |
-          cd dev/depcheck
-          cargo run 
+
 
   # Run `cargo test doc` (test documentation examples)
   linux-test-doc:

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/arrow-datafusion/pull/9865

Related to https://github.com/apache/arrow-datafusion/issues/9278

## Rationale for this change

It would be nice not to waste runner time (and burn CO2) on unecessary jobs

## What changes are included in this PR?
Only trigger dependency check on changes to `Cargo.toml`

## Are these changes tested?

I tested them manually:
* commit [f106ff1](https://github.com/apache/arrow-datafusion/pull/10099/commits/f106ff1838e1aca96f18eeb9552c2f623c955aad): no depcheck ran https://github.com/apache/arrow-datafusion/pull/10099/checks
* https://github.com/apache/arrow-datafusion/pull/10099/commits/809cdcf0358d634e3bd990e25e2dd2ca4a11582a: Manually introduced a change to Cargo.toml: [depcheck ran ](https://github.com/apache/arrow-datafusion/actions/runs/8709157731/job/23888226710?pr=10099)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
