### PR TITLE
Enable ObjectMeta Cache for ListingTable

### DIFF
--- a/datafusion/execution/Cargo.toml
+++ b/datafusion/execution/Cargo.toml
@@ -46,3 +46,4 @@ parking_lot = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
 url = { workspace = true }
+sequence_trie = "*"

--- a/datafusion/execution/src/cache/cache_manager.rs
+++ b/datafusion/execution/src/cache/cache_manager.rs
@@ -15,13 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use super::cache_unit::{self, DefaultFileStatisticsCache};
 use crate::cache::CacheAccessor;
 use datafusion_common::{Result, Statistics};
 use object_store::path::Path;
 use object_store::ObjectMeta;
+use parking_lot::Mutex;
+use parking_lot::RwLock;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-
 /// The cache of listing files statistics.
 /// if set [`CacheManagerConfig::with_files_statistics_cache`]
 /// Will avoid infer same file statistics repeatedly during the session lifetime,
@@ -73,7 +75,7 @@ impl CacheManager {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct CacheManagerConfig {
     /// Enable cache of files statistics when listing files.
     /// Avoid get same file statistics repeatedly in same datafusion session.
@@ -87,7 +89,14 @@ pub struct CacheManagerConfig {
     /// Default is disable.
     pub list_files_cache: Option<ListFilesCache>,
 }
-
+impl Default for CacheManagerConfig {
+    fn default() -> Self {
+        Self {
+            table_files_statistics_cache: None,
+            list_files_cache: Some(Arc::new(cache_unit::TrieFileCache::default())),
+        }
+    }
+}
 impl CacheManagerConfig {
     pub fn with_files_statistics_cache(
         mut self,


### PR DESCRIPTION
## Which issue does this PR close?
Part of #9964
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Currently the ListingTable on remote storage contains two parts, [list_object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html), which is used to fetch the metadata, and [get_object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)  which is used to get the actual file, 
we could cache the metadata for subsequent queries to use the metadata
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
yes after adding cache, the following query has been faster for around 17%

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes increase performance around 17%
<img width="1168" alt="image" src="https://github.com/apache/arrow-datafusion/assets/48054792/d0b80922-ae0d-4426-9f89-6590fa94210a">
<img width="1173" alt="image" src="https://github.com/apache/arrow-datafusion/assets/48054792/11f4748c-5a22-47fc-9539-a932a5821d23">

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
