### PR TITLE
Fix intermittent CI test failure in `joins.slt`

### DIFF
--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3673,7 +3673,7 @@ physical_plan
 11)------------ProjectionExec: expr=[1 as c, 3 as d]
 12)--------------PlaceholderRowExec
 
-query IIII
+query IIII rowsort
 SELECT * FROM (
     SELECT 1 as c, 2 as d
     UNION ALL


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/10119

## Rationale for this change

Avoid intermittent failures in CI tests

## What changes are included in this PR?

Add a `rowsort` to a non deterministic query added in https://github.com/apache/arrow-datafusion/pull/10095 by @mustafasrepo  

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No, this is a test only change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
