### PR TITLE
Minor: Add default for `Expr`

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -184,6 +184,12 @@ pub enum Expr {
     Unnest(Unnest),
 }
 
+impl Default for Expr {
+    fn default() -> Self {
+        Expr::Literal(ScalarValue::Null)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Unnest {
     pub expr: Box<Expr>,

--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -179,8 +179,7 @@ impl TreeNodeRewriter for UnwrapCastExprRewriter {
                         };
                         **left = lit(value);
                         // unwrap the cast/try_cast for the right expr
-                        **right =
-                            mem::replace(right_expr, Expr::Literal(ScalarValue::Null));
+                        **right = mem::take(right_expr);
                         Ok(Transformed::yes(expr))
                     }
                     (
@@ -203,8 +202,7 @@ impl TreeNodeRewriter for UnwrapCastExprRewriter {
                             return Ok(Transformed::no(expr));
                         };
                         // unwrap the cast/try_cast for the left expr
-                        **left =
-                            mem::replace(left_expr, Expr::Literal(ScalarValue::Null));
+                        **left = mem::take(left_expr);
                         **right = lit(value);
                         Ok(Transformed::yes(expr))
                     }
@@ -262,7 +260,7 @@ impl TreeNodeRewriter for UnwrapCastExprRewriter {
                     .collect::<Result<Vec<_>>>() else {
                     return Ok(Transformed::no(expr))
                 };
-                **left = mem::replace(left_expr, Expr::Literal(ScalarValue::Null));
+                **left = mem::take(left_expr);
                 *list = right_exprs;
                 Ok(Transformed::yes(expr))
             }


### PR DESCRIPTION
## Which issue does this PR close?

This PR adds default for `Expr` as `Expr::Literal(ScalarValue::Null)`. This makes possible to use `mem::take()` in `UnwrapCastExprRewriter` and other rules in the future.