### PR TITLE
Fix AVG groups accummulator ignoring return type

### DIFF
--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -519,7 +519,8 @@ where
         // don't evaluate averages with null inputs to avoid errors on null values
 
         let array: PrimitiveArray<T> = if nulls.null_count() > 0 {
-            let mut builder = PrimitiveBuilder::<T>::with_capacity(nulls.len());
+            let mut builder = PrimitiveBuilder::<T>::with_capacity(nulls.len())
+                .with_data_type(self.return_data_type.clone());
             let iter = sums.into_iter().zip(counts).zip(nulls.iter());
 
             for ((sum, count), is_valid) in iter {

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2429,12 +2429,12 @@ statement ok
 INSERT INTO test_decimal_table VALUES (1, 10.10, 100.1, NULL), (1, 20.20, 200.2, NULL), (2, 10.10, 700.1, NULL), (2, 20.20, 700.1, NULL), (3, 10.1, 100.1, NULL), (3, 10.1, NULL, NULL)
 
 # aggregate_decimal_with_group_by
-query IIRRRRIIR rowsort
-select c1, count(c2), avg(c2), sum(c2), min(c2), max(c2), count(c3), count(c4), sum(c4) from test_decimal_table group by c1
+query IIRRRRIIRR rowsort
+select c1, count(c2), avg(c2), sum(c2), min(c2), max(c2), count(c3), count(c4), sum(c4), avg(c4) from test_decimal_table group by c1
 ----
-1 2 15.15 30.3 10.1 20.2 2 0 NULL
-2 2 15.15 30.3 10.1 20.2 2 0 NULL
-3 2 10.1 20.2 10.1 10.1 1 0 NULL
+1 2 15.15 30.3 10.1 20.2 2 0 NULL NULL
+2 2 15.15 30.3 10.1 20.2 2 0 NULL NULL
+3 2 10.1 20.2 10.1 10.1 1 0 NULL NULL
 
 # aggregate_decimal_with_group_by_decimal
 query RIRRRRIR rowsort

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3627,7 +3627,7 @@ physical_plan
 13)------------ProjectionExec: expr=[1 as c, 3 as d]
 14)--------------PlaceholderRowExec
 
-query IIII
+query IIII rowsort
 SELECT * FROM (
     SELECT 1 as c, 2 as d
     UNION ALL
@@ -3673,7 +3673,7 @@ physical_plan
 11)------------ProjectionExec: expr=[1 as c, 3 as d]
 12)--------------PlaceholderRowExec
 
-query IIII
+query IIII rowsort
 SELECT * FROM (
     SELECT 1 as c, 2 as d
     UNION ALL


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10113 .

## Rationale for this change

## What changes are included in this PR?

Coerce AVG accumulator to designated return type in case of columns with nulls.

## Are these changes tested?

Yes, also a test is extended.

## Are there any user-facing changes?

The query reported in the issue works now.
